### PR TITLE
Experimental data store layer to aid tracking client state

### DIFF
--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -256,6 +256,8 @@ var init = function(exports){
         //   local echo
         //   disambiguating display names in a room
         //   event dup suppression? - apparently we should still be doing so
+        //   tracking current display name / avatar per-message
+        //   pagination
         
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI
@@ -283,7 +285,7 @@ var init = function(exports){
                 var userId = this.credentials.userId;
                 var members = this.store.getStateEvents(roomId, 'm.room.member')
                     .filter(function(event) {
-                        event.event.user_id !== userId;
+                        return event.event.user_id !== userId;
                     });
                 
                 if (members.length == 0) {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -110,13 +110,13 @@ var init = function(exports){
         
     MatrixInMemoryStore.prototype = {
         /*
-         * Add an array of one or more raw state events into the store, overwriting
+         * Add an array of one or more state MatrixEvents into the store, overwriting
          * any existing state with the same {room, type, stateKey} tuple.
          */
-        setRawStateEvents: function(stateEvents) {
+        setStateEvents: function(stateEvents) {
             // we store stateEvents indexed by room, event type and state key.
             for (var i = 0; i < stateEvents.length; i++) {
-                var event = stateEvents[i];
+                var event = stateEvents[i].event;
                 var roomId = event.room_id;
                 if (this.rooms[roomId] === undefined) {
                     this.rooms[roomId] = {};
@@ -127,7 +127,7 @@ var init = function(exports){
                 if (this.rooms[roomId].state[event.type] === undefined) {
                     this.rooms[roomId].state[event.type] = {};
                 }
-                this.rooms[roomId].state[event.type][event.state_key] = new MatrixEvent(event);
+                this.rooms[roomId].state[event.type][event.state_key] = stateEvents[i];
             }
         },
        
@@ -183,14 +183,14 @@ var init = function(exports){
         },
         
         /*
-         * Adds a list of arbitrary raw events into the store.
+         * Adds a list of arbitrary MatrixEvents into the store.
          * If the event is a state event, it is also updates state.
          */
-        setRawEvents: function(events) {
+        setEvents: function(events) {
             for (var i = 0; i < events.length; i++) {
-                var event = events[i];
+                var event = events[i].event;
                 if (event.type === "m.presence") {
-                    this.setRawPresenceEvents([event]);
+                    this.setPresenceEvents([events[i]]);
                     continue;
                 }
                 var roomId = event.room_id;
@@ -201,9 +201,9 @@ var init = function(exports){
                     this.rooms[roomId].timeline = [];
                 }
                 if (event.state_key !== undefined) {
-                    this.setRawStateEvents([event]);
+                    this.setStateEvents([events[i]]);
                 }
-                this.rooms[roomId].timeline.push(new MatrixEvent(event));
+                this.rooms[roomId].timeline.push(events[i]);
             }
         },
         
@@ -215,10 +215,10 @@ var init = function(exports){
             return this.room[roomId].timeline;
         },
         
-        setRawPresenceEvents: function(presenceEvents) {
+        setPresenceEvents: function(presenceEvents) {
             for (var i = 0; i < presenceEvents.length; i++) {
-                var event = presenceEvents[i];
-                this.presence[event.user_id] = new MatrixEvent(event);
+                var matrixEvent = presenceEvents[i];
+                this.presence[matrixEvent.event.user_id] = matrixEvent;
             }
         },
         
@@ -258,6 +258,7 @@ var init = function(exports){
         //   event dup suppression? - apparently we should still be doing so
         //   tracking current display name / avatar per-message
         //   pagination
+        //   reconnection - DONE
         
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI
@@ -349,6 +350,10 @@ var init = function(exports){
                 if (err) {
                     console.error("err %s", JSON.stringify(err));
                     callback(err);
+                    // retry every few seconds
+                    setTimeout(function() {
+                        self._pollForEvents(callback);
+                    }, 2000);
                 } else {
                     var events = [];
                     for (var j = 0; j < data.chunk.length; j++) {
@@ -668,10 +673,22 @@ var init = function(exports){
                 function(err, data) {
                     if (self.store) {
                         // intercept the results and put them into our store
-                        self.store.setRawPresenceEvents(data.presence);
+                        self.store.setPresenceEvents(data.presence.map(
+                            function(event) {
+                                return new MatrixEvent(event);
+                            }
+                        ));
                         for (var i = 0 ; i < data.rooms.length; i++) {
-                            self.store.setRawStateEvents(data.rooms[i].state);
-                            self.store.setRawEvents(data.rooms[i].messages.chunk);
+                            self.store.setStateEvents(data.rooms[i].state.map(
+                                function(event) {
+                                    return new MatrixEvent(event);
+                                }
+                            ));
+                            self.store.setEvents(data.rooms[i].messages.chunk.map(
+                                function(event) {
+                                    return new MatrixEvent(event);
+                                }
+                            ));
                         }
                     }
                     if (data) self.fromToken = data.end;
@@ -726,7 +743,11 @@ var init = function(exports){
             return this._doAuthedRequest(
                 function(err, data) {
                     if (self.store) {
-                        self.store.setRawEvents(data.chunk);
+                        self.store.setEvents(data.chunk.map(
+                            function(event) {
+                                return new MatrixEvent(event);
+                            }
+                        ));
                     }
                     if (data) self.fromToken = data.end;
                     callback(err, data); // continue with original callback

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -21,6 +21,9 @@ var init = function(exports){
      * Construct a Matrix Client.
      * @param {Object} credentials The credentials for this client
      * @param {Object} config The config (if any) for this client.
+     *  Valid config params include:
+     *      noUserAgent: true // to avoid warnings whilst setting UA headers
+     *      debug: true // to use console.err() style debugging from the lib
      * @param {Object} store The data store (if any) for this client.
      */
     function MatrixClient(credentials, config, store) {
@@ -68,7 +71,7 @@ var init = function(exports){
      * @param {Object} event The raw event to be wrapped in this DAO
      */
     function MatrixEvent(event) {
-        this.event = event;
+        this.event = event || {};
     };
     exports.MatrixEvent = MatrixEvent;
     
@@ -133,13 +136,22 @@ var init = function(exports){
                 this.rooms[roomId].state[event.type][event.state_key] = stateEvents[i];
             }
         },
+
+        /*
+         * Add a single state MatrixEvents into the store, overwriting
+         * any existing state with the same {room, type, stateKey} tuple.
+         */
+        setStateEvent: function(stateEvent) {
+            this.setStateEvents([stateEvent]);
+        },
        
         /*
-         * Return a list of MatrixEvents from the store, filtered by roomid, type and state key.
+         * Return a list of MatrixEvents from the store
          * @param {String} roomId the Room ID whose state is to be returned
          * @param {String} type the type of the state events to be returned (optional)
          * @param {String} stateKey the stateKey of the state events to be returned
          *                 (optional, requires type to be specified)
+         * @return an array of MatrixEvents from the store, filtered by roomid, type and state key.
          */
         getStateEvents: function(roomId, type, stateKey) {
             var stateEvents = [];
@@ -170,7 +182,14 @@ var init = function(exports){
         
         /*
          * Return a single state MatrixEvent from the store for the given roomId
-         * and type.  stateKey is optional; if missing, is assumed to be blank.
+         * and type.  stateKey is optional; if missing, the first matching event is
+         * returned irrespective of stateKey.
+         * @param {String} roomId the Room ID whose state is to be returned
+         * @param {String} type the type of the state events to be returned
+         * @param {String} stateKey the stateKey of the state events to be returned
+         *                 (optional. if missing, the first matching event is returned
+         *                  irrespective of its stateKey)
+         * @return a single MatrixEvent from the store, filtered by roomid, type and state key.
          */
         getStateEvent: function(roomId, type, stateKey) {
             if (stateKey === undefined) {
@@ -240,10 +259,10 @@ var init = function(exports){
         },
         
         // TODO
-        setMaxHistoryPerRoom: function(maxHistory) {},
+        //setMaxHistoryPerRoom: function(maxHistory) {},
         
         // TODO
-        reapOldMessages: function() {},
+        //reapOldMessages: function() {},
     };
 
     MatrixClient.prototype = {
@@ -353,7 +372,9 @@ var init = function(exports){
             if (!this.fromToken) {
                 this.initialSync(historyLen, function(err, data) {
                     if (err) {
-                        console.error("err %s", JSON.stringify(err));
+                        if (this.config && this.config.debug) {
+                            console.error("startClient error on initialSync: %s", JSON.stringify(err));
+                        }
                         callback(err);
                     } else {
                         var events = []
@@ -384,9 +405,12 @@ var init = function(exports){
             if (!this.clientRunning) return;
             this.eventStream(this.fromToken, 30000, function(err, data) {
                 if (err) {
-                    console.error("err %s", JSON.stringify(err));
+                    if (this.config && this.config.debug) {
+                        console.error("error polling for events via eventStream: %s", JSON.stringify(err));
+                    }
                     callback(err);
                     // retry every few seconds
+                    // FIXME: this should be exponential backoff with an option to nudge
                     setTimeout(function() {
                         self._pollForEvents(callback);
                     }, 2000);
@@ -709,18 +733,18 @@ var init = function(exports){
                 function(err, data) {
                     if (self.store) {
                         // intercept the results and put them into our store
-                        self.store.setPresenceEvents(data.presence.map(
+                        self.store.setPresenceEvents(map(data.presence,
                             function(event) {
                                 return new MatrixEvent(event);
                             }
                         ));
                         for (var i = 0 ; i < data.rooms.length; i++) {
-                            self.store.setStateEvents(data.rooms[i].state.map(
+                            self.store.setStateEvents(map(data.rooms[i].state,
                                 function(event) {
                                     return new MatrixEvent(event);
                                 }
                             ));
-                            self.store.setEvents(data.rooms[i].messages.chunk.map(
+                            self.store.setEvents(map(data.rooms[i].messages.chunk,
                                 function(event) {
                                     return new MatrixEvent(event);
                                 }
@@ -779,7 +803,7 @@ var init = function(exports){
             return this._doAuthedRequest(
                 function(err, data) {
                     if (self.store) {
-                        self.store.setEvents(data.chunk.map(
+                        self.store.setEvents(map(data.chunk,
                             function(event) {
                                 return new MatrixEvent(event);
                             }
@@ -1012,6 +1036,14 @@ var init = function(exports){
 
     var isFunction = function(value) {
         return Object.prototype.toString.call(value) == "[object Function]";
+    };
+
+    var map = function(array, fn) {
+        var results = Array(array.length);
+        for (var i = 0; i < array.length; i++) {
+            results[i] = fn(array[i]);
+        }
+        return results;
     };
 };
 

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -20,9 +20,10 @@ var init = function(exports){
     /*
      * Construct a Matrix Client.
      * @param {Object} credentials The credentials for this client
-     * @param {Object} config The config for this client.
+     * @param {Object} config The config (if any) for this client.
+     * @param {Object} store The data store (if any) for this client.
      */
-    function MatrixClient(credentials, config) {
+    function MatrixClient(credentials, config, store) {
         if (typeof credentials === "string") {
             credentials = {
                 "baseUrl": credentials
@@ -41,10 +42,15 @@ var init = function(exports){
         }
         this.config = config;
         this.credentials = credentials;
+        this.store = store;
+
+        // track our position in the overall eventstream
+        this.fromToken = undefined;
+        this.clientRunning = false;
     };
     exports.MatrixClient = MatrixClient;  // expose the class
-    exports.createClient = function(credentials, config) {
-        return new MatrixClient(credentials, config);
+    exports.createClient = function(credentials, config, store) {
+        return new MatrixClient(credentials, config, store);
     };
 
     var CLIENT_PREFIX = "/_matrix/client/api/v1";
@@ -52,11 +58,253 @@ var init = function(exports){
     var HEADERS = {
         "User-Agent": "matrix-js"
     };
+    
+    function MatrixInMemoryStore() {
+        this.rooms = {
+            // state: { },
+            // timeline: [ ],
+        };
+        
+        this.presence = {
+            // presence objects keyed by userId
+        };
+    };
+    exports.MatrixInMemoryStore = MatrixInMemoryStore;
+    
+    MatrixInMemoryStore.prototype = {
+        // XXX: this isn't very OOP - we could have Room and User objects etc
+        // but instead we deliberately keep the primitives from the line protocol
+        // around instead, to avoid lots of unnecessary shuffling.
+        
+        /*
+         * Add an array of one or more state events into the store, overwriting
+         * any existing state with the same {room, type, stateKey} tuple.
+         */
+        setStateEvents: function(stateEvents) {
+            // we store stateEvents indexed by room, event type and state key.
+            for (var i = 0; i < stateEvents.length; i++) {
+                var event = stateEvents[i];
+                var roomId = event.room_id;
+                if (this.rooms[roomId] === undefined) {
+                    this.rooms[roomId] = {};
+                }
+                if (this.rooms[roomId].state === undefined) {
+                    this.rooms[roomId].state = {};
+                }
+                if (this.rooms[roomId].state[event.type] === undefined) {
+                    this.rooms[roomId].state[event.type] = {};
+                }
+                this.rooms[roomId].state[event.type][event.state_key] = event;
+            }
+        },
+       
+        /*
+         * Return a list of events from the store, filtered by roomid, type and state key.
+         * @param {String} roomId the Room ID whose state is to be returned
+         * @param {String} type the type of the state events to be returned (optional)
+         * @param {String} stateKey the stateKey of the state events to be returned
+         *                 (optional, requires type to be specified)
+         */
+        getStateEvents: function(roomId, type, stateKey) {
+            var stateEvents = [];
+            if (stateKey === undefined && type === undefined) {
+                for (type in this.rooms[roomId].state) {
+                    if (this.rooms[roomId].state.hasOwnProperty(type)) {
+                        for (stateKey in this.rooms[roomId].state[type]) {
+                            if (this.rooms[roomId].state[type].hasOwnProperty(stateKey)) {
+                                stateEvents.push(this.rooms[roomId].state[type][stateKey]);
+                            }
+                        }
+                    }
+                }                    
+                return stateEvents;
+            }
+            else if (stateKey === undefined) {
+                for (stateKey in this.rooms[roomId].state[type]) {
+                    if (this.rooms[roomId].state[type].hasOwnProperty(stateKey)) {
+                        stateEvents.push(this.rooms[roomId].state[type][stateKey]);
+                    }
+                }
+                return stateEvents;
+            }
+            else {
+                return [this.rooms[roomId].state[type][stateKey]];
+            }
+        },
+        
+        /*
+         * Return a single state event from the store for the given roomId
+         * and type.  stateKey is optional; if missing, is assumed to be blank.
+         */
+        getStateEvent: function(roomId, type, stateKey) {
+            if (stateKey === undefined) {
+                return this.rooms[roomId].state[type][''];
+            }
+            else {
+                return this.rooms[roomId].state[type][stateKey];
+            }
+        },
+        
+        /*
+         * Adds a list of arbitrary events into the store.
+         * If the event is a state event, it is also updates state.
+         */
+        setEvents: function(events) {
+            for (var i = 0; i < events.length; i++) {
+                var event = events[i];
+                if (event.type === "m.presence") {
+                    setPresenceEvents([event]);
+                    continue;
+                }
+                var roomId = event.room_id;
+                if (this.rooms[roomId] === undefined) {
+                    this.rooms[roomId] = {};
+                }                
+                if (this.rooms[roomId].timeline === undefined) {
+                    this.rooms[roomId].timeline = [];
+                }
+                if (event.state_key !== undefined) {
+                    this.setStateEvents([event]);
+                }
+                this.rooms[roomId].timeline.push(event);
+            }
+        },
+        
+        /*
+         * Get the timeline of events for a given room
+         * TODO: ordering?
+         */
+        getEvents: function(roomId) {
+            return this.room[roomId].timeline;
+        },
+        
+        setPresenceEvents: function(presenceEvents) {
+            for (var i = 0; i < presenceEvents.length; i++) {
+                var event = presenceEvents[i];
+                this.presence[event.user_id] = event;
+            }
+        },
+        
+        getPresenceEvents: function(userId) {
+            return this.presence[userId];
+        },
+        
+        getRoomList: function() {
+            var roomIds = [];
+            for (var roomId in this.rooms) {
+                if (this.rooms.hasOwnProperty(roomId)) {
+                    roomIds.push(roomId);
+                }
+            }
+            return roomIds;
+        },
+        
+        // TODO
+        setMaxHistoryPerRoom: function(maxHistory) {},
+        
+        // TODO
+        reapOldMessages: function() {},
+    };
 
     MatrixClient.prototype = {
         isLoggedIn: function() {
             return this.credentials.accessToken != undefined &&
-            this.credentials.userId != undefined;
+                   this.credentials.userId != undefined;
+        },
+        
+        // Higher level APIs
+        // =================
+        
+        // stuff to handle:
+        //   local echo
+        //   disambiguating display names in a room
+        //   event dup suppression? - apparently we should still be doing so
+        
+        /*
+         * Helper method for retrieving the name of a room suitable for display in the UI
+         * TODO: in future, this should be being generated serverside.
+         */
+        getRoomFriendlyName: function(roomId) {
+            // we need a store to track the inputs for calculating room names
+            if (!this.store) return roomId;
+            
+            // check for an alias, if any. for now, assume first alias is the official one.
+            var alias;
+            var mRoomAliases = this.store.getStateEvent(roomId, 'm.room.aliases');
+            if (mRoomAliases) {
+                alias = mRoomAliases['aliases'][0];
+            }
+            
+            var mRoomName = this.store.getStateEvent(roomId, 'm.room.name');
+            if (mRoomName) {
+                return mRoomName.name + (alias ? " (" + alias + ")": "");
+            }
+            else if (alias) {
+                return alias;
+            }
+            else {
+                var members = this.store.getStateEvents(roomId, 'm.room.member')
+                    .filter(function(event) {
+                        event.user_id !== this.credentials.userId;
+                    });
+                
+                if (members.length == 1) {
+                    return members[0].content.displayname || members[0].user_id;
+                }
+                else if (members.length == 2) {
+                    return (members[0].content.displayname || members[0].user_id) + " and " +
+                           (members[1].content.displayname || members[1].user_id);
+                }
+                else {
+                    return (members[0].content.displayname || members[0].user_id) + " and " +
+                           (members.length - 1) + " others";
+                }
+            }
+        },
+        
+        /*
+         * High level helper method to call initialSync, emit the resulting events,
+         * and then start polling the eventStream for new events.
+         */
+        startClient: function(callback, historyLen) {
+            historyLen = historyLen || 12;
+            
+            if (!this.fromToken) {
+                this.initialSync(historyLen, function(err, data) {
+                    if (err) {
+                        console.error("err %s", JSON.stringify(err));
+                        callback(err);
+                    } else {
+                        for (var i = 0; i < data.rooms.length; i++) {
+                            callback(undefined, data.rooms[i].presence, false);
+                            callback(undefined, data.rooms[i].state, false);
+                            callback(undefined, data.rooms[i].messages.chunk, false);
+                        }
+                        this.clientRunning = true;
+                        this._pollForEvents(callback);
+                    }
+                });
+            }
+            else {
+                this._pollForEvents(callback);
+            }
+        },
+        
+        _pollForEvents: function(callback) {
+            if (!this.clientRunning) return;
+            this.eventStream(this.fromToken, 30000, function(err, data) {
+                if (err) {
+                    console.error("err %s", JSON.stringify(err));
+                    callback(err);
+                } else {
+                    callback(undefined, data.chunk, true);
+                    _pollForEvents(callback);
+                }
+            });
+        },
+        
+        stopClient: function() {
+            this.clientRunning = false;
         },
 
         // Room operations
@@ -359,7 +607,18 @@ var init = function(exports){
                 limit: limit
             };
             return this._doAuthedRequest(
-                callback, "GET", "/initialSync", params
+                function(err, data) {
+                    if (this.store) {
+                        // intercept the results and put them into our store
+                        this.store.setPresence(data.presence);
+                        for (var i = 0 ; i < data.rooms.length; i++) {
+                            this.store.setStateEvents(data.rooms[i].state);
+                            this.store.setEvents(data.rooms[i].messages.chunk);
+                        }
+                    }
+                    if (data) this.fromToken = data.end;
+                    callback(err, data); // continue with original callback
+                }, "GET", "/initialSync", params
             );
         },
 
@@ -405,7 +664,14 @@ var init = function(exports){
                 from: from,
                 timeout: timeout
             };
-            return this._doAuthedRequest(callback, "GET", "/events", params);
+            return this._doAuthedRequest(
+                function(err, data) {
+                    if (this.store) {
+                        this.store.setEvents(data.chunk);
+                    }
+                    if (data) this.fromToken = data.end;
+                    callback(err, data); // continue with original callback
+                }, "GET", "/events", params);
         },
 
         // Registration/Login operations
@@ -416,6 +682,7 @@ var init = function(exports){
             return this._doAuthedRequest(
                 callback, "POST", "/login", undefined, data
             );
+            // XXX: surely we should store the results of this into our credentials
         },
 
         register: function(loginType, data, callback) {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -322,7 +322,7 @@ var init = function(exports){
             
             var displayName;
             var memberEvent = this.store.getStateEvent(roomId, 'm.room.member', userId);
-            if (memberEvent) {
+            if (memberEvent && memberEvent.event.content.displayname) {
                 displayName = memberEvent.event.content.displayname;
             }
             else {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -270,6 +270,7 @@ var init = function(exports){
         //   re-sending (including persisting pending messages to be sent)
         //   - Need a nice way to callback the app for arbitrary events like displayname changes
         //   due to ambiguity (or should this be on a chat-specific layer)?
+        //   reconnect after connectivity outages
                         
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -59,6 +59,43 @@ var init = function(exports){
         "User-Agent": "matrix-js"
     };
     
+    // Basic DAOs to abstract slightly from the line protocol and let the
+    // application customise events with domain-specific info
+    // (e.g. chat-specific semantics) if it so desires.
+    
+    /*
+     * Construct a Matrix Event object
+     * @param {Object} event The raw event to be wrapped in this DAO
+     */
+    function MatrixEvent(event) {
+        this.event = event;
+    };
+    exports.MatrixEvent = MatrixEvent;
+    
+    MatrixEvent.prototype = {
+        getId: function() {
+            return this.event.event_id;
+        },
+        getSender: function() {
+            return this.event.user_id;
+        },
+        getType: function() {
+            return this.event.type;
+        },
+        getRoomId: function() {
+            return this.event.room_id;
+        },
+        getTs: function() {
+            return this.event.ts;
+        },
+        getContent: function() {
+            return this.event.content;
+        },
+        isState: function() {
+            return this.event.state_key !== undefined;
+        },
+    };
+    
     function MatrixInMemoryStore() {
         this.rooms = {
             // state: { },
@@ -70,17 +107,13 @@ var init = function(exports){
         };
     };
     exports.MatrixInMemoryStore = MatrixInMemoryStore;
-    
-    MatrixInMemoryStore.prototype = {
-        // XXX: this isn't very OOP - we could have Room and User objects etc
-        // but instead we deliberately keep the primitives from the line protocol
-        // around instead, to avoid lots of unnecessary shuffling.
         
+    MatrixInMemoryStore.prototype = {
         /*
-         * Add an array of one or more state events into the store, overwriting
+         * Add an array of one or more raw state events into the store, overwriting
          * any existing state with the same {room, type, stateKey} tuple.
          */
-        setStateEvents: function(stateEvents) {
+        setRawStateEvents: function(stateEvents) {
             // we store stateEvents indexed by room, event type and state key.
             for (var i = 0; i < stateEvents.length; i++) {
                 var event = stateEvents[i];
@@ -94,12 +127,12 @@ var init = function(exports){
                 if (this.rooms[roomId].state[event.type] === undefined) {
                     this.rooms[roomId].state[event.type] = {};
                 }
-                this.rooms[roomId].state[event.type][event.state_key] = event;
+                this.rooms[roomId].state[event.type][event.state_key] = new MatrixEvent(event);
             }
         },
        
         /*
-         * Return a list of events from the store, filtered by roomid, type and state key.
+         * Return a list of MatrixEvents from the store, filtered by roomid, type and state key.
          * @param {String} roomId the Room ID whose state is to be returned
          * @param {String} type the type of the state events to be returned (optional)
          * @param {String} stateKey the stateKey of the state events to be returned
@@ -133,12 +166,16 @@ var init = function(exports){
         },
         
         /*
-         * Return a single state event from the store for the given roomId
+         * Return a single state MatrixEvent from the store for the given roomId
          * and type.  stateKey is optional; if missing, is assumed to be blank.
          */
         getStateEvent: function(roomId, type, stateKey) {
             if (stateKey === undefined) {
-                return this.rooms[roomId].state[type][''];
+                for (var i in this.rooms[roomId].state[type]) {
+                    if (this.rooms[roomId].state[type].hasOwnProperty(i)) {
+                        return this.rooms[roomId].state[type][i];
+                    }
+                }
             }
             else {
                 return this.rooms[roomId].state[type][stateKey];
@@ -146,14 +183,14 @@ var init = function(exports){
         },
         
         /*
-         * Adds a list of arbitrary events into the store.
+         * Adds a list of arbitrary raw events into the store.
          * If the event is a state event, it is also updates state.
          */
-        setEvents: function(events) {
+        setRawEvents: function(events) {
             for (var i = 0; i < events.length; i++) {
                 var event = events[i];
                 if (event.type === "m.presence") {
-                    setPresenceEvents([event]);
+                    this.setRawPresenceEvents([event]);
                     continue;
                 }
                 var roomId = event.room_id;
@@ -164,9 +201,9 @@ var init = function(exports){
                     this.rooms[roomId].timeline = [];
                 }
                 if (event.state_key !== undefined) {
-                    this.setStateEvents([event]);
+                    this.setRawStateEvents([event]);
                 }
-                this.rooms[roomId].timeline.push(event);
+                this.rooms[roomId].timeline.push(new MatrixEvent(event));
             }
         },
         
@@ -178,10 +215,10 @@ var init = function(exports){
             return this.room[roomId].timeline;
         },
         
-        setPresenceEvents: function(presenceEvents) {
+        setRawPresenceEvents: function(presenceEvents) {
             for (var i = 0; i < presenceEvents.length; i++) {
                 var event = presenceEvents[i];
-                this.presence[event.user_id] = event;
+                this.presence[event.user_id] = new MatrixEvent(event);
             }
         },
         
@@ -224,7 +261,7 @@ var init = function(exports){
          * Helper method for retrieving the name of a room suitable for display in the UI
          * TODO: in future, this should be being generated serverside.
          */
-        getRoomFriendlyName: function(roomId) {
+        getFriendlyRoomName: function(roomId) {
             // we need a store to track the inputs for calculating room names
             if (!this.store) return roomId;
             
@@ -232,31 +269,35 @@ var init = function(exports){
             var alias;
             var mRoomAliases = this.store.getStateEvent(roomId, 'm.room.aliases');
             if (mRoomAliases) {
-                alias = mRoomAliases['aliases'][0];
+                alias = mRoomAliases.event.content.aliases[0];
             }
             
             var mRoomName = this.store.getStateEvent(roomId, 'm.room.name');
             if (mRoomName) {
-                return mRoomName.name + (alias ? " (" + alias + ")": "");
+                return mRoomName.event.content.name + (alias ? " (" + alias + ")": "");
             }
             else if (alias) {
                 return alias;
             }
             else {
+                var userId = this.credentials.userId;
                 var members = this.store.getStateEvents(roomId, 'm.room.member')
                     .filter(function(event) {
-                        event.user_id !== this.credentials.userId;
+                        event.event.user_id !== userId;
                     });
                 
-                if (members.length == 1) {
-                    return members[0].content.displayname || members[0].user_id;
+                if (members.length == 0) {
+                    return "Unknown";
+                }
+                else if (members.length == 1) {
+                    return members[0].event.content.displayname || members[0].event.user_id;
                 }
                 else if (members.length == 2) {
-                    return (members[0].content.displayname || members[0].user_id) + " and " +
-                           (members[1].content.displayname || members[1].user_id);
+                    return (members[0].event.content.displayname || members[0].event.user_id) + " and " +
+                           (members[1].event.content.displayname || members[1].event.user_id);
                 }
                 else {
-                    return (members[0].content.displayname || members[0].user_id) + " and " +
+                    return (members[0].event.content.displayname || members[0].event.user_id) + " and " +
                            (members.length - 1) + " others";
                 }
             }
@@ -269,19 +310,28 @@ var init = function(exports){
         startClient: function(callback, historyLen) {
             historyLen = historyLen || 12;
             
+            var self = this;
             if (!this.fromToken) {
                 this.initialSync(historyLen, function(err, data) {
                     if (err) {
                         console.error("err %s", JSON.stringify(err));
                         callback(err);
                     } else {
-                        for (var i = 0; i < data.rooms.length; i++) {
-                            callback(undefined, data.rooms[i].presence, false);
-                            callback(undefined, data.rooms[i].state, false);
-                            callback(undefined, data.rooms[i].messages.chunk, false);
+                        var events = []
+                        for (var i = 0; i < data.presence.length; i++) {
+                            events.push(new MatrixEvent(data.presence[i]));
                         }
-                        this.clientRunning = true;
-                        this._pollForEvents(callback);
+                        for (var i = 0; i < data.rooms.length; i++) {
+                            for (var j = 0; j < data.rooms[i].state.length; j++) {
+                                events.push(new MatrixEvent(data.rooms[i].state[j]));
+                            }
+                            for (var j = 0; j < data.rooms[i].messages.chunk.length; j++) {
+                                events.push(new MatrixEvent(data.rooms[i].messages.chunk[j]));
+                            }
+                        }
+                        callback(undefined, events, false);
+                        self.clientRunning = true;
+                        self._pollForEvents(callback);
                     }
                 });
             }
@@ -291,14 +341,19 @@ var init = function(exports){
         },
         
         _pollForEvents: function(callback) {
+            var self = this;
             if (!this.clientRunning) return;
             this.eventStream(this.fromToken, 30000, function(err, data) {
                 if (err) {
                     console.error("err %s", JSON.stringify(err));
                     callback(err);
                 } else {
-                    callback(undefined, data.chunk, true);
-                    _pollForEvents(callback);
+                    var events = [];
+                    for (var j = 0; j < data.chunk.length; j++) {
+                        events.push(new MatrixEvent(data.chunk[j]));
+                    }                    
+                    callback(undefined, events, true);
+                    self._pollForEvents(callback);
                 }
             });
         },
@@ -606,17 +661,18 @@ var init = function(exports){
             var params = {
                 limit: limit
             };
+            var self = this;
             return this._doAuthedRequest(
                 function(err, data) {
-                    if (this.store) {
+                    if (self.store) {
                         // intercept the results and put them into our store
-                        this.store.setPresence(data.presence);
+                        self.store.setRawPresenceEvents(data.presence);
                         for (var i = 0 ; i < data.rooms.length; i++) {
-                            this.store.setStateEvents(data.rooms[i].state);
-                            this.store.setEvents(data.rooms[i].messages.chunk);
+                            self.store.setRawStateEvents(data.rooms[i].state);
+                            self.store.setRawEvents(data.rooms[i].messages.chunk);
                         }
                     }
-                    if (data) this.fromToken = data.end;
+                    if (data) self.fromToken = data.end;
                     callback(err, data); // continue with original callback
                 }, "GET", "/initialSync", params
             );
@@ -664,12 +720,13 @@ var init = function(exports){
                 from: from,
                 timeout: timeout
             };
+            var self = this;
             return this._doAuthedRequest(
                 function(err, data) {
-                    if (this.store) {
-                        this.store.setEvents(data.chunk);
+                    if (self.store) {
+                        self.store.setRawEvents(data.chunk);
                     }
-                    if (data) this.fromToken = data.end;
+                    if (data) self.fromToken = data.end;
                     callback(err, data); // continue with original callback
                 }, "GET", "/events", params);
         },

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -6,8 +6,6 @@ TODO:
 - Internal: rate limiting
 - Identity server: linkEmail, authEmail, bindEmail, lookup3pid
 - uploadContent (?)
-- Need a nice way to callback the app for arbitrary events like displayname changes
-  due to ambiguity (or should this be on a chat-specific layer)?
 */
 
 // wrap in a closure for browsers
@@ -259,12 +257,12 @@ var init = function(exports){
         
         // TODO: stuff to handle:
         //   local echo
-        //   disambiguating display names in a room
-        //   event dup suppression? - apparently we should still be doing so
+        //   event dup suppression? - apparently we should still be doing this
         //   tracking current display name / avatar per-message
         //   pagination
-        //   reconnection - DONE
-        //   re-sending
+        //   re-sending (including persisting pending messages to be sent)
+        //   - Need a nice way to callback the app for arbitrary events like displayname changes
+        //   due to ambiguity (or should this be on a chat-specific layer)?
                         
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -182,26 +182,14 @@ var init = function(exports){
         
         /*
          * Return a single state MatrixEvent from the store for the given roomId
-         * and type.  stateKey is optional; if missing, the first matching event is
-         * returned irrespective of stateKey.
+         * and type.
          * @param {String} roomId the Room ID whose state is to be returned
          * @param {String} type the type of the state events to be returned
          * @param {String} stateKey the stateKey of the state events to be returned
-         *                 (optional. if missing, the first matching event is returned
-         *                  irrespective of its stateKey)
          * @return {MatrixEvent} a single MatrixEvent from the store, filtered by roomid, type and state key.
          */
         getStateEvent: function(roomId, type, stateKey) {
-            if (stateKey === undefined) {
-                for (var i in this.rooms[roomId].state[type]) {
-                    if (this.rooms[roomId].state[type].hasOwnProperty(i)) {
-                        return this.rooms[roomId].state[type][i];
-                    }
-                }
-            }
-            else {
-                return this.rooms[roomId].state[type][stateKey];
-            }
+            return this.rooms[roomId].state[type][stateKey];
         },
         
         /*
@@ -295,12 +283,12 @@ var init = function(exports){
             
             // check for an alias, if any. for now, assume first alias is the official one.
             var alias;
-            var mRoomAliases = this.store.getStateEvent(roomId, 'm.room.aliases');
+            var mRoomAliases = this.store.getStateEvents(roomId, 'm.room.aliases')[0];
             if (mRoomAliases) {
                 alias = mRoomAliases.event.content.aliases[0];
             }
             
-            var mRoomName = this.store.getStateEvent(roomId, 'm.room.name');
+            var mRoomName = this.store.getStateEvent(roomId, 'm.room.name', '');
             if (mRoomName) {
                 return mRoomName.event.content.name + (alias ? " (" + alias + ")": "");
             }

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -151,7 +151,7 @@ var init = function(exports){
          * @param {String} type the type of the state events to be returned (optional)
          * @param {String} stateKey the stateKey of the state events to be returned
          *                 (optional, requires type to be specified)
-         * @return an array of MatrixEvents from the store, filtered by roomid, type and state key.
+         * @return {MatrixEvent[]} an array of MatrixEvents from the store, filtered by roomid, type and state key.
          */
         getStateEvents: function(roomId, type, stateKey) {
             var stateEvents = [];
@@ -189,7 +189,7 @@ var init = function(exports){
          * @param {String} stateKey the stateKey of the state events to be returned
          *                 (optional. if missing, the first matching event is returned
          *                  irrespective of its stateKey)
-         * @return a single MatrixEvent from the store, filtered by roomid, type and state key.
+         * @return {MatrixEvent} a single MatrixEvent from the store, filtered by roomid, type and state key.
          */
         getStateEvent: function(roomId, type, stateKey) {
             if (stateKey === undefined) {
@@ -286,6 +286,8 @@ var init = function(exports){
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI
          * TODO: in future, this should be being generated serverside.
+         * @param {String} roomId ID of room whose name is to be resolved
+         * @return {String} human-readable label for room.
          */
         getFriendlyRoomName: function(roomId) {
             // we need a store to track the inputs for calculating room names
@@ -334,6 +336,9 @@ var init = function(exports){
          * in the context of a room - i.e. disambiguating from any other users in the room.
          * XXX: This could perhaps also be generated serverside, perhaps by just passing 
          * a 'disambiguate' flag down on membership entries which have ambiguous displaynames?
+         * @param {String} userId ID of the user whose name is to be resolved
+         * @param {String} roomId ID of room to be used as the context for resolving the name
+         * @return {String} human-readable name of the user.
          */
         getFriendlyDisplayName: function(userId, roomId) {
             // we need a store to track the inputs for calculating display names
@@ -364,6 +369,8 @@ var init = function(exports){
         /*
          * High level helper method to call initialSync, emit the resulting events,
          * and then start polling the eventStream for new events.
+         * @param {function} callback Callback invoked whenever new event are available
+         * @param {Number} historyLen amount of historical timeline events to emit during from the initial sync
          */
         startClient: function(callback, historyLen) {
             historyLen = historyLen || 12;
@@ -425,6 +432,9 @@ var init = function(exports){
             });
         },
         
+        /*
+         * High level helper method to stop the client from polling and allow a clean shutdown
+         */
         stopClient: function() {
             this.clientRunning = false;
         },

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -6,6 +6,8 @@ TODO:
 - Internal: rate limiting
 - Identity server: linkEmail, authEmail, bindEmail, lookup3pid
 - uploadContent (?)
+- Need a nice way to callback the app for arbitrary events like displayname changes
+  due to ambiguity (or should this be on a chat-specific layer)?
 */
 
 // wrap in a closure for browsers
@@ -108,7 +110,10 @@ var init = function(exports){
     };
     exports.MatrixInMemoryStore = MatrixInMemoryStore;
         
+    // XXX: this is currently quite procedural - we could possibly pass back
+    // models of Rooms, Users, Events, etc instead.
     MatrixInMemoryStore.prototype = {
+                
         /*
          * Add an array of one or more state MatrixEvents into the store, overwriting
          * any existing state with the same {room, type, stateKey} tuple.
@@ -209,7 +214,7 @@ var init = function(exports){
         
         /*
          * Get the timeline of events for a given room
-         * TODO: ordering?
+         * TODO: ordering!
          */
         getEvents: function(roomId) {
             return this.room[roomId].timeline;
@@ -252,14 +257,15 @@ var init = function(exports){
         // Higher level APIs
         // =================
         
-        // stuff to handle:
+        // TODO: stuff to handle:
         //   local echo
         //   disambiguating display names in a room
         //   event dup suppression? - apparently we should still be doing so
         //   tracking current display name / avatar per-message
         //   pagination
         //   reconnection - DONE
-        
+        //   re-sending
+                        
         /*
          * Helper method for retrieving the name of a room suitable for display in the UI
          * TODO: in future, this should be being generated serverside.
@@ -306,6 +312,38 @@ var init = function(exports){
             }
         },
         
+        /*
+         * Helper method for retrieving the name of a user suitable for display in the UI
+         * in the context of a room - i.e. disambiguating from any other users in the room.
+         * XXX: This could perhaps also be generated serverside, perhaps by just passing 
+         * a 'disambiguate' flag down on membership entries which have ambiguous displaynames?
+         */
+        getFriendlyDisplayName: function(userId, roomId) {
+            // we need a store to track the inputs for calculating display names
+            if (!this.store) return userId;
+            
+            var displayName;
+            var memberEvent = this.store.getStateEvent(roomId, 'm.room.member', userId);
+            if (memberEvent) {
+                displayName = memberEvent.event.content.displayname;
+            }
+            else {
+                return userId;
+            }
+            
+            var members = this.store.getStateEvents(roomId, 'm.room.member')
+                .filter(function(event) {
+                    return event.event.content.displayname === displayName;
+                });
+                
+            if (members.length > 1) {
+                return displayName + " (" + userId + ")";
+            }
+            else {
+                return displayName;
+            }
+        },
+
         /*
          * High level helper method to call initialSync, emit the resulting events,
          * and then start polling the eventStream for new events.


### PR DESCRIPTION
This is an experiment in adding a data store layer to let clients actually track all the events they receive and expose the state to clients in a sensible manner.

Events are wrapped up as MatrixEvent objects, which in practice do nothing useful at all other than possibly provide a way to annotate the events in future.  This feels deeply wrong, currently.