### PR TITLE
Avoid paginating forever in private rooms

### DIFF
--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -241,7 +241,7 @@ TimelineWindow.prototype.paginate = function(direction, size, makeRequest,
 
     if (!makeRequest || requestLimit === 0) {
         // todo: should we return something different to indicate that there
-        // might be more envets out there, but we haven't found them yet?
+        // might be more events out there, but we haven't found them yet?
         return q(false);
     }
 

--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -31,6 +31,13 @@ var DEBUG = false;
 var debuglog = DEBUG ? console.log.bind(console) : function() {};
 
 /**
+ * the number of times we ask the server for more events before giving up
+ *
+ * @private
+ */
+var DEFAULT_PAGINATE_LOOP_LIMIT = 5;
+
+/**
  * Construct a TimelineWindow.
  *
  * <p>This abstracts the separate timelines in a Matrix {@link
@@ -179,15 +186,23 @@ TimelineWindow.prototype.canPaginate = function(direction) {
  *    even if there are fewer than 'size' of them, as we will just return those
  *    we already know about.)
  *
+ * @param {number} [requestLimit=5] limit for the number of API requests we should
+ *    make.
+ *
  * @return {module:client.Promise} Resolves to a boolean which is true if more events
  *    were successfully retrieved.
  */
-TimelineWindow.prototype.paginate = function(direction, size, makeRequest) {
+TimelineWindow.prototype.paginate = function(direction, size, makeRequest,
+                                             requestLimit) {
     // Either wind back the message cap (if there are enough events in the
     // timeline to do so), or fire off a pagination request.
 
     if (makeRequest === undefined) {
         makeRequest = true;
+    }
+
+    if (requestLimit === undefined) {
+        requestLimit = DEFAULT_PAGINATE_LOOP_LIMIT;
     }
 
     var tl;
@@ -224,7 +239,9 @@ TimelineWindow.prototype.paginate = function(direction, size, makeRequest) {
         return q(true);
     }
 
-    if (!makeRequest) {
+    if (!makeRequest || requestLimit === 0) {
+        // todo: should we return something different to indicate that there
+        // might be more envets out there, but we haven't found them yet?
         return q(false);
     }
 
@@ -256,7 +273,12 @@ TimelineWindow.prototype.paginate = function(direction, size, makeRequest) {
         // token. In particular, we want to know if we've actually hit the
         // start of the timeline, or if we just happened to know about all of
         // the events thanks to https://matrix.org/jira/browse/SYN-645.
-        return self.paginate(direction, size, true);
+        //
+        // On the other hand, we necessarily want to wait forever for the
+        // server to make its mind up about whether there are other events,
+        // because it gives a bad user experience
+        // (https://github.com/vector-im/vector-web/issues/1204).
+        return self.paginate(direction, size, true, requestLimit - 1);
     });
     tl.pendingPaginate = prom;
     return prom;

--- a/lib/timeline-window.js
+++ b/lib/timeline-window.js
@@ -186,8 +186,8 @@ TimelineWindow.prototype.canPaginate = function(direction) {
  *    even if there are fewer than 'size' of them, as we will just return those
  *    we already know about.)
  *
- * @param {number} [requestLimit=5] limit for the number of API requests we should
- *    make.
+ * @param {number} [requestLimit = 5] limit for the number of API requests we
+ *    should make.
  *
  * @return {module:client.Promise} Resolves to a boolean which is true if more events
  *    were successfully retrieved.

--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -431,7 +431,7 @@ describe("TimelineWindow", function() {
                 expect(timeline0).toBe(timeline);
                 expect(opts.backwards).toBe(false);
                 expect(opts.limit).toEqual(2);
-                paginateCount += 1
+                paginateCount += 1;
                 return q(true);
             };
 


### PR DESCRIPTION
In TimelineWindow.paginate, keep a count of the number of API requests we have
made, and bail out if it gets too high, to ensure that we don't get stuck in a
loop of paginating right back to the start of the room.