### PR TITLE
Room.getImplicitRoomName

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -192,6 +192,14 @@ MatrixClient.prototype.getIdentityServerUrl = function() {
 };
 
 /**
+ * Get the domain for this client's MXID
+ * @return {string} Domain of this MXID
+ */
+MatrixClient.prototype.getDomain = function() {
+    return this.credentials.userId.replace(/^.*:/, '');
+};
+
+/**
  * Check if the runtime environment supports VoIP calling.
  * @return {boolean} True if VoIP is supported.
  */

--- a/lib/client.js
+++ b/lib/client.js
@@ -196,7 +196,7 @@ MatrixClient.prototype.getIdentityServerUrl = function() {
  * @return {string} Domain of this MXID
  */
 MatrixClient.prototype.getDomain = function() {
-    return this.credentials.userId.replace(/^.*:/, '');
+    return this.credentials.userId.split(':')[0];
 };
 
 /**

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -667,12 +667,12 @@ function setEventMetadata(event, stateContext, toStartOfTimeline) {
  * @param {Room} room The matrix room.
  * @param {string} userId The client's user ID. Used to filter room members
  * correctly.
- * @param {bool} implicit Return the implicit room name that we'd see if there
+ * @param {bool} ignoreRoomNameEvent Return the implicit room name that we'd see if there
  * was no m.room.name event.
  * @return {string} The calculated room name.
  */
-function calculateRoomName(room, userId, implicit) {
-    if (!implicit) {
+function calculateRoomName(room, userId, ignoreRoomNameEvent) {
+    if (!ignoreRoomNameEvent) {
         // check for an alias, if any. for now, assume first alias is the
         // official one.
         var mRoomName = room.currentState.getStateEvents("m.room.name", "");

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -191,6 +191,18 @@ Room.prototype.getAvatarUrl = function(baseUrl, width, height, resizeMethod,
  };
 
  /**
+  * Get the implicit room name (i.e. what a given user would see if the
+  * room had no m.room.name)
+  * @param {string} userId The userId from whose perspective we want
+  * to calculate the implicit name
+  * @return {string} The implicit room name
+  */
+ Room.prototype.getImplicitRoomName = function(userId) {
+    return calculateRoomName(this, userId, true);
+ };
+
+
+ /**
  * Check if the given user_id has the given membership state.
  * @param {string} userId The user ID to check.
  * @param {string} membership The membership e.g. <code>'join'</code>
@@ -655,14 +667,18 @@ function setEventMetadata(event, stateContext, toStartOfTimeline) {
  * @param {Room} room The matrix room.
  * @param {string} userId The client's user ID. Used to filter room members
  * correctly.
+ * @param {bool} implicit Return the implicit room name that we'd see if there
+ * was no m.room.name event.
  * @return {string} The calculated room name.
  */
-function calculateRoomName(room, userId) {
-    // check for an alias, if any. for now, assume first alias is the
-    // official one.
-    var mRoomName = room.currentState.getStateEvents("m.room.name", "");
-    if (mRoomName && mRoomName.getContent() && mRoomName.getContent().name) {
-        return mRoomName.getContent().name;
+function calculateRoomName(room, userId, implicit) {
+    if (!implicit) {
+        // check for an alias, if any. for now, assume first alias is the
+        // official one.
+        var mRoomName = room.currentState.getStateEvents("m.room.name", "");
+        if (mRoomName && mRoomName.getContent() && mRoomName.getContent().name) {
+            return mRoomName.getContent().name;
+        }
     }
 
     var alias;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -340,7 +340,7 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             joinRooms.forEach(function(joinObj) {
                 var room = joinObj.room;
                 var stateEvents = self._mapSyncEventsFormat(joinObj.state, room, 'state');
-                var timelineEvents = 
+                var timelineEvents =
                     self._mapSyncEventsFormat(joinObj.timeline, room, 'timeline');
                 var ephemeralEvents =
                     self._mapSyncEventsFormat(joinObj.ephemeral, undefined, 'ephemeral');


### PR DESCRIPTION
add a Room.getImplicitRoomName so clients can know what a room would be named if it had no explicit m.room.name.

(This seems to also be pulling in matthew/accountdata - oops)