### PR TITLE
Add support for archived=true in initial sync

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1857,10 +1857,15 @@ MatrixClient.prototype.isLoggedIn = function() {
  * This is an internal method.
  * @param {MatrixClient} client
  * @param {integer} historyLen
+ * @param {integer} includeArchived
  */
-function doInitialSync(client, historyLen) {
+function doInitialSync(client, historyLen, includeArchived) {
+    var qps = { limit: historyLen };
+    if (includeArchived) {
+        qps.archived = true;
+    }
     client._http.authedRequest(
-        undefined, "GET", "/initialSync", { limit: (historyLen || 12) }
+        undefined, "GET", "/initialSync", qps
     ).done(function(data) {
         var i, j;
         // intercept the results and put them into our store
@@ -1944,14 +1949,27 @@ function doInitialSync(client, historyLen) {
  * and then start polling the eventStream for new events. To listen for these
  * events, add a listener for {@link module:client~MatrixClient#event:"event"}
  * via {@link module:client~MatrixClient#on}.
- * @param {Number} historyLen amount of historical timeline events to
- * emit during from the initial sync. Default: 12.
+ * @param {Object} opts Options to apply when syncing.
+ * @param {Number} opts.initialSyncLimit The event <code>limit=</code> to apply
+ * to initial sync. Default: 8.
+ * @param {Boolean} opts.includeArchivedRooms True to put <code>archived=true</code>
+ * on the <code>/initialSync</code> request. Default: false.
  */
-MatrixClient.prototype.startClient = function(historyLen) {
+MatrixClient.prototype.startClient = function(opts) {
     if (this.clientRunning) {
         // client is already running.
         return;
     }
+    // backwards compat for when 'opts' was 'historyLen'.
+    if (typeof opts === "number") {
+        opts = {
+            initialSyncLimit: opts
+        };
+    }
+
+    opts = opts || {};
+    opts.initialSyncLimit = opts.initialSyncLimit || 8;
+    opts.includeArchivedRooms = opts.includeArchivedRooms || false;
 
     if (CRYPTO_ENABLED && this.sessionStore !== null) {
         this.uploadKeys(5);
@@ -1969,7 +1987,7 @@ MatrixClient.prototype.startClient = function(historyLen) {
     var self = this;
     this.pushRules().done(function(result) {
         self.pushRules = result;
-        doInitialSync(self, historyLen);
+        doInitialSync(self, opts.initialSyncLimit, opts.includeArchivedRooms);
     }, function(err) {
         self.emit("syncError", err);
     });


### PR DESCRIPTION
Make `MatrixClient.startClient` take `opts` instead of `historyLen` in a backwards compatible way. Add `opts.includeArchivedRooms` as an option.