### PR TITLE
Check old timelines when looking for echoes of sent messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1156,18 +1156,17 @@ function _sendEvent(client, room, event, callback) {
     promise.done(function(res) {  // the request was sent OK
         if (room) {
             var eventId = res.event_id;
-            // try to find an event with this event_id. If we find it, this is
-            // the echo of this event *from the event stream* so we can remove
-            // the fake event we made above. If we don't find it, we're still
-            // waiting on the real event and so should assign the fake event
-            // with the real event_id for matching later.
 
             // FIXME: This manipulation of the room should probably be done
             // inside the room class, not by the client.
-            var matchingEvent = utils.findElement(room.timeline, function(ev) {
-                return ev.getId() === eventId;
-            }, true);
-            if (matchingEvent) {
+            var timeline = room.getTimelineForEvent(eventId);
+            if (timeline) {
+                // we've already received the event via the event stream.
+                // update it and remove the fake event.
+                var matchingEvent =
+                    utils.findElement(timeline.getEvents(), function(ev) {
+                        return ev.getId() === eventId;
+                    }, true);
                 if (event.encryptedType) {
                     // Replace the content and type of the event with the
                     // plaintext that we sent to the server.
@@ -1180,6 +1179,9 @@ function _sendEvent(client, room, event, callback) {
                 matchingEvent.status = null; // make sure it's still marked as sent
             }
             else {
+                // we haven't yet received the event from the stream; we
+                // need to update the fake event with the right event id.
+                //
                 // best way to make sure the room timeline structures are updated
                 // correctly is to remove the event and add it again with the right
                 // ID.


### PR DESCRIPTION
After /send completes, we check the room to see if the echo has already come
back via /sync. It's a bit of an edge-case, but we ought to check all
timelines, not just the live one.

Furthermore, we now have a map from eventId to timeline, so we can handle the
case where the echo has *not* yet come back more efficiently than searching
through the whole timeline.