### PR TITLE
Change calculating display names from O(n^2) to O(n)

### DIFF
--- a/lib/models/room-member.js
+++ b/lib/models/room-member.js
@@ -208,18 +208,13 @@ function calculateDisplayName(member, event, roomState) {
         return displayName;
     }
 
-    var stateEvents = utils.filter(
-        roomState.getStateEvents("m.room.member"),
-        function(e) {
-            return e.getContent().displayname === displayName &&
-                e.getSender() !== selfUserId;
-        }
-    );
-    if (stateEvents.length > 0) {
-        // need to disambiguate
+    var userIds = roomState.getUserIdsWithDisplayName(displayName);
+    var otherUsers = userIds.filter(function(u) {
+        return u !== selfUserId;
+    });
+    if (otherUsers.length > 0) {
         return displayName + " (" + selfUserId + ")";
     }
-
     return displayName;
 }
 

--- a/lib/models/room-state.js
+++ b/lib/models/room-state.js
@@ -31,6 +31,8 @@ function RoomState(roomId) {
         // userId: RoomMember
     };
     this._updateModifiedTime();
+    this._displayNameToUserIds = {};
+    this._userIdsToDisplayNames = {};
 }
 utils.inherits(RoomState, EventEmitter);
 
@@ -108,6 +110,11 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             self.events[event.getType()] = {};
         }
         self.events[event.getType()][event.getStateKey()] = event;
+        if (event.getType() === "m.room.member") {
+            _updateDisplayNameCache(
+                self, event.getStateKey(), event.getContent().displayname
+            );
+        }
         self.emit("RoomState.events", event, self);
     });
 
@@ -180,10 +187,36 @@ RoomState.prototype.getLastModifiedTime = function() {
     return this._modified;
 };
 
+RoomState.prototype.getUserIdsWithDisplayName = function(displayName) {
+    return this._displayNameToUserIds[displayName] || [];
+};
+
 /**
  * The RoomState class.
  */
 module.exports = RoomState;
+
+
+function _updateDisplayNameCache(roomState, userId, displayName) {
+    var oldName = roomState._userIdsToDisplayNames[userId];
+    delete roomState._userIdsToDisplayNames[userId];
+    if (oldName) {
+        var existing = roomState._displayNameToUserIds[oldName] || [];
+        for (var i = 0; i < existing.length; i++) {
+            if (existing[i] === userId) {
+                existing.splice(i, 1);
+                i--;
+            }
+        }
+        roomState._displayNameToUserIds[oldName] = existing;
+    }
+
+    roomState._userIdsToDisplayNames[userId] = displayName;
+    if (!roomState._displayNameToUserIds[displayName]) {
+        roomState._displayNameToUserIds[displayName] = [];
+    }
+    roomState._displayNameToUserIds[displayName].push(userId);
+}
 
 /**
  * Fires whenever the event dictionary in room state is updated.

--- a/lib/models/room-state.js
+++ b/lib/models/room-state.js
@@ -187,6 +187,11 @@ RoomState.prototype.getLastModifiedTime = function() {
     return this._modified;
 };
 
+/**
+ * Get user IDs with the specified display name.
+ * @param {string} displayName The display name to get user IDs from.
+ * @return {string[]} An array of user IDs or an empty array.
+ */
 RoomState.prototype.getUserIdsWithDisplayName = function(displayName) {
     return this._displayNameToUserIds[displayName] || [];
 };

--- a/lib/models/room-state.js
+++ b/lib/models/room-state.js
@@ -209,6 +209,7 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
         var existing = roomState._displayNameToUserIds[oldName] || [];
         for (var i = 0; i < existing.length; i++) {
             if (existing[i] === userId) {
+                // remove this user ID from this array
                 existing.splice(i, 1);
                 i--;
             }

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -201,6 +201,9 @@ describe("RoomMember", function() {
                         }),
                         joinEvent
                     ];
+                },
+                getUserIdsWithDisplayName: function(displayName) {
+                    return [userA, userC];
                 }
             };
             expect(member.name).toEqual(userA); // default = user_id


### PR DESCRIPTION
Reduces initial sync times from ~30s to ~1s on accounts with heavily
populated rooms.

The problem was that f.e. RoomMember it would try to calculate the
display name, which involved looping each RoomMember to get their
display name to check for disambiguation. We now cache display names
to user IDs so we don't need to loop every member when disambiguating.

Updated tests.