### PR TITLE
Use /sync instead of /initialSync and /events

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -621,9 +621,10 @@ MatrixClient.prototype.joinRoom = function(roomIdOrAlias, opts, callback) {
     this._http.authedRequest(undefined, "POST", path, undefined, {}).then(
     function(res) {
         var roomId = res.room_id;
-        var room = createNewRoom(self, roomId); // XXX FIXME TODO
+        var syncApi = new SyncApi(self);
+        var room = syncApi.createRoom(roomId);
         if (opts.syncRoom) {
-            return _syncRoom(self, room); // XXX FIXME TODO
+            return syncApi.syncRoom(room);
         }
         return q(room);
     }, function(err) {
@@ -2424,12 +2425,6 @@ function checkTurnServers(client) {
     });
 }
 
-function retryTimeMsForAttempt(attempt) {
-    // 2,4,8,16,32,64,128,128,128,... seconds
-    // max 2^7 secs = 2.1 mins
-    return Math.pow(2, Math.min(attempt, 7)) * 1000;
-}
-
 function _reject(callback, defer, err) {
     if (callback) {
         callback(err);
@@ -2455,6 +2450,10 @@ function _PojoToMatrixEventMapper(client) {
     }
     return mapper;
 }
+
+MatrixClient.prototype.getEventMapper = function() {
+    return _PojoToMatrixEventMapper(this);
+};
 
 // Identity Server Operations
 // ==========================
@@ -2502,8 +2501,6 @@ MatrixClient.prototype.generateClientSecret = function() {
 module.exports.MatrixClient = MatrixClient;
 /** */
 module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
-/** */
-module.exports.EventMapper = _PojoToMatrixEventMapper;
 
 // MatrixClient Event JSDocs
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,12 +13,11 @@ var httpApi = require("./http-api");
 var MatrixEvent = require("./models/event").MatrixEvent;
 var EventStatus = require("./models/event").EventStatus;
 var StubStore = require("./store/stub");
-var Room = require("./models/room");
-var User = require("./models/user");
 var webRtcCall = require("./webrtc/call");
 var utils = require("./utils");
 var contentRepo = require("./content-repo");
 var Filter = require("./filter");
+var SyncApi = require("./sync");
 
 var SCROLLBACK_DELAY_MS = 3000;
 var CRYPTO_ENABLED = false;
@@ -622,9 +621,9 @@ MatrixClient.prototype.joinRoom = function(roomIdOrAlias, opts, callback) {
     this._http.authedRequest(undefined, "POST", path, undefined, {}).then(
     function(res) {
         var roomId = res.room_id;
-        var room = createNewRoom(self, roomId);
+        var room = createNewRoom(self, roomId); // XXX FIXME TODO
         if (opts.syncRoom) {
-            return _syncRoom(self, room);
+            return _syncRoom(self, room); // XXX FIXME TODO
         }
         return q(room);
     }, function(err) {
@@ -2174,136 +2173,12 @@ MatrixClient.prototype.isLoggedIn = function() {
 /**
  * This is an internal method.
  * @param {MatrixClient} client
- * @param {integer} historyLen
- * @param {integer} includeArchived
- * @param {integer} attempt
  */
-function doInitialSync(client, historyLen, includeArchived, attempt) {
-    attempt = attempt || 1;
-    var qps = { limit: historyLen };
-    if (includeArchived) {
-        qps.archived = true;
-    }
-    if (client._guestRooms && client._isGuest) {
-        console.log(client._guestRooms);
-        qps.room_id = JSON.stringify(client._guestRooms);
-    }
-    client._http.authedRequest(
-        undefined, "GET", "/initialSync", qps
-    ).done(function(data) {
-        var i, j;
-        // intercept the results and put them into our store
-        if (!(client.store instanceof StubStore)) {
-            utils.forEach(
-                utils.map(data.presence, _PojoToMatrixEventMapper(client)),
-            function(e) {
-                var user = createNewUser(client, e.getContent().user_id);
-                user.setPresenceEvent(e);
-                client.store.storeUser(user);
-            });
-
-            // group receipts by room ID.
-            var receiptsByRoom = {};
-            data.receipts = data.receipts || [];
-            utils.forEach(data.receipts.map(_PojoToMatrixEventMapper(client)),
-                function(receiptEvent) {
-                    if (!receiptsByRoom[receiptEvent.getRoomId()]) {
-                        receiptsByRoom[receiptEvent.getRoomId()] = [];
-                    }
-                    receiptsByRoom[receiptEvent.getRoomId()].push(receiptEvent);
-                }
-            );
-
-            for (i = 0; i < data.rooms.length; i++) {
-                var room = createNewRoom(client, data.rooms[i].room_id);
-                if (!data.rooms[i].state) {
-                    data.rooms[i].state = [];
-                }
-                if (data.rooms[i].membership === "invite") {
-                    var inviteEvent = data.rooms[i].invite;
-                    if (!inviteEvent) {
-                        // fallback for servers which don't serve the invite key yet
-                        inviteEvent = {
-                            event_id: "$fake_" + room.roomId,
-                            content: {
-                                membership: "invite"
-                            },
-                            state_key: client.credentials.userId,
-                            user_id: data.rooms[i].inviter,
-                            room_id: room.roomId,
-                            type: "m.room.member"
-                        };
-                    }
-                    data.rooms[i].state.push(inviteEvent);
-                }
-
-                _processRoomEvents(
-                    client, room, data.rooms[i].state, data.rooms[i].messages
-                );
-
-                var receipts = receiptsByRoom[room.roomId] || [];
-                for (j = 0; j < receipts.length; j++) {
-                    room.addReceipt(receipts[j]);
-                }
-
-                var privateUserData = data.rooms[i].account_data || [];
-                var privateUserDataEvents =
-                    utils.map(privateUserData, _PojoToMatrixEventMapper(client));
-                for (j = 0; j < privateUserDataEvents.length; j++) {
-                    var event = privateUserDataEvents[j];
-                    if (event.getType() === "m.tag") {
-                        room.addTags(event);
-                    }
-                    // XXX: unhandled private user data event - we should probably
-                    // put it somewhere useful once the API has settled
-                }
-
-                // cache the name/summary/etc prior to storage since we don't
-                // know how the store will serialise the Room.
-                room.recalculate(client.credentials.userId);
-
-                client.store.storeRoom(room);
-                client.emit("Room", room);
-            }
-        }
-
-        if (data) {
-            client.store.setSyncToken(data.end);
-            var events = [];
-            for (i = 0; i < data.presence.length; i++) {
-                events.push(new MatrixEvent(data.presence[i]));
-            }
-            for (i = 0; i < data.rooms.length; i++) {
-                if (data.rooms[i].state) {
-                    for (j = 0; j < data.rooms[i].state.length; j++) {
-                        events.push(new MatrixEvent(data.rooms[i].state[j]));
-                    }
-                }
-                if (data.rooms[i].messages) {
-                    for (j = 0; j < data.rooms[i].messages.chunk.length; j++) {
-                        events.push(
-                            new MatrixEvent(data.rooms[i].messages.chunk[j])
-                        );
-                    }
-                }
-            }
-            utils.forEach(events, function(e) {
-                client.emit("event", e);
-            });
-        }
-
-        client.clientRunning = true;
-        updateSyncState(client, "PREPARED");
-        // assume success until we fail which may be 30+ secs
-        updateSyncState(client, "SYNCING");
-        _pollForEvents(client);
-    }, function(err) {
-        console.error("/initialSync error (%s attempts): %s", attempt, err);
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            doInitialSync(client, historyLen, includeArchived, attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
+function doSync(client) {
+    var syncApi = new SyncApi(client);
+    syncApi.sync({
+        historyLen: client._config.initialSyncLimit,
+        includeArchived: client._config.includeArchivedRooms
     });
 }
 
@@ -2352,249 +2227,11 @@ MatrixClient.prototype.startClient = function(opts) {
         this.uploadKeys(5);
     }
 
-    if (this.store.getSyncToken()) {
-        // resume from where we left off.
-        _pollForEvents(this);
-        return;
-    }
-
     // periodically poll for turn servers if we support voip
     checkTurnServers(this);
 
-    prepareForSync(this);
+    doSync(this);
 };
-
-function prepareForSync(client, attempt) {
-    if (client.isGuest()) {
-        // no push rules for guests
-        doInitialSync(
-            client,
-            client._config.initialSyncLimit,
-            client._config.includeArchivedRooms
-        );
-        return;
-    }
-
-    attempt = attempt || 1;
-    // we do push rules before syncing so when we gets events down we know immediately
-    // whether they are bing-worthy.
-    client.pushRules().done(function(result) {
-        client.pushRules = result;
-        doInitialSync(
-            client,
-            client._config.initialSyncLimit,
-            client._config.includeArchivedRooms
-        );
-    }, function(err) {
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            prepareForSync(client, attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
-    });
-}
-
-/**
- * This is an internal method.
- * @param {MatrixClient} client
- * @param {Number} attempt The attempt number
- */
-function _pollForEvents(client, attempt) {
-    attempt = attempt || 1;
-    var self = client;
-    if (!client.clientRunning) {
-        return;
-    }
-    var timeoutMs = client._config.pollTimeout;
-    if (attempt > 1) {
-        // we think the connection is dead. If it comes back up, we won't know
-        // about it till /events returns. If the timeout= is high, this could
-        // be a long time. Set it to 1 when doing retries.
-        timeoutMs = 1;
-    }
-    var discardResult = false;
-    var timeoutObj = setTimeout(function() {
-        discardResult = true;
-        console.error("/events request timed out.");
-        _pollForEvents(client);
-    }, timeoutMs + (20 * 1000)); // 20s buffer
-
-    var queryParams = {
-        from: client.store.getSyncToken(),
-        timeout: timeoutMs
-    };
-    if (client._guestRooms && client._isGuest) {
-        queryParams.room_id = client._guestRooms;
-    }
-
-    client._http.authedRequest(undefined, "GET", "/events", queryParams).done(
-    function(data) {
-        if (discardResult) {
-            return;
-        }
-        else {
-            clearTimeout(timeoutObj);
-        }
-
-        if (self._syncState !== "SYNCING") {
-            updateSyncState(self, "SYNCING");
-        }
-
-        try {
-            var events = [];
-            if (data) {
-                events = utils.map(data.chunk, _PojoToMatrixEventMapper(self));
-            }
-            if (!(self.store instanceof StubStore)) {
-                var roomIdsWithNewInvites = {};
-                // bucket events based on room.
-                var i = 0;
-                var roomIdToEvents = {};
-                for (i = 0; i < events.length; i++) {
-                    var roomId = events[i].getRoomId();
-                    // possible to have no room ID e.g. for presence events.
-                    if (roomId) {
-                        if (!roomIdToEvents[roomId]) {
-                            roomIdToEvents[roomId] = [];
-                        }
-                        roomIdToEvents[roomId].push(events[i]);
-                        if (events[i].getType() === "m.room.member" &&
-                                events[i].getContent().membership === "invite") {
-                            roomIdsWithNewInvites[roomId] = true;
-                        }
-                    }
-                    else if (events[i].getType() === "m.presence") {
-                        var usr = self.store.getUser(events[i].getContent().user_id);
-                        if (usr) {
-                            usr.setPresenceEvent(events[i]);
-                        }
-                        else {
-                            usr = createNewUser(self, events[i].getContent().user_id);
-                            usr.setPresenceEvent(events[i]);
-                            self.store.storeUser(usr);
-                        }
-                    }
-                }
-
-                // add events to room
-                var roomIds = utils.keys(roomIdToEvents);
-                utils.forEach(roomIds, function(roomId) {
-                    var room = self.store.getRoom(roomId);
-                    var isBrandNewRoom = false;
-                    if (!room) {
-                        room = createNewRoom(self, roomId);
-                        isBrandNewRoom = true;
-                    }
-
-                    var wasJoined = room.hasMembershipState(
-                        self.credentials.userId, "join"
-                    );
-
-                    room.addEvents(roomIdToEvents[roomId], "replace");
-                    room.recalculate(self.credentials.userId);
-
-                    // store the Room for things like invite events so developers
-                    // can update the UI
-                    if (isBrandNewRoom) {
-                        self.store.storeRoom(room);
-                        self.emit("Room", room);
-                    }
-
-                    var justJoined = room.hasMembershipState(
-                        self.credentials.userId, "join"
-                    );
-
-                    if (!wasJoined && justJoined) {
-                        // we've just transitioned into a join state for this room,
-                        // so sync state.
-                        _syncRoom(self, room);
-                    }
-                });
-
-                Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
-                    _resolveInvites(self, self.store.getRoom(inviteRoomId));
-                });
-            }
-            if (data) {
-                self.store.setSyncToken(data.end);
-                utils.forEach(events, function(e) {
-                    self.emit("event", e);
-                });
-            }
-        }
-        catch (e) {
-            console.error("Event stream error:");
-            console.error(e);
-        }
-        _pollForEvents(self);
-    }, function(err) {
-        console.error("/events error: %s", JSON.stringify(err));
-        if (discardResult) {
-            return;
-        }
-        else {
-            clearTimeout(timeoutObj);
-        }
-
-        attempt += 1;
-        startSyncingRetryTimer(self, attempt, function() {
-            _pollForEvents(self, attempt);
-        });
-        updateSyncState(self, "ERROR", { error: err });
-    });
-}
-
-function _syncRoom(client, room) {
-    if (client._syncingRooms[room.roomId]) {
-        return client._syncingRooms[room.roomId];
-    }
-    var defer = q.defer();
-    client._syncingRooms[room.roomId] = defer.promise;
-    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
-    function(res) {
-        room.timeline = []; // blow away any previous messages.
-        _processRoomEvents(client, room, res.state, res.messages);
-        room.recalculate(client.credentials.userId);
-        client.store.storeRoom(room);
-        client.emit("Room", room);
-        defer.resolve(room);
-        client._syncingRooms[room.roomId] = undefined;
-    }, function(err) {
-        defer.reject(err);
-        client._syncingRooms[room.roomId] = undefined;
-    });
-    return defer.promise;
-}
-
-function _processRoomEvents(client, room, stateEventList, messageChunk) {
-    // "old" and "current" state are the same initially; they
-    // start diverging if the user paginates.
-    // We must deep copy otherwise membership changes in old state
-    // will leak through to current state!
-    var oldStateEvents = utils.map(
-        utils.deepCopy(stateEventList), _PojoToMatrixEventMapper(client)
-    );
-    var stateEvents = utils.map(stateEventList, _PojoToMatrixEventMapper(client));
-    room.oldState.setStateEvents(oldStateEvents);
-    room.currentState.setStateEvents(stateEvents);
-
-    _resolveInvites(client, room);
-
-    // add events to the timeline *after* setting the state
-    // events so messages use the right display names. Initial sync
-    // returns messages in chronological order, so we need to reverse
-    // it to get most recent -> oldest. We need it in that order in
-    // order to diverge old/current state correctly.
-    room.addEventsToTimeline(
-        utils.map(
-            messageChunk ? messageChunk.chunk : [],
-            _PojoToMatrixEventMapper(client)
-        ).reverse(), true
-    );
-    if (messageChunk) {
-        room.oldState.paginationToken = messageChunk.start;
-    }
-}
 
 /**
  * High level helper method to stop the client from polling and allow a
@@ -2604,66 +2241,6 @@ MatrixClient.prototype.stopClient = function() {
     this.clientRunning = false;
     // TODO: f.e. Room => self.store.storeRoom(room) ?
 };
-
-
-function reEmit(reEmitEntity, emittableEntity, eventNames) {
-    utils.forEach(eventNames, function(eventName) {
-        // setup a listener on the entity (the Room, User, etc) for this event
-        emittableEntity.on(eventName, function() {
-            // take the args from the listener and reuse them, adding the
-            // event name to the arg list so it works with .emit()
-            // Transformation Example:
-            // listener on "foo" => function(a,b) { ... }
-            // Re-emit on "thing" => thing.emit("foo", a, b)
-            var newArgs = [eventName];
-            for (var i = 0; i < arguments.length; i++) {
-                newArgs.push(arguments[i]);
-            }
-            reEmitEntity.emit.apply(reEmitEntity, newArgs);
-        });
-    });
-}
-
-function _resolveInvites(client, room) {
-    if (!room || !client._config.resolveInvitesToProfiles) {
-        return;
-    }
-    // For each invited room member we want to give them a displayname/avatar url
-    // if they have one (the m.room.member invites don't contain this).
-    room.getMembersWithMembership("invite").forEach(function(member) {
-        if (member._requestedProfileInfo) {
-            return;
-        }
-        member._requestedProfileInfo = true;
-        // try to get a cached copy first.
-        var user = client.getUser(member.userId);
-        var promise;
-        if (user) {
-            promise = q({
-                avatar_url: user.avatarUrl,
-                displayname: user.displayName
-            });
-        }
-        else {
-            promise = client.getProfileInfo(member.userId);
-        }
-        promise.done(function(info) {
-            // slightly naughty by doctoring the invite event but this means all
-            // the code paths remain the same between invite/join display name stuff
-            // which is a worthy trade-off for some minor pollution.
-            var inviteEvent = member.events.member;
-            if (inviteEvent.getContent().membership !== "invite") {
-                // between resolving and now they have since joined, so don't clobber
-                return;
-            }
-            inviteEvent.getContent().avatar_url = info.avatar_url;
-            inviteEvent.getContent().displayname = info.displayname;
-            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
-        }, function(err) {
-            // OH WELL.
-        });
-    });
-}
 
 function setupCallEventHandler(client) {
     var candidatesByCall = {
@@ -2820,20 +2397,6 @@ function setupCallEventHandler(client) {
     });
 }
 
-function startSyncingRetryTimer(client, attempt, fn) {
-    client._syncingRetry = {};
-    client._syncingRetry.fn = fn;
-    client._syncingRetry.timeoutId = setTimeout(function() {
-        fn();
-    }, retryTimeMsForAttempt(attempt));
-}
-
-function updateSyncState(client, newState, data) {
-    var old = client._syncState;
-    client._syncState = newState;
-    client.emit("sync", client._syncState, old, data);
-}
-
 function checkTurnServers(client) {
     if (!client._supportsVoip) {
         return;
@@ -2859,37 +2422,6 @@ function checkTurnServers(client) {
         console.error("Failed to get TURN URIs");
         setTimeout(function() { checkTurnServers(client); }, 60000);
     });
-}
-
-function createNewUser(client, userId) {
-    var user = new User(userId);
-    reEmit(client, user, ["User.avatarUrl", "User.displayName", "User.presence"]);
-    return user;
-}
-
-function createNewRoom(client, roomId) {
-    var room = new Room(roomId, {
-        pendingEventOrdering: client._config.pendingEventOrdering
-    });
-    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
-
-    // we need to also re-emit room state and room member events, so hook it up
-    // to the client now. We need to add a listener for RoomState.members in
-    // order to hook them correctly. (TODO: find a better way?)
-    reEmit(client, room.currentState, [
-        "RoomState.events", "RoomState.members", "RoomState.newMember"
-    ]);
-    room.currentState.on("RoomState.newMember", function(event, state, member) {
-        member.user = client.getUser(member.userId);
-        reEmit(
-            client, member,
-            [
-                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
-                "RoomMember.membership"
-            ]
-        );
-    });
-    return room;
 }
 
 function retryTimeMsForAttempt(attempt) {
@@ -2970,7 +2502,8 @@ MatrixClient.prototype.generateClientSecret = function() {
 module.exports.MatrixClient = MatrixClient;
 /** */
 module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
-
+/** */
+module.exports.EventMapper = _PojoToMatrixEventMapper;
 
 // MatrixClient Event JSDocs
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -2502,7 +2502,7 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * a state of SYNCING. <i>This is the equivalent of "syncComplete" in the
  * previous API.</i></li>
  * <li>SYNCING : The client is currently polling for new events from the server.
- * The client may fire this before or after processing latest events from a sync.</li>
+ * This will be called <i>after</i> processing latest events from a sync.</li>
  * <li>ERROR : The client has had a problem syncing with the server. If this is
  * called <i>before</i> PREPARED then there was a problem performing the initial
  * sync. If this is called <i>after</i> PREPARED then there was a problem polling
@@ -2523,7 +2523,7 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * Transitions:
  * <ul>
  * <li><code>null -> PREPARED</code> : Occurs when the initial sync is completed
- * first time.
+ * first time. This involves setting up filters and obtaining push rules.
  * <li><code>null -> ERROR</code> : Occurs when the initial sync failed first time.
  * <li><code>ERROR -> PREPARED</code> : Occurs when the initial sync succeeds
  * after previously failing.
@@ -2535,6 +2535,8 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * live update after having previously failed.
  * <li><code>ERROR -> ERROR</code> : Occurs when the client has failed to sync
  * for a second time or more.</li>
+ * <li><code>SYNCING -> SYNCING</code> : Occurs when the client has performed a live
+ * update. This is called <i>after</i> processing.</li>
  * </ul>
  *
  * @event module:client~MatrixClient#"sync"

--- a/lib/client.js
+++ b/lib/client.js
@@ -2172,18 +2172,6 @@ MatrixClient.prototype.isLoggedIn = function() {
 
 
 /**
- * This is an internal method.
- * @param {MatrixClient} client
- */
-function doSync(client) {
-    var syncApi = new SyncApi(client);
-    syncApi.sync({
-        historyLen: client._config.initialSyncLimit,
-        includeArchived: client._config.includeArchivedRooms
-    });
-}
-
-/**
  * High level helper method to call initialSync, emit the resulting events,
  * and then start polling the eventStream for new events. To listen for these
  * events, add a listener for {@link module:client~MatrixClient#event:"event"}
@@ -2231,7 +2219,11 @@ MatrixClient.prototype.startClient = function(opts) {
     // periodically poll for turn servers if we support voip
     checkTurnServers(this);
 
-    doSync(this);
+    var syncApi = new SyncApi(this);
+    syncApi.sync({
+        historyLen: this._config.initialSyncLimit,
+        includeArchived: this._config.includeArchivedRooms
+    });
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -2451,6 +2451,9 @@ function _PojoToMatrixEventMapper(client) {
     return mapper;
 }
 
+/**
+ * @return {Function}
+ */
 MatrixClient.prototype.getEventMapper = function() {
     return _PojoToMatrixEventMapper(this);
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -138,9 +138,6 @@ function MatrixClient(opts) {
         userId: (opts.userId || null)
     };
     this._http = new httpApi.MatrixHttpApi(httpOpts);
-    this._syncingRooms = {
-        // room_id: Promise
-    };
     this.callList = {
         // callId: MatrixCall
     };
@@ -620,7 +617,8 @@ MatrixClient.prototype.joinRoom = function(roomIdOrAlias, opts, callback) {
         var syncApi = new SyncApi(self);
         var room = syncApi.createRoom(roomId);
         if (opts.syncRoom) {
-            return syncApi.syncRoom(room);
+            // v2 will do this for us
+            // return syncApi.syncRoom(room);
         }
         return q(room);
     }, function(err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,9 +31,6 @@ try {
     // Olm not installed.
 }
 
-// TODO:
-// Internal: rate limiting
-
 var OLM_ALGORITHM = "m.olm.v1.curve25519-aes-sha2";
 
 /**
@@ -147,7 +144,6 @@ function MatrixClient(opts) {
     this.callList = {
         // callId: MatrixCall
     };
-    this._config = {}; // see startClient()
 
     // try constructing a MatrixCall to see if we are running in an environment
     // which has WebRTC. If we are, listen for and handle m.call.* events.
@@ -2197,20 +2193,13 @@ MatrixClient.prototype.startClient = function(opts) {
         // client is already running.
         return;
     }
+    this.clientRunning = true;
     // backwards compat for when 'opts' was 'historyLen'.
     if (typeof opts === "number") {
         opts = {
             initialSyncLimit: opts
         };
     }
-
-    opts = opts || {};
-    opts.initialSyncLimit = opts.initialSyncLimit || 8;
-    opts.includeArchivedRooms = opts.includeArchivedRooms || false;
-    opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
-    opts.pollTimeout = opts.pollTimeout || (30 * 1000);
-    opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
-    this._config = opts;
 
     if (CRYPTO_ENABLED && this.sessionStore !== null) {
         this.uploadKeys(5);
@@ -2219,11 +2208,8 @@ MatrixClient.prototype.startClient = function(opts) {
     // periodically poll for turn servers if we support voip
     checkTurnServers(this);
 
-    var syncApi = new SyncApi(this);
-    syncApi.sync({
-        historyLen: this._config.initialSyncLimit,
-        includeArchived: this._config.includeArchivedRooms
-    });
+    var syncApi = new SyncApi(this, opts);
+    syncApi.sync();
 };
 
 /**
@@ -2233,6 +2219,7 @@ MatrixClient.prototype.startClient = function(opts) {
 MatrixClient.prototype.stopClient = function() {
     this.clientRunning = false;
     // TODO: f.e. Room => self.store.storeRoom(room) ?
+    // TODO: Actually stop the SyncApi
 };
 
 function setupCallEventHandler(client) {

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -242,6 +242,8 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {Object} queryParams A dict of query params (these will NOT be
      * urlencoded).
      * @param {Object} data The HTTP JSON body.
+     * @param {Number=} localTimeoutMs The maximum amount of time to wait before
+     * timing out the request. If not specified, there is no timeout.
      * @return {module:client.Promise} Resolves to <code>{data: {Object},
      * headers: {Object}, code: {Number}}</code>.
      * If <code>onlyData</code> is set, this will resolve to the <code>data</code>
@@ -249,10 +251,10 @@ module.exports.MatrixHttpApi.prototype = {
      * @return {module:http-api.MatrixError} Rejects with an error if a problem
      * occurred. This includes network problems and Matrix-specific error JSON.
      */
-    authedRequest: function(callback, method, path, queryParams, data) {
+    authedRequest: function(callback, method, path, queryParams, data, localTimeoutMs) {
         if (!queryParams) { queryParams = {}; }
         queryParams.access_token = this.opts.accessToken;
-        return this.request(callback, method, path, queryParams, data);
+        return this.request(callback, method, path, queryParams, data, localTimeoutMs);
     },
 
     /**
@@ -265,6 +267,8 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {Object} queryParams A dict of query params (these will NOT be
      * urlencoded).
      * @param {Object} data The HTTP JSON body.
+     * @param {Number=} localTimeoutMs The maximum amount of time to wait before
+     * timing out the request. If not specified, there is no timeout.
      * @return {module:client.Promise} Resolves to <code>{data: {Object},
      * headers: {Object}, code: {Number}}</code>.
      * If <code>onlyData</code> is set, this will resolve to the <code>data</code>
@@ -272,9 +276,9 @@ module.exports.MatrixHttpApi.prototype = {
      * @return {module:http-api.MatrixError} Rejects with an error if a problem
      * occurred. This includes network problems and Matrix-specific error JSON.
      */
-    request: function(callback, method, path, queryParams, data) {
+    request: function(callback, method, path, queryParams, data, localTimeoutMs) {
         return this.requestWithPrefix(
-            callback, method, path, queryParams, data, this.opts.prefix
+            callback, method, path, queryParams, data, this.opts.prefix, localTimeoutMs
         );
     },
 
@@ -292,6 +296,8 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {Object} data The HTTP JSON body.
      * @param {string} prefix The full prefix to use e.g.
      * "/_matrix/client/v2_alpha".
+     * @param {Number=} localTimeoutMs The maximum amount of time to wait before
+     * timing out the request. If not specified, there is no timeout.
      * @return {module:client.Promise} Resolves to <code>{data: {Object},
      * headers: {Object}, code: {Number}}</code>.
      * If <code>onlyData</code> is set, this will resolve to the <code>data</code>
@@ -300,13 +306,15 @@ module.exports.MatrixHttpApi.prototype = {
      * occurred. This includes network problems and Matrix-specific error JSON.
      */
     authedRequestWithPrefix: function(callback, method, path, queryParams, data,
-                                      prefix) {
+                                      prefix, localTimeoutMs) {
         var fullUri = this.opts.baseUrl + prefix + path;
         if (!queryParams) {
             queryParams = {};
         }
         queryParams.access_token = this.opts.accessToken;
-        return this._request(callback, method, fullUri, queryParams, data);
+        return this._request(
+            callback, method, fullUri, queryParams, data, localTimeoutMs
+        );
     },
 
     /**
@@ -323,6 +331,8 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {Object} data The HTTP JSON body.
      * @param {string} prefix The full prefix to use e.g.
      * "/_matrix/client/v2_alpha".
+     * @param {Number=} localTimeoutMs The maximum amount of time to wait before
+     * timing out the request. If not specified, there is no timeout.
      * @return {module:client.Promise} Resolves to <code>{data: {Object},
      * headers: {Object}, code: {Number}}</code>.
      * If <code>onlyData</code> is set, this will resolve to the <code>data</code>
@@ -330,12 +340,15 @@ module.exports.MatrixHttpApi.prototype = {
      * @return {module:http-api.MatrixError} Rejects with an error if a problem
      * occurred. This includes network problems and Matrix-specific error JSON.
      */
-    requestWithPrefix: function(callback, method, path, queryParams, data, prefix) {
+    requestWithPrefix: function(callback, method, path, queryParams, data, prefix,
+                                localTimeoutMs) {
         var fullUri = this.opts.baseUrl + prefix + path;
         if (!queryParams) {
             queryParams = {};
         }
-        return this._request(callback, method, fullUri, queryParams, data);
+        return this._request(
+            callback, method, fullUri, queryParams, data, localTimeoutMs
+        );
     },
 
     /**
@@ -357,12 +370,13 @@ module.exports.MatrixHttpApi.prototype = {
         return this.opts.baseUrl + prefix + path + queryString;
     },
 
-    _request: function(callback, method, uri, queryParams, data) {
+    _request: function(callback, method, uri, queryParams, data, localTimeoutMs) {
         if (callback !== undefined && !utils.isFunction(callback)) {
             throw Error(
                 "Expected callback to be a function but got " + typeof callback
             );
         }
+        var self = this;
         if (!queryParams) {
             queryParams = {};
         }
@@ -373,6 +387,20 @@ module.exports.MatrixHttpApi.prototype = {
             }
         }
         var defer = q.defer();
+
+        var timeoutId;
+        var timedOut = false;
+        if (localTimeoutMs) {
+            timeoutId = setTimeout(function() {
+                timedOut = true;
+                defer.reject(new module.exports.MatrixError({
+                    error: "Locally timed out waiting for a response",
+                    errcode: "ORG_MATRIX_JSSDK_TIMEOUT",
+                    timeout: localTimeoutMs
+                }));
+            }, localTimeoutMs);
+        }
+
         try {
             this.opts.request(
                 {
@@ -384,7 +412,16 @@ module.exports.MatrixHttpApi.prototype = {
                     json: true,
                     _matrix_opts: this.opts
                 },
-                requestCallback(defer, callback, this.opts.onlyData)
+                function(err, response, body) {
+                    if (localTimeoutMs) {
+                        clearTimeout(timeoutId);
+                        if (timedOut) {
+                            return; // already rejected promise
+                        }
+                    }
+                    var handlerFn = requestCallback(defer, callback, self.opts.onlyData);
+                    handlerFn(err, response, body);
+                }
             );
         }
         catch (ex) {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -81,7 +81,9 @@ module.exports.createClient = function(opts) {
         };
     }
     opts.request = opts.request || request;
-    opts.store = opts.store || new module.exports.MatrixInMemoryStore();
+    opts.store = opts.store || new module.exports.MatrixInMemoryStore({
+      localStorage: global.localStorage
+    });
     opts.scheduler = opts.scheduler || new module.exports.MatrixScheduler();
     return new module.exports.MatrixClient(opts);
 };

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -143,10 +143,7 @@ module.exports.MatrixEvent.prototype = {
      * @return {Number} The age of this event in milliseconds.
      */
     getAge: function() {
-        if (this.event.unsigned && this.event.unsigned.age) {
-            return this.event.unsigned.age; // v2
-        }
-        return this.event.age; // v1
+        return this.getUnsigned().age || this.event.age; // v2 / v1
     },
 
     /**
@@ -172,5 +169,9 @@ module.exports.MatrixEvent.prototype = {
      */
     isEncrypted: function() {
         return this.encrypted;
+    },
+
+    getUnsigned: function() {
+        return this.event.unsigned || {};
     }
 };

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -63,7 +63,7 @@ module.exports.MatrixEvent.prototype = {
      * @return {string} The user ID, e.g. <code>@alice:matrix.org</code>
      */
     getSender: function() {
-        return this.event.user_id;
+        return this.event.sender || this.event.user_id; // v2 / v1
     },
 
     /**

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -143,7 +143,10 @@ module.exports.MatrixEvent.prototype = {
      * @return {Number} The age of this event in milliseconds.
      */
     getAge: function() {
-        return this.event.age;
+        if (this.event.unsigned && this.event.unsigned.age) {
+            return this.event.unsigned.age; // v2
+        }
+        return this.event.age; // v1
     },
 
     /**

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -79,6 +79,7 @@ function Room(roomId, opts) {
     this.storageToken = opts.storageToken;
     this._opts = opts;
     this._redactions = [];
+    this._txnToEvent = {}; // Pending in-flight requests { string: MatrixEvent }
     // receipts should clobber based on receipt_type and user_id pairs hence
     // the form of this structure. This is sub-optimal for the exposed APIs
     // which pass in an event ID and get back some receipts, so we also store
@@ -210,6 +211,23 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline) {
                 events[i].status === EventStatus.QUEUED
             )
         );
+
+        // FIXME: HORRIBLE ASSUMPTION THAT THIS PROP EXISTS
+        // Exists due to client.js:815 (MatrixClient.sendEvent)
+        // We should make txnId a first class citizen.
+        if (!toStartOfTimeline && events[i]._txnId) {
+            this._txnToEvent[events[i]._txnId] = events[i];
+        }
+        else if(!toStartOfTimeline && events[i].getUnsigned().transaction_id) {
+            var existingEvent = this._txnToEvent[events[i].getUnsigned().transaction_id];
+            if (existingEvent) {
+                // no longer pending
+                delete this._txnToEvent[events[i].getUnsigned().transaction_id];
+                // replace the event source
+                existingEvent.event = events[i].event;
+                continue;
+            }
+        }
 
         setEventMetadata(events[i], stateContext, toStartOfTimeline);
         // modify state

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -218,7 +218,7 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline) {
         if (!toStartOfTimeline && events[i]._txnId) {
             this._txnToEvent[events[i]._txnId] = events[i];
         }
-        else if(!toStartOfTimeline && events[i].getUnsigned().transaction_id) {
+        else if (!toStartOfTimeline && events[i].getUnsigned().transaction_id) {
             var existingEvent = this._txnToEvent[events[i].getUnsigned().transaction_id];
             if (existingEvent) {
                 // no longer pending

--- a/lib/pushprocessor.js
+++ b/lib/pushprocessor.js
@@ -195,7 +195,7 @@ function PushProcessor(client) {
     };
 
     var matchingRuleForEventWithRulesets = function(ev, rulesets) {
-        if (!rulesets) { return null; }
+        if (!rulesets || !rulesets.device) { return null; }
         if (ev.user_id == client.credentials.userId) { return null; }
 
         var allDevNames = Object.keys(rulesets.device);

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -159,7 +159,7 @@ module.exports.MatrixInMemoryStore.prototype = {
         try {
             return this.localStorage.getItem("mxjssdk_memory_filter_" + filterName);
         }
-        catch(e) {}
+        catch (e) {}
         return null;
     },
 

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -8,8 +8,13 @@
 /**
  * Construct a new in-memory data store for the Matrix Client.
  * @constructor
+ * @param {Object=} opts Config options
+ * @param {LocalStorage} opts.localStorage The local storage instance to persist some forms
+ * of data such as tokens. Rooms will NOT be stored. See {@link WebStorageStore} to
+ * persist rooms.
  */
-module.exports.MatrixInMemoryStore = function MatrixInMemoryStore() {
+module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
+    opts = opts || {};
     this.rooms = {
         // roomId: Room
     };
@@ -22,6 +27,7 @@ module.exports.MatrixInMemoryStore = function MatrixInMemoryStore() {
         //    filterId: Filter
         // }
     };
+    this.localStorage = opts.localStorage;
 };
 
 module.exports.MatrixInMemoryStore.prototype = {
@@ -139,6 +145,37 @@ module.exports.MatrixInMemoryStore.prototype = {
             return null;
         }
         return this.filters[userId][filterId];
+    },
+
+    /**
+     * Retrieve a filter ID with the given name.
+     * @param {string} filterName The filter name.
+     * @return {?string} The filter ID or null.
+     */
+    getFilterIdByName: function(filterName) {
+        if (!this.localStorage) {
+            return null;
+        }
+        try {
+            return this.localStorage.getItem("mxjssdk_memory_filter_" + filterName);
+        }
+        catch(e) {}
+        return null;
+    },
+
+    /**
+     * Set a filter name to ID mapping.
+     * @param {string} filterName
+     * @param {string} filterId
+     */
+    setFilterIdByName: function(filterName, filterId) {
+        if (!this.localStorage) {
+            return;
+        }
+        try {
+            this.localStorage.setItem("mxjssdk_memory_filter_" + filterName, filterId);
+        }
+        catch (e) {}
     }
 
     // TODO

--- a/lib/store/memory.js
+++ b/lib/store/memory.js
@@ -9,9 +9,9 @@
  * Construct a new in-memory data store for the Matrix Client.
  * @constructor
  * @param {Object=} opts Config options
- * @param {LocalStorage} opts.localStorage The local storage instance to persist some forms
- * of data such as tokens. Rooms will NOT be stored. See {@link WebStorageStore} to
- * persist rooms.
+ * @param {LocalStorage} opts.localStorage The local storage instance to persist
+ * some forms of data such as tokens. Rooms will NOT be stored. See
+ * {@link WebStorageStore} to persist rooms.
  */
 module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
     opts = opts || {};

--- a/lib/store/stub.js
+++ b/lib/store/stub.js
@@ -113,6 +113,15 @@ StubStore.prototype = {
      */
     getFilter: function(userId, filterId) {
         return null;
+    },
+
+    /**
+     * Retrieve a filter ID with the given name.
+     * @param {string} filterName The filter name.
+     * @return {?string} The filter ID or null.
+     */
+    getFilterIdByName: function(filterName) {
+        return null;
     }
 
     // TODO

--- a/lib/store/stub.js
+++ b/lib/store/stub.js
@@ -122,6 +122,15 @@ StubStore.prototype = {
      */
     getFilterIdByName: function(filterName) {
         return null;
+    },
+
+    /**
+     * Set a filter name to ID mapping.
+     * @param {string} filterName
+     * @param {string} filterId
+     */
+    setFilterIdByName: function(filterName, filterId) {
+
     }
 
     // TODO

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -161,7 +161,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     }
 
     if (client._guestRooms && client._isGuest) {
-        qps.room_id = JSON.stringify(client._guestRooms);
+        qps.room_id = client._guestRooms;
     }
 
     // Set up local timer and error handler for retries.

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -277,10 +277,18 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 var room = joinObj.room;
                 var stateEvents = self._mapSyncEventsFormat(joinObj.state, room);
                 var timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room);
+                var ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
+                var accountDataEvents = self._mapSyncEventsFormat(joinObj.account_data);
+
+                if (joinObj.timeline.limited) {
+                    // nuke the timeline so we don't get holes
+                    room.timeline = [];
+                }
                 self._processRoomEvents(
                     room, stateEvents, timelineEvents, joinObj.timeline.prev_batch
                 );
-                // TODO: Receipts, Typing, Tags from ephermeral + account_data
+                room.addEvents(ephemeralEvents);
+                room.addEvents(accountDataEvents);
                 room.recalculate(client.credentials.userId);
                 if (joinObj.isBrandNewRoom) {
                     client.store.storeRoom(room);
@@ -296,57 +304,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             console.error("Caught /sync error:");
             console.error(e);
         }
-
-        /*
-        var i, j;
-        // intercept the results and put them into our store
-        if (!(client.store instanceof StubStore)) {
-            // group receipts by room ID.
-            var receiptsByRoom = {};
-            data.receipts = data.receipts || [];
-            utils.forEach(data.receipts.map(client.getEventMapper()),
-                function(receiptEvent) {
-                    if (!receiptsByRoom[receiptEvent.getRoomId()]) {
-                        receiptsByRoom[receiptEvent.getRoomId()] = [];
-                    }
-                    receiptsByRoom[receiptEvent.getRoomId()].push(receiptEvent);
-                }
-            );
-
-            for (i = 0; i < data.rooms.length; i++) {
-
-                _processRoomEvents(
-                    client, room, data.rooms[i].state, data.rooms[i].messages
-                );
-
-                var receipts = receiptsByRoom[room.roomId] || [];
-                for (j = 0; j < receipts.length; j++) {
-                    room.addReceipt(receipts[j]);
-                }
-
-                var privateUserData = data.rooms[i].account_data || [];
-                var privateUserDataEvents =
-                    utils.map(privateUserData, client.getEventMapper());
-                for (j = 0; j < privateUserDataEvents.length; j++) {
-                    var event = privateUserDataEvents[j];
-                    if (event.getType() === "m.tag") {
-                        room.addTags(event);
-                    }
-                    // XXX: unhandled private user data event - we should probably
-                    // put it somewhere useful once the API has settled
-                }
-
-                // cache the name/summary/etc prior to storage since we don't
-                // know how the store will serialise the Room.
-                room.recalculate(client.credentials.userId);
-
-                client.store.storeRoom(room);
-                client.emit("Room", room);
-            }
-        }
-
-        */
-
         
         // emit synced events
         if (!syncOptions.hasSyncedBefore) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -180,6 +180,7 @@ function _resolveInvites(client, room) {
 /**
  * <b>Internal class - unstable.</b>
  * Construct an entity which is able to sync with a homeserver.
+ * @constructor
  * @param {MatrixClient} client The matrix client instance to use.
  */
 function SyncApi(client) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,168 +15,6 @@ var Room = require("./models/room");
 var utils = require("./utils");
 var MatrixEvent = require("./models/event").MatrixEvent;
 
-function retryTimeMsForAttempt(attempt) {
-    // 2,4,8,16,32,64,128,128,128,... seconds
-    // max 2^7 secs = 2.1 mins
-    return Math.pow(2, Math.min(attempt, 7)) * 1000;
-}
-
-function startSyncingRetryTimer(client, attempt, fn) {
-    client._syncingRetry = {};
-    client._syncingRetry.fn = fn;
-    client._syncingRetry.timeoutId = setTimeout(function() {
-        fn();
-    }, retryTimeMsForAttempt(attempt));
-}
-
-function updateSyncState(client, newState, data) {
-    var old = client._syncState;
-    client._syncState = newState;
-    client.emit("sync", client._syncState, old, data);
-}
-
-function createNewUser(client, userId) {
-    var user = new User(userId);
-    reEmit(client, user, ["User.avatarUrl", "User.displayName", "User.presence"]);
-    return user;
-}
-
-function createNewRoom(client, roomId) {
-    var room = new Room(roomId, {
-        pendingEventOrdering: client._config.pendingEventOrdering
-    });
-    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
-
-    // we need to also re-emit room state and room member events, so hook it up
-    // to the client now. We need to add a listener for RoomState.members in
-    // order to hook them correctly. (TODO: find a better way?)
-    reEmit(client, room.currentState, [
-        "RoomState.events", "RoomState.members", "RoomState.newMember"
-    ]);
-    room.currentState.on("RoomState.newMember", function(event, state, member) {
-        member.user = client.getUser(member.userId);
-        reEmit(
-            client, member,
-            [
-                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
-                "RoomMember.membership"
-            ]
-        );
-    });
-    return room;
-}
-
-function reEmit(reEmitEntity, emittableEntity, eventNames) {
-    utils.forEach(eventNames, function(eventName) {
-        // setup a listener on the entity (the Room, User, etc) for this event
-        emittableEntity.on(eventName, function() {
-            // take the args from the listener and reuse them, adding the
-            // event name to the arg list so it works with .emit()
-            // Transformation Example:
-            // listener on "foo" => function(a,b) { ... }
-            // Re-emit on "thing" => thing.emit("foo", a, b)
-            var newArgs = [eventName];
-            for (var i = 0; i < arguments.length; i++) {
-                newArgs.push(arguments[i]);
-            }
-            reEmitEntity.emit.apply(reEmitEntity, newArgs);
-        });
-    });
-}
-
-function _syncRoom(client, room) {
-    if (client._syncingRooms[room.roomId]) {
-        return client._syncingRooms[room.roomId];
-    }
-    var defer = q.defer();
-    client._syncingRooms[room.roomId] = defer.promise;
-    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
-    function(res) {
-        room.timeline = []; // blow away any previous messages.
-        _processRoomEvents(client, room, res.state, res.messages);
-        room.recalculate(client.credentials.userId);
-        client.store.storeRoom(room);
-        client.emit("Room", room);
-        defer.resolve(room);
-        client._syncingRooms[room.roomId] = undefined;
-    }, function(err) {
-        defer.reject(err);
-        client._syncingRooms[room.roomId] = undefined;
-    });
-    return defer.promise;
-}
-
-function _processRoomEvents(client, room, stateEventList, messageChunk) {
-    // "old" and "current" state are the same initially; they
-    // start diverging if the user paginates.
-    // We must deep copy otherwise membership changes in old state
-    // will leak through to current state!
-    var oldStateEvents = utils.map(
-        utils.deepCopy(stateEventList), client.getEventMapper()
-    );
-    var stateEvents = utils.map(stateEventList, client.getEventMapper());
-    room.oldState.setStateEvents(oldStateEvents);
-    room.currentState.setStateEvents(stateEvents);
-
-    _resolveInvites(client, room);
-
-    // add events to the timeline *after* setting the state
-    // events so messages use the right display names. Initial sync
-    // returns messages in chronological order, so we need to reverse
-    // it to get most recent -> oldest. We need it in that order in
-    // order to diverge old/current state correctly.
-    room.addEventsToTimeline(
-        utils.map(
-            messageChunk ? messageChunk.chunk : [],
-            client.getEventMapper()
-        ).reverse(), true
-    );
-    if (messageChunk) {
-        room.oldState.paginationToken = messageChunk.start;
-    }
-}
-
-function _resolveInvites(client, room) {
-    if (!room || !client._config.resolveInvitesToProfiles) {
-        return;
-    }
-    // For each invited room member we want to give them a displayname/avatar url
-    // if they have one (the m.room.member invites don't contain this).
-    room.getMembersWithMembership("invite").forEach(function(member) {
-        if (member._requestedProfileInfo) {
-            return;
-        }
-        member._requestedProfileInfo = true;
-        // try to get a cached copy first.
-        var user = client.getUser(member.userId);
-        var promise;
-        if (user) {
-            promise = q({
-                avatar_url: user.avatarUrl,
-                displayname: user.displayName
-            });
-        }
-        else {
-            promise = client.getProfileInfo(member.userId);
-        }
-        promise.done(function(info) {
-            // slightly naughty by doctoring the invite event but this means all
-            // the code paths remain the same between invite/join display name stuff
-            // which is a worthy trade-off for some minor pollution.
-            var inviteEvent = member.events.member;
-            if (inviteEvent.getContent().membership !== "invite") {
-                // between resolving and now they have since joined, so don't clobber
-                return;
-            }
-            inviteEvent.getContent().avatar_url = info.avatar_url;
-            inviteEvent.getContent().displayname = info.displayname;
-            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
-        }, function(err) {
-            // OH WELL.
-        });
-    });
-}
-
 /**
  * <b>Internal class - unstable.</b>
  * Construct an entity which is able to sync with a homeserver.
@@ -205,6 +43,7 @@ SyncApi.prototype.syncRoom = function(room) {
 };
 
 /**
+ * Main entry point
  * @param {Object} opts
  * @param {Number} opts.historyLen
  * @param {Boolean} opts.includeArchived
@@ -531,6 +370,170 @@ SyncApi.prototype._pollForEvents = function(attempt) {
         updateSyncState(client, "ERROR", { error: err });
     });
 };
+
+
+
+function retryTimeMsForAttempt(attempt) {
+    // 2,4,8,16,32,64,128,128,128,... seconds
+    // max 2^7 secs = 2.1 mins
+    return Math.pow(2, Math.min(attempt, 7)) * 1000;
+}
+
+function startSyncingRetryTimer(client, attempt, fn) {
+    client._syncingRetry = {};
+    client._syncingRetry.fn = fn;
+    client._syncingRetry.timeoutId = setTimeout(function() {
+        fn();
+    }, retryTimeMsForAttempt(attempt));
+}
+
+function updateSyncState(client, newState, data) {
+    var old = client._syncState;
+    client._syncState = newState;
+    client.emit("sync", client._syncState, old, data);
+}
+
+function createNewUser(client, userId) {
+    var user = new User(userId);
+    reEmit(client, user, ["User.avatarUrl", "User.displayName", "User.presence"]);
+    return user;
+}
+
+function createNewRoom(client, roomId) {
+    var room = new Room(roomId, {
+        pendingEventOrdering: client._config.pendingEventOrdering
+    });
+    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
+
+    // we need to also re-emit room state and room member events, so hook it up
+    // to the client now. We need to add a listener for RoomState.members in
+    // order to hook them correctly. (TODO: find a better way?)
+    reEmit(client, room.currentState, [
+        "RoomState.events", "RoomState.members", "RoomState.newMember"
+    ]);
+    room.currentState.on("RoomState.newMember", function(event, state, member) {
+        member.user = client.getUser(member.userId);
+        reEmit(
+            client, member,
+            [
+                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
+                "RoomMember.membership"
+            ]
+        );
+    });
+    return room;
+}
+
+function reEmit(reEmitEntity, emittableEntity, eventNames) {
+    utils.forEach(eventNames, function(eventName) {
+        // setup a listener on the entity (the Room, User, etc) for this event
+        emittableEntity.on(eventName, function() {
+            // take the args from the listener and reuse them, adding the
+            // event name to the arg list so it works with .emit()
+            // Transformation Example:
+            // listener on "foo" => function(a,b) { ... }
+            // Re-emit on "thing" => thing.emit("foo", a, b)
+            var newArgs = [eventName];
+            for (var i = 0; i < arguments.length; i++) {
+                newArgs.push(arguments[i]);
+            }
+            reEmitEntity.emit.apply(reEmitEntity, newArgs);
+        });
+    });
+}
+
+function _syncRoom(client, room) {
+    if (client._syncingRooms[room.roomId]) {
+        return client._syncingRooms[room.roomId];
+    }
+    var defer = q.defer();
+    client._syncingRooms[room.roomId] = defer.promise;
+    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
+    function(res) {
+        room.timeline = []; // blow away any previous messages.
+        _processRoomEvents(client, room, res.state, res.messages);
+        room.recalculate(client.credentials.userId);
+        client.store.storeRoom(room);
+        client.emit("Room", room);
+        defer.resolve(room);
+        client._syncingRooms[room.roomId] = undefined;
+    }, function(err) {
+        defer.reject(err);
+        client._syncingRooms[room.roomId] = undefined;
+    });
+    return defer.promise;
+}
+
+function _processRoomEvents(client, room, stateEventList, messageChunk) {
+    // "old" and "current" state are the same initially; they
+    // start diverging if the user paginates.
+    // We must deep copy otherwise membership changes in old state
+    // will leak through to current state!
+    var oldStateEvents = utils.map(
+        utils.deepCopy(stateEventList), client.getEventMapper()
+    );
+    var stateEvents = utils.map(stateEventList, client.getEventMapper());
+    room.oldState.setStateEvents(oldStateEvents);
+    room.currentState.setStateEvents(stateEvents);
+
+    _resolveInvites(client, room);
+
+    // add events to the timeline *after* setting the state
+    // events so messages use the right display names. Initial sync
+    // returns messages in chronological order, so we need to reverse
+    // it to get most recent -> oldest. We need it in that order in
+    // order to diverge old/current state correctly.
+    room.addEventsToTimeline(
+        utils.map(
+            messageChunk ? messageChunk.chunk : [],
+            client.getEventMapper()
+        ).reverse(), true
+    );
+    if (messageChunk) {
+        room.oldState.paginationToken = messageChunk.start;
+    }
+}
+
+function _resolveInvites(client, room) {
+    if (!room || !client._config.resolveInvitesToProfiles) {
+        return;
+    }
+    // For each invited room member we want to give them a displayname/avatar url
+    // if they have one (the m.room.member invites don't contain this).
+    room.getMembersWithMembership("invite").forEach(function(member) {
+        if (member._requestedProfileInfo) {
+            return;
+        }
+        member._requestedProfileInfo = true;
+        // try to get a cached copy first.
+        var user = client.getUser(member.userId);
+        var promise;
+        if (user) {
+            promise = q({
+                avatar_url: user.avatarUrl,
+                displayname: user.displayName
+            });
+        }
+        else {
+            promise = client.getProfileInfo(member.userId);
+        }
+        promise.done(function(info) {
+            // slightly naughty by doctoring the invite event but this means all
+            // the code paths remain the same between invite/join display name stuff
+            // which is a worthy trade-off for some minor pollution.
+            var inviteEvent = member.events.member;
+            if (inviteEvent.getContent().membership !== "invite") {
+                // between resolving and now they have since joined, so don't clobber
+                return;
+            }
+            inviteEvent.getContent().avatar_url = info.avatar_url;
+            inviteEvent.getContent().displayname = info.displayname;
+            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
+        }, function(err) {
+            // OH WELL.
+        });
+    });
+}
 
 /** */
 module.exports = SyncApi;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -8,13 +8,18 @@
  * an alternative syncing API, we may want to have a proper syncing interface
  * for HTTP and WS at some point.
  */
-
+var q = require("q");
 var StubStore = require("./store/stub");
-var EventMapper = require("./client").EventMapper;
 var User = require("./models/user");
 var Room = require("./models/room");
 var utils = require("./utils");
 var MatrixEvent = require("./models/event").MatrixEvent;
+
+function retryTimeMsForAttempt(attempt) {
+    // 2,4,8,16,32,64,128,128,128,... seconds
+    // max 2^7 secs = 2.1 mins
+    return Math.pow(2, Math.min(attempt, 7)) * 1000;
+}
 
 function startSyncingRetryTimer(client, attempt, fn) {
     client._syncingRetry = {};
@@ -79,6 +84,99 @@ function reEmit(reEmitEntity, emittableEntity, eventNames) {
     });
 }
 
+function _syncRoom(client, room) {
+    if (client._syncingRooms[room.roomId]) {
+        return client._syncingRooms[room.roomId];
+    }
+    var defer = q.defer();
+    client._syncingRooms[room.roomId] = defer.promise;
+    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
+    function(res) {
+        room.timeline = []; // blow away any previous messages.
+        _processRoomEvents(client, room, res.state, res.messages);
+        room.recalculate(client.credentials.userId);
+        client.store.storeRoom(room);
+        client.emit("Room", room);
+        defer.resolve(room);
+        client._syncingRooms[room.roomId] = undefined;
+    }, function(err) {
+        defer.reject(err);
+        client._syncingRooms[room.roomId] = undefined;
+    });
+    return defer.promise;
+}
+
+function _processRoomEvents(client, room, stateEventList, messageChunk) {
+    // "old" and "current" state are the same initially; they
+    // start diverging if the user paginates.
+    // We must deep copy otherwise membership changes in old state
+    // will leak through to current state!
+    var oldStateEvents = utils.map(
+        utils.deepCopy(stateEventList), client.getEventMapper()
+    );
+    var stateEvents = utils.map(stateEventList, client.getEventMapper());
+    room.oldState.setStateEvents(oldStateEvents);
+    room.currentState.setStateEvents(stateEvents);
+
+    _resolveInvites(client, room);
+
+    // add events to the timeline *after* setting the state
+    // events so messages use the right display names. Initial sync
+    // returns messages in chronological order, so we need to reverse
+    // it to get most recent -> oldest. We need it in that order in
+    // order to diverge old/current state correctly.
+    room.addEventsToTimeline(
+        utils.map(
+            messageChunk ? messageChunk.chunk : [],
+            client.getEventMapper()
+        ).reverse(), true
+    );
+    if (messageChunk) {
+        room.oldState.paginationToken = messageChunk.start;
+    }
+}
+
+function _resolveInvites(client, room) {
+    if (!room || !client._config.resolveInvitesToProfiles) {
+        return;
+    }
+    // For each invited room member we want to give them a displayname/avatar url
+    // if they have one (the m.room.member invites don't contain this).
+    room.getMembersWithMembership("invite").forEach(function(member) {
+        if (member._requestedProfileInfo) {
+            return;
+        }
+        member._requestedProfileInfo = true;
+        // try to get a cached copy first.
+        var user = client.getUser(member.userId);
+        var promise;
+        if (user) {
+            promise = q({
+                avatar_url: user.avatarUrl,
+                displayname: user.displayName
+            });
+        }
+        else {
+            promise = client.getProfileInfo(member.userId);
+        }
+        promise.done(function(info) {
+            // slightly naughty by doctoring the invite event but this means all
+            // the code paths remain the same between invite/join display name stuff
+            // which is a worthy trade-off for some minor pollution.
+            var inviteEvent = member.events.member;
+            if (inviteEvent.getContent().membership !== "invite") {
+                // between resolving and now they have since joined, so don't clobber
+                return;
+            }
+            inviteEvent.getContent().avatar_url = info.avatar_url;
+            inviteEvent.getContent().displayname = info.displayname;
+            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
+        }, function(err) {
+            // OH WELL.
+        });
+    });
+}
+
 /**
  * <b>Internal class - unstable.</b>
  * Construct an entity which is able to sync with a homeserver.
@@ -89,15 +187,23 @@ function SyncApi(client) {
     this.opts = {};
 }
 
+SyncApi.prototype.createRoom = function(roomId) {
+    return createNewRoom(this.client, roomId);
+};
+
+SyncApi.prototype.syncRoom = function(room) {
+    return _syncRoom(this.client, room);
+};
+
 /**
  * @param {Object} opts
  * @param {Number} opts.historyLen
  * @param {Boolean} opts.includeArchived
  */
 SyncApi.prototype.sync = function(opts) {
-    console.log("SyncApi.sync -> %s", opts);
+    console.log("SyncApi.sync");
     this.opts = opts || {};
-    return this._sync();
+    return this._prepareForSync();
 }
 
 
@@ -119,7 +225,7 @@ SyncApi.prototype._prepareForSync = function(attempt) {
     }, function(err) {
         attempt += 1;
         startSyncingRetryTimer(client, attempt, function() {
-            prepareForSync(client, attempt);
+            self._prepareForSync(attempt);
         });
         updateSyncState(client, "ERROR", { error: err });
     });
@@ -147,7 +253,7 @@ SyncApi.prototype._sync = function(attempt) {
         // intercept the results and put them into our store
         if (!(client.store instanceof StubStore)) {
             utils.forEach(
-                utils.map(data.presence, EventMapper(client)),
+                utils.map(data.presence, client.getEventMapper()),
             function(e) {
                 var user = createNewUser(client, e.getContent().user_id);
                 user.setPresenceEvent(e);
@@ -157,7 +263,7 @@ SyncApi.prototype._sync = function(attempt) {
             // group receipts by room ID.
             var receiptsByRoom = {};
             data.receipts = data.receipts || [];
-            utils.forEach(data.receipts.map(EventMapper(client)),
+            utils.forEach(data.receipts.map(client.getEventMapper()),
                 function(receiptEvent) {
                     if (!receiptsByRoom[receiptEvent.getRoomId()]) {
                         receiptsByRoom[receiptEvent.getRoomId()] = [];
@@ -189,7 +295,7 @@ SyncApi.prototype._sync = function(attempt) {
                     data.rooms[i].state.push(inviteEvent);
                 }
 
-                _processRoomEvents( // XXX
+                _processRoomEvents(
                     client, room, data.rooms[i].state, data.rooms[i].messages
                 );
 
@@ -200,7 +306,7 @@ SyncApi.prototype._sync = function(attempt) {
 
                 var privateUserData = data.rooms[i].account_data || [];
                 var privateUserDataEvents =
-                    utils.map(privateUserData, EventMapper(client));
+                    utils.map(privateUserData, client.getEventMapper());
                 for (j = 0; j < privateUserDataEvents.length; j++) {
                     var event = privateUserDataEvents[j];
                     if (event.getType() === "m.tag") {
@@ -253,7 +359,7 @@ SyncApi.prototype._sync = function(attempt) {
         console.error("/initialSync error (%s attempts): %s", attempt, err);
         attempt += 1;
         startSyncingRetryTimer(client, attempt, function() {
-            self._sync(opts, attempt);
+            self._sync(attempt);
         });
         updateSyncState(client, "ERROR", { error: err });
     });
@@ -305,13 +411,13 @@ SyncApi.prototype._pollForEvents = function(attempt) {
         }
 
         if (client._syncState !== "SYNCING") {
-            updateSyncState(self, "SYNCING");
+            updateSyncState(client, "SYNCING");
         }
 
         try {
             var events = [];
             if (data) {
-                events = utils.map(data.chunk, EventMapper(self));
+                events = utils.map(data.chunk, client.getEventMapper());
             }
             if (!(client.store instanceof StubStore)) {
                 var roomIdsWithNewInvites = {};
@@ -337,7 +443,7 @@ SyncApi.prototype._pollForEvents = function(attempt) {
                             usr.setPresenceEvent(events[i]);
                         }
                         else {
-                            usr = createNewUser(self, events[i].getContent().user_id);
+                            usr = createNewUser(client, events[i].getContent().user_id);
                             usr.setPresenceEvent(events[i]);
                             client.store.storeUser(usr);
                         }
@@ -350,7 +456,7 @@ SyncApi.prototype._pollForEvents = function(attempt) {
                     var room = client.store.getRoom(roomId);
                     var isBrandNewRoom = false;
                     if (!room) {
-                        room = createNewRoom(self, roomId);
+                        room = createNewRoom(client, roomId);
                         isBrandNewRoom = true;
                     }
 
@@ -375,12 +481,12 @@ SyncApi.prototype._pollForEvents = function(attempt) {
                     if (!wasJoined && justJoined) {
                         // we've just transitioned into a join state for this room,
                         // so sync state.
-                        _syncRoom(self, room); // XXX
+                        _syncRoom(client, room);
                     }
                 });
 
                 Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
-                    _resolveInvites(self, client.store.getRoom(inviteRoomId)); // XXX
+                    _resolveInvites(client, client.store.getRoom(inviteRoomId));
                 });
             }
             if (data) {
@@ -394,7 +500,7 @@ SyncApi.prototype._pollForEvents = function(attempt) {
             console.error("Event stream error:");
             console.error(e);
         }
-        client._pollForEvents();
+        self._pollForEvents();
     }, function(err) {
         console.error("/events error: %s", JSON.stringify(err));
         if (discardResult) {
@@ -405,10 +511,10 @@ SyncApi.prototype._pollForEvents = function(attempt) {
         }
 
         attempt += 1;
-        startSyncingRetryTimer(self, attempt, function() {
-            client._pollForEvents(attempt);
+        startSyncingRetryTimer(client, attempt, function() {
+            self._pollForEvents(attempt);
         });
-        updateSyncState(self, "ERROR", { error: err });
+        updateSyncState(client, "ERROR", { error: err });
     });
 }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,7 +15,11 @@ var utils = require("./utils");
 var httpApi = require("./http-api");
 var Filter = require("./filter");
 
-var FILTER_SYNC = "FILTER_SYNC";
+function getFilterName(userId) {
+    // scope this on the user ID because people may login on many accounts
+    // and they all need to be stored!
+    return "FILTER_SYNC_" + userId;
+}
 
 /**
  * <b>Internal class - unstable.</b>
@@ -96,7 +100,7 @@ SyncApi.prototype.sync = function() {
 
 
         // Get or create filter
-        var filterId = client.store.getFilterIdByName(FILTER_SYNC);
+        var filterId = client.store.getFilterIdByName(getFilterName(client.credentials.userId));
         if (filterId) {
             // super, just use that.
             console.log("Using existing filter ID %s", filterId);
@@ -108,7 +112,9 @@ SyncApi.prototype.sync = function() {
         var filter = new Filter(client.credentials.userId);
         filter.setTimelineLimit(self.opts.initialSyncLimit);
         client.createFilter(filter.getDefinition()).done(function(filter) {
-            client.store.setFilterIdByName(FILTER_SYNC, filter.filterId);
+            client.store.setFilterIdByName(
+                getFilterName(client.credentials.userId), filter.filterId
+            );
             console.log("Created filter ", filter.filterId);
             self._sync({ filterId: filter.filterId }); // Now start the /sync loop
         }, retryHandler(attempt, getFilter));

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -150,7 +150,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         // data looks like:
         // {
         //    next_batch: $token,
-        //    presence: [PresencEvents],
+        //    presence: { events: [] },
         //    rooms: {
         //      invite: {
         //        $roomid: {
@@ -174,6 +174,22 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         //    }
         // }
         console.log("Got data %s", data);
+
+        // handle presence events (User objects)
+        if (data.presence && utils.isArray(data.presence.events)) {
+            data.presence.events.map(client.getEventMapper()).forEach(function(presenceEvent) {
+                var user = client.store.getUser(presenceEvent.getSender());
+                if (user) {
+                    user.setPresenceEvent(presenceEvent);
+                }
+                else {
+                    user = createNewUser(client, presenceEvent.getSender());
+                    user.setPresenceEvent(presenceEvent);
+                    client.store.storeUser(user);
+                }
+                client.emit("event", presenceEvent);
+            });
+        }
 
         /*
         var i, j;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -22,6 +22,7 @@ var FILTER_SYNC = "FILTER_SYNC";
  * Construct an entity which is able to sync with a homeserver.
  * @constructor
  * @param {MatrixClient} client The matrix client instance to use.
+ * @param {Object} opts Config options
  */
 function SyncApi(client, opts) {
     this.client = client;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -299,6 +299,8 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 }
                 stateEvents.forEach(function(e) { client.emit("event", e); });
                 timelineEvents.forEach(function(e) { client.emit("event", e); });
+                ephemeralEvents.forEach(function(e) { client.emit("event", e); });
+                accountDataEvents.forEach(function(e) { client.emit("event", e); });
             });
 
             // Ignore leave rooms for now (TODO: Honour includeArchived opt)

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -297,7 +297,9 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 var ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
                 var accountDataEvents = self._mapSyncEventsFormat(joinObj.account_data);
 
-                if (joinObj.timeline && joinObj.timeline.limited) {
+                joinObj.timeline = joinObj.timeline || {};
+
+                if (joinObj.timeline.limited) {
                     // nuke the timeline so we don't get holes
                     room.timeline = [];
                 }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,0 +1,415 @@
+"use strict";
+
+/*
+ * TODO:
+ * This class mainly serves to take all the syncing logic out of client.js and
+ * into a separate file. It's all very fluid, and this class gut wrenches a lot
+ * of MatrixClient props (e.g. _http). Given we want to support WebSockets as
+ * an alternative syncing API, we may want to have a proper syncing interface
+ * for HTTP and WS at some point.
+ */
+
+var StubStore = require("./store/stub");
+var EventMapper = require("./client").EventMapper;
+var User = require("./models/user");
+var Room = require("./models/room");
+var utils = require("./utils");
+var MatrixEvent = require("./models/event").MatrixEvent;
+
+function startSyncingRetryTimer(client, attempt, fn) {
+    client._syncingRetry = {};
+    client._syncingRetry.fn = fn;
+    client._syncingRetry.timeoutId = setTimeout(function() {
+        fn();
+    }, retryTimeMsForAttempt(attempt));
+}
+
+function updateSyncState(client, newState, data) {
+    var old = client._syncState;
+    client._syncState = newState;
+    client.emit("sync", client._syncState, old, data);
+}
+
+function createNewUser(client, userId) {
+    var user = new User(userId);
+    reEmit(client, user, ["User.avatarUrl", "User.displayName", "User.presence"]);
+    return user;
+}
+
+function createNewRoom(client, roomId) {
+    var room = new Room(roomId, {
+        pendingEventOrdering: client._config.pendingEventOrdering
+    });
+    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
+
+    // we need to also re-emit room state and room member events, so hook it up
+    // to the client now. We need to add a listener for RoomState.members in
+    // order to hook them correctly. (TODO: find a better way?)
+    reEmit(client, room.currentState, [
+        "RoomState.events", "RoomState.members", "RoomState.newMember"
+    ]);
+    room.currentState.on("RoomState.newMember", function(event, state, member) {
+        member.user = client.getUser(member.userId);
+        reEmit(
+            client, member,
+            [
+                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
+                "RoomMember.membership"
+            ]
+        );
+    });
+    return room;
+}
+
+function reEmit(reEmitEntity, emittableEntity, eventNames) {
+    utils.forEach(eventNames, function(eventName) {
+        // setup a listener on the entity (the Room, User, etc) for this event
+        emittableEntity.on(eventName, function() {
+            // take the args from the listener and reuse them, adding the
+            // event name to the arg list so it works with .emit()
+            // Transformation Example:
+            // listener on "foo" => function(a,b) { ... }
+            // Re-emit on "thing" => thing.emit("foo", a, b)
+            var newArgs = [eventName];
+            for (var i = 0; i < arguments.length; i++) {
+                newArgs.push(arguments[i]);
+            }
+            reEmitEntity.emit.apply(reEmitEntity, newArgs);
+        });
+    });
+}
+
+/**
+ * <b>Internal class - unstable.</b>
+ * Construct an entity which is able to sync with a homeserver.
+ * @param {MatrixClient} client The matrix client instance to use.
+ */
+function SyncApi(client) {
+    this.client = client;
+    this.opts = {};
+}
+
+/**
+ * @param {Object} opts
+ * @param {Number} opts.historyLen
+ * @param {Boolean} opts.includeArchived
+ */
+SyncApi.prototype.sync = function(opts) {
+    console.log("SyncApi.sync -> %s", opts);
+    this.opts = opts || {};
+    return this._sync();
+}
+
+
+SyncApi.prototype._prepareForSync = function(attempt) {
+    var client = this.client;
+    var self = this;
+    if (client.isGuest()) {
+        // no push rules for guests
+        this._sync();
+        return;
+    }
+
+    attempt = attempt || 1;
+    // we do push rules before syncing so when we gets events down we know immediately
+    // whether they are bing-worthy.
+    client.pushRules().done(function(result) {
+        client.pushRules = result;
+        self._sync();
+    }, function(err) {
+        attempt += 1;
+        startSyncingRetryTimer(client, attempt, function() {
+            prepareForSync(client, attempt);
+        });
+        updateSyncState(client, "ERROR", { error: err });
+    });
+}
+
+SyncApi.prototype._sync = function(attempt) {
+    var opts = this.opts;
+    var client = this.client;
+    var self = this;
+    var historyLen = opts.historyLen;
+    var includeArchived = opts.includeArchived;
+    attempt = attempt || 1;
+
+    var qps = { limit: historyLen };
+    if (includeArchived) {
+        qps.archived = true;
+    }
+    if (client._guestRooms && client._isGuest) {
+        qps.room_id = JSON.stringify(client._guestRooms);
+    }
+    client._http.authedRequest(
+        undefined, "GET", "/initialSync", qps
+    ).done(function(data) {
+        var i, j;
+        // intercept the results and put them into our store
+        if (!(client.store instanceof StubStore)) {
+            utils.forEach(
+                utils.map(data.presence, EventMapper(client)),
+            function(e) {
+                var user = createNewUser(client, e.getContent().user_id);
+                user.setPresenceEvent(e);
+                client.store.storeUser(user);
+            });
+
+            // group receipts by room ID.
+            var receiptsByRoom = {};
+            data.receipts = data.receipts || [];
+            utils.forEach(data.receipts.map(EventMapper(client)),
+                function(receiptEvent) {
+                    if (!receiptsByRoom[receiptEvent.getRoomId()]) {
+                        receiptsByRoom[receiptEvent.getRoomId()] = [];
+                    }
+                    receiptsByRoom[receiptEvent.getRoomId()].push(receiptEvent);
+                }
+            );
+
+            for (i = 0; i < data.rooms.length; i++) {
+                var room = createNewRoom(client, data.rooms[i].room_id);
+                if (!data.rooms[i].state) {
+                    data.rooms[i].state = [];
+                }
+                if (data.rooms[i].membership === "invite") {
+                    var inviteEvent = data.rooms[i].invite;
+                    if (!inviteEvent) {
+                        // fallback for servers which don't serve the invite key yet
+                        inviteEvent = {
+                            event_id: "$fake_" + room.roomId,
+                            content: {
+                                membership: "invite"
+                            },
+                            state_key: client.credentials.userId,
+                            user_id: data.rooms[i].inviter,
+                            room_id: room.roomId,
+                            type: "m.room.member"
+                        };
+                    }
+                    data.rooms[i].state.push(inviteEvent);
+                }
+
+                _processRoomEvents( // XXX
+                    client, room, data.rooms[i].state, data.rooms[i].messages
+                );
+
+                var receipts = receiptsByRoom[room.roomId] || [];
+                for (j = 0; j < receipts.length; j++) {
+                    room.addReceipt(receipts[j]);
+                }
+
+                var privateUserData = data.rooms[i].account_data || [];
+                var privateUserDataEvents =
+                    utils.map(privateUserData, EventMapper(client));
+                for (j = 0; j < privateUserDataEvents.length; j++) {
+                    var event = privateUserDataEvents[j];
+                    if (event.getType() === "m.tag") {
+                        room.addTags(event);
+                    }
+                    // XXX: unhandled private user data event - we should probably
+                    // put it somewhere useful once the API has settled
+                }
+
+                // cache the name/summary/etc prior to storage since we don't
+                // know how the store will serialise the Room.
+                room.recalculate(client.credentials.userId);
+
+                client.store.storeRoom(room);
+                client.emit("Room", room);
+            }
+        }
+
+        if (data) {
+            client.store.setSyncToken(data.end);
+            var events = [];
+            for (i = 0; i < data.presence.length; i++) {
+                events.push(new MatrixEvent(data.presence[i]));
+            }
+            for (i = 0; i < data.rooms.length; i++) {
+                if (data.rooms[i].state) {
+                    for (j = 0; j < data.rooms[i].state.length; j++) {
+                        events.push(new MatrixEvent(data.rooms[i].state[j]));
+                    }
+                }
+                if (data.rooms[i].messages) {
+                    for (j = 0; j < data.rooms[i].messages.chunk.length; j++) {
+                        events.push(
+                            new MatrixEvent(data.rooms[i].messages.chunk[j])
+                        );
+                    }
+                }
+            }
+            utils.forEach(events, function(e) {
+                client.emit("event", e);
+            });
+        }
+
+        client.clientRunning = true;
+        updateSyncState(client, "PREPARED");
+        // assume success until we fail which may be 30+ secs
+        updateSyncState(client, "SYNCING");
+        self._pollForEvents();
+    }, function(err) {
+        console.error("/initialSync error (%s attempts): %s", attempt, err);
+        attempt += 1;
+        startSyncingRetryTimer(client, attempt, function() {
+            self._sync(opts, attempt);
+        });
+        updateSyncState(client, "ERROR", { error: err });
+    });
+};
+
+/**
+ * This is an internal method.
+ * @param {MatrixClient} client
+ * @param {Number} attempt The attempt number
+ */
+SyncApi.prototype._pollForEvents = function(attempt) {
+    var client = this.client;
+    var self = this;
+
+    attempt = attempt || 1;
+    
+    if (!client.clientRunning) {
+        return;
+    }
+    var timeoutMs = client._config.pollTimeout;
+    if (attempt > 1) {
+        // we think the connection is dead. If it comes back up, we won't know
+        // about it till /events returns. If the timeout= is high, this could
+        // be a long time. Set it to 1 when doing retries.
+        timeoutMs = 1;
+    }
+    var discardResult = false;
+    var timeoutObj = setTimeout(function() {
+        discardResult = true;
+        console.error("/events request timed out.");
+        self._pollForEvents();
+    }, timeoutMs + (20 * 1000)); // 20s buffer
+
+    var queryParams = {
+        from: client.store.getSyncToken(),
+        timeout: timeoutMs
+    };
+    if (client._guestRooms && client._isGuest) {
+        queryParams.room_id = client._guestRooms;
+    }
+
+    client._http.authedRequest(undefined, "GET", "/events", queryParams).done(
+    function(data) {
+        if (discardResult) {
+            return;
+        }
+        else {
+            clearTimeout(timeoutObj);
+        }
+
+        if (client._syncState !== "SYNCING") {
+            updateSyncState(self, "SYNCING");
+        }
+
+        try {
+            var events = [];
+            if (data) {
+                events = utils.map(data.chunk, EventMapper(self));
+            }
+            if (!(client.store instanceof StubStore)) {
+                var roomIdsWithNewInvites = {};
+                // bucket events based on room.
+                var i = 0;
+                var roomIdToEvents = {};
+                for (i = 0; i < events.length; i++) {
+                    var roomId = events[i].getRoomId();
+                    // possible to have no room ID e.g. for presence events.
+                    if (roomId) {
+                        if (!roomIdToEvents[roomId]) {
+                            roomIdToEvents[roomId] = [];
+                        }
+                        roomIdToEvents[roomId].push(events[i]);
+                        if (events[i].getType() === "m.room.member" &&
+                                events[i].getContent().membership === "invite") {
+                            roomIdsWithNewInvites[roomId] = true;
+                        }
+                    }
+                    else if (events[i].getType() === "m.presence") {
+                        var usr = client.store.getUser(events[i].getContent().user_id);
+                        if (usr) {
+                            usr.setPresenceEvent(events[i]);
+                        }
+                        else {
+                            usr = createNewUser(self, events[i].getContent().user_id);
+                            usr.setPresenceEvent(events[i]);
+                            client.store.storeUser(usr);
+                        }
+                    }
+                }
+
+                // add events to room
+                var roomIds = utils.keys(roomIdToEvents);
+                utils.forEach(roomIds, function(roomId) {
+                    var room = client.store.getRoom(roomId);
+                    var isBrandNewRoom = false;
+                    if (!room) {
+                        room = createNewRoom(self, roomId);
+                        isBrandNewRoom = true;
+                    }
+
+                    var wasJoined = room.hasMembershipState(
+                        client.credentials.userId, "join"
+                    );
+
+                    room.addEvents(roomIdToEvents[roomId], "replace");
+                    room.recalculate(client.credentials.userId);
+
+                    // store the Room for things like invite events so developers
+                    // can update the UI
+                    if (isBrandNewRoom) {
+                        client.store.storeRoom(room);
+                        client.emit("Room", room);
+                    }
+
+                    var justJoined = room.hasMembershipState(
+                        client.credentials.userId, "join"
+                    );
+
+                    if (!wasJoined && justJoined) {
+                        // we've just transitioned into a join state for this room,
+                        // so sync state.
+                        _syncRoom(self, room); // XXX
+                    }
+                });
+
+                Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
+                    _resolveInvites(self, client.store.getRoom(inviteRoomId)); // XXX
+                });
+            }
+            if (data) {
+                client.store.setSyncToken(data.end);
+                utils.forEach(events, function(e) {
+                    client.emit("event", e);
+                });
+            }
+        }
+        catch (e) {
+            console.error("Event stream error:");
+            console.error(e);
+        }
+        client._pollForEvents();
+    }, function(err) {
+        console.error("/events error: %s", JSON.stringify(err));
+        if (discardResult) {
+            return;
+        }
+        else {
+            clearTimeout(timeoutObj);
+        }
+
+        attempt += 1;
+        startSyncingRetryTimer(self, attempt, function() {
+            client._pollForEvents(attempt);
+        });
+        updateSyncState(self, "ERROR", { error: err });
+    });
+}
+
+module.exports = SyncApi;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -175,20 +175,30 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         // }
         console.log("Got data %s", data);
 
-        // handle presence events (User objects)
-        if (data.presence && utils.isArray(data.presence.events)) {
-            data.presence.events.map(client.getEventMapper()).forEach(function(presenceEvent) {
-                var user = client.store.getUser(presenceEvent.getSender());
-                if (user) {
-                    user.setPresenceEvent(presenceEvent);
-                }
-                else {
-                    user = createNewUser(client, presenceEvent.getSender());
-                    user.setPresenceEvent(presenceEvent);
-                    client.store.storeUser(user);
-                }
-                client.emit("event", presenceEvent);
-            });
+        // set the sync token NOW *before* processing the events. We do this so if something
+        // barfs on an event we can skip it rather than constantly polling with the same token.
+        client.store.setSyncToken(data.next_batch);
+
+        try {
+            // handle presence events (User objects)
+            if (data.presence && utils.isArray(data.presence.events)) {
+                data.presence.events.map(client.getEventMapper()).forEach(function(presenceEvent) {
+                    var user = client.store.getUser(presenceEvent.getSender());
+                    if (user) {
+                        user.setPresenceEvent(presenceEvent);
+                    }
+                    else {
+                        user = createNewUser(client, presenceEvent.getSender());
+                        user.setPresenceEvent(presenceEvent);
+                        client.store.storeUser(user);
+                    }
+                    client.emit("event", presenceEvent);
+                });
+            }
+        }
+        catch (e) {
+            console.error("Caught /sync error:");
+            console.error(e);
         }
 
         /*
@@ -292,11 +302,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             });
         }
 
+        */
+
         
-        // assume success until we fail which may be 30+ secs */
-
-        client.store.setSyncToken(data.next_batch);
-
+        // emit synced events
         if (!syncOptions.hasSyncedBefore) {
             updateSyncState(client, "PREPARED");
             syncOptions.hasSyncedBefore = true;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -301,9 +301,16 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                     // nuke the timeline so we don't get holes
                     room.timeline = [];
                 }
+
+                // we want to set a new pagination token if this is the first time
+                // we've made this room or if we're nuking the timeline
+                var paginationToken = null;
+                if (joinObj.isBrandNewRoom || joinObj.timeline.limited) {
+                    paginationToken = joinObj.timeline.prev_batch;
+                }
+
                 self._processRoomEvents(
-                    room, stateEvents, timelineEvents,
-                    joinObj.timeline ? joinObj.timeline.prev_batch : null
+                    room, stateEvents, timelineEvents, paginationToken
                 );
                 room.addEvents(ephemeralEvents);
                 room.addEvents(accountDataEvents);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -14,6 +14,10 @@ var User = require("./models/user");
 var Room = require("./models/room");
 var utils = require("./utils");
 var MatrixEvent = require("./models/event").MatrixEvent;
+var httpApi = require("./http-api");
+var Filter = require("./filter");
+
+var FILTER_SYNC = "FILTER_SYNC";
 
 /**
  * <b>Internal class - unstable.</b>
@@ -21,9 +25,15 @@ var MatrixEvent = require("./models/event").MatrixEvent;
  * @constructor
  * @param {MatrixClient} client The matrix client instance to use.
  */
-function SyncApi(client) {
+function SyncApi(client, opts) {
     this.client = client;
-    this.opts = {};
+    opts = opts || {};
+    opts.initialSyncLimit = opts.initialSyncLimit || 8;
+    opts.includeArchivedRooms = opts.includeArchivedRooms || false;
+    opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
+    opts.pollTimeout = opts.pollTimeout || (30 * 1000);
+    opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
+    this.opts = opts;
 }
 
 /**
@@ -44,65 +54,128 @@ SyncApi.prototype.syncRoom = function(room) {
 
 /**
  * Main entry point
- * @param {Object} opts
- * @param {Number} opts.historyLen
- * @param {Boolean} opts.includeArchived
  */
-SyncApi.prototype.sync = function(opts) {
+SyncApi.prototype.sync = function() {
     console.log("SyncApi.sync");
-    this.opts = opts || {};
-    this._prepareForSync();
-};
-
-
-/**
- * @param {Number=} attempt
- */
-SyncApi.prototype._prepareForSync = function(attempt) {
     var client = this.client;
     var self = this;
+
+    // We need to do one-off checks before we can begin the /sync loop.
+    // These are:
+    //   1) We need to get push rules so we can check if events should bing as we get
+    //      them from /sync.
+    //   2) We need to get/create a filter which we can use for /sync.
+
+    function getPushRules(attempt) {
+        attempt = attempt || 0;
+        attempt += 1;
+
+        client.pushRules().done(function(result) {
+            console.log("Got push rules");
+            client.pushRules = result;
+            getFilter(); // Now get the filter
+        }, retryHandler(attempt, getPushRules));
+    }
+
+    function getFilter(attempt) {
+        attempt = attempt || 0;
+        attempt += 1;
+
+
+        // Get or create filter
+        var filterId = client.store.getFilterIdByName(FILTER_SYNC);
+        if (filterId) {
+            // super, just use that.
+            console.log("Using existing filter ID %s", filterId);
+            self._sync({ filterId: filterId });
+            return;
+        }
+
+        // create a filter
+        var filter = new Filter(client.credentials.userId);
+        filter.setTimelineLimit(self.opts.initialSyncLimit);
+        client.createFilter(filter.getDefinition()).done(function(filter) {
+            client.store.setFilterIdByName(FILTER_SYNC, filter.filterId);
+            console.log("Created filter ", filter.filterId);
+            self._sync({ filterId: filter.filterId }); // Now start the /sync loop
+        }, retryHandler(attempt, getFilter));
+    }
+
+    // sets the sync state to error and waits a bit before re-invoking the function.
+    function retryHandler(attempt, fnToRun) {
+        return function(err) {
+            startSyncingRetryTimer(client, attempt, function() {
+                fnToRun(attempt);
+            });
+            updateSyncState(client, "ERROR", { error: err });
+        };
+    }
+
     if (client.isGuest()) {
         // no push rules for guests
-        this._sync();
-        return;
+        getFilter();
     }
-
-    attempt = attempt || 1;
-    // we do push rules before syncing so when we gets events down we know immediately
-    // whether they are bing-worthy.
-    client.pushRules().done(function(result) {
-        client.pushRules = result;
-        self._sync();
-    }, function(err) {
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            self._prepareForSync(attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
-    });
+    else {
+        getPushRules();
+    }
 };
 
 /**
+ * Invoke me to do /sync calls
+ * @param {Object} syncOptions
+ * @param {string} syncOptions.filterId
+ * @param {boolean} syncOptions.hasSyncedBefore
  * @param {Number=} attempt
  */
-SyncApi.prototype._sync = function(attempt) {
-    var opts = this.opts;
+SyncApi.prototype._sync = function(syncOptions, attempt) {
     var client = this.client;
     var self = this;
-    var historyLen = opts.historyLen;
-    var includeArchived = opts.includeArchived;
     attempt = attempt || 1;
 
-    var qps = { limit: historyLen };
-    if (includeArchived) {
-        qps.archived = true;
-    }
+    // TODO include archived rooms flag.
+
+    var qps = {
+        filter: syncOptions.filterId,
+        timeout: this.opts.pollTimeout,
+        since: client.store.getSyncToken() || undefined // do not send 'null'
+    };
+
     if (client._guestRooms && client._isGuest) {
         qps.room_id = JSON.stringify(client._guestRooms);
     }
-    client._http.authedRequest(
-        undefined, "GET", "/initialSync", qps
+
+    client._http.authedRequestWithPrefix(
+        undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA
     ).done(function(data) {
+        // data looks like:
+        // {
+        //    next_batch: $token,
+        //    presence: [PresencEvents],
+        //    rooms: {
+        //      invite: {
+        //        $roomid: {
+        //          invite_state: { events: [] }
+        //        }
+        //      },
+        //      join: {
+        //        $roomid: {
+        //          state: { events: [] },
+        //          timeline: { events: [], prev_batch: $token, limited: true },
+        //          ephemeral: { events: [] },
+        //          account_data: { events: [] }
+        //        }
+        //      },
+        //      leave: {
+        //        $roomid: {
+        //          state: { events: [] },
+        //          timeline: { events: [], prev_batch: $token }
+        //        }
+        //      }
+        //    }
+        // }
+        console.log("Got data %s", data);
+
+        /*
         var i, j;
         // intercept the results and put them into our store
         if (!(client.store instanceof StubStore)) {
@@ -180,7 +253,6 @@ SyncApi.prototype._sync = function(attempt) {
         }
 
         if (data) {
-            client.store.setSyncToken(data.end);
             var events = [];
             for (i = 0; i < data.presence.length; i++) {
                 events.push(new MatrixEvent(data.presence[i]));
@@ -204,16 +276,22 @@ SyncApi.prototype._sync = function(attempt) {
             });
         }
 
-        client.clientRunning = true;
-        updateSyncState(client, "PREPARED");
-        // assume success until we fail which may be 30+ secs
+        
+        // assume success until we fail which may be 30+ secs */
+
+        client.store.setSyncToken(data.next_batch);
+
+        if (!syncOptions.hasSyncedBefore) {
+            updateSyncState(client, "PREPARED");
+            syncOptions.hasSyncedBefore = true;
+        }
         updateSyncState(client, "SYNCING");
-        self._pollForEvents();
+        self._sync(syncOptions);
     }, function(err) {
-        console.error("/initialSync error (%s attempts): %s", attempt, err);
+        console.error("/sync error (%s attempts): %s", attempt, err);
         attempt += 1;
         startSyncingRetryTimer(client, attempt, function() {
-            self._sync(attempt);
+            self._sync(syncOptions, attempt);
         });
         updateSyncState(client, "ERROR", { error: err });
     });

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -456,6 +456,14 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     );
     var stateEvents = stateEventList;
 
+    // Set the pagination token BEFORE adding events to the timeline: it's not
+    // unreasonable for clients to call scrollback() in response to Room.timeline
+    // events which addEventsToTimeline will emit-- we want to make sure they use
+    // the right token if and when they do.
+    if (paginationToken) {
+        room.oldState.paginationToken = paginationToken;
+    }
+
     // set the state of the room to as it was before the timeline executes
     room.oldState.setStateEvents(oldStateEvents);
     room.currentState.setStateEvents(stateEvents);
@@ -465,9 +473,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // execute the timeline events, this will begin to diverge the current state
     // if the timeline has any state events in it.
     room.addEventsToTimeline(timelineEventList);
-    if (paginationToken) {
-        room.oldState.paginationToken = paginationToken;
-    }
+
 };
 
 function retryTimeMsForAttempt(attempt) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -15,6 +15,12 @@ var utils = require("./utils");
 var httpApi = require("./http-api");
 var Filter = require("./filter");
 
+// /sync requests allow you to set a timeout= but the request may continue
+// beyond that and wedge forever, so we need to track how long we are willing
+// to keep open the connection. This constant is *ADDED* to the timeout= value
+// to determine the max time we're willing to wait.
+var BUFFER_PERIOD_MS = 90 * 1000;
+
 function getFilterName(userId) {
     // scope this on the user ID because people may login on many accounts
     // and they all need to be stored!
@@ -185,7 +191,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     var timeoutObj = setTimeout(function() {
         discardResult = true;
         errHandler("Locally timed out waiting for a response");
-    }, qps.timeout + (20 * 1000)); // 20s buffer
+    }, qps.timeout + BUFFER_PERIOD_MS);
 
     client._http.authedRequestWithPrefix(
         undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA
@@ -324,7 +330,9 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             updateSyncState(client, "PREPARED");
             syncOptions.hasSyncedBefore = true;
         }
-        updateSyncState(client, "SYNCING");
+        if (client._syncState !== "SYNCING") {
+            updateSyncState(client, "SYNCING");
+        }
         self._sync(syncOptions);
     }, errHandler);
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -283,12 +283,13 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 var ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
                 var accountDataEvents = self._mapSyncEventsFormat(joinObj.account_data);
 
-                if (joinObj.timeline.limited) {
+                if (joinObj.timeline && joinObj.timeline.limited) {
                     // nuke the timeline so we don't get holes
                     room.timeline = [];
                 }
                 self._processRoomEvents(
-                    room, stateEvents, timelineEvents, joinObj.timeline.prev_batch
+                    room, stateEvents, timelineEvents,
+                    joinObj.timeline ? joinObj.timeline.prev_batch : null
                 );
                 room.addEvents(ephemeralEvents);
                 room.addEvents(accountDataEvents);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -204,7 +204,7 @@ SyncApi.prototype.sync = function(opts) {
     console.log("SyncApi.sync");
     this.opts = opts || {};
     return this._prepareForSync();
-}
+};
 
 
 SyncApi.prototype._prepareForSync = function(attempt) {
@@ -229,7 +229,7 @@ SyncApi.prototype._prepareForSync = function(attempt) {
         });
         updateSyncState(client, "ERROR", { error: err });
     });
-}
+};
 
 SyncApi.prototype._sync = function(attempt) {
     var opts = this.opts;
@@ -516,6 +516,6 @@ SyncApi.prototype._pollForEvents = function(attempt) {
         });
         updateSyncState(client, "ERROR", { error: err });
     });
-}
+};
 
 module.exports = SyncApi;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -67,34 +67,6 @@ SyncApi.prototype.createRoom = function(roomId) {
 };
 
 /**
- * @param {Room} room
- * @return {Promise}
- */
-SyncApi.prototype.syncRoom = function(room) {
-    var client = this.client;
-    var self = this;
-    if (client._syncingRooms[room.roomId]) {
-        return client._syncingRooms[room.roomId];
-    }
-    var defer = q.defer();
-    client._syncingRooms[room.roomId] = defer.promise;
-    client.roomInitialSync(room.roomId, this.opts.initialSyncLimit).done(
-    function(res) {
-        room.timeline = []; // blow away any previous messages.
-        self._processRoomEvents(room, res.state, res.messages);
-        room.recalculate(client.credentials.userId);
-        client.store.storeRoom(room);
-        client.emit("Room", room);
-        defer.resolve(room);
-        client._syncingRooms[room.roomId] = undefined;
-    }, function(err) {
-        defer.reject(err);
-        client._syncingRooms[room.roomId] = undefined;
-    });
-    return defer.promise;
-};
-
-/**
  * Main entry point
  */
 SyncApi.prototype.sync = function() {
@@ -182,13 +154,41 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         since: client.store.getSyncToken() || undefined // do not send 'null'
     };
 
+    if (attempt > 1) {
+        // we think the connection is dead. If it comes back up, we won't know
+        // about it till /sync returns. If the timeout= is high, this could
+        // be a long time. Set it to 1 when doing retries.
+        qps.timeout = 1;
+    }
+
     if (client._guestRooms && client._isGuest) {
         qps.room_id = JSON.stringify(client._guestRooms);
     }
 
+    // Set up local timer and error handler for retries.
+    function errHandler(err) {
+        console.error("/sync error (%s attempts): %s", attempt, err);
+        attempt += 1;
+        startSyncingRetryTimer(client, attempt, function() {
+            self._sync(syncOptions, attempt);
+        });
+        updateSyncState(client, "ERROR", { error: err });
+    }
+    var discardResult = false;
+    var timeoutObj = setTimeout(function() {
+        discardResult = true;
+        errHandler("Locally timed out waiting for a response");
+    }, qps.timeout + (20 * 1000)); // 20s buffer
+
     client._http.authedRequestWithPrefix(
         undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA
     ).done(function(data) {
+        if (discardResult) {
+            return;
+        }
+        else {
+            clearTimeout(timeoutObj);
+        }
         // data looks like:
         // {
         //    next_batch: $token,
@@ -219,6 +219,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         // set the sync token NOW *before* processing the events. We do this so if something
         // barfs on an event we can skip it rather than constantly polling with the same token.
         client.store.setSyncToken(data.next_batch);
+
+        // TODO-arch:
+        // - Each event we pass through needs to be emitted via 'event', can we do this in one place?
+        // - The isBrandNewRoom boilerplate is boilerplatey.
 
         try {
             // handle presence events (User objects)
@@ -258,22 +262,33 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             // Handle invites
             inviteRooms.forEach(function(inviteObj) {
                 var room = inviteObj.room;
-                var stateEvents = inviteObj.invite_state.events || [];
-                // add room_id back in f.e event
-                stateEvents = stateEvents.map(function(e) {
-                    e.room_id = room.roomId;
-                    return e;
-                });
+                var stateEvents = self._mapSyncEventsFormat(inviteObj.invite_state, room);
                 self._processRoomEvents(room, stateEvents);
                 if (inviteObj.isBrandNewRoom) {
                     room.recalculate(client.credentials.userId);
                     client.store.storeRoom(room);
                     client.emit("Room", room);
-                    console.log("Storing %s %s", room.roomId, JSON.stringify(stateEvents));
                 }
+                stateEvents.forEach(function(e) { client.emit("event", e); });
             });
 
             // Handle joins
+            joinRooms.forEach(function(joinObj) {
+                var room = joinObj.room;
+                var stateEvents = self._mapSyncEventsFormat(joinObj.state, room);
+                var timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room);
+                self._processRoomEvents(
+                    room, stateEvents, timelineEvents, joinObj.timeline.prev_batch
+                );
+                // TODO: Receipts, Typing, Tags from ephermeral + account_data
+                room.recalculate(client.credentials.userId);
+                if (joinObj.isBrandNewRoom) {
+                    client.store.storeRoom(room);
+                    client.emit("Room", room);
+                }
+                stateEvents.forEach(function(e) { client.emit("event", e); });
+                timelineEvents.forEach(function(e) { client.emit("event", e); });
+            });
 
             // Ignore leave rooms for now (TODO: Honour includeArchived opt)
         }
@@ -286,14 +301,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         var i, j;
         // intercept the results and put them into our store
         if (!(client.store instanceof StubStore)) {
-            utils.forEach(
-                utils.map(data.presence, client.getEventMapper()),
-            function(e) {
-                var user = createNewUser(client, e.getContent().user_id);
-                user.setPresenceEvent(e);
-                client.store.storeUser(user);
-            });
-
             // group receipts by room ID.
             var receiptsByRoom = {};
             data.receipts = data.receipts || [];
@@ -307,27 +314,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             );
 
             for (i = 0; i < data.rooms.length; i++) {
-                var room = createNewRoom(client, data.rooms[i].room_id);
-                if (!data.rooms[i].state) {
-                    data.rooms[i].state = [];
-                }
-                if (data.rooms[i].membership === "invite") {
-                    var inviteEvent = data.rooms[i].invite;
-                    if (!inviteEvent) {
-                        // fallback for servers which don't serve the invite key yet
-                        inviteEvent = {
-                            event_id: "$fake_" + room.roomId,
-                            content: {
-                                membership: "invite"
-                            },
-                            state_key: client.credentials.userId,
-                            user_id: data.rooms[i].inviter,
-                            room_id: room.roomId,
-                            type: "m.room.member"
-                        };
-                    }
-                    data.rooms[i].state.push(inviteEvent);
-                }
 
                 _processRoomEvents(
                     client, room, data.rooms[i].state, data.rooms[i].messages
@@ -359,30 +345,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             }
         }
 
-        if (data) {
-            var events = [];
-            for (i = 0; i < data.presence.length; i++) {
-                events.push(new MatrixEvent(data.presence[i]));
-            }
-            for (i = 0; i < data.rooms.length; i++) {
-                if (data.rooms[i].state) {
-                    for (j = 0; j < data.rooms[i].state.length; j++) {
-                        events.push(new MatrixEvent(data.rooms[i].state[j]));
-                    }
-                }
-                if (data.rooms[i].messages) {
-                    for (j = 0; j < data.rooms[i].messages.chunk.length; j++) {
-                        events.push(
-                            new MatrixEvent(data.rooms[i].messages.chunk[j])
-                        );
-                    }
-                }
-            }
-            utils.forEach(events, function(e) {
-                client.emit("event", e);
-            });
-        }
-
         */
 
         
@@ -393,14 +355,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         }
         updateSyncState(client, "SYNCING");
         self._sync(syncOptions);
-    }, function(err) {
-        console.error("/sync error (%s attempts): %s", attempt, err);
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            self._sync(syncOptions, attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
-    });
+    }, errHandler);
 };
 
 SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
@@ -422,6 +377,19 @@ SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
         return arrObj;
     });
 }
+
+SyncApi.prototype._mapSyncEventsFormat = function(obj, room) {
+    if (!obj || !utils.isArray(obj.events)) {
+        return [];
+    }
+    var mapper = this.client.getEventMapper();
+    return obj.events.map(function(e) {
+        if (room) {
+            e.room_id = room.roomId;
+        }
+        return mapper(e);
+    });
+};
 
 SyncApi.prototype._resolveInvites = function(room) {
     if (!room || !this.opts.resolveInvitesToProfiles) {
@@ -465,189 +433,42 @@ SyncApi.prototype._resolveInvites = function(room) {
     });
 }
 
-SyncApi.prototype._processRoomEvents = function(room, stateEventList, messageChunk) {
+/**
+ * @param {Room} room
+ * @param {MatrixEvent[]} stateEventList A list of state events. This is the state
+ * at the *START* of the timeline list if it is supplied.
+ * @param {MatrixEvent[]=} timelineEventList A list of timeline events. Lower index
+ * is earlier in time. Higher index is later.
+ * @param {string=} paginationToken
+ */
+SyncApi.prototype._processRoomEvents = function(room, stateEventList, timelineEventList,
+                                                paginationToken) {
+    timelineEventList = timelineEventList || [];
     var client = this.client;
     // "old" and "current" state are the same initially; they
     // start diverging if the user paginates.
     // We must deep copy otherwise membership changes in old state
     // will leak through to current state!
     var oldStateEvents = utils.map(
-        utils.deepCopy(stateEventList), client.getEventMapper()
+        utils.deepCopy(
+            stateEventList.map(function(mxEvent) { return mxEvent.event; })
+        ), client.getEventMapper()
     );
-    var stateEvents = utils.map(stateEventList, client.getEventMapper());
+    var stateEvents = stateEventList;
+
+    // set the state of the room to as it was before the timeline executes
     room.oldState.setStateEvents(oldStateEvents);
     room.currentState.setStateEvents(stateEvents);
 
     this._resolveInvites(room);
 
-    // add events to the timeline *after* setting the state
-    // events so messages use the right display names. Initial sync
-    // returns messages in chronological order, so we need to reverse
-    // it to get most recent -> oldest. We need it in that order in
-    // order to diverge old/current state correctly.
-    room.addEventsToTimeline(
-        utils.map(
-            messageChunk ? messageChunk.chunk : [],
-            client.getEventMapper()
-        ).reverse(), true
-    );
-    if (messageChunk) {
-        room.oldState.paginationToken = messageChunk.start;
+    // execute the timeline events, this will begin to diverge the current state
+    // if the timeline has any state events in it.
+    room.addEventsToTimeline(timelineEventList);
+    if (paginationToken) {
+        room.oldState.paginationToken = paginationToken;
     }
 }
-
-/**
- * This is an internal method.
- * @param {Number=} attempt The attempt number
- */ /*
-SyncApi.prototype._pollForEvents = function(attempt) {
-    var client = this.client;
-    var self = this;
-
-    attempt = attempt || 1;
-
-    if (!client.clientRunning) {
-        return;
-    }
-    var timeoutMs = client._config.pollTimeout;
-    if (attempt > 1) {
-        // we think the connection is dead. If it comes back up, we won't know
-        // about it till /events returns. If the timeout= is high, this could
-        // be a long time. Set it to 1 when doing retries.
-        timeoutMs = 1;
-    }
-    var discardResult = false;
-    var timeoutObj = setTimeout(function() {
-        discardResult = true;
-        console.error("/events request timed out.");
-        self._pollForEvents();
-    }, timeoutMs + (20 * 1000)); // 20s buffer
-
-    var queryParams = {
-        from: client.store.getSyncToken(),
-        timeout: timeoutMs
-    };
-    if (client._guestRooms && client._isGuest) {
-        queryParams.room_id = client._guestRooms;
-    }
-
-    client._http.authedRequest(undefined, "GET", "/events", queryParams).done(
-    function(data) {
-        if (discardResult) {
-            return;
-        }
-        else {
-            clearTimeout(timeoutObj);
-        }
-
-        if (client._syncState !== "SYNCING") {
-            updateSyncState(client, "SYNCING");
-        }
-
-        try {
-            var events = [];
-            if (data) {
-                events = utils.map(data.chunk, client.getEventMapper());
-            }
-            if (!(client.store instanceof StubStore)) {
-                var roomIdsWithNewInvites = {};
-                // bucket events based on room.
-                var i = 0;
-                var roomIdToEvents = {};
-                for (i = 0; i < events.length; i++) {
-                    var roomId = events[i].getRoomId();
-                    // possible to have no room ID e.g. for presence events.
-                    if (roomId) {
-                        if (!roomIdToEvents[roomId]) {
-                            roomIdToEvents[roomId] = [];
-                        }
-                        roomIdToEvents[roomId].push(events[i]);
-                        if (events[i].getType() === "m.room.member" &&
-                                events[i].getContent().membership === "invite") {
-                            roomIdsWithNewInvites[roomId] = true;
-                        }
-                    }
-                    else if (events[i].getType() === "m.presence") {
-                        var usr = client.store.getUser(events[i].getContent().user_id);
-                        if (usr) {
-                            usr.setPresenceEvent(events[i]);
-                        }
-                        else {
-                            usr = createNewUser(client, events[i].getContent().user_id);
-                            usr.setPresenceEvent(events[i]);
-                            client.store.storeUser(usr);
-                        }
-                    }
-                }
-
-                // add events to room
-                var roomIds = utils.keys(roomIdToEvents);
-                utils.forEach(roomIds, function(roomId) {
-                    var room = client.store.getRoom(roomId);
-                    var isBrandNewRoom = false;
-                    if (!room) {
-                        room = createNewRoom(client, roomId);
-                        isBrandNewRoom = true;
-                    }
-
-                    var wasJoined = room.hasMembershipState(
-                        client.credentials.userId, "join"
-                    );
-
-                    room.addEvents(roomIdToEvents[roomId], "replace");
-                    room.recalculate(client.credentials.userId);
-
-                    // store the Room for things like invite events so developers
-                    // can update the UI
-                    if (isBrandNewRoom) {
-                        client.store.storeRoom(room);
-                        client.emit("Room", room);
-                    }
-
-                    var justJoined = room.hasMembershipState(
-                        client.credentials.userId, "join"
-                    );
-
-                    if (!wasJoined && justJoined) {
-                        // we've just transitioned into a join state for this room,
-                        // so sync state.
-                        _syncRoom(client, room);
-                    }
-                });
-
-                Object.keys(roomIdsWithNewInvites).forEach(function(inviteRoomId) {
-                    _resolveInvites(client, client.store.getRoom(inviteRoomId));
-                });
-            }
-            if (data) {
-                client.store.setSyncToken(data.end);
-                utils.forEach(events, function(e) {
-                    client.emit("event", e);
-                });
-            }
-        }
-        catch (e) {
-            console.error("Event stream error:");
-            console.error(e);
-        }
-        self._pollForEvents();
-    }, function(err) {
-        console.error("/events error: %s", JSON.stringify(err));
-        if (discardResult) {
-            return;
-        }
-        else {
-            clearTimeout(timeoutObj);
-        }
-
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            self._pollForEvents(attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
-    });
-}; */
-
 
 function retryTimeMsForAttempt(attempt) {
     // 2,4,8,16,32,64,128,128,128,... seconds

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -330,9 +330,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             updateSyncState(client, "PREPARED");
             syncOptions.hasSyncedBefore = true;
         }
-        if (client._syncState !== "SYNCING") {
-            updateSyncState(client, "SYNCING");
-        }
+
+        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
+        updateSyncState(client, "SYNCING");
+
         self._sync(syncOptions);
     }, errHandler);
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -41,7 +41,29 @@ function SyncApi(client, opts) {
  * @return {Room}
  */
 SyncApi.prototype.createRoom = function(roomId) {
-    return createNewRoom(this.client, roomId);
+    var client = this.client;
+    var room = new Room(roomId, {
+        pendingEventOrdering: this.opts.pendingEventOrdering
+    });
+    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
+
+    // we need to also re-emit room state and room member events, so hook it up
+    // to the client now. We need to add a listener for RoomState.members in
+    // order to hook them correctly. (TODO: find a better way?)
+    reEmit(client, room.currentState, [
+        "RoomState.events", "RoomState.members", "RoomState.newMember"
+    ]);
+    room.currentState.on("RoomState.newMember", function(event, state, member) {
+        member.user = client.getUser(member.userId);
+        reEmit(
+            client, member,
+            [
+                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
+                "RoomMember.membership"
+            ]
+        );
+    });
+    return room;
 };
 
 /**
@@ -49,7 +71,27 @@ SyncApi.prototype.createRoom = function(roomId) {
  * @return {Promise}
  */
 SyncApi.prototype.syncRoom = function(room) {
-    return _syncRoom(this.client, room);
+    var client = this.client;
+    var self = this;
+    if (client._syncingRooms[room.roomId]) {
+        return client._syncingRooms[room.roomId];
+    }
+    var defer = q.defer();
+    client._syncingRooms[room.roomId] = defer.promise;
+    client.roomInitialSync(room.roomId, this.opts.initialSyncLimit).done(
+    function(res) {
+        room.timeline = []; // blow away any previous messages.
+        self._processRoomEvents(room, res.state, res.messages);
+        room.recalculate(client.credentials.userId);
+        client.store.storeRoom(room);
+        client.emit("Room", room);
+        defer.resolve(room);
+        client._syncingRooms[room.roomId] = undefined;
+    }, function(err) {
+        defer.reject(err);
+        client._syncingRooms[room.roomId] = undefined;
+    });
+    return defer.promise;
 };
 
 /**
@@ -173,7 +215,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         //      }
         //    }
         // }
-        console.log("Got data %s", data);
 
         // set the sync token NOW *before* processing the events. We do this so if something
         // barfs on an event we can skip it rather than constantly polling with the same token.
@@ -195,6 +236,46 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                     client.emit("event", presenceEvent);
                 });
             }
+
+            // the returned json structure is abit crap, so make it into a nicer form (array) after
+            // applying sanity to make sure we don't fail on missing keys (on the off chance)
+            var inviteRooms = [];
+            var joinRooms = [];
+            var leaveRooms = [];
+
+            if (data.rooms) {
+                if (data.rooms.invite) {
+                    inviteRooms = self._mapSyncResponseToRoomArray(data.rooms.invite);
+                }
+                if (data.rooms.join) {
+                    joinRooms = self._mapSyncResponseToRoomArray(data.rooms.join);
+                }
+                if (data.rooms.leave) {
+                    leaveRooms = self._mapSyncResponseToRoomArray(data.rooms.leave);
+                }
+            }
+
+            // Handle invites
+            inviteRooms.forEach(function(inviteObj) {
+                var room = inviteObj.room;
+                var stateEvents = inviteObj.invite_state.events || [];
+                // add room_id back in f.e event
+                stateEvents = stateEvents.map(function(e) {
+                    e.room_id = room.roomId;
+                    return e;
+                });
+                self._processRoomEvents(room, stateEvents);
+                if (inviteObj.isBrandNewRoom) {
+                    room.recalculate(client.credentials.userId);
+                    client.store.storeRoom(room);
+                    client.emit("Room", room);
+                    console.log("Storing %s %s", room.roomId, JSON.stringify(stateEvents));
+                }
+            });
+
+            // Handle joins
+
+            // Ignore leave rooms for now (TODO: Honour includeArchived opt)
         }
         catch (e) {
             console.error("Caught /sync error:");
@@ -322,10 +403,103 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     });
 };
 
+SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
+    // Maps { roomid: {stuff}, roomid: {stuff} }
+    // to
+    // [{stuff+Room+isBrandNewRoom}, {stuff+Room+isBrandNewRoom}]
+    var client = this.client;
+    var self = this;
+    return utils.keys(obj).map(function(roomId) {
+        var arrObj = obj[roomId];
+        var room = client.store.getRoom(roomId);
+        var isBrandNewRoom = false;
+        if (!room) {
+            room = self.createRoom(roomId);
+            isBrandNewRoom = true;
+        }
+        arrObj.room = room;
+        arrObj.isBrandNewRoom = isBrandNewRoom;
+        return arrObj;
+    });
+}
+
+SyncApi.prototype._resolveInvites = function(room) {
+    if (!room || !this.opts.resolveInvitesToProfiles) {
+        return;
+    }
+    var client = this.client;
+    // For each invited room member we want to give them a displayname/avatar url
+    // if they have one (the m.room.member invites don't contain this).
+    room.getMembersWithMembership("invite").forEach(function(member) {
+        if (member._requestedProfileInfo) {
+            return;
+        }
+        member._requestedProfileInfo = true;
+        // try to get a cached copy first.
+        var user = client.getUser(member.userId);
+        var promise;
+        if (user) {
+            promise = q({
+                avatar_url: user.avatarUrl,
+                displayname: user.displayName
+            });
+        }
+        else {
+            promise = client.getProfileInfo(member.userId);
+        }
+        promise.done(function(info) {
+            // slightly naughty by doctoring the invite event but this means all
+            // the code paths remain the same between invite/join display name stuff
+            // which is a worthy trade-off for some minor pollution.
+            var inviteEvent = member.events.member;
+            if (inviteEvent.getContent().membership !== "invite") {
+                // between resolving and now they have since joined, so don't clobber
+                return;
+            }
+            inviteEvent.getContent().avatar_url = info.avatar_url;
+            inviteEvent.getContent().displayname = info.displayname;
+            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
+        }, function(err) {
+            // OH WELL.
+        });
+    });
+}
+
+SyncApi.prototype._processRoomEvents = function(room, stateEventList, messageChunk) {
+    var client = this.client;
+    // "old" and "current" state are the same initially; they
+    // start diverging if the user paginates.
+    // We must deep copy otherwise membership changes in old state
+    // will leak through to current state!
+    var oldStateEvents = utils.map(
+        utils.deepCopy(stateEventList), client.getEventMapper()
+    );
+    var stateEvents = utils.map(stateEventList, client.getEventMapper());
+    room.oldState.setStateEvents(oldStateEvents);
+    room.currentState.setStateEvents(stateEvents);
+
+    this._resolveInvites(room);
+
+    // add events to the timeline *after* setting the state
+    // events so messages use the right display names. Initial sync
+    // returns messages in chronological order, so we need to reverse
+    // it to get most recent -> oldest. We need it in that order in
+    // order to diverge old/current state correctly.
+    room.addEventsToTimeline(
+        utils.map(
+            messageChunk ? messageChunk.chunk : [],
+            client.getEventMapper()
+        ).reverse(), true
+    );
+    if (messageChunk) {
+        room.oldState.paginationToken = messageChunk.start;
+    }
+}
+
 /**
  * This is an internal method.
  * @param {Number=} attempt The attempt number
- */
+ */ /*
 SyncApi.prototype._pollForEvents = function(attempt) {
     var client = this.client;
     var self = this;
@@ -472,8 +646,7 @@ SyncApi.prototype._pollForEvents = function(attempt) {
         });
         updateSyncState(client, "ERROR", { error: err });
     });
-};
-
+}; */
 
 
 function retryTimeMsForAttempt(attempt) {
@@ -502,31 +675,6 @@ function createNewUser(client, userId) {
     return user;
 }
 
-function createNewRoom(client, roomId) {
-    var room = new Room(roomId, {
-        pendingEventOrdering: client._config.pendingEventOrdering
-    });
-    reEmit(client, room, ["Room.name", "Room.timeline", "Room.receipt", "Room.tags"]);
-
-    // we need to also re-emit room state and room member events, so hook it up
-    // to the client now. We need to add a listener for RoomState.members in
-    // order to hook them correctly. (TODO: find a better way?)
-    reEmit(client, room.currentState, [
-        "RoomState.events", "RoomState.members", "RoomState.newMember"
-    ]);
-    room.currentState.on("RoomState.newMember", function(event, state, member) {
-        member.user = client.getUser(member.userId);
-        reEmit(
-            client, member,
-            [
-                "RoomMember.name", "RoomMember.typing", "RoomMember.powerLevel",
-                "RoomMember.membership"
-            ]
-        );
-    });
-    return room;
-}
-
 function reEmit(reEmitEntity, emittableEntity, eventNames) {
     utils.forEach(eventNames, function(eventName) {
         // setup a listener on the entity (the Room, User, etc) for this event
@@ -541,99 +689,6 @@ function reEmit(reEmitEntity, emittableEntity, eventNames) {
                 newArgs.push(arguments[i]);
             }
             reEmitEntity.emit.apply(reEmitEntity, newArgs);
-        });
-    });
-}
-
-function _syncRoom(client, room) {
-    if (client._syncingRooms[room.roomId]) {
-        return client._syncingRooms[room.roomId];
-    }
-    var defer = q.defer();
-    client._syncingRooms[room.roomId] = defer.promise;
-    client.roomInitialSync(room.roomId, client._config.initialSyncLimit).done(
-    function(res) {
-        room.timeline = []; // blow away any previous messages.
-        _processRoomEvents(client, room, res.state, res.messages);
-        room.recalculate(client.credentials.userId);
-        client.store.storeRoom(room);
-        client.emit("Room", room);
-        defer.resolve(room);
-        client._syncingRooms[room.roomId] = undefined;
-    }, function(err) {
-        defer.reject(err);
-        client._syncingRooms[room.roomId] = undefined;
-    });
-    return defer.promise;
-}
-
-function _processRoomEvents(client, room, stateEventList, messageChunk) {
-    // "old" and "current" state are the same initially; they
-    // start diverging if the user paginates.
-    // We must deep copy otherwise membership changes in old state
-    // will leak through to current state!
-    var oldStateEvents = utils.map(
-        utils.deepCopy(stateEventList), client.getEventMapper()
-    );
-    var stateEvents = utils.map(stateEventList, client.getEventMapper());
-    room.oldState.setStateEvents(oldStateEvents);
-    room.currentState.setStateEvents(stateEvents);
-
-    _resolveInvites(client, room);
-
-    // add events to the timeline *after* setting the state
-    // events so messages use the right display names. Initial sync
-    // returns messages in chronological order, so we need to reverse
-    // it to get most recent -> oldest. We need it in that order in
-    // order to diverge old/current state correctly.
-    room.addEventsToTimeline(
-        utils.map(
-            messageChunk ? messageChunk.chunk : [],
-            client.getEventMapper()
-        ).reverse(), true
-    );
-    if (messageChunk) {
-        room.oldState.paginationToken = messageChunk.start;
-    }
-}
-
-function _resolveInvites(client, room) {
-    if (!room || !client._config.resolveInvitesToProfiles) {
-        return;
-    }
-    // For each invited room member we want to give them a displayname/avatar url
-    // if they have one (the m.room.member invites don't contain this).
-    room.getMembersWithMembership("invite").forEach(function(member) {
-        if (member._requestedProfileInfo) {
-            return;
-        }
-        member._requestedProfileInfo = true;
-        // try to get a cached copy first.
-        var user = client.getUser(member.userId);
-        var promise;
-        if (user) {
-            promise = q({
-                avatar_url: user.avatarUrl,
-                displayname: user.displayName
-            });
-        }
-        else {
-            promise = client.getProfileInfo(member.userId);
-        }
-        promise.done(function(info) {
-            // slightly naughty by doctoring the invite event but this means all
-            // the code paths remain the same between invite/join display name stuff
-            // which is a worthy trade-off for some minor pollution.
-            var inviteEvent = member.events.member;
-            if (inviteEvent.getContent().membership !== "invite") {
-                // between resolving and now they have since joined, so don't clobber
-                return;
-            }
-            inviteEvent.getContent().avatar_url = info.avatar_url;
-            inviteEvent.getContent().displayname = info.displayname;
-            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
-        }, function(err) {
-            // OH WELL.
         });
     });
 }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -187,10 +187,18 @@ function SyncApi(client) {
     this.opts = {};
 }
 
+/**
+ * @param {string} roomId
+ * @return {Room}
+ */
 SyncApi.prototype.createRoom = function(roomId) {
     return createNewRoom(this.client, roomId);
 };
 
+/**
+ * @param {Room} room
+ * @return {Promise}
+ */
 SyncApi.prototype.syncRoom = function(room) {
     return _syncRoom(this.client, room);
 };
@@ -203,10 +211,13 @@ SyncApi.prototype.syncRoom = function(room) {
 SyncApi.prototype.sync = function(opts) {
     console.log("SyncApi.sync");
     this.opts = opts || {};
-    return this._prepareForSync();
+    this._prepareForSync();
 };
 
 
+/**
+ * @param {Number=} attempt
+ */
 SyncApi.prototype._prepareForSync = function(attempt) {
     var client = this.client;
     var self = this;
@@ -231,6 +242,9 @@ SyncApi.prototype._prepareForSync = function(attempt) {
     });
 };
 
+/**
+ * @param {Number=} attempt
+ */
 SyncApi.prototype._sync = function(attempt) {
     var opts = this.opts;
     var client = this.client;
@@ -367,15 +381,14 @@ SyncApi.prototype._sync = function(attempt) {
 
 /**
  * This is an internal method.
- * @param {MatrixClient} client
- * @param {Number} attempt The attempt number
+ * @param {Number=} attempt The attempt number
  */
 SyncApi.prototype._pollForEvents = function(attempt) {
     var client = this.client;
     var self = this;
 
     attempt = attempt || 1;
-    
+
     if (!client.clientRunning) {
         return;
     }
@@ -518,4 +531,5 @@ SyncApi.prototype._pollForEvents = function(attempt) {
     });
 };
 
+/** */
 module.exports = SyncApi;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -100,7 +100,9 @@ SyncApi.prototype.sync = function() {
 
 
         // Get or create filter
-        var filterId = client.store.getFilterIdByName(getFilterName(client.credentials.userId));
+        var filterId = client.store.getFilterIdByName(
+            getFilterName(client.credentials.userId)
+        );
         if (filterId) {
             // super, just use that.
             console.log("Using existing filter ID %s", filterId);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -9,11 +9,9 @@
  * for HTTP and WS at some point.
  */
 var q = require("q");
-var StubStore = require("./store/stub");
 var User = require("./models/user");
 var Room = require("./models/room");
 var utils = require("./utils");
-var MatrixEvent = require("./models/event").MatrixEvent;
 var httpApi = require("./http-api");
 var Filter = require("./filter");
 
@@ -216,18 +214,21 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         //    }
         // }
 
-        // set the sync token NOW *before* processing the events. We do this so if something
-        // barfs on an event we can skip it rather than constantly polling with the same token.
+        // set the sync token NOW *before* processing the events. We do this so
+        // if something barfs on an event we can skip it rather than constantly
+        // polling with the same token.
         client.store.setSyncToken(data.next_batch);
 
         // TODO-arch:
-        // - Each event we pass through needs to be emitted via 'event', can we do this in one place?
+        // - Each event we pass through needs to be emitted via 'event', can we
+        //   do this in one place?
         // - The isBrandNewRoom boilerplate is boilerplatey.
 
         try {
             // handle presence events (User objects)
             if (data.presence && utils.isArray(data.presence.events)) {
-                data.presence.events.map(client.getEventMapper()).forEach(function(presenceEvent) {
+                data.presence.events.map(client.getEventMapper()).forEach(
+                function(presenceEvent) {
                     var user = client.store.getUser(presenceEvent.getSender());
                     if (user) {
                         user.setPresenceEvent(presenceEvent);
@@ -241,8 +242,9 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 });
             }
 
-            // the returned json structure is abit crap, so make it into a nicer form (array) after
-            // applying sanity to make sure we don't fail on missing keys (on the off chance)
+            // the returned json structure is abit crap, so make it into a
+            // nicer form (array) after applying sanity to make sure we don't fail
+            // on missing keys (on the off chance)
             var inviteRooms = [];
             var joinRooms = [];
             var leaveRooms = [];
@@ -304,7 +306,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             console.error("Caught /sync error:");
             console.error(e);
         }
-        
+
         // emit synced events
         if (!syncOptions.hasSyncedBefore) {
             updateSyncState(client, "PREPARED");
@@ -315,6 +317,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     }, errHandler);
 };
 
+/**
+ * @param {Object} obj
+ * @return {Object[]}
+ */
 SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
     // Maps { roomid: {stuff}, roomid: {stuff} }
     // to
@@ -333,8 +339,13 @@ SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
         arrObj.isBrandNewRoom = isBrandNewRoom;
         return arrObj;
     });
-}
+};
 
+/**
+ * @param {Object} obj
+ * @param {Room} room
+ * @return {MatrixEvent[]}
+ */
 SyncApi.prototype._mapSyncEventsFormat = function(obj, room) {
     if (!obj || !utils.isArray(obj.events)) {
         return [];
@@ -348,6 +359,9 @@ SyncApi.prototype._mapSyncEventsFormat = function(obj, room) {
     });
 };
 
+/**
+ * @param {Room} room
+ */
 SyncApi.prototype._resolveInvites = function(room) {
     if (!room || !this.opts.resolveInvitesToProfiles) {
         return;
@@ -383,12 +397,13 @@ SyncApi.prototype._resolveInvites = function(room) {
             }
             inviteEvent.getContent().avatar_url = info.avatar_url;
             inviteEvent.getContent().displayname = info.displayname;
-            member.setMembershipEvent(inviteEvent, room.currentState); // fire listeners
+            // fire listeners
+            member.setMembershipEvent(inviteEvent, room.currentState);
         }, function(err) {
             // OH WELL.
         });
     });
-}
+};
 
 /**
  * @param {Room} room
@@ -398,8 +413,8 @@ SyncApi.prototype._resolveInvites = function(room) {
  * is earlier in time. Higher index is later.
  * @param {string=} paginationToken
  */
-SyncApi.prototype._processRoomEvents = function(room, stateEventList, timelineEventList,
-                                                paginationToken) {
+SyncApi.prototype._processRoomEvents = function(room, stateEventList,
+                                                timelineEventList, paginationToken) {
     timelineEventList = timelineEventList || [];
     var client = this.client;
     // "old" and "current" state are the same initially; they
@@ -425,7 +440,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList, timelineEv
     if (paginationToken) {
         room.oldState.paginationToken = paginationToken;
     }
-}
+};
 
 function retryTimeMsForAttempt(attempt) {
     // 2,4,8,16,32,64,128,128,128,... seconds

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -19,7 +19,7 @@ var Filter = require("./filter");
 // beyond that and wedge forever, so we need to track how long we are willing
 // to keep open the connection. This constant is *ADDED* to the timeout= value
 // to determine the max time we're willing to wait.
-var BUFFER_PERIOD_MS = 90 * 1000;
+var BUFFER_PERIOD_MS = 20 * 1000;
 
 function getFilterName(userId) {
     // scope this on the user ID because people may login on many accounts
@@ -178,30 +178,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         qps.room_id = client._guestRooms;
     }
 
-    // Set up local timer and error handler for retries.
-    function errHandler(err) {
-        console.error("/sync error (%s attempts): %s", attempt, err);
-        attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            self._sync(syncOptions, attempt);
-        });
-        updateSyncState(client, "ERROR", { error: err });
-    }
-    var discardResult = false;
-    var timeoutObj = setTimeout(function() {
-        discardResult = true;
-        errHandler("Locally timed out waiting for a response");
-    }, qps.timeout + BUFFER_PERIOD_MS);
-
     client._http.authedRequestWithPrefix(
-        undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA
+        undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA,
+        this.opts.pollTimeout + BUFFER_PERIOD_MS // normal timeout= plus buffer time
     ).done(function(data) {
-        if (discardResult) {
-            return;
-        }
-        else {
-            clearTimeout(timeoutObj);
-        }
         // data looks like:
         // {
         //    next_batch: $token,
@@ -344,7 +324,15 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         updateSyncState(client, "SYNCING");
 
         self._sync(syncOptions);
-    }, errHandler);
+    }, function(err) {
+        console.error("/sync error (%s attempts): %s", attempt, err);
+        console.error(err);
+        attempt += 1;
+        startSyncingRetryTimer(client, attempt, function() {
+            self._sync(syncOptions, attempt);
+        });
+        updateSyncState(client, "ERROR", { error: err });
+    });
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -371,7 +371,7 @@ module.exports.runPolyfills = function() {
     //                Array.prototype.forEach
     // ========================================================
     // SOURCE:
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
     // Production steps of ECMA-262, Edition 5, 15.4.4.18
     // Reference: http://es5.github.io/#x15.4.4.18
     if (!Array.prototype.forEach) {
@@ -380,14 +380,15 @@ module.exports.runPolyfills = function() {
 
         var T, k;
 
-        if (this == null) {
+        if (this === null || this === undefined) {
           throw new TypeError(' this is null or not defined');
         }
 
         // 1. Let O be the result of calling ToObject passing the |this| value as the argument.
         var O = Object(this);
 
-        // 2. Let lenValue be the result of calling the Get internal method of O with the argument "length".
+        // 2. Let lenValue be the result of calling the Get internal method of O with the
+        // argument "length".
         // 3. Let len be ToUint32(lenValue).
         var len = O.length >>> 0;
 
@@ -412,12 +413,14 @@ module.exports.runPolyfills = function() {
 
           // a. Let Pk be ToString(k).
           //   This is implicit for LHS operands of the in operator
-          // b. Let kPresent be the result of calling the HasProperty internal method of O with argument Pk.
+          // b. Let kPresent be the result of calling the HasProperty internal
+          //    method of O with
+          //    argument Pk.
           //   This step can be combined with c
           // c. If kPresent is true, then
           if (k in O) {
 
-            // i. Let kValue be the result of calling the Get internal method of O with argument Pk.
+            // i. Let kValue be the result of calling the Get internal method of O with argument Pk
             kValue = O[k];
 
             // ii. Call the Call internal method of callback with T as the this value and

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -367,6 +367,69 @@ module.exports.runPolyfills = function() {
         return A;
       };
     }
+
+    //                Array.prototype.forEach
+    // ========================================================
+    // SOURCE:
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+    // Production steps of ECMA-262, Edition 5, 15.4.4.18
+    // Reference: http://es5.github.io/#x15.4.4.18
+    if (!Array.prototype.forEach) {
+
+      Array.prototype.forEach = function(callback, thisArg) {
+
+        var T, k;
+
+        if (this == null) {
+          throw new TypeError(' this is null or not defined');
+        }
+
+        // 1. Let O be the result of calling ToObject passing the |this| value as the argument.
+        var O = Object(this);
+
+        // 2. Let lenValue be the result of calling the Get internal method of O with the argument "length".
+        // 3. Let len be ToUint32(lenValue).
+        var len = O.length >>> 0;
+
+        // 4. If IsCallable(callback) is false, throw a TypeError exception.
+        // See: http://es5.github.com/#x9.11
+        if (typeof callback !== "function") {
+          throw new TypeError(callback + ' is not a function');
+        }
+
+        // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+        if (arguments.length > 1) {
+          T = thisArg;
+        }
+
+        // 6. Let k be 0
+        k = 0;
+
+        // 7. Repeat, while k < len
+        while (k < len) {
+
+          var kValue;
+
+          // a. Let Pk be ToString(k).
+          //   This is implicit for LHS operands of the in operator
+          // b. Let kPresent be the result of calling the HasProperty internal method of O with argument Pk.
+          //   This step can be combined with c
+          // c. If kPresent is true, then
+          if (k in O) {
+
+            // i. Let kValue be the result of calling the Get internal method of O with argument Pk.
+            kValue = O[k];
+
+            // ii. Call the Call internal method of callback with T as the this value and
+            // argument list containing kValue, k, and O.
+            callback.call(T, kValue, k, O);
+          }
+          // d. Increase k by 1.
+          k++;
+        }
+        // 8. return undefined
+      };
+    }
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -384,7 +384,8 @@ module.exports.runPolyfills = function() {
           throw new TypeError(' this is null or not defined');
         }
 
-        // 1. Let O be the result of calling ToObject passing the |this| value as the argument.
+        // 1. Let O be the result of calling ToObject passing the |this| value as the
+        // argument.
         var O = Object(this);
 
         // 2. Let lenValue be the result of calling the Get internal method of O with the
@@ -420,7 +421,8 @@ module.exports.runPolyfills = function() {
           // c. If kPresent is true, then
           if (k in O) {
 
-            // i. Let kValue be the result of calling the Get internal method of O with argument Pk
+            // i. Let kValue be the result of calling the Get internal method of O with
+            // argument Pk
             kValue = O[k];
 
             // ii. Call the Call internal method of callback with T as the this value and

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -200,22 +200,26 @@ describe("MatrixClient crypto", function() {
     });
 
     function bobRecvMessage(done) {
-        var initialSync = {
-            end: "alpha",
-            presence: [],
-            rooms: []
+        var syncData = {
+            next_batch: "x",
+            rooms: {
+                join: {
+
+                }
+            }
         };
-        var events = {
-            start: "alpha",
-            end: "beta",
-            chunk: [utils.mkEvent({
-                type: "m.room.encrypted",
-                room: roomId,
-                content: aliMessage
-            })]
+        syncData.rooms.join[roomId] = {
+            timeline: {
+                events: [
+                    utils.mkEvent({
+                        type: "m.room.encrypted",
+                        room: roomId,
+                        content: aliMessage
+                    })
+                ]
+            }
         };
-        httpBackend.when("GET", "initialSync").respond(200, initialSync);
-        httpBackend.when("GET", "events").respond(200, events);
+        httpBackend.when("GET", "/sync").respond(200, syncData);
         bobClient.on("event", function(event) {
             expect(event.getType()).toEqual("m.room.message");
             expect(event.getContent()).toEqual({

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -67,6 +67,7 @@ describe("MatrixClient crypto", function() {
         });
 
         httpBackend.when("GET", "/pushrules").respond(200, {});
+        httpBackend.when("POST", "/filter").respond(200, { filter_id: "fid" });
     });
 
     describe("Ali account setup", function() {

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -19,6 +19,7 @@ describe("MatrixClient events", function() {
             accessToken: selfAccessToken
         });
         httpBackend.when("GET", "/pushrules").respond(200, {});
+        httpBackend.when("POST", "/filter").respond(200, { filter_id: "a filter id" });
     });
 
     afterEach(function() {
@@ -26,108 +27,113 @@ describe("MatrixClient events", function() {
     });
 
     describe("emissions", function() {
-        var initialSync = {
-            end: "s_5_3",
-            presence: [{
-                event_id: "$wefiuewh:bar",
-                type: "m.presence",
-                content: {
-                    user_id: "@foo:bar",
-                    displayname: "Foo Bar",
-                    presence: "online"
-                }
-            }],
-            rooms: [{
-                room_id: "!erufh:bar",
-                membership: "join",
-                messages: {
-                    start: "s",
-                    end: "t",
-                    chunk: [
-                        utils.mkMessage({
-                            room: "!erufh:bar", user: "@foo:bar", msg: "hmmm"
-                        })
-                    ]
-                },
-                state: [
-                    utils.mkMembership({
-                        room: "!erufh:bar", mship: "join", user: "@foo:bar"
-                    }),
-                    utils.mkEvent({
-                        type: "m.room.create", room: "!erufh:bar", user: "@foo:bar",
-                        content: {
-                            creator: "@foo:bar"
-                        }
+        var SYNC_DATA = {
+            next_batch: "s_5_3",
+            presence: {
+                events: [
+                    utils.mkPresence({
+                        user: "@foo:bar", name: "Foo Bar", presence: "online"
                     })
                 ]
-            }]
-        };
-        var eventData = {
-            start: "s_5_3",
-            end: "e_6_7",
-            chunk: [
-                utils.mkMessage({
-                    room: "!erufh:bar", user: "@foo:bar", msg: "ello ello"
-                }),
-                utils.mkMessage({
-                    room: "!erufh:bar", user: "@foo:bar", msg: ":D"
-                }),
-                utils.mkEvent({
-                    type: "m.typing", room: "!erufh:bar", content: {
-                        user_ids: ["@foo:bar"]
+            },
+            rooms: {
+                join: {
+                    "!erufh:bar": {
+                        timeline: {
+                            events: [
+                                utils.mkMessage({
+                                    room: "!erufh:bar", user: "@foo:bar", msg: "hmmm"
+                                })
+                            ],
+                            prev_batch: "s"
+                        },
+                        state: {
+                            events: [
+                                utils.mkMembership({
+                                    room: "!erufh:bar", mship: "join", user: "@foo:bar"
+                                }),
+                                utils.mkEvent({
+                                    type: "m.room.create", room: "!erufh:bar", user: "@foo:bar",
+                                    content: {
+                                        creator: "@foo:bar"
+                                    }
+                                })
+                            ]
+                        }
                     }
-                })
-            ]
+                }
+            }
+        };
+        var NEXT_SYNC_DATA = {
+            next_batch: "e_6_7",
+            rooms: {
+                join: {
+                    "!erufh:bar": {
+                        timeline: {
+                            events: [
+                                utils.mkMessage({
+                                    room: "!erufh:bar", user: "@foo:bar", msg: "ello ello"
+                                }),
+                                utils.mkMessage({
+                                    room: "!erufh:bar", user: "@foo:bar", msg: ":D"
+                                }),
+                            ]
+                        },
+                        ephemeral: {
+                            events: [
+                                utils.mkEvent({
+                                    type: "m.typing", room: "!erufh:bar", content: {
+                                        user_ids: ["@foo:bar"]
+                                    }
+                                })
+                            ]
+                        }
+                    }
+                }
+            }
         };
 
-        it("should emit events from both /initialSync and /events", function(done) {
-            httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-            httpBackend.when("GET", "/events").respond(200, eventData);
+        it("should emit events from both the first and subsequent /sync calls",
+        function(done) {
+            httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+            httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
 
-            // initial sync events are unordered, so make an array of the types
-            // that should be emitted and we'll just pick them off one by one,
-            // so long as this is emptied we're good.
-            var initialSyncEventTypes = [
-                "m.presence", "m.room.member", "m.room.message", "m.room.create"
-            ];
+            var expectedEvents = [];
+            expectedEvents = expectedEvents.concat(
+                SYNC_DATA.presence.events,
+                SYNC_DATA.rooms.join["!erufh:bar"].timeline.events,
+                SYNC_DATA.rooms.join["!erufh:bar"].state.events,
+                NEXT_SYNC_DATA.rooms.join["!erufh:bar"].timeline.events,
+                NEXT_SYNC_DATA.rooms.join["!erufh:bar"].ephemeral.events
+            );
+
+
             var chunkIndex = 0;
             client.on("event", function(event) {
-                if (initialSyncEventTypes.length === 0) {
-                    if (chunkIndex + 1 >= eventData.chunk.length) {
-                        return;
+                var found = false;
+                for (var i = 0; i < expectedEvents.length; i++) {
+                    if (expectedEvents[i].event_id === event.getId()) {
+                        expectedEvents.splice(i, 1);
+                        found = true;
+                        break;
                     }
-                    // this should be /events now
-                    expect(eventData.chunk[chunkIndex].event_id).toEqual(
-                        event.getId()
-                    );
-                    chunkIndex++;
-                    return;
                 }
-                var index = initialSyncEventTypes.indexOf(event.getType());
-                expect(index).not.toEqual(
-                    -1, "Unexpected event type: " + event.getType()
-                );
-                if (index >= 0) {
-                    initialSyncEventTypes.splice(index, 1);
-                }
+                expect(found).toBe(true, "Unexpected 'event' emitted: " + event.getType());
             });
 
             client.startClient();
 
             httpBackend.flush().done(function() {
-                expect(initialSyncEventTypes.length).toEqual(
-                    0, "Failed to see all events from /initialSync"
-                );
-                expect(chunkIndex + 1).toEqual(
-                    eventData.chunk.length, "Failed to see all events from /events"
+                expect(expectedEvents.length).toEqual(
+                    0, "Failed to see all events from /sync calls"
                 );
                 done();
             });
         });
 
         it("should emit User events", function(done) {
-            httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-            httpBackend.when("GET", "/events").respond(200, eventData);
+            httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+            httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
             var fired = false;
             client.on("User.presence", function(event, user) {
                 fired = true;
@@ -135,9 +141,9 @@ describe("MatrixClient events", function() {
                 expect(event).toBeDefined();
                 if (!user || !event) { return; }
 
-                expect(event.event).toEqual(initialSync.presence[0]);
+                expect(event.event).toEqual(SYNC_DATA.presence.events[0]);
                 expect(user.presence).toEqual(
-                    initialSync.presence[0].content.presence
+                    SYNC_DATA.presence.events[0].content.presence
                 );
             });
             client.startClient();
@@ -149,8 +155,8 @@ describe("MatrixClient events", function() {
         });
 
         it("should emit Room events", function(done) {
-            httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-            httpBackend.when("GET", "/events").respond(200, eventData);
+            httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+            httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
             var roomInvokeCount = 0;
             var roomNameInvokeCount = 0;
             var timelineFireCount = 0;
@@ -183,8 +189,8 @@ describe("MatrixClient events", function() {
         });
 
         it("should emit RoomState events", function(done) {
-            httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-            httpBackend.when("GET", "/events").respond(200, eventData);
+            httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+            httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
 
             var roomStateEventTypes = [
                 "m.room.member", "m.room.create"
@@ -232,8 +238,8 @@ describe("MatrixClient events", function() {
         });
 
         it("should emit RoomMember events", function(done) {
-            httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-            httpBackend.when("GET", "/events").respond(200, eventData);
+            httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+            httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
 
             var typingInvokeCount = 0;
             var powerLevelInvokeCount = 0;

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -107,8 +107,6 @@ describe("MatrixClient events", function() {
                 NEXT_SYNC_DATA.rooms.join["!erufh:bar"].ephemeral.events
             );
 
-
-            var chunkIndex = 0;
             client.on("event", function(event) {
                 var found = false;
                 for (var i = 0; i < expectedEvents.length; i++) {

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -53,7 +53,8 @@ describe("MatrixClient events", function() {
                                     room: "!erufh:bar", mship: "join", user: "@foo:bar"
                                 }),
                                 utils.mkEvent({
-                                    type: "m.room.create", room: "!erufh:bar", user: "@foo:bar",
+                                    type: "m.room.create", room: "!erufh:bar",
+                                    user: "@foo:bar",
                                     content: {
                                         creator: "@foo:bar"
                                     }
@@ -116,7 +117,9 @@ describe("MatrixClient events", function() {
                         break;
                     }
                 }
-                expect(found).toBe(true, "Unexpected 'event' emitted: " + event.getType());
+                expect(found).toBe(
+                    true, "Unexpected 'event' emitted: " + event.getType()
+                );
             });
 
             client.startClient();

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -12,44 +12,92 @@ describe("MatrixClient room timelines", function() {
     var accessToken = "aseukfgwef";
     var roomId = "!foo:bar";
     var otherUserId = "@bob:localhost";
-    var eventData;
-    var initialSync = {
-        end: "s_5_3",
-        presence: [],
-        rooms: [{
-            membership: "join",
-            room_id: roomId,
-            messages: {
-                start: "f_1_1",
-                end: "f_2_2",
-                chunk: [
-                    utils.mkMessage({
-                        room: roomId, user: otherUserId, msg: "hello"
-                    })
-                ]
-            },
-            state: [
-                utils.mkEvent({
-                    type: "m.room.name", room: roomId, user: otherUserId,
-                    content: {
-                        name: "Old room name"
+    var USER_MEMBERSHIP_EVENT = utils.mkMembership({
+        room: roomId, mship: "join", user: userId, name: userName
+    });
+    var ROOM_NAME_EVENT = utils.mkEvent({
+        type: "m.room.name", room: roomId, user: otherUserId,
+        content: {
+            name: "Old room name"
+        }
+    });
+    var NEXT_SYNC_DATA;
+    var SYNC_DATA = {
+        next_batch: "s_5_3",
+        rooms: {
+            join: {
+                "!foo:bar": { // roomId
+                    timeline: {
+                        events: [
+                            utils.mkMessage({
+                                room: roomId, user: otherUserId, msg: "hello"
+                            })
+                        ],
+                        prev_batch: "f_1_1"
+                    },
+                    state: {
+                        events: [
+                            ROOM_NAME_EVENT,
+                            utils.mkMembership({
+                                room: roomId, mship: "join", user: otherUserId, name: "Bob"
+                            }),
+                            USER_MEMBERSHIP_EVENT,
+                            utils.mkEvent({
+                                type: "m.room.create", room: roomId, user: userId,
+                                content: {
+                                    creator: userId
+                                }
+                            })
+                        ]
                     }
-                }),
-                utils.mkMembership({
-                    room: roomId, mship: "join", user: otherUserId, name: "Bob"
-                }),
-                utils.mkMembership({
-                    room: roomId, mship: "join", user: userId, name: userName
-                }),
-                utils.mkEvent({
-                    type: "m.room.create", room: roomId, user: userId,
-                    content: {
-                        creator: userId
-                    }
-                })
-            ]
-        }]
+                }
+            }
+        }
     };
+
+    function setNextSyncData(events) {
+        events = events || [];
+        NEXT_SYNC_DATA = {
+            next_batch: "n",
+            presence: { events: [] },
+            rooms: {
+                invite: {},
+                join: {
+                    "!foo:bar": {
+                        timeline: { events: [] },
+                        state: { events: [] },
+                        ephemeral: { events: [] }
+                    }
+                },
+                leave: {}
+            }
+        };
+        events.forEach(function(e) {
+            if (e.room_id !== roomId) {
+                throw new Error("setNextSyncData only works with one room id");
+            }
+            if (e.state_key) {
+                if (e.__prev_event === undefined) {
+                    throw new Error(
+                        "setNextSyncData needs the prev state set to '__prev_event' " +
+                        "for " + e.type
+                    );
+                }
+                if (e.__prev_event !== null) {
+                    // push the previous state for this event type
+                    NEXT_SYNC_DATA.rooms.join[roomId].state.events.push(e.__prev_event);
+                }
+                // push the current
+                NEXT_SYNC_DATA.rooms.join[roomId].timeline.events.push(e);
+            }
+            else if (["m.typing", "m.receipt"].indexOf(e.type) !== -1) {
+                NEXT_SYNC_DATA.rooms.join[roomId].ephemeral.events.push(e);
+            }
+            else {
+                NEXT_SYNC_DATA.rooms.join[roomId].timeline.events.push(e);
+            }
+        });
+    }
 
     beforeEach(function(done) {
         utils.beforeEach(this);
@@ -60,18 +108,20 @@ describe("MatrixClient room timelines", function() {
             userId: userId,
             accessToken: accessToken
         });
-        eventData = {
-            chunk: [],
-            end: "end_",
-            start: "start_"
-        };
+        setNextSyncData();
         httpBackend.when("GET", "/pushrules").respond(200, {});
-        httpBackend.when("GET", "/initialSync").respond(200, initialSync);
-        httpBackend.when("GET", "/events").respond(200, function() {
-            return eventData;
+        httpBackend.when("POST", "/filter").respond(200, { filter_id: "fid" });
+        httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
+        httpBackend.when("GET", "/sync").respond(200, function() {
+            return NEXT_SYNC_DATA;
         });
         client.startClient();
-        httpBackend.flush("/pushrules").done(done);
+        httpBackend.flush("/pushrules").then(function() {
+            console.log("Flushed push");
+            return httpBackend.flush("/filter");
+        }).done(function () {
+            console.log("ALL READY"); done();
+        });
     });
 
     afterEach(function() {
@@ -97,11 +147,11 @@ describe("MatrixClient room timelines", function() {
                 expect(member.userId).toEqual(userId);
                 expect(member.name).toEqual(userName);
 
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     done();
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should be updated correctly when the send request finishes " +
@@ -110,12 +160,12 @@ describe("MatrixClient room timelines", function() {
             httpBackend.when("PUT", "/txn1").respond(200, {
                 event_id: eventId
             });
-            eventData.chunk = [
-                utils.mkMessage({
-                    body: "I am a fish", user: userId, room: roomId
-                })
-            ];
-            eventData.chunk[0].event_id = eventId;
+
+            var ev = utils.mkMessage({
+                body: "I am a fish", user: userId, room: roomId
+            })
+            ev.event_id = eventId;
+            setNextSyncData([ev]);
 
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
@@ -123,14 +173,14 @@ describe("MatrixClient room timelines", function() {
                 client.sendTextMessage(roomId, "I am a fish", "txn1").done(
                 function() {
                     expect(room.timeline[1].getId()).toEqual(eventId);
-                    httpBackend.flush("/events", 1).done(function() {
+                    httpBackend.flush("/sync", 1).done(function() {
                         expect(room.timeline[1].getId()).toEqual(eventId);
                         done();
                     });
                 });
                 httpBackend.flush("/txn1", 1);
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should be updated correctly when the send request finishes " +
@@ -139,18 +189,18 @@ describe("MatrixClient room timelines", function() {
             httpBackend.when("PUT", "/txn1").respond(200, {
                 event_id: eventId
             });
-            eventData.chunk = [
-                utils.mkMessage({
-                    body: "I am a fish", user: userId, room: roomId
-                })
-            ];
-            eventData.chunk[0].event_id = eventId;
+
+            var ev = utils.mkMessage({
+                body: "I am a fish", user: userId, room: roomId
+            })
+            ev.event_id = eventId;
+            setNextSyncData([ev]);
 
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
                 var promise = client.sendTextMessage(roomId, "I am a fish", "txn1");
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     // expect 3rd msg, it doesn't know this is the request is just did
                     expect(room.timeline.length).toEqual(3);
                     httpBackend.flush("/txn1", 1);
@@ -162,7 +212,7 @@ describe("MatrixClient room timelines", function() {
                 });
 
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
     });
 
@@ -195,9 +245,9 @@ describe("MatrixClient room timelines", function() {
                 });
 
                 httpBackend.flush("/messages", 1);
-                httpBackend.flush("/events", 1);
+                httpBackend.flush("/sync", 1);
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should set the right event.sender values", function(done) {
@@ -238,9 +288,9 @@ describe("MatrixClient room timelines", function() {
                 });
 
                 httpBackend.flush("/messages", 1);
-                httpBackend.flush("/events", 1);
+                httpBackend.flush("/sync", 1);
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should add it them to the right place in the timeline", function(done) {
@@ -267,9 +317,9 @@ describe("MatrixClient room timelines", function() {
                 });
 
                 httpBackend.flush("/messages", 1);
-                httpBackend.flush("/events", 1);
+                httpBackend.flush("/sync", 1);
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should use 'end' as the next pagination token", function(done) {
@@ -289,21 +339,23 @@ describe("MatrixClient room timelines", function() {
                     expect(room.oldState.paginationToken).toEqual(sbEndTok);
                 });
 
-                httpBackend.flush("/events", 1);
+                httpBackend.flush("/sync", 1);
                 httpBackend.flush("/messages", 1).done(function() {
                     done();
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
     });
 
     describe("new events", function() {
         it("should be added to the right place in the timeline", function(done) {
-            eventData.chunk = [
+            var eventData = [
                 utils.mkMessage({user: userId, room: roomId}),
                 utils.mkMessage({user: userId, room: roomId})
             ];
+            setNextSyncData(eventData);
+
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
@@ -312,37 +364,40 @@ describe("MatrixClient room timelines", function() {
                 client.on("Room.timeline", function(event, rm, toStart) {
                     expect(toStart).toBe(false);
                     expect(rm).toEqual(room);
-                    expect(event.event).toEqual(eventData.chunk[index]);
+                    expect(event.event).toEqual(eventData[index]);
                     index += 1;
                 });
 
                 httpBackend.flush("/messages", 1);
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     expect(index).toEqual(2);
                     expect(room.timeline[room.timeline.length - 1].event).toEqual(
-                        eventData.chunk[1]
+                        eventData[1]
                     );
                     expect(room.timeline[room.timeline.length - 2].event).toEqual(
-                        eventData.chunk[0]
+                        eventData[0]
                     );
                     done();
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should set the right event.sender values", function(done) {
-            eventData.chunk = [
+            var eventData = [
                 utils.mkMessage({user: userId, room: roomId}),
                 utils.mkMembership({
                     user: userId, room: roomId, mship: "join", name: "New Name"
                 }),
                 utils.mkMessage({user: userId, room: roomId})
             ];
+            eventData[1].__prev_event = USER_MEMBERSHIP_EVENT;
+            setNextSyncData(eventData);
+
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     var preNameEvent = room.timeline[room.timeline.length - 3];
                     var postNameEvent = room.timeline[room.timeline.length - 1];
                     expect(preNameEvent.sender.name).toEqual(userName);
@@ -350,17 +405,18 @@ describe("MatrixClient room timelines", function() {
                     done();
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should set the right room.name", function(done) {
-            eventData.chunk = [
-                utils.mkEvent({
-                    user: userId, room: roomId, type: "m.room.name", content: {
-                        name: "Room 2"
-                    }
-                })
-            ];
+            var secondRoomNameEvent = utils.mkEvent({
+                user: userId, room: roomId, type: "m.room.name", content: {
+                    name: "Room 2"
+                }
+            });
+            secondRoomNameEvent.__prev_event = ROOM_NAME_EVENT;
+            setNextSyncData([secondRoomNameEvent]);
+
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
@@ -369,32 +425,32 @@ describe("MatrixClient room timelines", function() {
                     nameEmitCount += 1;
                 });
 
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     expect(nameEmitCount).toEqual(1);
                     expect(room.name).toEqual("Room 2");
                     // do another round
-                    eventData.chunk = [
-                        utils.mkEvent({
-                            user: userId, room: roomId, type: "m.room.name", content: {
-                                name: "Room 3"
-                            }
-                        })
-                    ];
-                    httpBackend.when("GET", "/events").respond(200, eventData);
-                    httpBackend.flush("/events", 1).done(function() {
+                    var thirdRoomNameEvent = utils.mkEvent({
+                        user: userId, room: roomId, type: "m.room.name", content: {
+                            name: "Room 3"
+                        }
+                    });
+                    thirdRoomNameEvent.__prev_event = secondRoomNameEvent;
+                    setNextSyncData([thirdRoomNameEvent]);
+                    httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
+                    httpBackend.flush("/sync", 1).done(function() {
                         expect(nameEmitCount).toEqual(2);
                         expect(room.name).toEqual("Room 3");
                         done();
                     });
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
 
         it("should set the right room members", function(done) {
             var userC = "@cee:bar";
             var userD = "@dee:bar";
-            eventData.chunk = [
+            var eventData = [
                 utils.mkMembership({
                     user: userC, room: roomId, mship: "join", name: "C"
                 }),
@@ -402,10 +458,14 @@ describe("MatrixClient room timelines", function() {
                     user: userC, room: roomId, mship: "invite", skey: userD
                 })
             ];
+            eventData[0].__prev_event = null;
+            eventData[1].__prev_event = null;
+            setNextSyncData(eventData);
+
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
-                httpBackend.flush("/events", 1).done(function() {
+                httpBackend.flush("/sync", 1).done(function() {
                     expect(room.currentState.getMembers().length).toEqual(4);
                     expect(room.currentState.getMember(userC).name).toEqual("C");
                     expect(room.currentState.getMember(userC).membership).toEqual(
@@ -418,7 +478,7 @@ describe("MatrixClient room timelines", function() {
                     done();
                 });
             });
-            httpBackend.flush("/initialSync", 1);
+            httpBackend.flush("/sync", 1);
         });
     });
 });

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -163,7 +163,7 @@ describe("MatrixClient room timelines", function() {
 
             var ev = utils.mkMessage({
                 body: "I am a fish", user: userId, room: roomId
-            })
+            });
             ev.event_id = eventId;
             setNextSyncData([ev]);
 
@@ -192,7 +192,7 @@ describe("MatrixClient room timelines", function() {
 
             var ev = utils.mkMessage({
                 body: "I am a fish", user: userId, room: roomId
-            })
+            });
             ev.event_id = eventId;
             setNextSyncData([ev]);
 

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -39,7 +39,8 @@ describe("MatrixClient room timelines", function() {
                         events: [
                             ROOM_NAME_EVENT,
                             utils.mkMembership({
-                                room: roomId, mship: "join", user: otherUserId, name: "Bob"
+                                room: roomId, mship: "join",
+                                user: otherUserId, name: "Bob"
                             }),
                             USER_MEMBERSHIP_EVENT,
                             utils.mkEvent({
@@ -117,11 +118,8 @@ describe("MatrixClient room timelines", function() {
         });
         client.startClient();
         httpBackend.flush("/pushrules").then(function() {
-            console.log("Flushed push");
             return httpBackend.flush("/filter");
-        }).done(function () {
-            console.log("ALL READY"); done();
-        });
+        }).done(done);
     });
 
     afterEach(function() {

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -61,7 +61,7 @@ module.exports.mkEvent = function(opts) {
     var event = {
         type: opts.type,
         room_id: opts.room,
-        user_id: opts.user,
+        sender: opts.user,
         content: opts.content,
         event_id: "$" + Math.random() + "-" + Math.random()
     };

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -88,8 +88,8 @@ module.exports.mkPresence = function(opts) {
     var event = {
         event_id: "$" + Math.random() + "-" + Math.random(),
         type: "m.presence",
+        sender: opts.user,
         content: {
-            user_id: opts.user,
             avatar_url: opts.url,
             displayname: opts.name,
             last_active_ago: opts.ago,

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -159,6 +159,23 @@ describe("MatrixClient", function() {
         });
     });
 
+    it("should not POST /filter if a filter already exists", function(done) {
+        httpLookups = [];
+        httpLookups.push(PUSH_RULES_RESPONSE);
+        httpLookups.push(SYNC_RESPONSE);
+        var filterId = "ehfewf";
+        store.getFilterIdByName.andReturn(filterId);
+        client.startClient();
+
+        client.on("sync", function syncListener(state) {
+            if (state === "SYNCING") {
+                expect(httpLookups.length).toEqual(0);
+                client.removeListener("sync", syncListener);
+                done();
+            }
+        });
+    });
+
     describe("getSyncState", function() {
 
         it("should return null if the client isn't started", function() {


### PR DESCRIPTION
The PR converts the JS SDK to use v2 `/sync` rather than v1 `/initialSync` and `/events`.

A brief overview of the changes:
 - All the syncing code has been moved from `client.js` to a new file: `sync.js`. A nice interface has not yet been written, so `sync.js` horribly gut wrenches `MatrixClient` currently.
 - `MatrixEvent` now supports v2-style events *in addition* to v1.
 - v2 transaction ID matching has been implemented (so the JS SDK does not need to do a linear scan for duplicate suppression on *every event* anymore!)
 - v2 catchup has been implemented (so if you put your computer to sleep overnight and start it back up, it won't lock up your browser!)
 - `/sync` call processing has been made more robust (read: paranoid) - we don't assume keys exists which we did in v1 and we set the sync token *before* processing events to "skip over" bad events.
 - Added a polyfill for `Array.forEach` because seriously, `utils.forEach` is yucky to type.

Tests:
 - All UTs and integration tests have been fixed.
 - Manual testing on Vector `develop` which involved:
    * Login and logout multiple times, make sure it all works.
    * Make sure BAU works (event sending, receiving)
    * Room invites and joining
    * Scrollback
    * Catchup after sleeping for a while

Whilst the diff looks huge, about half of it is just fixing the tests(!)