### PR TITLE
Add syncLeftRooms()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2119,14 +2119,11 @@ MatrixClient.prototype.search = function(opts, callback) {
 MatrixClient.prototype.syncLeftRooms = function() {
     // Guard against multiple calls whilst ongoing and multiple calls post success
     if (this._syncedLeftRooms) {
-        console.log("Already synced left rooms");
         return q([]); // don't call syncRooms again if it succeeded.
     }
     if (this._syncLeftRoomsPromise) {
-        console.log("Returning ongoing request promise");
         return this._syncLeftRoomsPromise; // return the ongoing request
     }
-    console.log("Making sync left rooms request");
     var self = this;
     var syncApi = new SyncApi(this);
     this._syncLeftRoomsPromise = syncApi.syncLeftRooms();
@@ -2136,7 +2133,6 @@ MatrixClient.prototype.syncLeftRooms = function() {
         console.log("Marking success of sync left room request");
         self._syncedLeftRooms = true; // flip the bit on success
     }).finally(function() {
-        console.log("Cleaning up request state");
         self._syncLeftRoomsPromise = null; // cleanup ongoing request state
     });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -2110,6 +2110,18 @@ MatrixClient.prototype.search = function(opts, callback) {
 
 
 /**
+ * Populate the store with rooms the user has left.
+ * @return {module:client.Promise} Resolves: TODO - Resolved when the rooms have
+ * been added to the data store.
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.syncLeftRooms = function() {
+    var syncApi = new SyncApi(this);
+    return syncApi.syncLeftRooms();
+};
+
+
+/**
  * Create a new filter.
  * @param {Object} content The HTTP body for the request
  * @return {Filter} Resolves to a Filter object.

--- a/lib/client.js
+++ b/lib/client.js
@@ -2117,8 +2117,30 @@ MatrixClient.prototype.search = function(opts, callback) {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.syncLeftRooms = function() {
+    // Guard against multiple calls whilst ongoing and multiple calls post success
+    if (this._syncedLeftRooms) {
+        console.log("Already synced left rooms");
+        return q([]); // don't call syncRooms again if it succeeded.
+    }
+    if (this._syncLeftRoomsPromise) {
+        console.log("Returning ongoing request promise");
+        return this._syncLeftRoomsPromise; // return the ongoing request
+    }
+    console.log("Making sync left rooms request");
+    var self = this;
     var syncApi = new SyncApi(this);
-    return syncApi.syncLeftRooms();
+    this._syncLeftRoomsPromise = syncApi.syncLeftRooms();
+
+    // cleanup locks
+    this._syncLeftRoomsPromise.then(function(res) {
+        console.log("Marking success of sync left room request");
+        self._syncedLeftRooms = true; // flip the bit on success
+    }).finally(function() {
+        console.log("Cleaning up request state");
+        self._syncLeftRoomsPromise = null; // cleanup ongoing request state
+    });
+
+    return this._syncLeftRoomsPromise;
 };
 
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -84,7 +84,7 @@ SyncApi.prototype.syncLeftRooms = function() {
     var client = this.client;
     var self = this;
 
-    // grab a filter with limit=0 and include_leave=true
+    // grab a filter with limit=1 and include_leave=true
     var filter = new Filter(this.client.credentials.userId);
     filter.setTimelineLimit(1);
     filter.setIncludeLeaveRooms(true);
@@ -135,7 +135,6 @@ SyncApi.prototype.syncLeftRooms = function() {
             client.store.storeRoom(room);
             client.emit("Room", room);
         });
-        client._syncedLeftRooms = true;
         return rooms;
     });
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -21,11 +21,13 @@ var Filter = require("./filter");
 // to determine the max time we're willing to wait.
 var BUFFER_PERIOD_MS = 20 * 1000;
 
-function getFilterName(userId) {
+function getFilterName(userId, suffix) {
     // scope this on the user ID because people may login on many accounts
     // and they all need to be stored!
-    return "FILTER_SYNC_" + userId;
+    return "FILTER_SYNC_" + userId + (suffix ? "_" + suffix : "");
 }
+
+
 
 /**
  * <b>Internal class - unstable.</b>
@@ -79,8 +81,63 @@ SyncApi.prototype.createRoom = function(roomId) {
  * @return {Promise} Resolved when they've been added to the store.
  */
 SyncApi.prototype.syncLeftRooms = function() {
-    // TODO
-    return null;
+    var client = this.client;
+    var self = this;
+
+    // grab a filter with limit=0 and include_leave=true
+    var filter = new Filter(this.client.credentials.userId);
+    filter.setTimelineLimit(1);
+    filter.setIncludeLeaveRooms(true);
+
+    var localTimeoutMs = this.opts.pollTimeout + BUFFER_PERIOD_MS;
+    var qps = {
+        timeout: 1 // don't want to block since this is a single isolated req
+    };
+
+    return this._getOrCreateFilter(
+        getFilterName(client.credentials.userId, "LEFT_ROOMS"), filter
+    ).then(function(filterId) {
+        qps.filter = filterId;
+        return client._http.authedRequestWithPrefix(
+            undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA,
+            localTimeoutMs
+        );
+    }).then(function(data) {
+        var leaveRooms = [];
+        if (data.rooms && data.rooms.leave) {
+            leaveRooms = self._mapSyncResponseToRoomArray(data.rooms.leave);
+        }
+        var rooms = [];
+        leaveRooms.forEach(function(leaveObj) {
+            var room = leaveObj.room;
+            rooms.push(room);
+            if (!leaveObj.isBrandNewRoom) {
+                // the intention behind syncLeftRooms is to add in rooms which were
+                // *omitted* from the initial /sync. Rooms the user were joined to
+                // but then left whilst the app is running will appear in this list
+                // and we do not want to bother with them since they will have the
+                // current state already (and may get dupe messages if we add
+                // yet more timeline events!), so skip them.
+                // NB: When we persist rooms to localStorage this will be more
+                //     complicated...
+                return;
+            }
+            leaveObj.timeline = leaveObj.timeline || {};
+            var timelineEvents = self._mapSyncEventsFormat(leaveObj.timeline, room);
+            var stateEvents = self._mapSyncEventsFormat(leaveObj.state, room);
+            var paginationToken = (
+                leaveObj.timeline.limited ? leaveObj.timeline.prev_batch : null
+            );
+            self._processRoomEvents(
+                room, stateEvents, timelineEvents, paginationToken
+            );
+            room.recalculate(client.credentials.userId);
+            client.store.storeRoom(room);
+            client.emit("Room", room);
+        });
+        client._syncedLeftRooms = true;
+        return rooms;
+    });
 };
 
 /**
@@ -112,27 +169,14 @@ SyncApi.prototype.sync = function() {
         attempt = attempt || 0;
         attempt += 1;
 
-
-        // Get or create filter
-        var filterId = client.store.getFilterIdByName(
-            getFilterName(client.credentials.userId)
-        );
-        if (filterId) {
-            // super, just use that.
-            console.log("Using existing filter ID %s", filterId);
-            self._sync({ filterId: filterId });
-            return;
-        }
-
-        // create a filter
         var filter = new Filter(client.credentials.userId);
         filter.setTimelineLimit(self.opts.initialSyncLimit);
-        client.createFilter(filter.getDefinition()).done(function(filter) {
-            client.store.setFilterIdByName(
-                getFilterName(client.credentials.userId), filter.filterId
-            );
-            console.log("Created filter ", filter.filterId);
-            self._sync({ filterId: filter.filterId }); // Now start the /sync loop
+
+        self._getOrCreateFilter(
+            getFilterName(client.credentials.userId), filter
+        ).done(function(filterId) {
+            console.log("Using existing filter ID %s", filterId);
+            self._sync({ filterId: filterId });
         }, retryHandler(attempt, getFilter));
     }
 
@@ -345,6 +389,27 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             self._sync(syncOptions, newAttempt);
         });
         updateSyncState(client, "ERROR", { error: err });
+    });
+};
+
+/**
+ * @param {string} filterName
+ * @param {Filter} filter
+ * @return {Promise<String>} Filter ID
+ */
+SyncApi.prototype._getOrCreateFilter = function(filterName, filter) {
+    var client = this.client;
+    var filterId = client.store.getFilterIdByName(filterName);
+    if (filterId) {
+        // super, just use that.
+        console.log("Using existing filter ID %s", filterId);
+        return q(filterId);
+    }
+
+    // create a filter
+    return client.createFilter(filter.getDefinition()).then(function(createdFilter) {
+        client.store.setFilterIdByName(filterName, createdFilter.filterId);
+        return createdFilter.filterId;
     });
 };
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -402,7 +402,6 @@ SyncApi.prototype._getOrCreateFilter = function(filterName, filter) {
     var filterId = client.store.getFilterIdByName(filterName);
     if (filterId) {
         // super, just use that.
-        console.log("Using existing filter ID %s", filterId);
         return q(filterId);
     }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -38,7 +38,6 @@ function SyncApi(client, opts) {
     this.client = client;
     opts = opts || {};
     opts.initialSyncLimit = opts.initialSyncLimit || 8;
-    opts.includeArchivedRooms = opts.includeArchivedRooms || false;
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
     opts.pollTimeout = opts.pollTimeout || (30 * 1000);
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
@@ -73,6 +72,15 @@ SyncApi.prototype.createRoom = function(roomId) {
         );
     });
     return room;
+};
+
+/**
+ * Sync rooms the user has left.
+ * @return {Promise} Resolved when they've been added to the store.
+ */
+SyncApi.prototype.syncLeftRooms = function() {
+    // TODO
+    return null;
 };
 
 /**
@@ -158,8 +166,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     var client = this.client;
     var self = this;
     attempt = attempt || 1;
-
-    // TODO include archived rooms flag.
 
     var qps = {
         filter: syncOptions.filterId,
@@ -313,9 +319,6 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 var room = leaveObj.room;
                 var timelineEvents = self._mapSyncEventsFormat(leaveObj.timeline, room);
                 room.addEvents(timelineEvents);
-
-                // TODO: honour includeArchived opt
-
                 timelineEvents.forEach(function(e) { client.emit("event", e); });
             });
         }


### PR DESCRIPTION
Implemented for https://github.com/vector-im/vector-web/issues/348

This adds `MatrixClient.syncLeftRooms()` which fetches left rooms and dumps them into the store. Everything Just Works. Multiple calls to `syncLeftRooms()` will return the same promise if the request is ongoing, or NOP if the request was successful. If the request failed, it will be retried. Manually tested these cases.

See also:
 - https://github.com/vector-im/vector-web/pull/541
 - https://github.com/matrix-org/matrix-react-sdk/pull/62