### PR TITLE
Add Session.logged_out event

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -162,7 +162,7 @@ function MatrixClient(opts) {
     this.credentials = {
         userId: (opts.userId || null)
     };
-    this._http = new httpApi.MatrixHttpApi(httpOpts);
+    this._http = new httpApi.MatrixHttpApi(this, httpOpts);
     this.callList = {
         // callId: MatrixCall
     };
@@ -2995,8 +2995,10 @@ MatrixClient.prototype.startClient = function(opts) {
 MatrixClient.prototype.stopClient = function() {
     this.clientRunning = false;
     // TODO: f.e. Room => self.store.storeRoom(room) ?
-    this._syncApi.stop();
-    this._syncApi = null;
+    if (this._syncApi) {
+        this._syncApi.stop();
+        this._syncApi = null;
+    }
 };
 
 function setupCallEventHandler(client) {
@@ -3429,6 +3431,18 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * @example
  * matrixClient.on("Call.incoming", function(call){
  *   call.answer(); // auto-answer
+ * });
+ */
+
+/**
+ * Fires whenever the login session the JS SDK is using is no
+ * longer valid and the user must log in again.
+ * NB. This only fires when action is required from the user, not
+ * when then login session can be renewed by using a refresh token.
+ * @event module:client~MatrixClient#"Session.logged_out"
+ * @example
+ * matrixClient.on("Session.logged_out", function(call){
+ *   // show the login screen
  * });
  */
 

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -45,6 +45,7 @@ module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
 /**
  * Construct a MatrixHttpApi.
  * @constructor
+ * @param {MatrixClient} client The matrix client instance to use.
  * @param {Object} opts The options to use for this HTTP API.
  * @param {string} opts.baseUrl Required. The base client-server URL e.g.
  * 'http://localhost:8008'.
@@ -60,9 +61,10 @@ module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
  * @param {Object} opts.extraParams Optional. Extra query parameters to send on
  * requests.
  */
-module.exports.MatrixHttpApi = function MatrixHttpApi(opts) {
+module.exports.MatrixHttpApi = function MatrixHttpApi(client, opts) {
     utils.checkObjectHasKeys(opts, ["baseUrl", "request", "prefix"]);
     opts.onlyData = opts.onlyData || false;
+    this.client = client;
     this.opts = opts;
     this.uploads = [];
 };
@@ -268,7 +270,15 @@ module.exports.MatrixHttpApi.prototype = {
     authedRequest: function(callback, method, path, queryParams, data, localTimeoutMs) {
         if (!queryParams) { queryParams = {}; }
         queryParams.access_token = this.opts.accessToken;
-        return this.request(callback, method, path, queryParams, data, localTimeoutMs);
+        var self = this;
+        return this.request(
+            callback, method, path, queryParams, data, localTimeoutMs
+        ).catch(function(err) {
+            if (err.errcode == 'M_UNKNOWN_TOKEN') {
+                self.client.emit("Session.logged_out");
+            }
+            throw err;
+        });
     },
 
     /**

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -45,7 +45,7 @@ module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
 /**
  * Construct a MatrixHttpApi.
  * @constructor
- * @param {MatrixClient} client The matrix client instance to use.
+ * @param {EventEmitter} event_emitter The event emitter to use for emitting events
  * @param {Object} opts The options to use for this HTTP API.
  * @param {string} opts.baseUrl Required. The base client-server URL e.g.
  * 'http://localhost:8008'.
@@ -61,10 +61,10 @@ module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
  * @param {Object} opts.extraParams Optional. Extra query parameters to send on
  * requests.
  */
-module.exports.MatrixHttpApi = function MatrixHttpApi(client, opts) {
+module.exports.MatrixHttpApi = function MatrixHttpApi(event_emitter, opts) {
     utils.checkObjectHasKeys(opts, ["baseUrl", "request", "prefix"]);
     opts.onlyData = opts.onlyData || false;
-    this.client = client;
+    this.event_emitter = event_emitter;
     this.opts = opts;
     this.uploads = [];
 };
@@ -275,7 +275,7 @@ module.exports.MatrixHttpApi.prototype = {
             callback, method, path, queryParams, data, localTimeoutMs
         ).catch(function(err) {
             if (err.errcode == 'M_UNKNOWN_TOKEN') {
-                self.client.emit("Session.logged_out");
+                self.event_emitter.emit("Session.logged_out");
             }
             throw err;
         });

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -278,7 +278,6 @@ module.exports.MatrixHttpApi.prototype = {
             if (err.errcode == 'M_UNKNOWN_TOKEN') {
                 self.event_emitter.emit("Session.logged_out");
             }
-            throw err;
         });
         // return the original promise, otherwise tests break due to it having to
         // go around the event loop one more time to process the result of the request

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -271,14 +271,18 @@ module.exports.MatrixHttpApi.prototype = {
         if (!queryParams) { queryParams = {}; }
         queryParams.access_token = this.opts.accessToken;
         var self = this;
-        return this.request(
+        var request_promise = this.request(
             callback, method, path, queryParams, data, localTimeoutMs
-        ).catch(function(err) {
+        );
+        request_promise.catch(function(err) {
             if (err.errcode == 'M_UNKNOWN_TOKEN') {
                 self.event_emitter.emit("Session.logged_out");
             }
             throw err;
         });
+        // return the original promise, otherwise tests break due to it having to
+        // go around the event loop one more time to process the result of the request
+        return request_promise;
     },
 
     /**

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -279,6 +279,24 @@ describe("MatrixClient events", function() {
                 done();
             });
         });
+
+        it("should emit Session.logged_out on M_UNKNOWN_TOKEN", function(done) {
+            httpBackend.when("GET", "/sync").respond(401, { errcode: 'M_UNKNOWN_TOKEN' });
+
+            var sessionLoggedOutCount = 0;
+            client.on("Session.logged_out", function(event, member) {
+                sessionLoggedOutCount++;
+            });
+
+            client.startClient();
+
+            httpBackend.flush().done(function() {
+                expect(sessionLoggedOutCount).toEqual(
+                    1, "Session.logged_out fired wrong number of times"
+                );
+                done();
+            });
+        });
     });
 
 });


### PR DESCRIPTION
Session.logged_out fires whenever the current session is no longer valid and the user needs to log in again.

Also null check _syncApi before trying to stop it.

https://github.com/vector-im/vector-web/issues/414