### PR TITLE
crypto: use memberlist to derive recipient list

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -643,90 +643,116 @@ MatrixClient.prototype.setRoomEncryption = function(roomId, config) {
         return q.reject(new Error("End-to-End encryption disabled"));
     }
 
+    var self = this;
+
     if (config.algorithm === OLM_ALGORITHM) {
-        if (!config.members) {
-            throw new Error(
-                "Config must include a 'members' list with a list of userIds"
-            );
-        }
-        var devicesWithoutSession = [];
-        var userWithoutDevices = [];
-        for (var i = 0; i < config.members.length; ++i) {
-            var userId = config.members[i];
-            var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
-            if (!devices) {
-                userWithoutDevices.push(userId);
-            } else {
-                for (var deviceId in devices) {
-                    if (devices.hasOwnProperty(deviceId)) {
-                        var keys = devices[deviceId];
-                        var key = keys.keys["curve25519:" + deviceId];
-                        if (key == this._olmDevice.deviceCurve25519Key) {
-                            continue;
-                        }
-                        if (!this.sessionStore.getEndToEndSessions(key)) {
-                            devicesWithoutSession.push([userId, deviceId, key]);
-                        }
-                    }
-                }
-            }
-        }
-        var deferred = q.defer();
-        if (devicesWithoutSession.length > 0) {
-            var queries = {};
-            for (i = 0; i < devicesWithoutSession.length; ++i) {
-                var device = devicesWithoutSession[i];
-                var query = queries[device[0]] || {};
-                queries[device[0]] = query;
-                query[device[1]] = "curve25519";
-            }
-            var path = "/keys/claim";
-            var content = {one_time_keys: queries};
-            var self = this;
-            this._http.authedRequestWithPrefix(
-                undefined, "POST", path, undefined, content,
-                httpApi.PREFIX_UNSTABLE
-            ).done(function(res) {
-                var missing = {};
-                for (i = 0; i < devicesWithoutSession.length; ++i) {
-                    var device = devicesWithoutSession[i];
-                    var userRes = res.one_time_keys[device[0]] || {};
-                    var deviceRes = userRes[device[1]];
-                    var oneTimeKey;
-                    for (var keyId in deviceRes) {
-                        if (keyId.indexOf("curve25519:") === 0) {
-                            oneTimeKey = deviceRes[keyId];
-                        }
-                    }
-                    if (oneTimeKey) {
-                        var sid = self._olmDevice.createOutboundSession(
-                            device[2], oneTimeKey
-                        );
-                        console.log("Started new sessionid " + sid +
-                                    " for device " + device[2]);
-                    } else {
-                        missing[device[0]] = missing[device[0]] || [];
-                        missing[device[0]].push([device[1]]);
-                    }
-                }
-                deferred.resolve({
-                    missingUsers: userWithoutDevices,
-                    missingDevices: missing
-                });
-            });
-        } else {
-            deferred.resolve({
-                missingUsers: userWithoutDevices,
-                missingDevices: []
-            });
-        }
         this.sessionStore.storeEndToEndRoom(roomId, config);
-        return deferred.promise;
+
+        var room = this.getRoom(roomId);
+
+        if (!room) {
+            console.warn("Enabling encryption in unknown room " + roomId);
+            return q({});
+        }
+
+        var users = utils.map(room.getJoinedMembers(), function(u) {
+            return u.userId;
+        });
+
+        return self.downloadKeys(users, true).then(function(res) {
+            return self._ensureOlmSessionsForUsers(users);
+        });
     } else {
         throw new Error("Unknown algorithm: " + config.algorithm);
     }
 };
 
+/**
+ * Try to make sure we have established olm sessions for the given users.
+ *
+ * @param {string[]} users list of user ids
+ *
+ * @return {module:client.Promise} resolves once the sessions are complete, to
+ *  an object with keys <tt>missingUsers</tt> (a list of users with no known
+ *  olm devices), and <tt>missingDevices</tt> a list of olm devices with no
+ *  known one-time keys.
+ *
+ * @private
+ */
+MatrixClient.prototype._ensureOlmSessionsForUsers = function(users) {
+    var devicesWithoutSession = [];
+    var userWithoutDevices = [];
+    for (var i = 0; i < users.length; ++i) {
+        var userId = users[i];
+        var devices = this.sessionStore.getEndToEndDevicesForUser(userId);
+        if (!devices) {
+            userWithoutDevices.push(userId);
+        } else {
+            for (var deviceId in devices) {
+                if (devices.hasOwnProperty(deviceId)) {
+                    var keys = devices[deviceId];
+                    var key = keys.keys["curve25519:" + deviceId];
+                    if (key == this._olmDevice.deviceCurve25519Key) {
+                        continue;
+                    }
+                    if (!this.sessionStore.getEndToEndSessions(key)) {
+                        devicesWithoutSession.push([userId, deviceId, key]);
+                    }
+                }
+            }
+        }
+    }
+
+    if (devicesWithoutSession.length === 0) {
+        return q({
+            missingUsers: userWithoutDevices,
+            missingDevices: []
+        });
+    }
+
+    var queries = {};
+    for (i = 0; i < devicesWithoutSession.length; ++i) {
+        var device = devicesWithoutSession[i];
+        var query = queries[device[0]] || {};
+        queries[device[0]] = query;
+        query[device[1]] = "curve25519";
+    }
+    var path = "/keys/claim";
+    var content = {one_time_keys: queries};
+    var self = this;
+    return this._http.authedRequestWithPrefix(
+        undefined, "POST", path, undefined, content,
+        httpApi.PREFIX_UNSTABLE
+    ).then(function(res) {
+        var missing = {};
+        for (i = 0; i < devicesWithoutSession.length; ++i) {
+            var device = devicesWithoutSession[i];
+            var userRes = res.one_time_keys[device[0]] || {};
+            var deviceRes = userRes[device[1]];
+            var oneTimeKey;
+            for (var keyId in deviceRes) {
+                if (keyId.indexOf("curve25519:") === 0) {
+                    oneTimeKey = deviceRes[keyId];
+                }
+            }
+            if (oneTimeKey) {
+                var sid = self._olmDevice.createOutboundSession(
+                    device[2], oneTimeKey
+                );
+                console.log("Started new sessionid " + sid +
+                            " for device " + device[2]);
+            } else {
+                missing[device[0]] = missing[device[0]] || [];
+                missing[device[0]].push([device[1]]);
+            }
+        }
+
+        return {
+            missingUsers: userWithoutDevices,
+            missingDevices: missing
+        };
+    });
+};
 
 /**
  * Disable encryption for a room.
@@ -1177,9 +1203,23 @@ function _encryptMessage(client, roomId, e2eRoomInfo, eventType, content) {
     }
 
     if (e2eRoomInfo.algorithm === OLM_ALGORITHM) {
+        var room = client.getRoom(roomId);
+        if (!room) {
+            throw new Error("Cannot send encrypted messages in unknown rooms");
+        }
+
+        // pick the list of recipients based on the membership list.
+        //
+        // TODO: there is a race condition here! What if a new user turns up
+        // just as you are sending a secret message?
+
+        var users = utils.map(room.getJoinedMembers(), function(u) {
+            return u.userId;
+        });
+
         var participantKeys = [];
-        for (var i = 0; i < e2eRoomInfo.members.length; ++i) {
-            var userId = e2eRoomInfo.members[i];
+        for (var i = 0; i < users.length; ++i) {
+            var userId = users[i];
             var devices = client.sessionStore.getEndToEndDevicesForUser(userId);
             for (var deviceId in devices) {
                 if (devices.hasOwnProperty(deviceId)) {


### PR DESCRIPTION
When we send an encrypted message with Olm, we need to know who to send it
to. Currently that is based on a user list passed to setRoomEncryption. We want
to be able to change the list as people join and leave the room; I also want to
not have to keep the member list in local storage.

So, use the member list at the point of enabling encryption to set up sessions,
and at the point of sending a message to encrypt the message.

Further work here includes:

 * updating the react-sdk not to bother setting the member list
 * monitoring for new users/devices in the room, and setting up new sessions
   with them