### PR TITLE
Try again if a pagination request gives us no new messages

### DIFF
--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -248,11 +248,15 @@ TimelineWindow.prototype.paginate = function(direction, size, makeRequest) {
             // end of timeline
             return false;
         }
-        // recurse to advance the index into the results, but before we do, set
-        // makeRequest=false. It's not an absolute given that the paginate
-        // request returned events which we can now use, but we certainly don't
-        // want to get stuck in a tight loop here if things start going wrong.
-        return self.paginate(direction, size, false);
+
+        // recurse to advance the index into the results.
+        //
+        // If we don't get any new events, we want to make sure we keep asking
+        // the server for events for as long as we have a valid pagination
+        // token. In particular, we want to know if we've actually hit the
+        // start of the timeline, or if we just happened to know about all of
+        // the events thanks to https://matrix.org/jira/browse/SYN-645.
+        return self.paginate(direction, size, true);
     });
     tl.pendingPaginate = prom;
     return prom;


### PR DESCRIPTION
This is basically a workaround for https://matrix.org/jira/browse/SYN-645: if
we knew about all of the events already, we want to try again.

Fixes the second half of https://github.com/vector-im/vector-web/issues/1014