### PR TITLE
VoIP local muting

### DIFF
--- a/lib/webrtc/call.js
+++ b/lib/webrtc/call.js
@@ -260,6 +260,33 @@ MatrixCall.prototype.hangup = function(reason, suppressEvent) {
 };
 
 /**
+ * Set whether the local video preview should be muted or not.
+ * @param {boolean} muted True to mute the local video.
+ */
+MatrixCall.prototype.setLocalVideoMuted = function(muted) {
+    if (!this.localAVStream) {
+        return;
+    }
+    setTracksEnabled(this.localAVStream.getVideoTracks(), !muted);
+};
+
+/**
+ * Check if local video is muted.
+ *
+ * If there are multiple video tracks, <i>all</i> of the tracks need to be muted
+ * for this to return true. This means if there are no video tracks, this will
+ * return true.
+ * @return {Boolean} True if the local preview video is muted, else false
+ * (including if the call is not set up yet).
+ */
+MatrixCall.prototype.isLocalVideoMuted = function(muted) {
+    if (!this.localAVStream) {
+        return false;
+    }
+    return !isTracksEnabled(this.localAVStream.getVideoTracks());
+};
+
+/**
  * Set whether the microphone should be muted or not.
  * @param {boolean} muted True to mute the mic.
  */
@@ -267,7 +294,7 @@ MatrixCall.prototype.setMicrophoneMuted = function(muted) {
     if (!this.localAVStream) {
         return;
     }
-    setAudioTracksEnabled(this.localAVStream, !muted);
+    setTracksEnabled(this.localAVStream.getAudioTracks(), !muted);
 };
 
 /**
@@ -283,13 +310,7 @@ MatrixCall.prototype.isMicrophoneMuted = function(muted) {
     if (!this.localAVStream) {
         return false;
     }
-    var audioTracks = this.localAVStream.getAudioTracks();
-    for (var i = 0; i < audioTracks.length; i++) {
-        if (audioTracks[i].enabled) {
-            return false; // track is enabled; so mic is not muted
-        }
-    }
-    return true;
+    return !isTracksEnabled(this.localAVStream.getAudioTracks());
 };
 
 /**
@@ -321,7 +342,7 @@ MatrixCall.prototype._gotUserMediaForInvite = function(stream) {
     }
 
     this.localAVStream = stream;
-    setAudioTracksEnabled(stream, true);
+    setTracksEnabled(stream.getAudioTracks(), true);
     this.peerConn = _createPeerConnection(this);
     this.peerConn.addStream(stream);
     this.peerConn.createOffer(
@@ -356,7 +377,7 @@ MatrixCall.prototype._gotUserMediaForAnswer = function(stream) {
     }
 
     self.localAVStream = stream;
-    setAudioTracksEnabled(stream, true);
+    setTracksEnabled(stream.getAudioTracks(), true);
     self.peerConn.addStream(stream);
 
     var constraints = {
@@ -658,11 +679,19 @@ MatrixCall.prototype._onAnsweredElsewhere = function(msg) {
     terminate(this, "remote", "answered_elsewhere", true);
 };
 
-var setAudioTracksEnabled = function(stream, enabled) {
-    var audioTracks = stream.getAudioTracks();
-    for (var i = 0; i < audioTracks.length; i++) {
-        audioTracks[i].enabled = enabled;
+var setTracksEnabled = function(tracks, enabled) {
+    for (var i = 0; i < tracks.length; i++) {
+        tracks[i].enabled = enabled;
     }
+};
+
+var isTracksEnabled = function(tracks) {
+    for (var i = 0; i < tracks.length; i++) {
+        if (tracks[i].enabled) {
+            return true; // at least one track is enabled
+        }
+    }
+    return false;
 };
 
 var setState = function(self, state) {

--- a/lib/webrtc/call.js
+++ b/lib/webrtc/call.js
@@ -279,7 +279,7 @@ MatrixCall.prototype.setLocalVideoMuted = function(muted) {
  * @return {Boolean} True if the local preview video is muted, else false
  * (including if the call is not set up yet).
  */
-MatrixCall.prototype.isLocalVideoMuted = function(muted) {
+MatrixCall.prototype.isLocalVideoMuted = function() {
     if (!this.localAVStream) {
         return false;
     }
@@ -306,7 +306,7 @@ MatrixCall.prototype.setMicrophoneMuted = function(muted) {
  * @return {Boolean} True if the mic is muted, else false (including if the call
  * is not set up yet).
  */
-MatrixCall.prototype.isMicrophoneMuted = function(muted) {
+MatrixCall.prototype.isMicrophoneMuted = function() {
     if (!this.localAVStream) {
         return false;
     }

--- a/lib/webrtc/call.js
+++ b/lib/webrtc/call.js
@@ -260,6 +260,17 @@ MatrixCall.prototype.hangup = function(reason, suppressEvent) {
 };
 
 /**
+ * Set whether the microphone should be muted or not.
+ * @param {boolean} muted True to mute the mic.
+ */
+MatrixCall.prototype.setMicrophoneMuted = function(muted) {
+    if (!this.localAVStream) {
+        return;
+    }
+    setAudioTracksEnabled(this.localAVStream, !muted);
+};
+
+/**
  * Internal
  * @private
  * @param {Object} stream
@@ -288,10 +299,7 @@ MatrixCall.prototype._gotUserMediaForInvite = function(stream) {
     }
 
     this.localAVStream = stream;
-    var audioTracks = stream.getAudioTracks();
-    for (var i = 0; i < audioTracks.length; i++) {
-        audioTracks[i].enabled = true;
-    }
+    setAudioTracksEnabled(stream, true);
     this.peerConn = _createPeerConnection(this);
     this.peerConn.addStream(stream);
     this.peerConn.createOffer(
@@ -326,10 +334,7 @@ MatrixCall.prototype._gotUserMediaForAnswer = function(stream) {
     }
 
     self.localAVStream = stream;
-    var audioTracks = stream.getAudioTracks();
-    for (var i = 0; i < audioTracks.length; i++) {
-        audioTracks[i].enabled = true;
-    }
+    setAudioTracksEnabled(stream, true);
     self.peerConn.addStream(stream);
 
     var constraints = {
@@ -629,6 +634,13 @@ MatrixCall.prototype._onHangupReceived = function(msg) {
 MatrixCall.prototype._onAnsweredElsewhere = function(msg) {
     debuglog("Answered elsewhere");
     terminate(this, "remote", "answered_elsewhere", true);
+};
+
+var setAudioTracksEnabled = function(stream, enabled) {
+    var audioTracks = stream.getAudioTracks();
+    for (var i = 0; i < audioTracks.length; i++) {
+        audioTracks[i].enabled = enabled;
+    }
 };
 
 var setState = function(self, state) {

--- a/lib/webrtc/call.js
+++ b/lib/webrtc/call.js
@@ -271,6 +271,28 @@ MatrixCall.prototype.setMicrophoneMuted = function(muted) {
 };
 
 /**
+ * Check if the microphone is muted.
+ *
+ * If there are multiple audio tracks, <i>all</i> of the tracks need to be muted
+ * for this to return true. This means if there are no audio tracks, this will
+ * return true.
+ * @return {Boolean} True if the mic is muted, else false (including if the call
+ * is not set up yet).
+ */
+MatrixCall.prototype.isMicrophoneMuted = function(muted) {
+    if (!this.localAVStream) {
+        return false;
+    }
+    var audioTracks = this.localAVStream.getAudioTracks();
+    for (var i = 0; i < audioTracks.length; i++) {
+        if (audioTracks[i].enabled) {
+            return false; // track is enabled; so mic is not muted
+        }
+    }
+    return true;
+};
+
+/**
  * Internal
  * @private
  * @param {Object} stream


### PR DESCRIPTION
This PR adds the following methods to `MatrixCall`:
 - `isLocalVideoMuted()`
 - `setLocalVideoMuted(muted)`
 - `isMicrophoneMuted()`
 - `setMicrophoneMuted(muted)`

Each method has been manually tested against an Android device.