### PR TITLE
Propagate the unread count from sync onto rooms

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -246,7 +246,8 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
         //          state: { events: [] },
         //          timeline: { events: [], prev_batch: $token, limited: true },
         //          ephemeral: { events: [] },
-        //          account_data: { events: [] }
+        //          account_data: { events: [] },
+        //          unread_notification_count: 0
         //        }
         //      },
         //      leave: {
@@ -325,6 +326,9 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 var timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room);
                 var ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
                 var accountDataEvents = self._mapSyncEventsFormat(joinObj.account_data);
+
+                // we do this first so it's correct when any of the events fire
+                room.unread_notification_count = joinObj.unread_notification_count;
 
                 joinObj.timeline = joinObj.timeline || {};
 


### PR DESCRIPTION
Requires https://github.com/matrix-org/synapse/pull/456 to work sensibly (without it will just set the unread count to undefined).