### PR TITLE
Set a valid SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "browser": "browser-index.js",
   "author": "matrix.org",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "browser-request": "^0.3.3",
     "browserify": "^10.2.3",


### PR DESCRIPTION
When I installed the package dependencies with npm I got the following warning:

```
npm WARN matrix-js-sdk@0.5.4 license should be a valid SPDX license expression
```

This is because the license value in package.json was not a valid SPDX identifier. And because of this, the license also isn't displayed on https://www.npmjs.com/package/matrix-js-sdk

So I fixed it to be the SPDX identifier for the Apache License 2.0 according to https://spdx.org/licenses/

Signed-off-by: Thanos Lefteris <alefteris@gmail.com>