### PR TITLE
Support for marking devices as unverified

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -547,9 +547,16 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
  * @param {string} userId owner of the device
  * @param {string} deviceId unique identifier for the device
  *
+ * @param {boolean=} verified whether to mark the device as verified. defaults
+ *   to 'true'.
+ *
  * @fires module:client~event:MatrixClient"deviceVerified"
  */
-MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
+MatrixClient.prototype.setDeviceVerified = function(userId, deviceId, verified) {
+    if (verified === undefined) {
+        verified = true;
+    }
+
     if (!this.sessionStore) {
         throw new Error("End-to-End encryption disabled");
     }
@@ -560,10 +567,10 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId) {
     }
 
     var dev = devices[deviceId];
-    if (dev.verified) {
+    if (dev.verified === verified) {
         return;
     }
-    dev.verified = true;
+    dev.verified = verified;
     this.sessionStore.storeEndToEndDevicesForUser(userId, devices);
 
     this.emit("deviceVerified", userId, deviceId, dev);


### PR DESCRIPTION
Mostly because it's useful for testing, to be honest.