### PR TITLE
Add more events to User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes in \<unreleased>
 
  * Add room.getAliases() and room.getCanonicalAlias
  * Add API calls `/register/email/requestToken`, `/account/password/email/requestToken` and `/account/3pid/email/requestToken`
+ * Add more events for changes in fields on the User object
 
 Changes in [0.5.4](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.5.4) (2016-06-02)
 ================================================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes in \<unreleased>
 
  * Add room.getAliases() and room.getCanonicalAlias
  * Add API calls `/register/email/requestToken`, `/account/password/email/requestToken` and `/account/3pid/email/requestToken`
- * Add more events for changes in fields on the User object
+ * Add `User.currentlyActive` and `User.lastPresenceTs` events for changes in fields on the User object
 
 Changes in [0.5.4](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.5.4) (2016-06-02)
 ================================================================================================

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -87,8 +87,15 @@ User.prototype.setPresenceEvent = function(event) {
     {
         eventsToFire.push("User.displayName");
     }
+    if (event.getContent().currently_active &&
+        event.getContent().currently_active !== this.currentlyActive)
+    {
+        eventsToFire.push("User.currentlyActive");
+    }
 
     this.presence = event.getContent().presence;
+    eventsToFire.push("User.lastPresenceTs");
+
     if (event.getContent().displayname) {
         this.displayName = event.getContent().displayname;
     }
@@ -99,9 +106,7 @@ User.prototype.setPresenceEvent = function(event) {
     this.lastPresenceTs = Date.now();
     this.currentlyActive = event.getContent().currently_active;
 
-    if (eventsToFire.length > 0) {
-        this._updateModifiedTime();
-    }
+    this._updateModifiedTime();
 
     for (var i = 0; i < eventsToFire.length; i++) {
         this.emit(eventsToFire[i], event, this);
@@ -166,6 +171,18 @@ User.prototype.getLastActiveTs = function() {
 module.exports = User;
 
 /**
+ * Fires whenever any user's lastPresenceTs changes,
+ * ie. whenever any presence event is received for a user.
+ * @event module:client~MatrixClient#"User.lastPresenceTs"
+ * @param {MatrixEvent} event The matrix event which caused this event to fire.
+ * @param {User} user The user whose User.lastPresenceTs changed.
+ * @example
+ * matrixClient.on("User.lastPresenceTs", function(event, user){
+ *   var newlastPresenceTs = user.lastPresenceTs;
+ * });
+ */
+
+/**
  * Fires whenever any user's presence changes.
  * @event module:client~MatrixClient#"User.presence"
  * @param {MatrixEvent} event The matrix event which caused this event to fire.
@@ -173,6 +190,17 @@ module.exports = User;
  * @example
  * matrixClient.on("User.presence", function(event, user){
  *   var newPresence = user.presence;
+ * });
+ */
+
+/**
+ * Fires whenever any user's currentlyActive changes.
+ * @event module:client~MatrixClient#"User.currentlyActive"
+ * @param {MatrixEvent} event The matrix event which caused this event to fire.
+ * @param {User} user The user whose User.currentlyActive changed.
+ * @example
+ * matrixClient.on("User.currentlyActive", function(event, user){
+ *   var newCurrentlyActive = user.currentlyActive;
  * });
  */
 

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -87,7 +87,7 @@ User.prototype.setPresenceEvent = function(event) {
     {
         eventsToFire.push("User.displayName");
     }
-    if (event.getContent().currently_active &&
+    if (event.getContent().currently_active !== undefined &&
         event.getContent().currently_active !== this.currentlyActive)
     {
         eventsToFire.push("User.currentlyActive");

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1040,7 +1040,10 @@ SyncApi.prototype._onOnline = function() {
 
 function createNewUser(client, userId) {
     var user = new User(userId);
-    reEmit(client, user, ["User.avatarUrl", "User.displayName", "User.presence"]);
+    reEmit(client, user, [
+        "User.avatarUrl", "User.displayName", "User.presence",
+        "User.currentlyActive", "User.lastPresenceTs"
+    ]);
     return user;
 }
 


### PR DESCRIPTION
There was no way of observing changes to fields like currentlyActive, so add this and add one for lastPresenceTs that will be fired whenever we get a presence event.

This will hopefully help fix https://github.com/vector-im/vector-web/issues/1740