### PR TITLE
Include a counter in generated transaction IDs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -183,7 +183,7 @@ function MatrixClient(opts) {
     this._peekSync = null;
     this._isGuest = false;
     this._ongoingScrollbacks = {};
-
+    this._txnCtr = 0;
     this.timelineSupport = Boolean(opts.timelineSupport);
 }
 utils.inherits(MatrixClient, EventEmitter);
@@ -937,7 +937,7 @@ MatrixClient.prototype.sendEvent = function(roomId, eventType, content, txnId,
     if (utils.isFunction(txnId)) { callback = txnId; txnId = undefined; }
 
     if (!txnId) {
-        txnId = "m" + new Date().getTime();
+        txnId = "m" + new Date().getTime() + "." + (this._txnCtr++);
     }
 
     // we always construct a MatrixEvent when sending because the store and


### PR DESCRIPTION
Fixes a flaky test which sometimes failed due to sending two events in the same
millisecond.