### PR TITLE
Invite room state

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1878,17 +1878,21 @@ function doInitialSync(client, historyLen) {
                     data.rooms[i].state = [];
                 }
                 if (data.rooms[i].membership === "invite") {
-                    // create fake invite state event (v1 sucks)
-                    data.rooms[i].state.push({
-                        event_id: "$fake_" + room.roomId,
-                        content: {
-                            membership: "invite"
-                        },
-                        state_key: client.credentials.userId,
-                        user_id: data.rooms[i].inviter,
-                        room_id: room.roomId,
-                        type: "m.room.member"
-                    });
+                    var inviteEvent = data.rooms[i].invite;
+                    if (!inviteEvent) {
+                        // fallback for servers which don't serve the invite key yet
+                        inviteEvent = {
+                            event_id: "$fake_" + room.roomId,
+                            content: {
+                                membership: "invite"
+                            },
+                            state_key: client.credentials.userId,
+                            user_id: data.rooms[i].inviter,
+                            room_id: room.roomId,
+                            type: "m.room.member"
+                        };
+                    }
+                    data.rooms[i].state.push(inviteEvent);
                 }
 
                 _processRoomEvents(

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -6,6 +6,7 @@ var EventEmitter = require("events").EventEmitter;
 
 var RoomState = require("./room-state");
 var RoomSummary = require("./room-summary");
+var MatrixEvent = require("./event").MatrixEvent;
 var utils = require("../utils");
 
 /**
@@ -209,6 +210,34 @@ Room.prototype.addEvents = function(events, duplicateStrategy) {
  * @fires module:client~MatrixClient#event:"Room.name"
  */
 Room.prototype.recalculate = function(userId) {
+    // set fake stripped state events if this is an invite room so logic remains
+    // consistent elsewhere.
+    var self = this;
+    var membershipEvent = this.currentState.getStateEvents(
+        "m.room.member", userId
+    );
+    if (membershipEvent && membershipEvent.getContent().membership === "invite") {
+        var strippedStateEvents = membershipEvent.invite_room_state || [];
+        utils.forEach(strippedStateEvents, function(strippedEvent) {
+            var existingEvent = self.currentState.getStateEvents(
+                strippedEvent.type, strippedEvent.state_key
+            );
+            if (!existingEvent) {
+                // set the fake stripped event instead
+                self.currentState.setStateEvents([new MatrixEvent({
+                    type: strippedEvent.type,
+                    state_key: strippedEvent.state_key,
+                    content: strippedEvent.content,
+                    event_id: "$fake" + Date.now(),
+                    room_id: self.roomId,
+                    user_id: userId // technically a lie
+                })]);
+            }
+        });
+    }
+
+
+
     var oldName = this.name;
     this.name = calculateRoomName(this, userId);
     this.summary = new RoomSummary(this.roomId, {

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -217,7 +217,7 @@ Room.prototype.recalculate = function(userId) {
         "m.room.member", userId
     );
     if (membershipEvent && membershipEvent.getContent().membership === "invite") {
-        var strippedStateEvents = membershipEvent.invite_room_state || [];
+        var strippedStateEvents = membershipEvent.event.invite_room_state || [];
         utils.forEach(strippedStateEvents, function(strippedEvent) {
             var existingEvent = self.currentState.getStateEvents(
                 strippedEvent.type, strippedEvent.state_key


### PR DESCRIPTION
Read `invite_room_state` key from the `m.room.member` event if it exists and create fake state events to make invited rooms display the room name.

Has unit tests.