### PR TITLE
Log the stack when we get a sync error

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -519,8 +519,7 @@ SyncApi.prototype._sync = function(syncOptions) {
             self._processSyncResponse(syncToken, data);
         }
         catch (e) {
-            console.error("Caught /sync error:");
-            console.error(e);
+            console.error("Caught /sync error", e, e.stack);
         }
 
         // emit synced events

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -519,7 +519,9 @@ SyncApi.prototype._sync = function(syncOptions) {
             self._processSyncResponse(syncToken, data);
         }
         catch (e) {
-            console.error("Caught /sync error", e, e.stack);
+            // log the exception with stack if we have it, else fall back
+            // to the plain description
+            console.error("Caught /sync error", e.stack || e);
         }
 
         // emit synced events


### PR DESCRIPTION
If we have the stack for an exception in the /sync loop, we should log it.