### PR TITLE
Support for marking devices as verified

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -130,10 +130,15 @@ function MatrixClient(opts) {
         signatures[opts.userId]["ed25519:" + this.deviceId] = signature;
         this.deviceKeys.signatures = signatures;
 
+        var deviceInfo = {
+            keys: this.deviceKeys.keys,
+            algorithms: this.deviceKeys.algorithms,
+            verified: true,
+        };
         var myDevices = this.sessionStore.getEndToEndDevicesForUser(
             opts.userId
         ) || {};
-        myDevices[opts.deviceId] = this.deviceKeys;
+        myDevices[opts.deviceId] = deviceInfo;
         this.sessionStore.storeEndToEndDevicesForUser(
             opts.userId, myDevices
         );

--- a/lib/client.js
+++ b/lib/client.js
@@ -567,6 +567,60 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
     // TODO: raise an event so that the UI can update
 };
 
+
+/**
+ * Check if the sender of an event is verified
+ *
+ * @param {MatrixEvent} event event to be checked
+ * @return {boolean} true if the sender of this event has been verified
+ */
+MatrixClient.prototype.isEventSenderVerified = function(event) {
+    if (!this.sessionStore) {
+        return false;
+    }
+
+    var cryptoContent = event.getWireContent();
+    var algorithm = cryptoContent.algorithm;
+
+    if (algorithm !== OLM_ALGORITHM) {
+        console.warn("unable to verify event with algorithm " + algorithm);
+        return false;
+    }
+
+    var devices = this.sessionStore.getEndToEndDevicesForUser(event.getSender());
+    if (!devices) {
+        return false;
+    }
+
+    var sender_key = cryptoContent.sender_key;
+    if (!sender_key) {
+        return false;
+    }
+
+    for (var deviceId in devices) {
+        if (!devices.hasOwnProperty(deviceId)) {
+            continue;
+        }
+
+        var device = devices[deviceId];
+        for (var keyId in device.keys) {
+            if (!device.keys.hasOwnProperty(keyId)) {
+                continue;
+            }
+            if (keyId.indexOf("curve25519:") !== 0) {
+                continue;
+            }
+            var deviceKey = device.keys[keyId];
+            if (deviceKey == sender_key) {
+                return Boolean(device.verified);
+            }
+        }
+    }
+
+    // doesn't match a known device
+    return false;
+};
+
 /**
  * Enable end-to-end encryption for a room.
  * @param {string} roomId The room ID to enable encryption in.
@@ -1189,23 +1243,24 @@ function _decryptMessage(client, event) {
             }
         }
 
+        // TODO: Check the sender user id matches the sender key.
+
         if (payloadString !== null) {
             var payload = JSON.parse(payloadString);
             return new MatrixEvent({
-                // TODO: Add a key to indicate that the event was encrypted.
-                // TODO: Check the sender user id matches the sender key.
                 origin_server_ts: event.getTs(),
                 room_id: payload.room_id,
                 user_id: event.getSender(),
                 event_id: event.getId(),
                 unsigned: event.getUnsigned(),
                 type: payload.type,
-                content: payload.content
-            }, "encrypted");
+                content: payload.content,
+            }, event);
         } else {
             return _badEncryptedMessage(event, "**Bad Encrypted Message**");
         }
     }
+    return _badEncryptedMessage(event, "**Unknown algorithm**");
 }
 
 function _badEncryptedMessage(event, reason) {
@@ -1222,7 +1277,7 @@ function _badEncryptedMessage(event, reason) {
             body: reason,
             content: event.getContent()
         }
-    });
+    }, event);
 }
 
 function _sendEvent(client, room, event, callback) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -300,6 +300,19 @@ MatrixClient.prototype.isCryptoEnabled = function() {
 
 
 /**
+ * Get the Ed25519 key for this device
+ *
+ * @return {?string} base64-encoded ed25519 key. Null if crypto is
+ *    disabled.
+ */
+MatrixClient.prototype.getDeviceEd25519Key = function() {
+    if (!this._olmDevice) {
+        return null;
+    }
+    return this._olmDevice.deviceEd25519Key;
+};
+
+/**
  * Upload the device keys to the homeserver and ensure that the
  * homeserver has enough one-time keys.
  * @param {number} maxKeys The maximum number of keys to generate
@@ -356,32 +369,39 @@ function _doKeyUpload(client) {
 
 
 /**
+  * Stored information about a user's device
+  * @typedef {Object} DeviceInfo
+  * @property {string[]} list of algorithms supported by this device
+  * @property {Object} keys a map from &lt;key type&gt;:&lt;id&gt; -> key
+  * @property {boolean} verified true if the device has been verified by the user
+  */
+
+/**
  * Download the keys for a list of users and stores the keys in the session
  * store.
  * @param {Array} userIds The users to fetch.
  * @param {bool} forceDownload Always download the keys even if cached.
  *
- * @return {object} A promise that will resolve when the keys are downloaded;
- * resolves to a map userId->deviceId->device info
+ * @return {Promise} A promise which resolves to a map userId->deviceId->{@link
+ * module:client~DeviceInfo|DeviceInfo}.
  */
 MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
     if (this.sessionStore === null) {
         return q.reject(new Error("End-to-end encryption disabled"));
     }
     var stored = {};
-    var notStored = {};
+    var downloadQuery = {};
     var downloadKeys = false;
     for (var i = 0; i < userIds.length; ++i) {
         var userId = userIds[i];
-        if (!forceDownload) {
-            var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
-            if (devices) {
-                stored[userId] = devices;
-                continue;
-            }
+        var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
+
+        stored[userId] = devices || {};
+        if (devices && !forceDownload) {
+            continue;
         }
         downloadKeys = true;
-        notStored[userId] = {};
+        downloadQuery[userId] = {};
     }
 
     if (!downloadKeys) {
@@ -389,32 +409,104 @@ MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
     }
 
     var path = "/keys/query";
-    var content = {device_keys: notStored};
+    var content = {device_keys: downloadQuery};
     var self = this;
     return this._http.authedRequestWithPrefix(
         undefined, "POST", path, undefined, content,
         httpApi.PREFIX_UNSTABLE
     ).then(function(res) {
         for (var userId in res.device_keys) {
-            if (userId in notStored) {
+            if (!downloadQuery.hasOwnProperty(userId)) {
+                continue;
+            }
+
+            var userStore = stored[userId];
+            var updated = _updateStoredDeviceKeysForUser(
+                userId, userStore, res.device_keys[userId]
+            );
+
+            if (updated) {
                 self.sessionStore.storeEndToEndDevicesForUser(
-                    userId, res.device_keys[userId]
+                    userId, userStore
                 );
-                // TODO: validate the ed25519 signature.
-                stored[userId] = res.device_keys[userId];
             }
         }
         return stored;
     });
 };
 
+function _updateStoredDeviceKeysForUser(userId, userStore, userResult) {
+    var updated = false;
+
+    // remove any devices in the store which aren't in the response
+    for (var deviceId in userStore) {
+        if (!userStore.hasOwnProperty(deviceId)) {
+            continue;
+        }
+
+        if (!(deviceId in userResult)) {
+            console.log("Device " + userId + ":" + deviceId +
+                        " has been removed");
+            delete userStore[deviceId];
+            updated = true;
+        }
+    }
+
+    for (deviceId in userResult) {
+        if (!userResult.hasOwnProperty(deviceId)) {
+            continue;
+        }
+
+        var deviceRes = userResult[deviceId];
+        var deviceStore;
+
+        if (!deviceRes.keys) {
+            // no keys?
+            continue;
+        }
+
+        var signKey = deviceRes.keys["ed25519:" + deviceId];
+        if (!signKey) {
+            console.log("Device " + userId + ": " +
+                        deviceId + " has no ed25519 key");
+            continue;
+        }
+
+        if (deviceId in userStore) {
+            // already have this device.
+            deviceStore = userStore[deviceId];
+
+            if (deviceStore.keys["ed25519:" + deviceId] != signKey) {
+                console.warn("Ed25519 key for device" + userId + ": " +
+                             deviceId + " has changed");
+                continue;
+            }
+        } else {
+            userStore[deviceId] = deviceStore = {
+                verified: false,
+            };
+        }
+
+        // TODO: check signature. Remember that we need to check for
+        // _olmDevice.
+
+        deviceStore.keys = deviceRes.keys;
+        deviceStore.algorithms = deviceRes.algorithms;
+        updated = true;
+    }
+
+    return updated;
+}
+
 /**
  * List the stored device keys for a user id
+ *
  * @param {string} userId the user to list keys for.
- * @return {Array} list of devices with "id" and "key" parameters.
+ *
+ * @return {object[]} list of devices with "id", "verified", and "key" parameters.
  */
 MatrixClient.prototype.listDeviceKeys = function(userId) {
-    if (!CRYPTO_ENABLED) {
+    if (!this.sessionStore) {
         return [];
     }
     var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
@@ -435,12 +527,39 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
             if (ed25519Key) {
                 result.push({
                     id: deviceId,
-                    key: ed25519Key
+                    verified: device.verified,
+                    key: ed25519Key,
                 });
             }
         }
     }
     return result;
+};
+
+/**
+ * Mark the given device as verified
+ *
+ * @param {string} userId owner of the device
+ * @param {string} deviceId unique identifier for the device
+ */
+MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
+    if (!this.sessionStore) {
+        throw new Error("End-to-End encryption disabled");
+    }
+
+    var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
+    if (!devices || !devices[deviceId]) {
+        throw new Error("Unknown device " + userId + ":" + deviceId);
+    }
+
+    var dev = devices[deviceId];
+    if (dev.verified) {
+        return;
+    }
+    dev.verified = true;
+    this.sessionStore.storeEndToEndDevicesForUser(userId, devices);
+
+    // TODO: raise an event so that the UI can update
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -546,6 +546,8 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
  *
  * @param {string} userId owner of the device
  * @param {string} deviceId unique identifier for the device
+ *
+ * @fires module:client~event:MatrixClient"deviceVerified"
  */
 MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
     if (!this.sessionStore) {
@@ -563,6 +565,8 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
     }
     dev.verified = true;
     this.sessionStore.storeEndToEndDevicesForUser(userId, devices);
+
+    this.emit("deviceVerified", userId, deviceId, dev);
 };
 
 
@@ -570,7 +574,9 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
  * Check if the sender of an event is verified
  *
  * @param {MatrixEvent} event event to be checked
- * @return {boolean} true if the sender of this event has been verified
+ *
+ * @return {boolean} true if the sender of this event has been verified using
+ * {@link module:client~MatrixClient#setDeviceVerified|setDeviceVerified}.
  */
 MatrixClient.prototype.isEventSenderVerified = function(event) {
     if (!this.sessionStore) {
@@ -3678,6 +3684,15 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * matrixClient.on("Session.logged_out", function(call){
  *   // show the login screen
  * });
+ */
+
+ /**
+ * Fires when a device is marked as verified by {@link
+ * module:client~MatrixClient#setDeviceVerified|MatrixClient.setDeviceVerified}.
+ *
+ * @event module:client~MatrixClient#"deviceVerified"
+ * @param {string} userId the owner of the verified device
+ * @param {module:client~DeviceInfo} device information about the verified device
  */
 
 // EventEmitter JSDocs

--- a/lib/client.js
+++ b/lib/client.js
@@ -563,8 +563,6 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
     }
     dev.verified = true;
     this.sessionStore.storeEndToEndDevicesForUser(userId, devices);
-
-    // TODO: raise an event so that the UI can update
 };
 
 

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -45,7 +45,8 @@ module.exports.EventStatus = {
  * Construct a Matrix Event object
  * @constructor
  * @param {Object} event The raw event to be wrapped in this DAO
- * @param {boolean} encrypted Was the event encrypted
+ * @param {MatrixEvent} encrypted if the event was encrypted, the original encrypted event
+ *
  * @prop {Object} event The raw event. <b>Do not access this property</b>
  * directly unless you absolutely have to. Prefer the getter methods defined on
  * this class. Using the getter methods shields your app from
@@ -59,13 +60,19 @@ module.exports.EventStatus = {
  * that getDirectionalContent() will return event.content and not event.prev_content.
  * Default: true. <strong>This property is experimental and may change.</strong>
  */
-module.exports.MatrixEvent = function MatrixEvent(event, encrypted) {
+module.exports.MatrixEvent = function MatrixEvent(event, encryptedEvent) {
     this.event = event || {};
     this.sender = null;
     this.target = null;
     this.status = null;
     this.forwardLooking = true;
-    this.encrypted = Boolean(encrypted);
+    this.encryptedEvent = false;
+
+    if (encryptedEvent) {
+        this.encrypted = true;
+        this.encryptedType = encryptedEvent.getType();
+        this.encryptedContent = encryptedEvent.getContent();
+    }
 };
 module.exports.MatrixEvent.prototype = {
 

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -136,14 +136,16 @@ describe("MatrixClient crypto", function() {
         var p1 = aliClient.downloadKeys([bobUserId]).then(function() {
             expect(aliClient.listDeviceKeys(bobUserId)).toEqual([{
                 id: "bvcxz",
-                key: bobDeviceEd25519Key
+                key: bobDeviceEd25519Key,
+                verified: false,
             }]);
         });
         var p2 = aliHttpBackend.flush();
 
         return q.all([p1, p2]).then(function() {
             var devices = aliStorage.getEndToEndDevicesForUser(bobUserId);
-            expect(devices).toEqual(bobKeys);
+            expect(devices[bobDeviceId].keys).toEqual(bobDeviceKeys.keys);
+            expect(devices[bobDeviceId].verified).toBe(false);
         });
     }
 

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -183,8 +183,8 @@ describe("MatrixClient", function() {
 
     describe("downloadKeys", function() {
         it("should do an HTTP request and then store the keys", function(done) {
-            var borisKeys = {dev1: {a: 1}};
-            var chazKeys = {dev2: {a: 2}};
+            var borisKeys = {dev1: {algorithms: ["1"], keys: { "ed25519:dev1": "k1" }}};
+            var chazKeys = {dev2: {algorithms: ["2"], keys: { "ed25519:dev2": "k2" }}};
 
             httpBackend.when("POST", "/keys/query").check(function(req) {
                 expect(req.data).toEqual({device_keys: {boris: {}, chaz: {}}});
@@ -197,8 +197,20 @@ describe("MatrixClient", function() {
 
             client.downloadKeys(["boris", "chaz"]).then(function(res) {
                 expect(res).toEqual({
-                    boris: borisKeys,
-                    chaz: chazKeys
+                    boris: {
+                        dev1: {
+                            verified: false,
+                            keys: { "ed25519:dev1": "k1" },
+                            algorithms: ["1"],
+                        },
+                    },
+                    chaz: {
+                        dev2: {
+                            verified: false,
+                            keys: { "ed25519:dev2" : "k2" },
+                            algorithms: ["2"],
+                        },
+                    },
                 });
             }).catch(utils.failTest).done(done);
 


### PR DESCRIPTION
Changes the format of data stored for user devices in the session store (in a
backwards-compatible way), to include a 'verified' key (and get rid of a lot of
extraneous crap we don't use).

When we decrypt an event, keep the content we need to do a verification in the
MatrixEvent.

Add methods which allow us to flag a device as verified, and to verify the
sender of an event.