### PR TITLE
Guest access endpoints

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1771,18 +1771,21 @@ MatrixClient.prototype.login = function(loginType, data, callback) {
 
 /**
  * Register a guest account.
- * @param {Object=} opts Registration options (none at this time).
+ * @param {Object=} opts Registration options
+ * @param {Object} opts.body JSON HTTP body to provide.
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: TODO
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.registerGuest = function(opts, callback) {
     opts = opts || {};
+    opts.body = opts.body || {};
+
     return this._http.requestWithPrefix(
         callback, "POST", "/register", {
             kind: "guest"
         },
-        {}, httpApi.PREFIX_V2_ALPHA
+        opts.body, httpApi.PREFIX_V2_ALPHA
     );
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1770,6 +1770,23 @@ MatrixClient.prototype.login = function(loginType, data, callback) {
 };
 
 /**
+ * Register a guest account.
+ * @param {Object=} opts Registration options (none at this time).
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.registerGuest = function(opts, callback) {
+    opts = opts || {};
+    return this._http.requestWithPrefix(
+        callback, "POST", "/register", {
+            kind: "guest"
+        },
+        {}, httpApi.PREFIX_V2_ALPHA
+    );
+};
+
+/**
  * @param {string} username
  * @param {string} password
  * @param {string} sessionId

--- a/lib/client.js
+++ b/lib/client.js
@@ -153,6 +153,8 @@ function MatrixClient(opts) {
     }
     this._syncState = null;
     this._syncingRetry = null;
+
+    this._guestRooms = null;
 }
 utils.inherits(MatrixClient, EventEmitter);
 
@@ -1790,6 +1792,14 @@ MatrixClient.prototype.registerGuest = function(opts, callback) {
 };
 
 /**
+ * Set a list of rooms the Guest is interested in receiving events from.
+ * @param {String[]} A list of room IDs.
+ */
+MatrixClient.prototype.setGuestRooms = function(roomIds) {
+    this._guestRooms = roomIds;
+};
+
+/**
  * @param {string} username
  * @param {string} password
  * @param {string} sessionId
@@ -2220,10 +2230,16 @@ function _pollForEvents(client, attempt) {
         _pollForEvents(client);
     }, timeoutMs + (20 * 1000)); // 20s buffer
 
-    client._http.authedRequest(undefined, "GET", "/events", {
+    var queryParams = {
         from: client.store.getSyncToken(),
         timeout: timeoutMs
-    }).done(function(data) {
+    };
+    if (client._guestRooms) {
+        queryParams.room_id = client._guestRooms;
+    }
+
+    client._http.authedRequest(undefined, "GET", "/events", queryParams).done(
+    function(data) {
         if (discardResult) {
             return;
         }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1793,7 +1793,7 @@ MatrixClient.prototype.registerGuest = function(opts, callback) {
 
 /**
  * Set a list of rooms the Guest is interested in receiving events from.
- * @param {String[]} A list of room IDs.
+ * @param {String[]} roomIds A list of room IDs.
  */
 MatrixClient.prototype.setGuestRooms = function(roomIds) {
     this._guestRooms = roomIds;


### PR DESCRIPTION
This adds the following functions required for guest access:
 - `MatrixClient.registerGuest()` - Flexible registration endpoint `?kind=guest`.
 - `MatrixClient.setGuestRooms(roomIds)` - Sets stuff which is given to `/events` as query params. Provided here rather than in `startClient(opts)` because rooms will be added whilst the client is running.