### PR TITLE
Clean up a codepath that was only used for crypto messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1112,6 +1112,7 @@ function _decryptMessage(client, event) {
                 room_id: payload.room_id,
                 user_id: event.getSender(),
                 event_id: event.getId(),
+                unsigned: event.getUnsigned(),
                 type: payload.type,
                 content: payload.content
             }, "encrypted");
@@ -1129,6 +1130,7 @@ function _badEncryptedMessage(event, reason) {
         room_id: event.getRoomId(),
         user_id: event.getSender(),
         event_id: event.getId(),
+        unsigned: event.getUnsigned(),
         content: {
             msgtype: "m.bad.encrypted",
             body: reason,
@@ -1170,29 +1172,7 @@ function _sendEvent(client, room, event, callback) {
             // FIXME: This manipulation of the room should probably be done
             // inside the room class, not by the client.
             var timeline = room.getTimelineForEvent(eventId);
-            if (timeline) {
-                // we've already received the event via the event stream.
-                // update it and remove the fake event.
-                //
-                // (This codepath is only useful for encrypted events; for
-                // normal events, everything here is already done when we
-                // got the echo).
-                var matchingEvent =
-                    utils.findElement(timeline.getEvents(), function(ev) {
-                        return ev.getId() === eventId;
-                    }, true);
-                if (event.encryptedType) {
-                    // Replace the content and type of the event with the
-                    // plaintext that we sent to the server.
-                    // TODO: Persist the changes if we storing events somewhere
-                    // otherthan in memory.
-                    matchingEvent.event.content = event.event.content;
-                    matchingEvent.event.type = event.event.type;
-                }
-                room.removeEvents([localEventId]);
-                matchingEvent.status = null; // make sure it's still marked as sent
-            }
-            else {
+            if (!timeline) {
                 // we haven't yet received the event from the stream; we
                 // need to update the fake event with the right event id.
                 //

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -621,8 +621,13 @@ Room.prototype._addLiveEvents = function(events) {
                     this._eventIdToTimeline[events[i].getId()] = existingTimeline;
                 }
 
-                // replace the event source
+                // replace the event source, but preserve the original content
+                // and type in case it was encrypted (we won't be able to
+                // decrypt it, even though we sent it.)
+                var existingSource = existingEvent.event;
                 existingEvent.event = events[i].event;
+                existingEvent.event.content = existingSource.content;
+                existingEvent.event.type = existingSource.type;
 
                 // successfully sent.
                 existingEvent.status = null;

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -194,6 +194,7 @@ describe("MatrixClient room timelines", function() {
                 body: "I am a fish", user: userId, room: roomId
             });
             ev.event_id = eventId;
+            ev.unsigned = {transaction_id: "txn1"};
             setNextSyncData([ev]);
 
             client.on("sync", function(state) {
@@ -201,8 +202,7 @@ describe("MatrixClient room timelines", function() {
                 var room = client.getRoom(roomId);
                 var promise = client.sendTextMessage(roomId, "I am a fish", "txn1");
                 httpBackend.flush("/sync", 1).done(function() {
-                    // expect 3rd msg, it doesn't know this is the request is just did
-                    expect(room.timeline.length).toEqual(3);
+                    expect(room.timeline.length).toEqual(2);
                     httpBackend.flush("/txn1", 1);
                     promise.done(function() {
                         expect(room.timeline.length).toEqual(2);

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -165,6 +165,7 @@ describe("MatrixClient room timelines", function() {
                 body: "I am a fish", user: userId, room: roomId
             });
             ev.event_id = eventId;
+            ev.unsigned = {transaction_id: "txn1"};
             setNextSyncData([ev]);
 
             client.on("sync", function(state) {


### PR DESCRIPTION
Transmission of encrypted messages was happening somewhat differently to
normal messages. In particular, we weren't copying the 'unsigned' field when we
got the remote-echo, which meant the 'sync' code didn't correctly match up the
echo with the original.

The separate codepath was becoming a thorn in my side, so fix things up to
bring it back in line.