### PR TITLE
TimelineWindow.load: make the livetimeline case quicker

### DIFF
--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -88,39 +88,41 @@ TimelineWindow.prototype.load = function(initialEventId, initialWindowSize) {
     var self = this;
     initialWindowSize = initialWindowSize || 20;
 
-    var prom;
+    // given an EventTimeline, and an event index within it, initialise our
+    // fields so that the event in question is in the middle of the window.
+    var initFields = function(timeline, eventIndex) {
+        var endIndex = Math.min(timeline.getEvents().length,
+                                eventIndex + Math.ceil(initialWindowSize / 2));
+        var startIndex = Math.max(0, endIndex - initialWindowSize);
+        self._start = new TimelineIndex(timeline, startIndex - timeline.getBaseIndex());
+        self._end = new TimelineIndex(timeline, endIndex - timeline.getBaseIndex());
+        self._eventCount = endIndex - startIndex;
+    };
+
+    // We avoid delaying the resolution of the promise by a reactor tick if
+    // we already have the data we need, which is important to keep room-switching
+    // feeling snappy.
+    //
+    // TODO: ideally we'd spot getEventTimeline returning a resolved promise and
+    // skip straight to the find-event loop.
     if (initialEventId) {
-        debuglog("TimelineWindow: initialising for event " + initialEventId);
-        prom = this._client.getEventTimeline(this._room, initialEventId)
+        return this._client.getEventTimeline(this._room, initialEventId)
             .then(function(tl) {
                 // make sure that our window includes the event
                 for (var i = 0; i < tl.getEvents().length; i++) {
                     if (tl.getEvents()[i].getId() == initialEventId) {
-                        return {timeline: tl, index: i};
+                        initFields(tl, i);
+                        return;
                     }
                 }
                 throw new Error("getEventTimeline result didn't include requested event");
             });
     } else {
-        debuglog("TimelineWindow: initialising with live timeline");
-
         // start with the most recent events
         var tl = this._room.getLiveTimeline();
-        prom = q({timeline: tl, index: tl.getEvents().length});
+        initFields(tl, tl.getEvents().length);
+        return q();
     }
-
-    prom = prom.then(function(v) {
-        var tl = v.timeline, eventIndex = v.index;
-
-        var endIndex = Math.min(tl.getEvents().length,
-                                eventIndex + Math.ceil(initialWindowSize / 2));
-        var startIndex = Math.max(0, endIndex - initialWindowSize);
-        self._start = new TimelineIndex(tl, startIndex - tl.getBaseIndex());
-        self._end = new TimelineIndex(tl, endIndex - tl.getBaseIndex());
-        self._eventCount = endIndex - startIndex;
-    });
-
-    return prom;
 };
 
 /**


### PR DESCRIPTION
Avoid doing a loop round the reactor if we are just loading the live timeline.