### PR TITLE
Add a method to the js sdk to look up 3pids on the ID server.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3242,7 +3242,9 @@ MatrixClient.prototype.requestEmailToken = function(email, clientSecret,
  * @param {string} medium The medium of the threepid, eg. 'email'
  * @param {string} address The textual address of the threepid
  * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
+ * @return {module:client.Promise} Resolves: A threepid mapping
+ *                                 object or the empty object if no mapping
+ *                                 exists
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.lookupThreePid = function(medium, address, callback) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -3233,12 +3233,27 @@ MatrixClient.prototype.requestEmailToken = function(email, clientSecret,
     return this._http.idServerRequest(
         callback, "POST", "/validate/email/requestToken",
         params, httpApi.PREFIX_IDENTITY_V1
-    ).then(function(res) {
-        if (typeof res === "string") {
-            return JSON.parse(res);
-        }
-        return res;
-    });
+    );
+};
+
+/**
+ * Looks up the public Matrix ID mapping for a given 3rd party
+ * identifier from the Identity Server
+ * @param {string} medium The medium of the threepid, eg. 'email'
+ * @param {string} address The textual address of the threepid
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.lookupThreePid = function(medium, address, callback) {
+    var params = {
+        medium: medium,
+        address: address,
+    };
+    return this._http.idServerRequest(
+        callback, "GET", "/lookup",
+        params, httpApi.PREFIX_IDENTITY_V1
+    );
 };
 
 /**

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -245,7 +245,12 @@ module.exports.MatrixHttpApi.prototype = {
             opts,
             requestCallback(defer, callback, this.opts.onlyData)
         );
-        return defer.promise;
+        // ID server does not always take JSON, so we can't use requests' 'json'
+        // option as we do with the home server, but it does return JSON, so
+        // parse it manually
+        return defer.promise.then(function(response) {
+            return JSON.parse(response);
+        });
     },
 
     /**


### PR DESCRIPTION
This also moves the manual json decoding for the ID server into the common ID server block, since we'll have to do it for all ID server requests, rather than doing it in requestEmailToken.