### PR TITLE
Syncing bugs/fixes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -151,7 +151,7 @@ function MatrixClient(opts) {
         setupCallEventHandler(this);
         this._supportsVoip = true;
     }
-
+    this._syncState = null;
 }
 utils.inherits(MatrixClient, EventEmitter);
 
@@ -177,6 +177,15 @@ MatrixClient.prototype.getIdentityServerUrl = function() {
  */
 MatrixClient.prototype.supportsVoip = function() {
     return this._supportsVoip;
+};
+
+/**
+ * Get the current sync state.
+ * @return {?string} the sync state, which may be null.
+ * @see module:client~MatrixClient#event:"sync"
+ */
+MatrixClient.prototype.getSyncState = function() {
+    return this._syncState;
 };
 
 /**
@@ -1979,16 +1988,17 @@ function doInitialSync(client, historyLen, includeArchived, attempt) {
         }
 
         client.clientRunning = true;
-        client.emit("syncComplete");
+        updateSyncState(client, "PREPARED");
+        // assume success until we fail which may be 30+ secs
+        updateSyncState(client, "SYNCING");
         _pollForEvents(client);
     }, function(err) {
         console.error("/initialSync error (%s attempts): %s", attempt, err);
-        client.emit("syncError", err);
+        updateSyncState(client, "ERROR", { error: err });
         attempt += 1;
         setTimeout(function() {
             doInitialSync(client, historyLen, includeArchived, attempt);
-        }, Math.pow(2, Math.min(attempt, 7)) * 1000); // max 2^7 secs = 2.1 mins
-        // TODO: Retries.
+        }, retryTimeMsForAttempt(attempt));
     });
 }
 
@@ -2040,20 +2050,34 @@ MatrixClient.prototype.startClient = function(opts) {
     // periodically poll for turn servers if we support voip
     checkTurnServers(this);
 
-    var self = this;
-    this.pushRules().done(function(result) {
-        self.pushRules = result;
-        doInitialSync(self, opts.initialSyncLimit, opts.includeArchivedRooms);
-    }, function(err) {
-        self.emit("syncError", err);
-    });
+    prepareForSync(this);
 };
+
+function prepareForSync(client, attempt) {
+    attempt = attempt || 1;
+    client.pushRules().done(function(result) {
+        client.pushRules = result;
+        doInitialSync(
+            client,
+            client._config.initialSyncLimit,
+            client._config.includeArchivedRooms
+        );
+    }, function(err) {
+        updateSyncState(client, "ERROR", { error: err });
+        attempt += 1;
+        setTimeout(function() {
+            prepareForSync(client, attempt);
+        }, retryTimeMsForAttempt(attempt));
+    });
+}
 
 /**
  * This is an internal method.
  * @param {MatrixClient} client
+ * @param {Number} attempt The attempt number
  */
-function _pollForEvents(client) {
+function _pollForEvents(client, attempt) {
+    attempt = attempt || 1;
     var self = client;
     if (!client.clientRunning) {
         return;
@@ -2075,6 +2099,11 @@ function _pollForEvents(client) {
         else {
             clearTimeout(timeoutObj);
         }
+
+        if (self._syncState !== "SYNCING") {
+            updateSyncState(self, "SYNCING");
+        }
+
         try {
             var events = [];
             if (data) {
@@ -2170,12 +2199,12 @@ function _pollForEvents(client) {
         else {
             clearTimeout(timeoutObj);
         }
-        self.emit("syncError", err);
-        // retry every few seconds
-        // FIXME: this should be exponential backoff with an option to nudge
+
+        updateSyncState(self, "ERROR", { error: err });
+        attempt += 1;
         setTimeout(function() {
-            _pollForEvents(self);
-        }, 2000);
+            _pollForEvents(self, attempt);
+        }, retryTimeMsForAttempt(attempt));
     });
 }
 
@@ -2455,6 +2484,12 @@ function setupCallEventHandler(client) {
     });
 }
 
+function updateSyncState(client, newState, data) {
+    var old = client._syncState;
+    client._syncState = newState;
+    client.emit("sync", client._syncState, old, data);
+}
+
 function checkTurnServers(client) {
     if (!client._supportsVoip) {
         return;
@@ -2509,6 +2544,12 @@ function createNewRoom(client, roomId) {
         );
     });
     return room;
+}
+
+function retryTimeMsForAttempt(attempt) {
+    // 2,4,8,16,32,64,128,128,128,... seconds
+    // max 2^7 secs = 2.1 mins
+    return Math.pow(2, Math.min(attempt, 7)) * 1000;
 }
 
 function _reject(callback, defer, err) {
@@ -2604,18 +2645,20 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * ready for methods to be called on it. This will be immediately followed by
  * a state of SYNCING. <i>This is the equivalent of "syncComplete" in the
  * previous API.</i></li>
- * <li>SYNCING : The client is currently polling for new events from the server.</li>
+ * <li>SYNCING : The client is currently polling for new events from the server.
+ * The client may fire this before or after processing latest events from a sync.</li>
  * <li>ERROR : The client has had a problem syncing with the server. If this is
  * called <i>before</i> PREPARED then there was a problem performing the initial
  * sync. If this is called <i>after</i> PREPARED then there was a problem polling
- * the server for updates. <i>This is the equivalent of "syncError" in the previous
+ * the server for updates. This may be called multiple times even if the state is
+ * already ERROR. <i>This is the equivalent of "syncError" in the previous
  * API.</i></li>
  * </ul>
  * State transition diagram:
  * <pre>
  *              +----->PREPARED -------> SYNCING <--+
  *              |        ^                  |       |
- *   null ------+        |  +----------------+      |
+ *   null ------+        |  +---------------+       |
  *              |        |  V                       |
  *              +------->ERROR ---------------------+
  *
@@ -2634,8 +2677,10 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * live update.
  * <li><code>ERROR -> SYNCING</code> : Occurs when the client has performed a
  * live update after having previously failed.
+ * <li><code>ERROR -> ERROR</code> : Occurs when the client has failed to sync
+ * for a second time or more.</li>
  * </ul>
- * 
+ *
  * @event module:client~MatrixClient#"sync"
  * @param {string} state An enum representing the syncing state. One of "PREPARED",
  * "SYNCING", "ERROR".

--- a/lib/client.js
+++ b/lib/client.js
@@ -2598,23 +2598,65 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  */
 
 /**
- * Fires whenever the SDK has a problem syncing. <strong>This event is experimental
- * and may change.</strong>
- * @event module:client~MatrixClient#"syncError"
- * @param {MatrixError} err The matrix error which caused this event to fire.
+ * Fires whenever the SDK's syncing state is updated. The state can be one of:
+ * <ul>
+ * <li>PREPARED : The client has synced with the server at least once and is
+ * ready for methods to be called on it. This will be immediately followed by
+ * a state of SYNCING. <i>This is the equivalent of "syncComplete" in the
+ * previous API.</i></li>
+ * <li>SYNCING : The client is currently polling for new events from the server.</li>
+ * <li>ERROR : The client has had a problem syncing with the server. If this is
+ * called <i>before</i> PREPARED then there was a problem performing the initial
+ * sync. If this is called <i>after</i> PREPARED then there was a problem polling
+ * the server for updates. <i>This is the equivalent of "syncError" in the previous
+ * API.</i></li>
+ * </ul>
+ * State transition diagram:
+ * <pre>
+ *              +----->PREPARED -------> SYNCING <--+
+ *              |        ^                  |       |
+ *   null ------+        |  +----------------+      |
+ *              |        |  V                       |
+ *              +------->ERROR ---------------------+
+ *
+ * NB: 'null' will never be emitted by this event.
+ * </pre>
+ * Transitions:
+ * <ul>
+ * <li><code>null -> PREPARED</code> : Occurs when the initial sync is completed
+ * first time.
+ * <li><code>null -> ERROR</code> : Occurs when the initial sync failed first time.
+ * <li><code>ERROR -> PREPARED</code> : Occurs when the initial sync succeeds
+ * after previously failing.
+ * <li><code>PREPARED -> SYNCING</code> : Occurs immediately after transitioning
+ * to PREPARED. Starts listening for live updates rather than catching up.
+ * <li><code>SYNCING -> ERROR</code> : Occurs the first time a client cannot perform a
+ * live update.
+ * <li><code>ERROR -> SYNCING</code> : Occurs when the client has performed a
+ * live update after having previously failed.
+ * </ul>
+ * 
+ * @event module:client~MatrixClient#"sync"
+ * @param {string} state An enum representing the syncing state. One of "PREPARED",
+ * "SYNCING", "ERROR".
+ * @param {?string} prevState An enum representing the previous syncing state.
+ * One of "PREPARED", "SYNCING", "ERROR" <b>or null</b>.
+ * @param {?Object} data Data about this transition.
+ * @param {MatrixError} data.err The matrix error if <code>state=ERROR</code>.
  * @example
- * matrixClient.on("syncError", function(err){
- *   // update UI to say "Connection Lost"
- * });
- */
-
-/**
- * Fires when the SDK has finished catching up and is now listening for live
- * events. <strong>This event is experimental and may change.</strong>
- * @event module:client~MatrixClient#"syncComplete"
- * @example
- * matrixClient.on("syncComplete", function(){
- *   var rooms = matrixClient.getRooms();
+ * matrixClient.on("sync", function(state, prevState, data) {
+ *   switch (state) {
+ *     case "ERROR":
+ *       // update UI to say "Connection Lost"
+ *       break;
+ *     case "SYNCING":
+ *       // update UI to remove any "Connection Lost" message
+ *       break;
+ *     case "PREPARED":
+ *       // the client instance is ready to be queried.
+ *       var rooms = matrixClient.getRooms();
+ *       break;
+ *   }
  * });
  */
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -2012,11 +2012,11 @@ function doInitialSync(client, historyLen, includeArchived, attempt) {
         _pollForEvents(client);
     }, function(err) {
         console.error("/initialSync error (%s attempts): %s", attempt, err);
-        updateSyncState(client, "ERROR", { error: err });
         attempt += 1;
         startSyncingRetryTimer(client, attempt, function() {
             doInitialSync(client, historyLen, includeArchived, attempt);
         });
+        updateSyncState(client, "ERROR", { error: err });
     });
 }
 
@@ -2081,11 +2081,11 @@ function prepareForSync(client, attempt) {
             client._config.includeArchivedRooms
         );
     }, function(err) {
-        updateSyncState(client, "ERROR", { error: err });
         attempt += 1;
         startSyncingRetryTimer(client, attempt, function() {
             prepareForSync(client, attempt);
         });
+        updateSyncState(client, "ERROR", { error: err });
     });
 }
 
@@ -2218,11 +2218,11 @@ function _pollForEvents(client, attempt) {
             clearTimeout(timeoutObj);
         }
 
-        updateSyncState(self, "ERROR", { error: err });
         attempt += 1;
         startSyncingRetryTimer(self, attempt, function() {
             _pollForEvents(self, attempt);
         });
+        updateSyncState(self, "ERROR", { error: err });
     });
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1999,6 +1999,8 @@ function doInitialSync(client, historyLen, includeArchived) {
  * @param {Boolean} opts.resolveInvitesToProfiles True to do /profile requests
  * on every invite event if the displayname/avatar_url is not known for this user ID.
  * Default: false.
+ * @param {Number} opts.pollTimeout The number of milliseconds to wait on /events.
+ * Default: 30000 (30 seconds).
  */
 MatrixClient.prototype.startClient = function(opts) {
     if (this.clientRunning) {
@@ -2016,6 +2018,7 @@ MatrixClient.prototype.startClient = function(opts) {
     opts.initialSyncLimit = opts.initialSyncLimit || 8;
     opts.includeArchivedRooms = opts.includeArchivedRooms || false;
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
+    opts.pollTimeout = opts.pollTimeout || (30 * 1000);
     this._config = opts;
 
     if (CRYPTO_ENABLED && this.sessionStore !== null) {
@@ -2054,11 +2057,11 @@ function _pollForEvents(client) {
         discardResult = true;
         console.error("/events request timed out.");
         _pollForEvents(client);
-    }, 40000);
+    }, client._config.pollTimeout + (20 * 1000)); // 20s buffer
 
     client._http.authedRequest(undefined, "GET", "/events", {
         from: client.store.getSyncToken(),
-        timeout: 30000
+        timeout: client._config.pollTimeout
     }).done(function(data) {
         if (discardResult) {
             return;

--- a/lib/client.js
+++ b/lib/client.js
@@ -152,6 +152,7 @@ function MatrixClient(opts) {
         this._supportsVoip = true;
     }
     this._syncState = null;
+    this._syncingRetry = null;
 }
 utils.inherits(MatrixClient, EventEmitter);
 
@@ -186,6 +187,23 @@ MatrixClient.prototype.supportsVoip = function() {
  */
 MatrixClient.prototype.getSyncState = function() {
     return this._syncState;
+};
+
+/**
+ * Retry a backed off syncing request immediately. This should only be used when
+ * the user <b>explicitly</b> attempts to retry their lost connection.
+ * @return {boolean} True if this resulted in a request being retried.
+ */
+MatrixClient.prototype.retryImmediately = function() {
+    if (!this._syncingRetry) {
+        return false;
+    }
+    // stop waiting
+    clearTimeout(this._syncingRetry.timeoutId);
+    // invoke immediately
+    this._syncingRetry.fn();
+    this._syncingRetry = null;
+    return true;
 };
 
 /**
@@ -1996,9 +2014,9 @@ function doInitialSync(client, historyLen, includeArchived, attempt) {
         console.error("/initialSync error (%s attempts): %s", attempt, err);
         updateSyncState(client, "ERROR", { error: err });
         attempt += 1;
-        setTimeout(function() {
+        startSyncingRetryTimer(client, attempt, function() {
             doInitialSync(client, historyLen, includeArchived, attempt);
-        }, retryTimeMsForAttempt(attempt));
+        });
     });
 }
 
@@ -2065,9 +2083,9 @@ function prepareForSync(client, attempt) {
     }, function(err) {
         updateSyncState(client, "ERROR", { error: err });
         attempt += 1;
-        setTimeout(function() {
+        startSyncingRetryTimer(client, attempt, function() {
             prepareForSync(client, attempt);
-        }, retryTimeMsForAttempt(attempt));
+        });
     });
 }
 
@@ -2202,9 +2220,9 @@ function _pollForEvents(client, attempt) {
 
         updateSyncState(self, "ERROR", { error: err });
         attempt += 1;
-        setTimeout(function() {
+        startSyncingRetryTimer(self, attempt, function() {
             _pollForEvents(self, attempt);
-        }, retryTimeMsForAttempt(attempt));
+        });
     });
 }
 
@@ -2482,6 +2500,14 @@ function setupCallEventHandler(client) {
             }
         }
     });
+}
+
+function startSyncingRetryTimer(client, attempt, fn) {
+    client._syncingRetry = {};
+    client._syncingRetry.fn = fn;
+    client._syncingRetry.timeoutId = setTimeout(function() {
+        fn();
+    }, retryTimeMsForAttempt(attempt));
 }
 
 function updateSyncState(client, newState, data) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1878,8 +1878,10 @@ MatrixClient.prototype.isLoggedIn = function() {
  * @param {MatrixClient} client
  * @param {integer} historyLen
  * @param {integer} includeArchived
+ * @param {integer} attempt
  */
-function doInitialSync(client, historyLen, includeArchived) {
+function doInitialSync(client, historyLen, includeArchived, attempt) {
+    attempt = attempt || 1;
     var qps = { limit: historyLen };
     if (includeArchived) {
         qps.archived = true;
@@ -1980,8 +1982,12 @@ function doInitialSync(client, historyLen, includeArchived) {
         client.emit("syncComplete");
         _pollForEvents(client);
     }, function(err) {
-        console.error("/initialSync error: %s", err);
+        console.error("/initialSync error (%s attempts): %s", attempt, err);
         client.emit("syncError", err);
+        attempt += 1;
+        setTimeout(function() {
+            doInitialSync(client, historyLen, includeArchived, attempt);
+        }, Math.pow(2, Math.min(attempt, 7)) * 1000); // max 2^7 secs = 2.1 mins
         // TODO: Retries.
     });
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -2176,7 +2176,8 @@ function _syncRoom(client, room) {
     }
     var defer = q.defer();
     client._syncingRooms[room.roomId] = defer.promise;
-    client.roomInitialSync(room.roomId, 8).done(function(res) {
+    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
+    function(res) {
         room.timeline = []; // blow away any previous messages.
         _processRoomEvents(client, room, res.state, res.messages);
         room.recalculate(client.credentials.userId);

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -326,7 +326,6 @@ Room.prototype.getUsersReadUpTo = function(event) {
  * have received no read receipts from them.
  * @param {String} userId The user ID to get read receipt event ID for
  * @return {String} ID of the latest event that the given user has read, or null.
- * an empty list.
  */
 Room.prototype.getEventReadUpTo = function(userId) {
     if (

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -82,7 +82,8 @@ describe("MatrixClient room timelines", function() {
 
         it("should be added immediately after calling MatrixClient.sendEvent " +
         "with EventStatus.SENDING and the right event.sender", function(done) {
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 expect(room.timeline.length).toEqual(1);
 
@@ -116,7 +117,8 @@ describe("MatrixClient room timelines", function() {
             ];
             eventData.chunk[0].event_id = eventId;
 
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 client.sendTextMessage(roomId, "I am a fish", "txn1").done(
                 function() {
@@ -144,7 +146,8 @@ describe("MatrixClient room timelines", function() {
             ];
             eventData.chunk[0].event_id = eventId;
 
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 var promise = client.sendTextMessage(roomId, "I am a fish", "txn1");
                 httpBackend.flush("/events", 1).done(function() {
@@ -180,7 +183,8 @@ describe("MatrixClient room timelines", function() {
 
         it("should set Room.oldState.paginationToken to null at the start" +
         " of the timeline.", function(done) {
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 expect(room.timeline.length).toEqual(1);
 
@@ -219,7 +223,8 @@ describe("MatrixClient room timelines", function() {
                 })
             ];
 
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 expect(room.timeline.length).toEqual(1);
 
@@ -249,7 +254,8 @@ describe("MatrixClient room timelines", function() {
                 })
             ];
 
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 expect(room.timeline.length).toEqual(1);
 
@@ -274,7 +280,8 @@ describe("MatrixClient room timelines", function() {
                 })
             ];
 
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 expect(room.oldState.paginationToken).toBeDefined();
 
@@ -297,7 +304,8 @@ describe("MatrixClient room timelines", function() {
                 utils.mkMessage({user: userId, room: roomId}),
                 utils.mkMessage({user: userId, room: roomId})
             ];
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
 
                 var index = 0;
@@ -331,7 +339,8 @@ describe("MatrixClient room timelines", function() {
                 }),
                 utils.mkMessage({user: userId, room: roomId})
             ];
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 httpBackend.flush("/events", 1).done(function() {
                     var preNameEvent = room.timeline[room.timeline.length - 3];
@@ -352,7 +361,8 @@ describe("MatrixClient room timelines", function() {
                     }
                 })
             ];
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 var nameEmitCount = 0;
                 client.on("Room.name", function(rm) {
@@ -392,7 +402,8 @@ describe("MatrixClient room timelines", function() {
                     user: userC, room: roomId, mship: "invite", skey: userD
                 })
             ];
-            client.on("syncComplete", function() {
+            client.on("sync", function(state) {
+                if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 httpBackend.flush("/events", 1).done(function() {
                     expect(room.currentState.getMembers().length).toEqual(4);

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -81,7 +81,8 @@ describe("MatrixClient", function() {
             accessToken: "my.access.token",
             request: function() {}, // NOP
             store: store,
-            scheduler: scheduler
+            scheduler: scheduler,
+            userId: userId
         });
         // FIXME: We shouldn't be yanking _http like this.
         client._http = jasmine.createSpyObj("httpApi", [

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -30,7 +30,7 @@ describe("MatrixClient", function() {
         // }
         // items are popped off when processed and block if no items left.
     ];
-    var pendingLookup = {};
+    var pendingLookup = null;
     function httpReq(cb, method, path, qp, data, prefix) {
         var next = httpLookups.shift();
         var logLine = (
@@ -40,6 +40,14 @@ describe("MatrixClient", function() {
         console.log(logLine);
 
         if (!next) { // no more things to return
+            if (pendingLookup) {
+                // >1 pending thing, whine.
+                expect(false).toBe(
+                    true, ">1 pending request. You should probably handle them. " +
+                    "PENDING: " + JSON.stringify(pendingLookup) + " JUST GOT: " +
+                    method + " " + path
+                );
+            }
             pendingLookup = {
                 promise: q.defer().promise,
                 method: method,
@@ -93,7 +101,7 @@ describe("MatrixClient", function() {
         client._http.authedRequestWithPrefix.andCallFake(httpReq);
 
         // set reasonable working defaults
-        pendingLookup = {};
+        pendingLookup = null;
         httpLookups = [];
         httpLookups.push({
             method: "GET", path: "/pushrules/", data: {}

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -1,0 +1,77 @@
+"use strict";
+var sdk = require("../..");
+var MatrixClient = sdk.MatrixClient;
+var utils = require("../test-utils");
+
+describe("MatrixClient", function() {
+    var userId = "@alice:bar";
+    var client;
+
+    beforeEach(function() {
+        utils.beforeEach(this);
+    });
+
+    describe("getSyncState", function() {
+
+        it("should return null if the client isn't started", function() {
+
+        });
+
+        it("should return the same sync state as emitted sync events", function() {
+
+        });
+    });
+
+    describe("retryImmediately", function() {
+        it("should return false if there is no request waiting", function() {
+
+        });
+
+        it("should return true if there is a request waiting", function() {
+
+        });
+
+        it("should work on /initialSync", function() {
+
+        });
+
+        it("should work on /events", function() {
+
+        });
+
+        it("should work on /pushrules", function() {
+
+        });
+    });
+
+    describe("emitted sync events", function() {
+
+        it("should transition null -> PREPARED after /initialSync", function() {
+
+        });
+
+        it("should transition null -> ERROR after a failed /initialSync", function() {
+
+        });
+
+        it("should transition ERROR -> PREPARED after /initialSync if prev failed", function() {
+
+        });
+
+        it("should transition PREPARED -> SYNCING after /initialSync", function() {
+
+        });
+
+        it("should transition SYNCING -> ERROR after a failed /events", function() {
+
+        });
+
+        it("should transition ERROR -> SYNCING after /events if prev failed", function() {
+
+        });
+
+        it("should transition ERROR -> ERROR if multiple /events fails", function() {
+
+        });
+    });
+});

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -1,24 +1,124 @@
 "use strict";
+var q = require("q");
 var sdk = require("../..");
 var MatrixClient = sdk.MatrixClient;
 var utils = require("../test-utils");
 
 describe("MatrixClient", function() {
     var userId = "@alice:bar";
-    var client;
+    var client, store, scheduler;
+
+    var initialSyncData = {
+        end: "s_5_3",
+        presence: [],
+        rooms: []
+    };
+
+    var eventData = {
+        start: "s_START",
+        end: "s_END",
+        chunk: []
+    };
+
+    var httpLookups = [
+        // items are objects which look like:
+        // {
+        //   method: "GET",
+        //   path: "/initialSync",
+        //   data: {},
+        //   error: { errcode: M_FORBIDDEN } // if present will reject promise
+        // }
+        // items are popped off when processed and block if no items left.
+    ];
+    var pendingLookup = {};
+    function httpReq(cb, method, path, qp, data, prefix) {
+        var next = httpLookups.shift();
+        var logLine = (
+            "MatrixClient[UT] RECV " + method + " " + path + "  " +
+            "EXPECT " + (next ? next.method : next) + " " + (next ? next.path : next)
+        );
+        console.log(logLine);
+
+        if (!next) { // no more things to return
+            pendingLookup = {
+                promise: q.defer().promise,
+                method: method,
+                path: path
+            };
+            return pendingLookup.promise;
+        }
+        if (next.path === path && next.method === method) {
+            console.log(
+                "MatrixClient[UT] Matched. Returning " +
+                (next.error ? "BAD" : "GOOD") + " response"
+            );
+            if (next.error) {
+                return q.reject({
+                    errcode: next.error.errcode,
+                    name: next.error.errcode,
+                    message: "Expected testing error",
+                    data: next.error
+                });
+            }
+            return q(next.data);
+        }
+        expect(true).toBe(false, "Expected different request. " + logLine);
+        return q.defer().promise;
+    }
 
     beforeEach(function() {
         utils.beforeEach(this);
+        scheduler = jasmine.createSpyObj("scheduler", [
+            "getQueueForEvent", "queueEvent", "removeEventFromQueue",
+            "setProcessFunction"
+        ]);
+        store = jasmine.createSpyObj("store", [
+            "getRoom", "getRooms", "getUser", "getSyncToken", "scrollback",
+            "setSyncToken", "storeEvents", "storeRoom", "storeUser"
+        ]);
+        client = new MatrixClient({
+            baseUrl: "https://my.home.server",
+            accessToken: "my.access.token",
+            request: function() {}, // NOP
+            store: store,
+            scheduler: scheduler
+        });
+        // FIXME: We shouldn't be yanking _http like this.
+        client._http = jasmine.createSpyObj("httpApi", [
+            "authedRequest", "authedRequestWithPrefix", "getContentUri",
+            "request", "requestWithPrefix", "uploadContent"
+        ]);
+        client._http.authedRequest.andCallFake(httpReq);
+        client._http.authedRequestWithPrefix.andCallFake(httpReq);
+
+        // set reasonable working defaults
+        pendingLookup = {};
+        httpLookups = [];
+        httpLookups.push({
+            method: "GET", path: "/pushrules/", data: {}
+        });
+        httpLookups.push({
+            method: "GET", path: "/initialSync", data: initialSyncData
+        });
+        httpLookups.push({
+            method: "GET", path: "/events", data: eventData
+        });
     });
 
     describe("getSyncState", function() {
 
         it("should return null if the client isn't started", function() {
-
+            expect(client.getSyncState()).toBeNull();
         });
 
-        it("should return the same sync state as emitted sync events", function() {
-
+        it("should return the same sync state as emitted sync events", function(done) {
+            client.on("sync", function(state) {
+                expect(state).toEqual(client.getSyncState());
+                if (state === "SYNCING") {
+                    done();
+                }
+            });
+            client.startClient();
         });
     });
 

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -54,7 +54,8 @@ describe("MatrixClient", function() {
 
         });
 
-        it("should transition ERROR -> PREPARED after /initialSync if prev failed", function() {
+        it("should transition ERROR -> PREPARED after /initialSync if prev failed",
+        function() {
 
         });
 


### PR DESCRIPTION
This PR adds the necessary structures for https://github.com/vector-im/vector-web/issues/197 to be implemented.

This PR fixes all the issues in SYJS-11:
 - We need to retry `/initialSync` if it fails. Currently we get wedged.
 - We need to emit an event when we recover from a `syncError` to let clients remove banners/warnings saying 'bad connection'.
 - We need to exp backoff on `/events` in the event of a failure.
 - We need to have a manual prod function to kick either `/initialSync` and/or `/events` if they are backing off.
 - We need to expose `/events?timeout=` to clients.
 - Room initial sync should be using `historyLen`.

This PR makes a breaking change:
 - `syncError` and `syncComplete` are no longer emitted, and are combined into a `sync` event with `state` arguments.

This PR has unit tests for the sync state transitions and forced retries.