### PR TITLE
Fix a bug which made the timelines get confused about local messages

### DIFF
--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -575,13 +575,23 @@ Room.prototype._addLiveEvents = function(events) {
         // Exists due to client.js:815 (MatrixClient.sendEvent)
         // We should make txnId a first class citizen.
         if (events[i]._txnId) {
+            // this is the outgoing copy of the event (ie, the local echo).
             this._txnToEvent[events[i]._txnId] = events[i];
         }
         else if (events[i].getUnsigned().transaction_id) {
+            // remote echo of an event we sent earlier
             var existingEvent = this._txnToEvent[events[i].getUnsigned().transaction_id];
             if (existingEvent) {
                 // no longer pending
                 delete this._txnToEvent[events[i].getUnsigned().transaction_id];
+
+                // update the timeline map, because the event id has changed
+                var existingTimeline = this._eventIdToTimeline[existingEvent.getId()];
+                if (existingTimeline) {
+                    delete this._eventIdToTimeline[existingEvent.getId()];
+                    this._eventIdToTimeline[events[i].getId()] = existingTimeline;
+                }
+
                 // replace the event source
                 existingEvent.event = events[i].event;
                 continue;

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -576,9 +576,10 @@ describe("MatrixClient event timelines", function() {
         beforeEach(function() {
             // set up handlers for both the message send, and the
             // /sync
-            httpBackend.when("PUT", "/send/m.room.message/"+TXN_ID).respond(200, {
-                event_id: event.event_id,
-            });
+            httpBackend.when("PUT", "/send/m.room.message/" + TXN_ID)
+                .respond(200, {
+                    event_id: event.event_id,
+                });
             httpBackend.when("GET", "/sync").respond(200, {
                 next_batch: "s_5_4",
                 rooms: {
@@ -603,7 +604,8 @@ describe("MatrixClient event timelines", function() {
                 expect(res.event_id).toEqual(event.event_id);
                 return client.getEventTimeline(room, event.event_id);
             }).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(2); // the initial sync contained an event
+                // 2 because the initial sync contained an event
+                expect(tl.getEvents().length).toEqual(2);
                 expect(tl.getEvents()[1].getContent().body).toEqual("a body");
 
                 // now let the sync complete, and check it again


### PR DESCRIPTION
Make sure that the timeline index is kept consistent when the id of an event
changes when we receive the remote echo of a message we sent.