### PR TITLE
EventTimeline: Fix baseIndex after removing the last event

### DIFF
--- a/lib/models/event-timeline.js
+++ b/lib/models/event-timeline.js
@@ -31,7 +31,7 @@ var MatrixEvent = require("./event").MatrixEvent;
 function EventTimeline(roomId) {
     this._roomId = roomId;
     this._events = [];
-    this._baseIndex = -1;
+    this._baseIndex = 0;
     this._startState = new RoomState(roomId);
     this._startState.paginationToken = null;
     this._endState = new RoomState(roomId);
@@ -252,7 +252,7 @@ EventTimeline.prototype.addEvent = function(event, atStart, spliceBeforeLocalEch
     }
 
     this._events.splice(insertIndex, 0, event); // insert element
-    if (insertIndex <= this._baseIndex || this._baseIndex == -1) {
+    if (atStart) {
         this._baseIndex++;
     }
 };

--- a/spec/unit/event-timeline.spec.js
+++ b/spec/unit/event-timeline.spec.js
@@ -143,9 +143,9 @@ describe("EventTimeline", function() {
 
         it("should be able to add events to the end", function() {
             timeline.addEvent(events[0], false);
-            expect(timeline.getBaseIndex()).toEqual(0);
+            var initialIndex = timeline.getBaseIndex();
             timeline.addEvent(events[1], false);
-            expect(timeline.getBaseIndex()).toEqual(0);
+            expect(timeline.getBaseIndex()).toEqual(initialIndex);
             expect(timeline.getEvents().length).toEqual(2);
             expect(timeline.getEvents()[0]).toEqual(events[0]);
             expect(timeline.getEvents()[1]).toEqual(events[1]);
@@ -153,9 +153,9 @@ describe("EventTimeline", function() {
 
         it("should be able to add events to the start", function() {
             timeline.addEvent(events[0], true);
-            expect(timeline.getBaseIndex()).toEqual(0);
+            var initialIndex = timeline.getBaseIndex();
             timeline.addEvent(events[1], true);
-            expect(timeline.getBaseIndex()).toEqual(1);
+            expect(timeline.getBaseIndex()).toEqual(initialIndex+1);
             expect(timeline.getEvents().length).toEqual(2);
             expect(timeline.getEvents()[0]).toEqual(events[1]);
             expect(timeline.getEvents()[1]).toEqual(events[0]);
@@ -346,6 +346,20 @@ describe("EventTimeline", function() {
             expect(timeline.getEvents().length).toEqual(1);
             expect(timeline.getBaseIndex()).toEqual(0);
         });
+
+        // this is basically https://github.com/vector-im/vector-web/issues/937
+        // - removing the last event got baseIndex into such a state that
+        // further addEvent(ev, false) calls made the index increase.
+        it("should not make baseIndex assplode when removing the last event",
+           function() {
+               timeline.addEvent(events[0], true);
+               timeline.removeEvent(events[0].getId());
+               var initialIndex = timeline.getBaseIndex();
+               timeline.addEvent(events[1], false);
+               timeline.addEvent(events[2], false);
+               expect(timeline.getBaseIndex()).toEqual(initialIndex);
+               expect(timeline.getEvents().length).toEqual(2);
+           });
     });
 });
 

--- a/spec/unit/event-timeline.spec.js
+++ b/spec/unit/event-timeline.spec.js
@@ -155,7 +155,7 @@ describe("EventTimeline", function() {
             timeline.addEvent(events[0], true);
             var initialIndex = timeline.getBaseIndex();
             timeline.addEvent(events[1], true);
-            expect(timeline.getBaseIndex()).toEqual(initialIndex+1);
+            expect(timeline.getBaseIndex()).toEqual(initialIndex + 1);
             expect(timeline.getEvents().length).toEqual(2);
             expect(timeline.getEvents()[0]).toEqual(events[1]);
             expect(timeline.getEvents()[1]).toEqual(events[0]);


### PR DESCRIPTION
Removing the last event in an EventTimeline (as we might, for instance, if it
was a local echo in an empty timeline) got us into a state where the baseIndex
would increment when adding events to the end of the timeline, causing much
confusion.

This should fix https://github.com/vector-im/vector-web/issues/937.