### PR TITLE
Retrieving profile info for invites

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -141,6 +141,7 @@ function MatrixClient(opts) {
     this.callList = {
         // callId: MatrixCall
     };
+    this._config = {}; // see startClient()
 
     // try constructing a MatrixCall to see if we are running in an environment
     // which has WebRTC. If we are, listen for and handle m.call.* events.
@@ -1948,6 +1949,9 @@ function doInitialSync(client, historyLen, includeArchived) {
  * @param {Number} opts.initialSyncLimit The event <code>limit=</code> to apply
  * to initial sync. Default: 8.
  * @param {Boolean} opts.includeArchivedRooms True to put <code>archived=true</code>
+ * @param {Boolean} opts.resolveInvitesToProfiles True to do /profile requests
+ * on every invite event if the displayname/avatar_url is not known for this user ID.
+ * Default: false.
  * on the <code>/initialSync</code> request. Default: false.
  */
 MatrixClient.prototype.startClient = function(opts) {
@@ -1965,6 +1969,8 @@ MatrixClient.prototype.startClient = function(opts) {
     opts = opts || {};
     opts.initialSyncLimit = opts.initialSyncLimit || 8;
     opts.includeArchivedRooms = opts.includeArchivedRooms || false;
+    opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
+    this._config = opts;
 
     if (CRYPTO_ENABLED && this.sessionStore !== null) {
         this.uploadKeys(5);
@@ -2019,6 +2025,7 @@ function _pollForEvents(client) {
             events = utils.map(data.chunk, _PojoToMatrixEventMapper(self));
         }
         if (!(self.store instanceof StubStore)) {
+            var roomIdsWithNewInvites = {};
             // bucket events based on room.
             var i = 0;
             var roomIdToEvents = {};
@@ -2030,6 +2037,10 @@ function _pollForEvents(client) {
                         roomIdToEvents[roomId] = [];
                     }
                     roomIdToEvents[roomId].push(events[i]);
+                    if (events[i].getType() === "m.room.member" &&
+                            events[i].getContent().membership === "invite") {
+                        roomIdsWithNewInvites[roomId] = true;
+                    }
                 }
                 else if (events[i].getType() === "m.presence") {
                     var usr = self.store.getUser(events[i].getContent().user_id);
@@ -2043,6 +2054,7 @@ function _pollForEvents(client) {
                     }
                 }
             }
+
             // add events to room
             var roomIds = utils.keys(roomIdToEvents);
             utils.forEach(roomIds, function(roomId) {
@@ -2076,6 +2088,10 @@ function _pollForEvents(client) {
                     // so sync state.
                     _syncRoom(self, room);
                 }
+            });
+
+            Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
+                _resolveInvites(self.store.getRoom(inviteRoomId));
             });
         }
         if (data) {
@@ -2135,6 +2151,8 @@ function _processRoomEvents(client, room, stateEventList, messageChunk) {
     room.oldState.setStateEvents(oldStateEvents);
     room.currentState.setStateEvents(stateEvents);
 
+    _resolveInvites(client, room);
+
     // add events to the timeline *after* setting the state
     // events so messages use the right display names. Initial sync
     // returns messages in chronological order, so we need to reverse
@@ -2175,6 +2193,47 @@ function reEmit(reEmitEntity, emittableEntity, eventNames) {
                 newArgs.push(arguments[i]);
             }
             reEmitEntity.emit.apply(reEmitEntity, newArgs);
+        });
+    });
+}
+
+function _resolveInvites(client, room) {
+    if (!room || !client.resolveInvitesToProfiles) {
+        return;
+    }
+    // For each invited room member we want to give them a displayname/avatar url
+    // if they have one (the m.room.member invites don't contain this).
+    room.getMembersWithMembership("invite").forEach(function(member) {
+        if (member._requestedProfileInfo) {
+            return;
+        }
+        member._requestedProfileInfo = true;
+        // try to get a cached copy first.
+        var user = client.getUser(member.userId);
+        var promise;
+        if (user) {
+            promise = q({
+                avatar_url: user.avatarUrl,
+                displayname: user.displayName
+            });
+        }
+        else {
+            promise = client.getProfileInfo(member.userId);
+        }
+        promise.done(function(info) {
+            // slightly naughty by doctoring the invite event but this means all
+            // the code paths remain the same between invite/join display name stuff
+            // which is a worthy trade-off for some minor pollution.
+            var inviteEvent = member.events.member;
+            if (inviteEvent.getContent().membership !== "invite") {
+                // between resolving and now they have since joined, so don't clobber
+                return;
+            }
+            inviteEvent.getContent().avatar_url = info.avatar_url;
+            inviteEvent.getContent().displayname = info.displayname;
+            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
+        }, function(err) {
+            // OH WELL.
         });
     });
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -2091,7 +2091,7 @@ function _pollForEvents(client) {
             });
 
             Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
-                _resolveInvites(self.store.getRoom(inviteRoomId));
+                _resolveInvites(self, self.store.getRoom(inviteRoomId));
             });
         }
         if (data) {
@@ -2198,7 +2198,7 @@ function reEmit(reEmitEntity, emittableEntity, eventNames) {
 }
 
 function _resolveInvites(client, room) {
-    if (!room || !client.resolveInvitesToProfiles) {
+    if (!room || !client._config.resolveInvitesToProfiles) {
         return;
     }
     // For each invited room member we want to give them a displayname/avatar url

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -121,10 +121,12 @@ describe("MatrixClient syncing", function() {
 
             httpBackend.when("GET", "/initialSync").respond(200, initialSync);
             httpBackend.when("GET", "/events").respond(200, eventData);
-            httpBackend.when("GET", "/profile/" + encodeURIComponent(userC)).respond(200, {
-                avatar_url: "mxc://flibble/wibble",
-                displayname: "The Boss"
-            });
+            httpBackend.when("GET", "/profile/" + encodeURIComponent(userC)).respond(
+                200, {
+                    avatar_url: "mxc://flibble/wibble",
+                    displayname: "The Boss"
+                }
+            );
 
             client.startClient({
                 resolveInvitesToProfiles: true

--- a/spec/mock-request.js
+++ b/spec/mock-request.js
@@ -13,6 +13,7 @@ function HttpBackend() {
     this.requestFn = function(opts, callback) {
         var realReq = new Request(opts.method, opts.uri, opts.body, opts.qs);
         realReq.callback = callback;
+        console.log("HTTP backend received request: %s %s", opts.method, opts.uri);
         self.requests.push(realReq);
     };
 }


### PR DESCRIPTION
This PR adds the ability for the SDK to fetch profile information for invitees. This is gated behind the flag `resolveInvitesToProfiles` which is set on `MatrixClient.startClient(opts)`.

If this flag is set to `true`, every incoming `m.room.member` **invite** event will be resolved. This resolution has the following steps:
 - Check for existing profile info in the store via `getUser(userId)`. If exists, use that. If not:
 - Hit `/profile/$user_id` to get their profile information. Set profile info from that.
 - Setting profile info involves munging the `m.room.member` `content` to include the `avatar_url` and `displayname`. This is preferable as it reduces the number of extraneous code paths this PR adds.

This has integration tests.