### PR TITLE
client.listDeviceKeys: Expose device display name

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -489,6 +489,7 @@ function _updateStoredDeviceKeysForUser(userId, userStore, userResult) {
 
         deviceStore.keys = deviceRes.keys;
         deviceStore.algorithms = deviceRes.algorithms;
+        deviceStore.unsigned = deviceRes.unsigned;
         updated = true;
     }
 
@@ -500,8 +501,8 @@ function _updateStoredDeviceKeysForUser(userId, userStore, userResult) {
  *
  * @param {string} userId the user to list keys for.
  *
- * @return {object[]} list of devices with "id", "verified", "blocked", and
- *    "key" parameters.
+ * @return {object[]} list of devices with "id", "verified", "blocked",
+ *    "key", and "display_name" parameters.
  */
 MatrixClient.prototype.listDeviceKeys = function(userId) {
     if (!this.sessionStore) {
@@ -522,12 +523,14 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
             deviceId = deviceIds[i];
             var device = devices[deviceId];
             var ed25519Key = device.keys["ed25519:" + deviceId];
+            var unsigned = device.unsigned || {};
             if (ed25519Key) {
                 result.push({
                     id: deviceId,
                     key: ed25519Key,
                     verified: Boolean(device.verified == DeviceVerification.VERIFIED),
                     blocked: Boolean(device.verified == DeviceVerification.BLOCKED),
+                    display_name: unsigned.device_display_name,
                 });
             }
         }


### PR DESCRIPTION
Synapse now (or will, after https://github.com/matrix-org/synapse/pull/978) returns the display_name in an e2e device query; we need to return it to the app.