### PR TITLE
Add config option to control how pending events are ordered

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2252,15 +2252,20 @@ function doInitialSync(client, historyLen, includeArchived, attempt) {
  * and then start polling the eventStream for new events. To listen for these
  * events, add a listener for {@link module:client~MatrixClient#event:"event"}
  * via {@link module:client~MatrixClient#on}.
- * @param {Object} opts Options to apply when syncing.
- * @param {Number} opts.initialSyncLimit The event <code>limit=</code> to apply
+ * @param {Object=} opts Options to apply when syncing.
+ * @param {Number=} opts.initialSyncLimit The event <code>limit=</code> to apply
  * to initial sync. Default: 8.
- * @param {Boolean} opts.includeArchivedRooms True to put <code>archived=true</code>
+ * @param {Boolean=} opts.includeArchivedRooms True to put <code>archived=true</code>
  * on the <code>/initialSync</code> request. Default: false.
- * @param {Boolean} opts.resolveInvitesToProfiles True to do /profile requests
+ * @param {Boolean=} opts.resolveInvitesToProfiles True to do /profile requests
  * on every invite event if the displayname/avatar_url is not known for this user ID.
  * Default: false.
- * @param {Number} opts.pollTimeout The number of milliseconds to wait on /events.
+ * @param {String=} opts.pendingEventOrdering Controls where pending messages appear
+ * in a room's timeline. If "<b>chronological</b>", messages will appear in the timeline
+ * when the call to <code>sendEvent</code> was made. If "<b>end</b>", pending messages
+ * will always appear at the end of the timeline (multiple pending messages will be sorted
+ * chronologically). Default: "chronological".
+ * @param {Number=} opts.pollTimeout The number of milliseconds to wait on /events.
  * Default: 30000 (30 seconds).
  */
 MatrixClient.prototype.startClient = function(opts) {
@@ -2280,6 +2285,7 @@ MatrixClient.prototype.startClient = function(opts) {
     opts.includeArchivedRooms = opts.includeArchivedRooms || false;
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
     opts.pollTimeout = opts.pollTimeout || (30 * 1000);
+    opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this._config = opts;
 
     if (CRYPTO_ENABLED && this.sessionStore !== null) {
@@ -2800,7 +2806,9 @@ function createNewUser(client, userId) {
 }
 
 function createNewRoom(client, roomId) {
-    var room = new Room(roomId);
+    var room = new Room(roomId, {
+        pendingEventOrdering: client._config.pendingEventOrdering
+    });
     reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
 
     // we need to also re-emit room state and room member events, so hook it up

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -4,6 +4,7 @@
  */
 var EventEmitter = require("events").EventEmitter;
 
+var EventStatus = require("./event").EventStatus;
 var RoomState = require("./room-state");
 var RoomSummary = require("./room-summary");
 var MatrixEvent = require("./event").MatrixEvent;
@@ -31,9 +32,15 @@ function synthesizeReceipt(userId, event, receiptType) {
  * Construct a new Room.
  * @constructor
  * @param {string} roomId Required. The ID of this room.
- * @param {*} storageToken Optional. The token which a data store can use
+ * @param {Object=} opts Configuration options
+ * @param {*} opts.storageToken Optional. The token which a data store can use
  * to remember the state of the room. What this means is dependent on the store
  * implementation.
+ * @param {String=} opts.pendingEventOrdering Controls where pending messages appear
+ * in a room's timeline. If "<b>chronological</b>", messages will appear in the timeline
+ * when the call to <code>sendEvent</code> was made. If "<b>end</b>", pending messages
+ * will always appear at the end of the timeline (multiple pending messages will be sorted
+ * chronologically). Default: "chronological".
  * @prop {string} roomId The ID of this room.
  * @prop {string} name The human-readable display name for this room.
  * @prop {Array<MatrixEvent>} timeline The ordered list of message events for
@@ -48,7 +55,17 @@ function synthesizeReceipt(userId, event, receiptType) {
  * @prop {*} storageToken A token which a data store can use to remember
  * the state of the room.
  */
-function Room(roomId, storageToken) {
+function Room(roomId, opts) {
+    opts = opts || {};
+    opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
+
+    if (["chronological", "end"].indexOf(opts.pendingEventOrdering) === -1) {
+        throw new Error(
+            "opts.pendingEventOrdering MUST be either 'chronological' or " +
+            "'end'. Got: '" + opts.pendingEventOrdering + "'"
+        );
+    }
+
     this.roomId = roomId;
     this.name = roomId;
     this.timeline = [];
@@ -59,7 +76,8 @@ function Room(roomId, storageToken) {
     this.oldState = new RoomState(roomId);
     this.currentState = new RoomState(roomId);
     this.summary = null;
-    this.storageToken = storageToken;
+    this.storageToken = opts.storageToken;
+    this._opts = opts;
     this._redactions = [];
     // receipts should clobber based on receipt_type and user_id pairs hence
     // the form of this structure. This is sub-optimal for the exposed APIs
@@ -180,10 +198,18 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline) {
         };
     }
 
+    var addLocalEchoToEnd = this._opts.pendingEventOrdering === "end";
+
     for (var i = 0; i < events.length; i++) {
         if (toStartOfTimeline && this._redactions.indexOf(events[i].getId()) >= 0) {
             continue; // do not add the redacted event.
         }
+        var isLocalEcho = (
+            !Boolean(toStartOfTimeline) && (
+                events[i].status === EventStatus.SENDING ||
+                events[i].status === EventStatus.QUEUED
+            )
+        );
 
         setEventMetadata(events[i], stateContext, toStartOfTimeline);
         // modify state
@@ -215,7 +241,22 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline) {
             this.timeline.unshift(events[i]);
         }
         else {
-            this.timeline.push(events[i]);
+            // everything gets added to the end by default. What we actually want to
+            // do in this scenario is *NOT* add REAL events to the end if there are
+            // existing local echo events at the end.
+            if (addLocalEchoToEnd && !isLocalEcho) {
+                var insertIndex = this.timeline.length;
+                for (var j = this.timeline.length - 1; j >= 0; j--) {
+                    if (!this.timeline[j].status) { // real events don't have a status
+                        insertIndex = j + 1;
+                        break;
+                    }
+                }
+                this.timeline.splice(insertIndex, 0, events[i]); // insert element
+            }
+            else {
+                this.timeline.push(events[i]);
+            }
         }
 
         // synthesize and inject implicit read receipts

--- a/lib/store/webstorage.js
+++ b/lib/store/webstorage.js
@@ -514,7 +514,9 @@ SerialisedRoom.fromRoom = function(room, batchSize) {
 };
 
 function loadRoom(store, roomId, numEvents, tokenArray) {
-    var room = new Room(roomId, tokenArray.length);
+    var room = new Room(roomId, {
+        storageToken: tokenArray.length
+    });
 
     // populate state (flatten nested struct to event array)
     var currentStateMap = getItem(store, keyName(roomId, "state"));


### PR DESCRIPTION
Specifically, consumers of the SDK can now do:

```javascript
client.startClient({
  pendingEventOrdering: "end"
});
```
to sort SENDING/QUEUED/NOT_SENT events to the **end** of the `room.timeline` always. The default value for `pendingEventOrdering` is `chronological` which is the current behaviour before this PR (pending events are ordered chronologically with other events).