### PR TITLE
Clean up test shutdown

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -419,6 +419,10 @@ SyncApi.prototype.stop = function() {
     }
     this._running = false;
     if (this._currentSyncRequest) { this._currentSyncRequest.abort(); }
+    if (this._keepAliveTimer) {
+        clearTimeout(this._keepAliveTimer);
+        this._keepAliveTimer = null;
+    }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Matrix Client-Server SDK for Javascript",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover --report cobertura --config .istanbul.yml -i \"lib/**/*.js\" jasmine-node -- spec --verbose --junitreport --forceexit --captureExceptions",
-    "check": "jasmine-node spec --verbose --junitreport --forceexit --captureExceptions",
+    "test": "istanbul cover --report cobertura --config .istanbul.yml -i \"lib/**/*.js\" jasmine-node -- spec --verbose --junitreport --captureExceptions",
+    "check": "jasmine-node spec --verbose --junitreport --captureExceptions",
     "gendoc": "jsdoc -r lib -P package.json -R README.md -d .jsdoc",
     "build": "jshint -c .jshint lib/ && browserify browser-index.js -o dist/browser-matrix-dev.js --ignore-missing",
     "watch": "watchify browser-index.js -o dist/browser-matrix-dev.js -v",

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -24,6 +24,7 @@ describe("MatrixClient events", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        client.stopClient();
     });
 
     describe("emissions", function() {

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -97,6 +97,7 @@ function startClient(httpBackend, client) {
 
 describe("getEventTimeline support", function() {
     var httpBackend;
+    var client;
 
     beforeEach(function() {
         utils.beforeEach(this);
@@ -104,8 +105,14 @@ describe("getEventTimeline support", function() {
         sdk.request(httpBackend.requestFn);
     });
 
+    afterEach(function() {
+        if (client) {
+            client.stopClient();
+        }
+    });
+
     it("timeline support must be enabled to work", function(done) {
-        var client = sdk.createClient({
+        client = sdk.createClient({
             baseUrl: baseUrl,
             userId: userId,
             accessToken: accessToken,
@@ -120,7 +127,7 @@ describe("getEventTimeline support", function() {
     });
 
     it("timeline support works when enabled", function(done) {
-        var client = sdk.createClient({
+        client = sdk.createClient({
             baseUrl: baseUrl,
             userId: userId,
             accessToken: accessToken,
@@ -141,7 +148,7 @@ describe("getEventTimeline support", function() {
     it("scrollback should be able to scroll back to before a gappy /sync",
       function(done) {
         // need a client with timelineSupport disabled to make this work
-        var client = sdk.createClient({
+        client = sdk.createClient({
             baseUrl: baseUrl,
             userId: userId,
             accessToken: accessToken,
@@ -229,6 +236,7 @@ describe("MatrixClient event timelines", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        client.stopClient();
     });
 
     describe("getEventTimeline", function() {

--- a/spec/integ/matrix-client-opts.spec.js
+++ b/spec/integ/matrix-client-opts.spec.js
@@ -73,6 +73,10 @@ describe("MatrixClient opts", function() {
             });
         });
 
+        afterEach(function() {
+            client.stopClient();
+        });
+
         it("should be able to send messages", function(done) {
             var eventId = "$flibble:wibble";
             httpBackend.when("PUT", "/txn1").respond(200, {

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -126,6 +126,7 @@ describe("MatrixClient room timelines", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        client.stopClient();
     });
 
     describe("local echo events", function() {
@@ -391,16 +392,16 @@ describe("MatrixClient room timelines", function() {
                 });
 
                 httpBackend.flush("/messages", 1);
-                httpBackend.flush("/sync", 1).done(function() {
+                httpBackend.flush("/sync", 1).then(function() {
                     expect(index).toEqual(2);
-                    expect(room.timeline[room.timeline.length - 1].event).toEqual(
+                    expect(room.timeline.length).toEqual(3);
+                    expect(room.timeline[2].event).toEqual(
                         eventData[1]
                     );
-                    expect(room.timeline[room.timeline.length - 2].event).toEqual(
+                    expect(room.timeline[1].event).toEqual(
                         eventData[0]
                     );
-                    done();
-                });
+                }).catch(utils.failTest).done(done);
             });
             httpBackend.flush("/sync", 1);
         });
@@ -419,13 +420,12 @@ describe("MatrixClient room timelines", function() {
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
-                httpBackend.flush("/sync", 1).done(function() {
+                httpBackend.flush("/sync", 1).then(function() {
                     var preNameEvent = room.timeline[room.timeline.length - 3];
                     var postNameEvent = room.timeline[room.timeline.length - 1];
                     expect(preNameEvent.sender.name).toEqual(userName);
                     expect(postNameEvent.sender.name).toEqual("New Name");
-                    done();
-                });
+                }).catch(utils.failTest).done(done);
             });
             httpBackend.flush("/sync", 1);
         });
@@ -487,7 +487,7 @@ describe("MatrixClient room timelines", function() {
             client.on("sync", function(state) {
                 if (state !== "PREPARED") { return; }
                 var room = client.getRoom(roomId);
-                httpBackend.flush("/sync", 1).done(function() {
+                httpBackend.flush("/sync", 1).then(function() {
                     expect(room.currentState.getMembers().length).toEqual(4);
                     expect(room.currentState.getMember(userC).name).toEqual("C");
                     expect(room.currentState.getMember(userC).membership).toEqual(
@@ -497,8 +497,7 @@ describe("MatrixClient room timelines", function() {
                     expect(room.currentState.getMember(userD).membership).toEqual(
                         "invite"
                     );
-                    done();
-                });
+                }).catch(utils.failTest).done(done);
             });
             httpBackend.flush("/sync", 1);
         });

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -32,6 +32,7 @@ describe("MatrixClient syncing", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        client.stopClient();
     });
 
     describe("startClient", function() {

--- a/spec/mock-request.js
+++ b/spec/mock-request.js
@@ -24,7 +24,8 @@ function HttpBackend() {
                 self.requests.splice(idx, 1);
                 realReq.callback("aborted");
             }
-        }
+        };
+
         return {
             abort: abort
         };

--- a/spec/mock-request.js
+++ b/spec/mock-request.js
@@ -15,6 +15,19 @@ function HttpBackend() {
         realReq.callback = callback;
         console.log("HTTP backend received request: %s %s", opts.method, opts.uri);
         self.requests.push(realReq);
+
+        var abort = function() {
+            var idx = self.requests.indexOf(realReq);
+            if (idx >= 0) {
+                console.log("Aborting HTTP request: %s %s", opts.method,
+                            opts.uri);
+                self.requests.splice(idx, 1);
+                realReq.callback("aborted");
+            }
+        }
+        return {
+            abort: abort
+        };
     };
 }
 HttpBackend.prototype = {


### PR DESCRIPTION
Make sure that the integration tests actually kill off all of their timers, so
that jasmine exits cleanly.

This probably also fixes https://github.com/vector-im/vector-web/issues/1365.