### PR TITLE
Disable end-to-end encryption if olm isn't installed.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,8 +18,11 @@ var User = require("./models/user");
 var webRtcCall = require("./webrtc/call");
 var utils = require("./utils");
 
-// TODO: package this somewhere separate.
-var Olm = require("olm");
+var CRYPTO_ENABLED = false;
+
+if (CRYPTO_ENABLED) {
+    var Olm = require("olm");
+}
 
 // TODO:
 // Internal: rate limiting
@@ -59,7 +62,7 @@ function MatrixClient(opts) {
     this.sessionStore = opts.sessionStore || null;
     this.accountKey = "DEFAULT_KEY";
     this.deviceId = opts.deviceId;
-    if (this.sessionStore !== null) {
+    if (CRYPTO_ENABLED && this.sessionStore !== null) {
         var e2eAccount = this.sessionStore.getEndToEndAccount();
         var account = new Olm.Account();
         try {
@@ -140,6 +143,16 @@ function MatrixClient(opts) {
 }
 utils.inherits(MatrixClient, EventEmitter);
 
+
+/**
+ * Is end-to-end crypto enabled for this client.
+ * @return {boolean} True if end-to-end is enabled.
+ */
+MatrixClient.prototype.isCryptoEnabled = function() {
+    return CRYPTO_ENABLED && this.sessionStore !== null;
+};
+
+
 /**
  * Upload the device keys to the homeserver and ensure that the
  * homeserver has enough one-time keys.
@@ -148,12 +161,15 @@ utils.inherits(MatrixClient, EventEmitter);
  * @return {object} A promise that will resolve when the keys are uploaded.
  */
 MatrixClient.prototype.uploadKeys = function(maxKeys, deferred) {
+    if (!CRYPTO_ENABLED || this.sessionStore === null) {
+        return q.reject(new Error("End-to-end encryption disabled"));
+    }
     var first_time = deferred === undefined;
     deferred = deferred || q.defer();
     var path = "/keys/upload/" + this.deviceId;
     var pickled = this.sessionStore.getEndToEndAccount();
     if (!pickled) {
-        throw new Error("End-to-end account not found");
+        return q.reject(new Error("End-to-end account not found"));
     }
     var account = new Olm.Account();
     var oneTimeKeys;
@@ -209,6 +225,7 @@ MatrixClient.prototype.uploadKeys = function(maxKeys, deferred) {
     return deferred.promise;
 };
 
+
 /**
  * Download the keys for a list of users and stores the keys in the session
  * store.
@@ -217,6 +234,9 @@ MatrixClient.prototype.uploadKeys = function(maxKeys, deferred) {
  * @return {object} A promise that will resolve when the keys are downloadded.
  */
 MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
+    if (!CRYPTO_ENABLED || this.sessionStore === null) {
+        return q.reject(new Error("End-to-end encryption disabled"));
+    }
     var stored = {};
     var notStored = {};
     var downloadKeys = false;
@@ -264,6 +284,9 @@ MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
  * @return {Array} list of devices with "id" and "key" parameters.
  */
 MatrixClient.prototype.listDeviceKeys = function(userId) {
+    if (!CRYPTO_ENABLED) {
+        return [];
+    }
     var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
     var result = [];
     if (devices) {
@@ -297,6 +320,9 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
  * @return {Object} A promise that will resolve when encryption is setup.
  */
 MatrixClient.prototype.setRoomEncryption = function(roomId, config) {
+    if (!this.sessionStore || !CRYPTO_ENABLED) {
+        return q.reject(new Error("End-to-End encryption disabled"));
+    }
     if (config.algorithm === OLM_ALGORITHM) {
         if (!config.members) {
             throw new Error(
@@ -397,7 +423,9 @@ MatrixClient.prototype.setRoomEncryption = function(roomId, config) {
  * @param {string} roomId the room to disable encryption for.
  */
 MatrixClient.prototype.disableRoomEncryption = function(roomId) {
-    this.sessionStore.storeEndToEndRoom(roomId, null);
+    if (this.sessionStore !== null) {
+        this.sessionStore.storeEndToEndRoom(roomId, null);
+    }
 };
 
 /**
@@ -406,7 +434,11 @@ MatrixClient.prototype.disableRoomEncryption = function(roomId) {
  * @return {bool} whether encryption is enabled.
  */
 MatrixClient.prototype.isRoomEncrypted = function(roomId) {
-    return (this.sessionStore.getEndToEndRoom(roomId) && true) || false;
+    if (CRYPTO_ENABLED && this.sessionStore !== null) {
+        return (this.sessionStore.getEndToEndRoom(roomId) && true) || false;
+    } else {
+        return false;
+    }
 };
 
 /**
@@ -638,7 +670,7 @@ MatrixClient.prototype.sendEvent = function(roomId, eventType, content, txnId,
         room.addEventsToTimeline([localEvent]);
     }
 
-    if (eventType === "m.room.message" && this.sessionStore) {
+    if (eventType === "m.room.message" && this.sessionStore && CRYPTO_ENABLED) {
         var e2eRoomInfo = this.sessionStore.getEndToEndRoom(roomId);
         if (e2eRoomInfo) {
             var encryptedContent = _encryptMessage(
@@ -736,7 +768,7 @@ function _encryptMessage(client, roomId, e2eRoomInfo, eventType, content,
 }
 
 function _decryptMessage(client, event) {
-    if (client.sessionStore === null) {
+    if (client.sessionStore === null || !CRYPTO_ENABLED) {
         // End to end encryption isn't enabled if we don't have a session
         // store.
         return _badEncryptedMessage(event, "Encryption not enabled");
@@ -2259,6 +2291,9 @@ MatrixClient.prototype.generateClientSecret = function() {
 
 /** */
 module.exports.MatrixClient = MatrixClient;
+/** */
+module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
+
 
 // MatrixClient Event JSDocs
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,8 +20,11 @@ var utils = require("./utils");
 
 var CRYPTO_ENABLED = false;
 
-if (CRYPTO_ENABLED) {
+try {
     var Olm = require("olm");
+    CRYPTO_ENABLED = true;
+} catch (e) {
+    // Olm not installed.
 }
 
 // TODO:
@@ -1799,7 +1802,7 @@ MatrixClient.prototype.startClient = function(historyLen) {
         return;
     }
 
-    if (this.sessionStore !== null) {
+    if (CRYPTO_ENABLED && this.sessionStore !== null) {
         this.uploadKeys(5);
     }
 

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -27,6 +27,8 @@ module.exports.MatrixScheduler = require("./scheduler");
 /** The {@link module:store/session/webstorage.WebStorageSessionStore|
  * ebStorageSessionStore} class */
 module.exports.WebStorageSessionStore = require("./store/session/webstorage");
+/** */
+module.exports.CRYPTO_ENABLED = require("./client").ENABLE_CRYPTO;
 
 /**
  * Create a new Matrix Call.

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -28,7 +28,7 @@ module.exports.MatrixScheduler = require("./scheduler");
  * ebStorageSessionStore} class */
 module.exports.WebStorageSessionStore = require("./store/session/webstorage");
 /** */
-module.exports.CRYPTO_ENABLED = require("./client").ENABLE_CRYPTO;
+module.exports.CRYPTO_ENABLED = require("./client").CRYPTO_ENABLED;
 
 /**
  * Create a new Matrix Call.

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "browser-request": "^0.3.3",
     "browserify": "^10.2.3",
     "q": "^1.4.1",
-    "request": "^2.53.0",
-    "olm": "0.1.0"
+    "request": "^2.53.0"
   },
   "devDependencies": {
     "watchify": "^3.2.1",

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -18,6 +18,10 @@ MockStorageApi.prototype = {
 };
 
 describe("MatrixClient crypto", function() {
+    if (!sdk.CRYPTO_ENABLED) {
+        return;
+    }
+
     var baseUrl = "http://localhost.or.something";
     var httpBackend;
     var aliClient;


### PR DESCRIPTION
Remove olm from the package dependencies. If olm isn't installed then don't enable any of the end-to-end encryption features that depend on it.