### PR TITLE
Implement a keep-alive timer for /sync requests 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -279,7 +279,7 @@ MatrixClient.prototype.retryImmediately = function() {
     // stop waiting
     clearTimeout(this._syncingRetry.timeoutId);
     // invoke immediately
-    this._syncingRetry.fn();
+    this._syncingRetry.fn(2); // FIXME: It shouldn't need to know about attempts :/
     this._syncingRetry = null;
     return true;
 };

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -43,6 +43,9 @@ module.exports.PREFIX_V2_ALPHA = "/_matrix/client/v2_alpha";
  */
 module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
 
+/**
+ * A constant representing the URI path for release 0 of the Client-Server HTTP API.
+ */
 module.exports.PREFIX_R0 = "/_matrix/client/r0";
 
 /**
@@ -443,9 +446,11 @@ module.exports.MatrixHttpApi.prototype = {
                     handlerFn(err, response, body);
                 }
             );
-            // FIXME: This is EVIL, but I can't think of a better way to expose
-            // abort() operations on underlying HTTP requests :(
-            reqPromise.abort = req.abort.bind(req);
+            if (req && req.abort) {
+                // FIXME: This is EVIL, but I can't think of a better way to expose
+                // abort() operations on underlying HTTP requests :(
+                reqPromise.abort = req.abort.bind(req);
+            }
         }
         catch (ex) {
             defer.reject(ex);

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -43,6 +43,8 @@ module.exports.PREFIX_V2_ALPHA = "/_matrix/client/v2_alpha";
  */
 module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
 
+module.exports.PREFIX_R0 = "/_matrix/client/r0";
+
 /**
  * Construct a MatrixHttpApi.
  * @constructor
@@ -416,8 +418,10 @@ module.exports.MatrixHttpApi.prototype = {
             }, localTimeoutMs);
         }
 
+        var reqPromise = defer.promise;
+
         try {
-            this.opts.request(
+            var req = this.opts.request(
                 {
                     uri: uri,
                     method: method,
@@ -425,6 +429,7 @@ module.exports.MatrixHttpApi.prototype = {
                     qs: queryParams,
                     body: data,
                     json: true,
+                    timeout: localTimeoutMs,
                     _matrix_opts: this.opts
                 },
                 function(err, response, body) {
@@ -438,6 +443,9 @@ module.exports.MatrixHttpApi.prototype = {
                     handlerFn(err, response, body);
                 }
             );
+            // FIXME: This is EVIL, but I can't think of a better way to expose
+            // abort() operations on underlying HTTP requests :(
+            reqPromise.abort = req.abort.bind(req);
         }
         catch (ex) {
             defer.reject(ex);
@@ -445,7 +453,7 @@ module.exports.MatrixHttpApi.prototype = {
                 callback(ex);
             }
         }
-        return defer.promise;
+        return reqPromise;
     }
 };
 

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -137,7 +137,7 @@ Room.prototype.getUnreadNotificationCount = function(type) {
 /**
  * Set one of the notification counts for this room
  * @param {String} type The type of notification count to set.
- * @param {Number} type The new count
+ * @param {Number} count The new count
  */
 Room.prototype.setUnreadNotificationCount = function(type, count) {
     this._notificationCounts[type] = count;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -66,6 +66,8 @@ function SyncApi(client, opts) {
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this.opts = opts;
     this._peekRoomId = null;
+    this._syncConnectionLost = false;
+    this._currentSyncRequest = null;
 }
 
 /**
@@ -348,10 +350,13 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     // normal timeout= plus buffer time
     var clientSideTimeoutMs = this.opts.pollTimeout + BUFFER_PERIOD_MS;
 
-    client._http.authedRequestWithPrefix(
+    this._currentSyncRequest = client._http.authedRequestWithPrefix(
         undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA,
         clientSideTimeoutMs
-    ).done(function(data) {
+    );
+
+    this._currentSyncRequest.done(function(data) {
+        self._syncConnectionLost = false;
         // data looks like:
         // {
         //    next_batch: $token,
@@ -525,6 +530,21 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
 
         self._sync(syncOptions);
     }, function(err) {
+        if (!self._syncConnectionLost) {
+            debuglog("Starting keep-alive");
+            self._syncConnectionLost = true;
+            retryPromise(self._pokeKeepAlive.bind(self), 2000).done(function() {
+                debuglog("Keep-alive successful.");
+                // blow away the current /sync request if the connection is still
+                // dead. It may be black-holed.
+                if (!self._syncConnectionLost) {
+                    return;
+                }
+                // kill the current sync request
+                debuglog("Aborting current /sync.");
+                self._currentSyncRequest.abort();
+            });
+        }
         console.error("/sync error (%s attempts): %s", attempt, err);
         console.error(err);
         attempt += 1;
@@ -532,6 +552,21 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
             self._sync(syncOptions, newAttempt);
         });
         updateSyncState(client, "ERROR", { error: err });
+    });
+};
+
+/**
+ * @return {Promise}
+ */
+SyncApi.prototype._pokeKeepAlive = function() {
+    return this.client._http.requestWithPrefix(
+        undefined, "GET", "/", undefined,
+        undefined, httpApi.PREFIX_R0, 5 * 1000
+    ).catch(function(err) {
+        if (err.httpStatus > 0) { // we hit the server alright
+            return q();
+        }
+        throw err;
     });
 };
 
@@ -712,6 +747,14 @@ function retryTimeMsForAttempt(attempt) {
     // 2,4,8,16,32,32,32,32,... seconds
     // max 2^5 secs = 32 secs
     return Math.pow(2, Math.min(attempt, 5)) * 1000;
+}
+
+function retryPromise(promiseFn, delay) {
+    delay = delay || 0;
+    return promiseFn().catch(function(reason) { // if it fails
+        // retry after waiting the delay time
+        return q.delay(delay).then(retryPromise.bind(null, promiseFn, delay));
+    });
 }
 
 function startSyncingRetryTimer(client, attempt, fn) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -562,14 +562,9 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
  */
 SyncApi.prototype._pokeKeepAlive = function() {
     return this.client._http.requestWithPrefix(
-        undefined, "GET", "/", undefined,
-        undefined, httpApi.PREFIX_R0, 5 * 1000
-    ).catch(function(err) {
-        if (err.httpStatus > 0) { // we hit the server alright
-            return q();
-        }
-        throw err;
-    });
+        undefined, "GET", "/_matrix/client/versions", undefined,
+        undefined, "", 5 * 1000
+    );
 };
 
 /**

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -66,7 +66,6 @@ function SyncApi(client, opts) {
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this.opts = opts;
     this._peekRoomId = null;
-    this._lowClientTimeouts = false;
 }
 
 /**
@@ -276,7 +275,7 @@ SyncApi.prototype.sync = function() {
         attempt += 1;
 
         client.getPushRules().done(function(result) {
-            console.log("Got push rules");
+            debuglog("Got push rules");
             client.pushRules = result;
             getFilter(); // Now get the filter
         }, retryHandler(attempt, getPushRules));
@@ -349,25 +348,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
     // normal timeout= plus buffer time
     var clientSideTimeoutMs = this.opts.pollTimeout + BUFFER_PERIOD_MS;
 
-    if (self._lowClientTimeouts) {
-        debuglog("_lowClientTimeouts flag set.");
-        clientSideTimeoutMs = this.opts.pollTimeout;
-    }
-
-    var dateStamp = new Date();
-    dateStamp = dateStamp.getHours() + ":" + dateStamp.getMinutes() + ":" +
-        dateStamp.getSeconds() + "." + dateStamp.getMilliseconds();
-    debuglog("DEBUG[%s]: NEW _sync attempt=%s qp_timeout=%s cli_timeout=%s",
-        dateStamp, attempt, qps.timeout, clientSideTimeoutMs);
-
-
-
     client._http.authedRequestWithPrefix(
         undefined, "GET", "/sync", qps, undefined, httpApi.PREFIX_V2_ALPHA,
         clientSideTimeoutMs
     ).done(function(data) {
-        debuglog("DEBUG[%s]: _sync RECV", dateStamp);
-        self._lowClientTimeouts = false;
         // data looks like:
         // {
         //    next_batch: $token,
@@ -541,16 +525,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
 
         self._sync(syncOptions);
     }, function(err) {
-        debuglog("DEBUG[%s]: RECV FAIL %s", dateStamp, require("util").inspect(err));
         console.error("/sync error (%s attempts): %s", attempt, err);
         console.error(err);
         attempt += 1;
-        startSyncingRetryTimer(client, attempt, function(newAttempt, extendedWait) {
-            debuglog("DEBUG[%s]: Init new _sync new_attempt=%s extended_wait=%s",
-                dateStamp, newAttempt, extendedWait);
-            if (extendedWait) {
-                self._lowClientTimeouts = true;
-            }
+        startSyncingRetryTimer(client, attempt, function(newAttempt) {
             self._sync(syncOptions, newAttempt);
         });
         updateSyncState(client, "ERROR", { error: err });
@@ -745,19 +723,17 @@ function startSyncingRetryTimer(client, attempt, fn) {
     client._syncingRetry.timeoutId = setTimeout(function() {
         var timeAfterWaitingMs = Date.now();
         var timeDeltaMs = timeAfterWaitingMs - timeBeforeWaitingMs;
-        var extendedWait = false;
         if (timeDeltaMs > (2 * timeToWaitMs)) {
             // we've waited more than twice what we were supposed to. Reset the
             // attempt number back to 1. This can happen when the comp goes to
             // sleep whilst the timer is running.
             newAttempt = 1;
-            extendedWait = true;
             console.warn(
                 "Sync retry timer: Tried to wait %s ms but actually waited %s ms",
                 timeToWaitMs, timeDeltaMs
             );
         }
-        fn(newAttempt, extendedWait);
+        fn(newAttempt);
     }, timeToWaitMs);
 }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -545,6 +545,10 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                     debuglog("Aborting current /sync.");
                     self._currentSyncRequest.abort();
                 }
+                // immediately retry if we were waiting
+                debuglog(
+                    "Interrupted /sync backoff: %s", self.client.retryImmediately()
+                );
             });
         }
         console.error("/sync error (%s attempts): %s", attempt, err);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -540,9 +540,11 @@ SyncApi.prototype._sync = function(syncOptions, attempt) {
                 if (!self._syncConnectionLost) {
                     return;
                 }
-                // kill the current sync request
-                debuglog("Aborting current /sync.");
-                self._currentSyncRequest.abort();
+                if (self._currentSyncRequest.abort) {
+                    // kill the current sync request
+                    debuglog("Aborting current /sync.");
+                    self._currentSyncRequest.abort();
+                }
             });
         }
         console.error("/sync error (%s attempts): %s", attempt, err);

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -10,7 +10,7 @@ describe("MatrixClient", function() {
     var identityServerDomain = "identity.server";
     var client, store, scheduler;
 
-    var KEEP_ALIVE_PATH = "/";
+    var KEEP_ALIVE_PATH = "/_matrix/client/versions";
 
     var PUSH_RULES_RESPONSE = {
         method: "GET",

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -10,6 +10,8 @@ describe("MatrixClient", function() {
     var identityServerDomain = "identity.server";
     var client, store, scheduler;
 
+    var KEEP_ALIVE_PATH = "/";
+
     var PUSH_RULES_RESPONSE = {
         method: "GET",
         path: "/pushrules/",
@@ -51,6 +53,9 @@ describe("MatrixClient", function() {
     ];
     var pendingLookup = null;
     function httpReq(cb, method, path, qp, data, prefix) {
+        if (path === KEEP_ALIVE_PATH) {
+            return q();
+        }
         var next = httpLookups.shift();
         var logLine = (
             "MatrixClient[UT] RECV " + method + " " + path + "  " +
@@ -137,6 +142,7 @@ describe("MatrixClient", function() {
         ]);
         client._http.authedRequest.andCallFake(httpReq);
         client._http.authedRequestWithPrefix.andCallFake(httpReq);
+        client._http.requestWithPrefix.andCallFake(httpReq);
 
         // set reasonable working defaults
         pendingLookup = null;


### PR DESCRIPTION
When a `/sync` request fails, we spin up a keep-alive poll to `/_matrix/client/r0`
which `400`s. We treat any HTTP response code as a success for the purposes of
polling the server. When a successful poll is done, we shoot the current `/sync`
request in the head immediately (via a hacky `abort()` on the promise) and retry
the `/sync`.

The point of this is to fix the problem where OSX can black-hole connections when waking. This would normally hit the 110s client-side timeout for `/sync` which is way too long for a timeout. We effectively now use the keep alive request to check for connectivity now (which has a 5s client-side timeout) and then resend the `/sync` request when it succeeds.