### PR TITLE
Make sure we don't end up calling /messages in a loop if things go weird

### DIFF
--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -246,7 +246,11 @@ TimelineWindow.prototype.paginate = function(direction, size, makeRequest) {
             // end of timeline
             return false;
         }
-        return self.paginate(direction, size);
+        // recurse to advance the index into the results, but before we do, set
+        // makeRequest=false. It's not an absolute given that the paginate
+        // request returned events which we can now use, but we certainly don't
+        // want to get stuck in a tight loop here if things start going wrong.
+        return self.paginate(direction, size, false);
     });
     tl.pendingPaginate = prom;
     return prom;


### PR DESCRIPTION
If we somehow end up in a situation where calling /messages returns a load
of messages, but none of them are new, then currently we start calling
/messages again and again in a tight loop. This is bad, so fix it.