### PR TITLE
Interpret the response from /context correctly

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2155,10 +2155,11 @@ MatrixClient.prototype.getEventTimeline = function(room, eventId) {
 
         // we start with the last event, since that's the point at which we
         // have known state.
-        var events = res.events_before
+        // events_after is already backwards; events_before is forwards.
+        res.events_after.reverse();
+        var events = res.events_after
             .concat([res.event])
-            .concat(res.events_after);
-        events.reverse();
+            .concat(res.events_before);
         var matrixEvents = utils.map(events, self.getEventMapper());
 
         var timeline = room.getTimelineForEvent(matrixEvents[0].getId());

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -238,9 +238,9 @@ describe("MatrixClient event timelines", function() {
                 .respond(200, function() {
                     return {
                         start: "start_token",
-                        events_before: [EVENTS[0]],
-                        event: EVENTS[1],
-                        events_after: [EVENTS[2]],
+                        events_before: [EVENTS[1], EVENTS[0]],
+                        event: EVENTS[2],
+                        events_after: [EVENTS[3]],
                         state: [
                             ROOM_NAME_EVENT,
                             USER_MEMBERSHIP_EVENT,
@@ -250,8 +250,8 @@ describe("MatrixClient event timelines", function() {
                 });
 
             client.getEventTimeline(room, "event1:bar").then(function(tl) {
-                expect(tl.getEvents().length).toEqual(3);
-                for (var i = 0; i < 3; i++) {
+                expect(tl.getEvents().length).toEqual(4);
+                for (var i = 0; i < 4; i++) {
                     expect(tl.getEvents()[i].event).toEqual(EVENTS[i]);
                     expect(tl.getEvents()[i].sender.name).toEqual(userName);
                 }


### PR DESCRIPTION
events_before are backwards

Fixes https://github.com/vector-im/vector-web/issues/963