### PR TITLE
Attempts to improve sleep-resume

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -446,6 +446,7 @@ module.exports.MatrixHttpApi.prototype = {
                 queryParams[key] = this.opts.extraParams[key];
             }
         }
+        var req;
         var defer = q.defer();
 
         var timeoutId;
@@ -453,6 +454,9 @@ module.exports.MatrixHttpApi.prototype = {
         if (localTimeoutMs) {
             timeoutId = setTimeout(function() {
                 timedOut = true;
+                if (req && req.abort) {
+                    req.abort();
+                }
                 defer.reject(new module.exports.MatrixError({
                     error: "Locally timed out waiting for a response",
                     errcode: "ORG.MATRIX.JSSDK_TIMEOUT",
@@ -464,7 +468,7 @@ module.exports.MatrixHttpApi.prototype = {
         var reqPromise = defer.promise;
 
         try {
-            var req = this.opts.request(
+            req = this.opts.request(
                 {
                     uri: uri,
                     method: method,

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -32,11 +32,19 @@ var EventTimeline = require("./models/event-timeline");
 
 var DEBUG = true;
 
+
+// the default value for the "timeout=" parameter on /sync requests. (This can
+// be overridden by the application's setting of opts.pollTimeout). This
+// determines the server-side timeout on incremental syncs. The client-side
+// timeout (for incremental and intial syncs) is determined by this, plus
+// BUFFER_PERIOD_MS.
+var DEFAULT_SYNC_TIMEOUT_MS = 15 * 1000;
+
 // /sync requests allow you to set a timeout= but the request may continue
 // beyond that and wedge forever, so we need to track how long we are willing
 // to keep open the connection. This constant is *ADDED* to the timeout= value
 // to determine the max time we're willing to wait.
-var BUFFER_PERIOD_MS = 5 * 1000;
+var BUFFER_PERIOD_MS = 30 * 1000;
 
 // if /sync fails, we call /versions in a loop until we get a response
 // (/versions typically returns much quicker than /sync, so this allows uys to
@@ -53,8 +61,8 @@ var BUFFER_PERIOD_MS = 5 * 1000;
 // KEEPALIVE_MIN_DELAY_MS and KEEPALIVE_MAX_MS before making another request.
 //
 var KEEPALIVE_MIN_DELAY_MS = 1000;
-var KEEPALIVE_TIMEOUT_MS = 2000;
-var KEEPALIVE_RANDOMNESS_MS = 500;
+var KEEPALIVE_TIMEOUT_MS = 4000;
+var KEEPALIVE_RANDOMNESS_MS = 2000;
 
 function getFilterName(userId, suffix) {
     // scope this on the user ID because people may login on many accounts
@@ -80,7 +88,7 @@ function SyncApi(client, opts) {
     opts = opts || {};
     opts.initialSyncLimit = opts.initialSyncLimit || 8;
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
-    opts.pollTimeout = opts.pollTimeout || (15 * 1000);
+    opts.pollTimeout = opts.pollTimeout || DEFAULT_SYNC_TIMEOUT_MS;
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this.opts = opts;
     this._peekRoomId = null;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -36,7 +36,25 @@ var DEBUG = true;
 // beyond that and wedge forever, so we need to track how long we are willing
 // to keep open the connection. This constant is *ADDED* to the timeout= value
 // to determine the max time we're willing to wait.
-var BUFFER_PERIOD_MS = 80 * 1000;
+var BUFFER_PERIOD_MS = 5 * 1000;
+
+// if /sync fails, we call /versions in a loop until we get a response
+// (/versions typically returns much quicker than /sync, so this allows uys to
+// recover from network outages).
+//
+// These parameters define the intervals between /versions requests, and the
+// amount of time we wait for each /versions request to return. The randomness
+// factor attempts to avoid having all clients getting in sync, causing a
+// thundering herd.
+//
+// Each request to /versions is given a timeout of between KEEPALIVE_TIMEOUT_MS
+// and KEEPALIVE_TIMEOUT_MS+KEEPALIVE_RANDOMNESS_MS. If it times out, we make
+// another request immediately. If it fails, we delay between
+// KEEPALIVE_MIN_DELAY_MS and KEEPALIVE_MAX_MS before making another request.
+//
+var KEEPALIVE_MIN_DELAY_MS = 1000;
+var KEEPALIVE_TIMEOUT_MS = 2000;
+var KEEPALIVE_RANDOMNESS_MS = 500;
 
 function getFilterName(userId, suffix) {
     // scope this on the user ID because people may login on many accounts
@@ -62,7 +80,7 @@ function SyncApi(client, opts) {
     opts = opts || {};
     opts.initialSyncLimit = opts.initialSyncLimit || 8;
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
-    opts.pollTimeout = opts.pollTimeout || (30 * 1000);
+    opts.pollTimeout = opts.pollTimeout || (15 * 1000);
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this.opts = opts;
     this._peekRoomId = null;
@@ -753,13 +771,15 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
  */
 SyncApi.prototype._startKeepAlives = function(delay) {
     if (delay === undefined) {
-        delay = 5000 + Math.floor(Math.random() * 5000);
+        delay = KEEPALIVE_MIN_DELAY_MS +
+            Math.floor(Math.random() * KEEPALIVE_RANDOMNESS_MS);
     }
 
     if (this._keepAliveTimer !== null) {
         clearTimeout(this._keepAliveTimer);
     }
     var self = this;
+    debuglog("Starting keepalives with initial delay " + delay + "ms");
     self._keepAliveTimer = setTimeout(
         self._pokeKeepAlive.bind(self),
         delay
@@ -783,25 +803,42 @@ SyncApi.prototype._pokeKeepAlive = function() {
         }
     }
 
+    var timeout = KEEPALIVE_TIMEOUT_MS +
+        Math.floor(Math.random() * KEEPALIVE_RANDOMNESS_MS);
+    debuglog("Calling /versions with timeout " + timeout + "ms");
     this.client._http.requestWithPrefix(
         undefined, "GET", "/_matrix/client/versions", undefined,
-        undefined, "", 15 * 1000
+        undefined, "", timeout
     ).done(function() {
+        debuglog("/versions returned successfully");
         success();
     }, function(err) {
         if (err.httpStatus == 400) {
             // treat this as a success because the server probably just doesn't
             // support /versions: point is, we're getting a response.
-            // We wait a short time though, just in case somehow the server
-            // is in a mode where it 400s /versions responses and sync etc.
-            // responses fail, this will mean we don't hammer in a loop.
-            self._keepAliveTimer = setTimeout(success, 2000);
-        } else {
-            self._keepAliveTimer = setTimeout(
-                self._pokeKeepAlive.bind(self),
-                5000 + Math.floor(Math.random() * 5000)
-            );
+            // There's no need to add a delay here, because even if /sync
+            // fails, _startKeepAlives adds another delay before we call /versions
+            // again.
+            debuglog("/versions returned 400; treating as success");
+            success();
+            return;
         }
+
+        var delay;
+        if (err.errcode == "ORG.MATRIX.JSSDK_TIMEOUT") {
+            // no need for more delay
+            delay = 0;
+            debuglog("/versions timed out; retrying");
+        } else {
+            delay = KEEPALIVE_MIN_DELAY_MS +
+                Math.floor(Math.random() * KEEPALIVE_RANDOMNESS_MS);
+            debuglog("/versions failed; delaying " + delay + "ms");
+        }
+
+        self._keepAliveTimer = setTimeout(
+            self._pokeKeepAlive.bind(self),
+            delay
+        );
     });
 };
 


### PR DESCRIPTION
Reduce a bunch of timeouts on /sync

* reduce the 'timeout' parameter on syncs to 15s (was 30s)
* reduce the additional delay on syncs to 5s (was 80s)
* reduce the timeout on /versions to 2.25s +/- .25s (was 15s)
* reduce the delay between /versions calls to 1.25s +/- .25s (was 7.5 +/- 2.5)
* If /versions times out, don't delay again

Also cancel timed-out requests.