### PR TITLE
Check filters before we reuse them

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -338,7 +338,6 @@ SyncApi.prototype.sync = function() {
         self._getOrCreateFilter(
             getFilterName(client.credentials.userId), filter
         ).done(function(filterId) {
-            debuglog("Using existing filter ID %s", filterId);
             self._sync({ filterId: filterId });
         }, function(err) {
             self._startKeepAlives().done(function() {
@@ -702,16 +701,42 @@ SyncApi.prototype._pokeKeepAlive = function() {
  */
 SyncApi.prototype._getOrCreateFilter = function(filterName, filter) {
     var client = this.client;
+
     var filterId = client.store.getFilterIdByName(filterName);
+    var promise = q();
+
     if (filterId) {
-        // super, just use that.
-        return q(filterId);
+        // check that the existing filter matches our expectations
+        promise = client.getFilter(client.credentials.userId,
+                         filterId, true
+        ).then(function(existingFilter) {
+            var oldStr = JSON.stringify(existingFilter.getDefinition());
+            var newStr = JSON.stringify(filter.getDefinition());
+
+            if ( oldStr == newStr ) {
+                // super, just use that.
+                debuglog("Using existing filter ID %s: %s", filterId, oldStr);
+                return q(filterId);
+            }
+            debuglog("Existing filter ID %s: %s; new filter: %s",
+                     filterId, oldStr, newStr);
+            return;
+        });
     }
 
-    // create a filter
-    return client.createFilter(filter.getDefinition()).then(function(createdFilter) {
-        client.store.setFilterIdByName(filterName, createdFilter.filterId);
-        return createdFilter.filterId;
+    return promise.then(function(existingId) {
+        if (existingId) {
+            return existingId;
+        }
+
+        // create a new filter
+        return client.createFilter(filter.getDefinition()
+        ).then(function(createdFilter) {
+            debuglog("Created new filter ID %s: %s", createdFilter.filterId,
+                     JSON.stringify(createdFilter.getDefinition()));
+            client.store.setFilterIdByName(filterName, createdFilter.filterId);
+            return createdFilter.filterId;
+        });
     });
 };
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -713,7 +713,7 @@ SyncApi.prototype._getOrCreateFilter = function(filterName, filter) {
             var oldStr = JSON.stringify(existingFilter.getDefinition());
             var newStr = JSON.stringify(filter.getDefinition());
 
-            if ( oldStr == newStr ) {
+            if (oldStr == newStr) {
                 // super, just use that.
                 debuglog("Using existing filter ID %s: %s", filterId, oldStr);
                 return q(filterId);

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -166,12 +166,15 @@ describe("MatrixClient", function() {
         });
     });
 
-    it("should not POST /filter if a filter already exists", function(done) {
+    it("should not POST /filter if a matching filter already exists", function(done) {
         httpLookups = [];
         httpLookups.push(PUSH_RULES_RESPONSE);
         httpLookups.push(SYNC_RESPONSE);
         var filterId = "ehfewf";
         store.getFilterIdByName.andReturn(filterId);
+        var filter = new sdk.Filter(0, filterId);
+        filter.setDefinition({"room": {"timeline": {"limit": 8}}});
+        store.getFilter.andReturn(filter);
         client.startClient();
 
         client.on("sync", function syncListener(state) {


### PR DESCRIPTION
Make sure that we check the content of existing filters before we blindly reuse
them.

This feels a bit nasty because the chances are that we could reuse an existing
filter. But taking advantage of that would mean changing the synapse API, which I have little appetite right at the moment.

Fixes https://github.com/vector-im/vector-web/issues/988