### PR TITLE
deviceId-related fixes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -118,7 +118,7 @@ function MatrixClient(opts) {
     this.store = opts.store || new StubStore();
     this.sessionStore = opts.sessionStore || null;
 
-    this.deviceId = opts.deviceId;
+    this.deviceId = opts.deviceId || null;
     this.defaultDeviceDisplayName = opts.defaultDeviceDisplayName || "js-sdk device";
 
     var userId = (opts.userId || null);
@@ -128,7 +128,8 @@ function MatrixClient(opts) {
 
     this._olmDevice = null;
 
-    if (CRYPTO_ENABLED && this.sessionStore !== null && userId !== null) {
+    if (CRYPTO_ENABLED && this.sessionStore !== null && userId !== null &&
+            this.deviceId !== null) {
         this._olmDevice = new OlmDevice(opts.sessionStore);
 
         var json = '{"algorithms":["' + OLM_ALGORITHM + '"]';
@@ -254,6 +255,15 @@ MatrixClient.prototype.getUserIdLocalpart = function() {
     }
     return null;
 };
+
+/**
+ * Get the device ID of this client
+ * @return {?string} device ID
+ */
+MatrixClient.prototype.getDeviceId = function() {
+    return this.deviceId;
+};
+
 
 /**
  * Check if the runtime environment supports VoIP calling.


### PR DESCRIPTION
A couple of changes to support bigger changes in the react-sdk:

1. Add getDeviceId() to MatrixClient
2. Don't attempt to upload e2e keys if deviceId wasn't set.