### PR TITLE
Add Olm as an optionalDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "jshint": "^2.8.0",
     "jsdoc": "^3.4.0",
     "uglifyjs": "^2.4.10"
+  },
+  "optionalDependencies": {
+    "olm": "https://matrix.org/packages/npm/olm/olm-0.1.0.tgz"
   }
 }


### PR DESCRIPTION
We have optional support for olm, so it makes sense to add it as an
optionalDependency here.

(I think this will mean that Olm ends up enabled on vector.im/develop)