### PR TITLE
Work around confused timelines causing pagination loops

### DIFF
--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -467,16 +467,26 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline,
     //       contained the event we knew about (steps 3, 5, 6).
     //
     //
-    // Finally, consider what we want to do with the pagination token. In the
-    // case above, we will be given a pagination token which tells us how to
+    // So much for adding events to the timeline. But what do we want to do
+    // with the pagination token?
+    //
+    // In the case above, we will be given a pagination token which tells us how to
     // get events beyond 'U' - in this case, it makes sense to store this
     // against timeline4. But what if timeline4 already had 'U' and beyond? in
     // that case, our best bet is to throw away the pagination token we were
     // given and stick with whatever token timeline4 had previously. In short,
     // we want to only store the pagination token if the last event we receive
     // is one we didn't previously know about.
+    //
+    // We make an exception for this if it turns out that we already knew about
+    // *all* of the events, and we weren't able to join up any timelines. When
+    // that happens, it means our existing pagination token is faulty, since it
+    // is only telling us what we already know. Rather than repeatedly
+    // paginating with the same token, we might as well use the new pagination
+    // token in the hope that we eventually work our way out of the mess.
 
-    var updateToken = false;
+    var didUpdate = false;
+    var lastEventWasNew = false;
     for (var i = 0; i < events.length; i++) {
         var event = events[i];
         var eventId = event.getId();
@@ -486,13 +496,12 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline,
         if (!existingTimeline) {
             // we don't know about this event yet. Just add it to the timeline.
             this._addEventToTimeline(event, timeline, toStartOfTimeline);
-            updateToken = true;
+            lastEventWasNew = true;
+            didUpdate = true;
             continue;
         }
 
-        // we already know about this event. We don't want to use the pagination
-        // token if this is the last event, as per the text above.
-        updateToken = false;
+        lastEventWasNew = false;
 
         if (existingTimeline == timeline) {
             console.log("Event " + eventId + " already in timeline " + timeline);
@@ -528,9 +537,13 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline,
         timeline.setNeighbouringTimeline(existingTimeline, direction);
         existingTimeline.setNeighbouringTimeline(timeline, inverseDirection);
         timeline = existingTimeline;
+        didUpdate = true;
     }
 
-    if (updateToken) {
+    // see above - if the last event was new to us, or if we didn't find any
+    // new information, we update the pagination token for whatever
+    // timeline we ended up on.
+    if (lastEventWasNew || !didUpdate) {
         timeline.setPaginationToken(paginationToken, direction);
     }
 };


### PR DESCRIPTION
Look out for us getting stuck in a loop of using the same pagination token,
and use something else next time.

Hopefully this will fix https://github.com/vector-im/vector-web/issues/1089.