### PR TITLE
URL previewing support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1450,11 +1450,15 @@ MatrixClient.prototype.getCurrentUploads = function() {
 };
 
 /**
- * Get a preview of the given URL as OpenGraph metadata.
+ * Get a preview of the given URL as of (roughly) the given point in time,
+ * described as an object with OpenGraph keys and associated values.
+ * Attributes may be synthesized where actual OG metadata is lacking.
  * Caches results to prevent hammering the server.
  * @param {string} url The URL to get preview data for
- * @param {Number} ts The timestamp (ms since epoch) for querying
- * historical preview data.
+ * @param {Number} ts The preferred point in time that the preview should
+ * describe (ms since epoch).  The preview returned will either be the most
+ * recent one preceding this timestamp if available, or failing that the next
+ * most recent available preview.
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: Object of OG metadata.
  * @return {module:http-api.MatrixError} Rejects: with an error response.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1449,6 +1449,23 @@ MatrixClient.prototype.getCurrentUploads = function() {
 };
 
 /**
+ * Get a preview of the given URL as OpenGraph metadata
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: Object of OG metadata.
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ * May return synthesized attributes if the URL lacked OG meta.
+ */
+MatrixClient.prototype.getUrlPreview = function(url, callback) {
+    // FIXME: maintain a clientside cache to stop hammering synapse
+    // especially as synapse doesn't cache yet
+    return this._http.authedRequestWithPrefix(
+        callback, "GET", "/preview_url", {
+            url: url
+        }, undefined, httpApi.PREFIX_MEDIA_R0
+    );
+};
+
+/**
  * @param {string} roomId
  * @param {boolean} isTyping
  * @param {Number} timeoutMs

--- a/lib/client.js
+++ b/lib/client.js
@@ -1460,7 +1460,7 @@ MatrixClient.prototype.getCurrentUploads = function() {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  * May return synthesized attributes if the URL lacked OG meta.
  */
-MatrixClient.prototype.getUrlPreview = function(url, callback, ts) {
+MatrixClient.prototype.getUrlPreview = function(url, ts, callback) {
     var key = ts + "_" + url;
     var og = this.urlPreviewCache[key];
     if (og) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -185,6 +185,7 @@ function MatrixClient(opts) {
     this._ongoingScrollbacks = {};
     this._txnCtr = 0;
     this.timelineSupport = Boolean(opts.timelineSupport);
+    this.urlPreviewCache = {};
 }
 utils.inherits(MatrixClient, EventEmitter);
 
@@ -1449,20 +1450,34 @@ MatrixClient.prototype.getCurrentUploads = function() {
 };
 
 /**
- * Get a preview of the given URL as OpenGraph metadata
+ * Get a preview of the given URL as OpenGraph metadata.
+ * Caches results to prevent hammering the server.
+ * @param {string} url The URL to get preview data for
+ * @param {Number} ts The timestamp (ms since epoch) for querying
+ * historical preview data.
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: Object of OG metadata.
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  * May return synthesized attributes if the URL lacked OG meta.
  */
-MatrixClient.prototype.getUrlPreview = function(url, callback) {
-    // FIXME: maintain a clientside cache to stop hammering synapse
-    // especially as synapse doesn't cache yet
+MatrixClient.prototype.getUrlPreview = function(url, callback, ts) {
+    var key = ts + "_" + url;
+    var og = this.urlPreviewCache[key];
+    if (og) {
+        return q(og);
+    }
+
+    var self = this;
     return this._http.authedRequestWithPrefix(
         callback, "GET", "/preview_url", {
-            url: url
+            url: url,
+            ts: ts,
         }, undefined, httpApi.PREFIX_MEDIA_R0
-    );
+    ).then(function(response) {
+        // TODO: expire cache occasionally
+        self.urlPreviewCache[key] = response;
+        return response;
+    });
 };
 
 /**

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -48,6 +48,11 @@ module.exports.PREFIX_UNSTABLE = "/_matrix/client/unstable";
 module.exports.PREFIX_IDENTITY_V1 = "/_matrix/identity/api/v1";
 
 /**
+ * URI path for the media repo API
+ */
+module.exports.PREFIX_MEDIA_R0 = "/_matrix/media/r0";
+
+/**
  * Construct a MatrixHttpApi.
  * @constructor
  * @param {EventEmitter} event_emitter The event emitter to use for emitting events


### PR DESCRIPTION
* Add client.getUrlPreview() method to wrap the new /preview_url endpoint, which attempts to get a preview of a URL as of a given point in time.
* Add a basic in-memory cache to avoid hammering synapse unnecessarily

This is part of a set of PRs spanning vector-web, matrix-react-sdk, matrix-js-sdk and synapse.
See also vector-im/vector-web#1343 and https://github.com/matrix-org/matrix-react-sdk/pull/260
