### PR TITLE
Remove defaultDeviceDisplayName from MatrixClient options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -78,9 +78,6 @@ try {
  *    tracking things like crypto keys and access tokens.  If not specified,
  *    end-to-end crypto will be disabled.
  *
- * @param {string=} opts.defaultDeviceDisplayName Initial display name to set
- *    on new devices
- *
  * @param {Object=} opts.sessionStore A store to be used for end-to-end crypto
  *    session data. This should be a {@link
  *    module:store/session/webstorage~WebStorageSessionStore|WebStorageSessionStore},
@@ -109,7 +106,6 @@ function MatrixClient(opts) {
     this.store = opts.store || new StubStore();
 
     this.deviceId = opts.deviceId || null;
-    this.defaultDeviceDisplayName = opts.defaultDeviceDisplayName || "js-sdk device";
 
     var userId = (opts.userId || null);
     this.credentials = {
@@ -1750,14 +1746,10 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
 MatrixClient.prototype.login = function(loginType, data, callback) {
     var login_data = {
         type: loginType,
-        device_id: this.deviceId,
-        initial_device_display_name: this.defaultDeviceDisplayName,
     };
 
     // merge data into login_data
-    for (var k in data) {
-        if (data.hasOwnProperty(k)) { login_data[k] = data[k]; }
-    }
+    login_data.extend(data);
 
     return this._http.authedRequest(
         callback, "POST", "/login", undefined, login_data


### PR DESCRIPTION
We no longer rely on js-sdk setting the initial_device_display_name and login_id on login, so remove them to make `login` simpler and allow the HS to impose its default behaviour on device display names (which is to leave them as null).