### PR TITLE
Reset /sync backoff if setTimeout takes a long time to fire

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -497,7 +497,8 @@ function startSyncingRetryTimer(client, attempt, fn) {
         var timeDeltaMs = timeAfterWaitingMs - timeBeforeWaitingMs;
         if (timeDeltaMs > (2 * timeToWaitMs)) {
             // we've waited more than twice what we were supposed to. Reset the
-            // attempt number back to 1;
+            // attempt number back to 1. This can happen when the comp goes to
+            // sleep whilst the timer is running.
             newAttempt = 1;
             console.warn(
                 "Sync retry timer: Tried to wait %s ms but actually waited %s ms",

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -131,8 +131,8 @@ SyncApi.prototype.sync = function() {
     // sets the sync state to error and waits a bit before re-invoking the function.
     function retryHandler(attempt, fnToRun) {
         return function(err) {
-            startSyncingRetryTimer(client, attempt, function() {
-                fnToRun(attempt);
+            startSyncingRetryTimer(client, attempt, function(newAttempt) {
+                fnToRun(newAttempt);
             });
             updateSyncState(client, "ERROR", { error: err });
         };
@@ -338,8 +338,8 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         console.error("/sync error (%s attempts): %s", attempt, err);
         console.error(err);
         attempt += 1;
-        startSyncingRetryTimer(client, attempt, function() {
-            self._sync(syncOptions, attempt);
+        startSyncingRetryTimer(client, attempt, function(newAttempt) {
+            self._sync(syncOptions, newAttempt);
         });
         updateSyncState(client, "ERROR", { error: err });
     });
@@ -481,17 +481,31 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
 };
 
 function retryTimeMsForAttempt(attempt) {
-    // 2,4,8,16,32,64,128,128,128,... seconds
-    // max 2^7 secs = 2.1 mins
-    return Math.pow(2, Math.min(attempt, 7)) * 1000;
+    // 2,4,8,16,32,32,32,32,... seconds
+    // max 2^5 secs = 32 secs
+    return Math.pow(2, Math.min(attempt, 5)) * 1000;
 }
 
 function startSyncingRetryTimer(client, attempt, fn) {
     client._syncingRetry = {};
     client._syncingRetry.fn = fn;
+    var newAttempt = attempt;
+    var timeBeforeWaitingMs = Date.now();
+    var timeToWaitMs = retryTimeMsForAttempt(attempt);
     client._syncingRetry.timeoutId = setTimeout(function() {
-        fn();
-    }, retryTimeMsForAttempt(attempt));
+        var timeAfterWaitingMs = Date.now();
+        var timeDeltaMs = timeAfterWaitingMs - timeBeforeWaitingMs;
+        if (timeDeltaMs > (2 * timeToWaitMs)) {
+            // we've waited more than twice what we were supposed to. Reset the
+            // attempt number back to 1;
+            newAttempt = 1;
+            console.warn(
+                "Sync retry timer: Tried to wait %s ms but actually waited %s ms",
+                timeToWaitMs, timeDeltaMs
+            );
+        }
+        fn(newAttempt);
+    }, timeToWaitMs);
 }
 
 function updateSyncState(client, newState, data) {


### PR DESCRIPTION
This fixes vector-web/vector-im#536

The bug here is that we were assuming `setTimeout` would fire after the
requested time. This is not true when the machine is asleep. We now timestamp
before and after `setTimeout` and reset the attempt count if we have waited
more than twice what we originally requested. This allows for some jitter which
is to be expected. This also reduces the max waiting time to 32s from 2.1min,
because 2 minutes was deemed excessive given "regular" clients would be polling
with a `timeout=30secs`.