### PR TITLE
Do not erroneously emit Call.incoming events on startup

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2224,7 +2224,48 @@ function setupCallEventHandler(client) {
     var candidatesByCall = {
         // callId: [Candidate]
     };
+
+    // Maintain a buffer of events before the client has synced for the first time.
+    // This buffer will be inspected to see if we should send incoming call
+    // notifications. It needs to be buffered to correctly determine if an
+    // incoming call has had a matching answer/hangup.
+    var callEventBuffer = [];
+    var isClientPrepared = false;
+    client.on("sync", function(state) {
+        if (state === "PREPARED") {
+            isClientPrepared = true;
+            var ignoreCallIds = {}; // Set<String>
+            // inspect the buffer and mark all calls which have been answered
+            // or hung up before passing them to the call event handler.
+            for (var i = callEventBuffer.length - 1; i >= 0; i--) {
+                var ev = callEventBuffer[i];
+                if (ev.getType() === "m.call.answer" ||
+                        ev.getType() === "m.call.hangup") {
+                    ignoreCallIds[ev.getContent().call_id] = "yep";
+                }
+            }
+            // now loop through the buffer chronologically and inject them
+            callEventBuffer.forEach(function(e) {
+                if (ignoreCallIds[e.getContent().call_id]) {
+                    return;
+                }
+                callEventHandler(e);
+            });
+            callEventBuffer = [];
+        }
+    });
+
     client.on("event", function(event) {
+        if (!isClientPrepared) {
+            if (event.getType().indexOf("m.call.") === 0) {
+                callEventBuffer.push(event);
+            }
+            return;
+        }
+        callEventHandler(event);
+    });
+
+    function callEventHandler(event) {
         if (event.getType().indexOf("m.call.") !== 0) {
             return; // not a call event
         }
@@ -2372,7 +2413,7 @@ function setupCallEventHandler(client) {
                 }
             }
         }
-    });
+    }
 }
 
 function checkTurnServers(client) {


### PR DESCRIPTION
Check to see if the call was answered or hung up in addition to having a valid
lifetime before emitting the event. Fixes vector-im/vector-web#344