### PR TITLE
Raise localEchoUpdated events in more places

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,7 +143,8 @@ function MatrixClient(opts) {
     if (this.scheduler) {
         var self = this;
         this.scheduler.setProcessFunction(function(eventToSend) {
-            eventToSend.status = EventStatus.SENDING;
+            var room = self.getRoom(eventToSend.getRoomId());
+            _updateLocalEchoStatus(room, eventToSend, EventStatus.SENDING);
             return _sendEventHttpRequest(self, eventToSend);
         });
     }
@@ -717,7 +718,7 @@ MatrixClient.prototype.joinRoom = function(roomIdOrAlias, opts, callback) {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.resendEvent = function(event, room) {
-    event.status = EventStatus.SENDING;
+    _updateLocalEchoStatus(room, event, EventStatus.SENDING);
     return _sendEvent(this, room, event);
 };
 
@@ -1154,7 +1155,7 @@ function _sendEvent(client, room, event, callback) {
         if (promise && client.scheduler.getQueueForEvent(event).length > 1) {
             // event is processed FIFO so if the length is 2 or more we know
             // this event is stuck behind an earlier event.
-            event.status = EventStatus.QUEUED;
+            _updateLocalEchoStatus(room, event, EventStatus.QUEUED);
         }
     }
 
@@ -1172,6 +1173,10 @@ function _sendEvent(client, room, event, callback) {
             if (timeline) {
                 // we've already received the event via the event stream.
                 // update it and remove the fake event.
+                //
+                // (This codepath is only useful for encrypted events; for
+                // normal events, everything here is already done when we
+                // got the echo).
                 var matchingEvent =
                     utils.findElement(timeline.getEvents(), function(ev) {
                         return ev.getId() === eventId;
@@ -1197,21 +1202,40 @@ function _sendEvent(client, room, event, callback) {
                 //
                 // This will also make us synthesize our own read receipt for the
                 // sent message.
+                var oldStatus = event.status;
                 room.removeEvents([localEventId]);
                 event.event.event_id = res.event_id;
+                // TODO: at this point, we're still expecting the remote echo
+                // to come back and update the server-generated fields for
+                // us. We should probably set the status to some distinct value
+                // so that the client app can figure out what is going on.
                 event.status = null;
                 room.addEventsToTimeline([event]);
+
+                // FIXME: doing this here is a horrible fudge, but this all
+                // needs unpicking, which will touch the crypto code.
+                room.emit("Room.localEchoUpdated", event, room, localEventId,
+                          oldStatus);
             }
         }
 
         _resolve(callback, defer, res);
     }, function(err) {
         // the request failed to send.
-        event.status = EventStatus.NOT_SENT;
+        _updateLocalEchoStatus(room, event, EventStatus.NOT_SENT);
+
         _reject(callback, defer, err);
     });
 
     return defer.promise;
+}
+
+function _updateLocalEchoStatus(room, event, newStatus) {
+    if (room) {
+        room.updateLocalEchoStatus(event, newStatus);
+    } else {
+        event.status = newStatus;
+    }
 }
 
 function _sendEventHttpRequest(client, event) {

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -609,6 +609,7 @@ Room.prototype._addLiveEvents = function(events) {
             var existingEvent = this._txnToEvent[events[i].getUnsigned().transaction_id];
             if (existingEvent) {
                 var oldEventId = existingEvent.getId();
+                var oldStatus = existingEvent.status;
 
                 // no longer pending
                 delete this._txnToEvent[events[i].getUnsigned().transaction_id];
@@ -623,7 +624,11 @@ Room.prototype._addLiveEvents = function(events) {
                 // replace the event source
                 existingEvent.event = events[i].event;
 
-                this.emit("Room.localEchoUpdated", existingEvent, this, oldEventId);
+                // successfully sent.
+                existingEvent.status = null;
+
+                this.emit("Room.localEchoUpdated", existingEvent, this, oldEventId,
+                          oldStatus);
                 continue;
             }
         }
@@ -670,6 +675,31 @@ Room.prototype._addLiveEvents = function(events) {
             ), true);
         }
     }
+};
+
+
+/**
+ * Update the status field on a local echo, to reflect its transmission
+ * progress.
+ *
+ * <p>This is an internal method.
+ *
+ * @param {MatrixEvent} event      local echo event
+ * @param {EventStatus} newStatus  status to assign
+ * @fires module:client~MatrixClient#event:"Room.localEchoUpdated"
+ */
+Room.prototype.updateLocalEchoStatus = function(event, newStatus) {
+    if (!event.status) {
+        throw new Error("updateLocalEchoStatus called on an event which is " +
+                        "not a local echo.");
+    }
+    if (!this.getTimelineForEvent(event.getId())) {
+        throw new Error("updateLocalEchoStatus called on an unknown event.");
+    }
+
+    var oldStatus = event.status;
+    event.status = newStatus;
+    this.emit("Room.localEchoUpdated", event, this, event.getId(), oldStatus);
 };
 
 /**
@@ -1334,19 +1364,36 @@ module.exports = Room;
  */
 
 /**
- * Fires when a local-echo of a transmitted event is replaced by its remote-echo.
+ * Fires when the status of a transmitted event is updated.
  *
- * <p>When an event is first transmitted, then (assuming the /send completes
- * before the event comes back from /sync), a temporary copy of the event is
- * inserted into the timeline, with a temporary event id. Once the echo comes
- * back from the server, the event is replaced by the complete event from the
- * homeserver, thus updating its event id.
+ * <p>When an event is first transmitted, a temporary copy of the event is
+ * inserted into the timeline, with a temporary event id, and a status of
+ * 'SENDING'.
  *
- * <p>If the event comes back from /sync before the /send completes, the
- * temporary event id is never stored, and this event is not raised.
+ * <p>Once the echo comes back from the server, the content of the event
+ * (MatrixEvent.event) is replaced by the complete event from the homeserver,
+ * thus updating its event id, as well as server-generated fields such as the
+ * timestamp. Its status is set to null.
+ *
+ * <p>Once the /send request completes, if the remote echo has not already
+ * arrived, the event is updated with a new event id and the status is set to
+ * null. The server-generated fields are of course not updated yet.
+ *
+ * <p>Finally, the /send might fail. In this case, the event's status is set to
+ * 'NOT_SENT'. If it is later resent, the process starts again, setting the
+ * status to 'SENDING'.
+ *
+ * <p>This event is raised to reflect each of the transitions above (except the
+ * first send attempt).
  *
  * @event module:client~MatrixClient#"Room.localEchoUpdated"
+ *
  * @param {MatrixEvent} event The matrix event which has been updated
+ *
  * @param {Room} room The room containing the redacted event
- * @param {string} oldEventId The temporary event id which has been replaced
+ *
+ * @param {string} oldEventId The previous event id (the temporary event id,
+ *    except when updating a successfully-sent event when its echo arrives)
+ *
+ * @param {EventStatus} oldStatus The previous event status.
  */


### PR DESCRIPTION
We need to know about more transitions for local-echo status changes, so raise
localEchoUpdated events for each transition.

Fixes an issue where we weren't turning failed transmissions red, because the
timeline wasn't being updated.