### PR TITLE
Move login and register methods into base-apis

### DIFF
--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -105,6 +105,66 @@ MatrixBaseApis.prototype.isLoggedIn = function() {
 // =============================
 
 /**
+ * @param {string} username
+ * @param {string} password
+ * @param {string} sessionId
+ * @param {Object} auth
+ * @param {boolean} bindEmail
+ * @param {string} guestAccessToken
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.register = function(
+    username, password,
+    sessionId, auth, bindEmail, guestAccessToken,
+    callback
+) {
+    if (auth === undefined) { auth = {}; }
+    if (sessionId) { auth.session = sessionId; }
+
+    var params = {
+        auth: auth
+    };
+    if (username !== undefined) { params.username = username; }
+    if (password !== undefined) { params.password = password; }
+    if (bindEmail !== undefined) { params.bind_email = bindEmail; }
+    if (guestAccessToken !== undefined) { params.guest_access_token = guestAccessToken; }
+
+    return this.registerRequest(params, undefined, callback);
+};
+
+/**
+ * Register a guest account.
+ * @param {Object=} opts Registration options
+ * @param {Object} opts.body JSON HTTP body to provide.
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.registerGuest = function(opts, callback) {
+    opts = opts || {};
+    opts.body = opts.body || {};
+    return this.registerRequest(opts.body, "guest", callback);
+};
+
+/**
+ * @param {Object} data   parameters for registration request
+ * @param {string=} kind  type of user to register. may be "guest"
+ * @param {module:client.callback=} callback
+ * @return {module:client.Promise} Resolves: to the /register response
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.registerRequest = function(data, kind, callback) {
+    var params = {};
+    if (kind) { params.kind = kind; }
+
+    return this._http.request(
+        callback, "POST", "/register", params, data
+    );
+};
+
+/**
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: TODO
  * @return {module:http-api.MatrixError} Rejects: with an error response.
@@ -112,6 +172,76 @@ MatrixBaseApis.prototype.isLoggedIn = function() {
 MatrixBaseApis.prototype.loginFlows = function(callback) {
     return this._http.request(callback, "GET", "/login");
 };
+
+/**
+ * @param {string} loginType
+ * @param {Object} data
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.login = function(loginType, data, callback) {
+    var login_data = {
+        type: loginType,
+    };
+
+    // merge data into login_data
+    login_data.extend(data);
+
+    return this._http.authedRequest(
+        callback, "POST", "/login", undefined, login_data
+    );
+};
+
+/**
+ * @param {string} user
+ * @param {string} password
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.loginWithPassword = function(user, password, callback) {
+    return this.login("m.login.password", {
+        user: user,
+        password: password
+    }, callback);
+};
+
+/**
+ * @param {string} relayState URL Callback after SAML2 Authentication
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.loginWithSAML2 = function(relayState, callback) {
+    return this.login("m.login.saml2", {
+        relay_state: relayState
+    }, callback);
+};
+
+/**
+ * @param {string} redirectUrl The URL to redirect to after the HS
+ * authenticates with CAS.
+ * @return {string} The HS URL to hit to begin the CAS login process.
+ */
+MatrixBaseApis.prototype.getCasLoginUrl = function(redirectUrl) {
+    return this._http.getUrl("/login/cas/redirect", {
+        "redirectUrl": redirectUrl
+    }, httpApi.PREFIX_UNSTABLE);
+};
+
+/**
+ * @param {string} token Login token previously received from homeserver
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.loginWithToken = function(token, callback) {
+    return this.login("m.login.token", {
+        token: token
+    }, callback);
+};
+
 
 /**
  * Logs out the current session.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1733,43 +1733,6 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
     return promise;
 };
 
-// Registration/Login operations
-// =============================
-
-/**
- * @param {string} loginType
- * @param {Object} data
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.login = function(loginType, data, callback) {
-    var login_data = {
-        type: loginType,
-    };
-
-    // merge data into login_data
-    login_data.extend(data);
-
-    return this._http.authedRequest(
-        callback, "POST", "/login", undefined, login_data
-    );
-};
-
-/**
- * Register a guest account.
- * @param {Object=} opts Registration options
- * @param {Object} opts.body JSON HTTP body to provide.
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.registerGuest = function(opts, callback) {
-    opts = opts || {};
-    opts.body = opts.body || {};
-    return this.registerRequest(opts.body, "guest", callback);
-};
-
 /**
  * Peek into a room and receive updates about the room. This only works if the
  * history visibility for the room is world_readable.
@@ -1823,49 +1786,8 @@ MatrixClient.prototype.setGuestAccess = function(roomId, opts) {
     return q.all(readPromise, writePromise);
 };
 
-/**
- * @param {string} username
- * @param {string} password
- * @param {string} sessionId
- * @param {Object} auth
- * @param {boolean} bindEmail
- * @param {string} guestAccessToken
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.register = function(username, password,
-                                           sessionId, auth, bindEmail, guestAccessToken,
-                                           callback) {
-    if (auth === undefined) { auth = {}; }
-    if (sessionId) { auth.session = sessionId; }
-
-    var params = {
-        auth: auth
-    };
-    if (username !== undefined) { params.username = username; }
-    if (password !== undefined) { params.password = password; }
-    if (bindEmail !== undefined) { params.bind_email = bindEmail; }
-    if (guestAccessToken !== undefined) { params.guest_access_token = guestAccessToken; }
-
-    return this.registerRequest(params, undefined, callback);
-};
-
-/**
- * @param {Object} data   parameters for registration request
- * @param {string=} kind  type of user to register. may be "guest"
- * @param {module:client.callback=} callback
- * @return {module:client.Promise} Resolves: to the /register response
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.registerRequest = function(data, kind, callback) {
-    var params = {};
-    if (kind) { params.kind = kind; }
-
-    return this._http.request(
-        callback, "POST", "/register", params, data
-    );
-};
+// Registration/Login operations
+// =============================
 
 /**
  * Requests an email verification token for the purposes of registration.
@@ -1983,54 +1905,6 @@ MatrixClient.prototype._requestTokenFromEndpoint = function(endpoint,
     );
 };
 
-/**
- * @param {string} user
- * @param {string} password
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.loginWithPassword = function(user, password, callback) {
-    return this.login("m.login.password", {
-        user: user,
-        password: password
-    }, callback);
-};
-
-/**
- * @param {string} relayState URL Callback after SAML2 Authentication
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.loginWithSAML2 = function(relayState, callback) {
-    return this.login("m.login.saml2", {
-        relay_state: relayState
-    }, callback);
-};
-
-/**
- * @param {string} redirectUrl The URL to redirect to after the HS
- * authenticates with CAS.
- * @return {string} The HS URL to hit to begin the CAS login process.
- */
-MatrixClient.prototype.getCasLoginUrl = function(redirectUrl) {
-    return this._http.getUrl("/login/cas/redirect", {
-        "redirectUrl": redirectUrl
-    }, httpApi.PREFIX_UNSTABLE);
-};
-
-/**
- * @param {string} token Login token previously received from homeserver
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.loginWithToken = function(token, callback) {
-    return this.login("m.login.token", {
-        token: token
-    }, callback);
-};
 
 // Push operations
 // ===============

--- a/lib/client.js
+++ b/lib/client.js
@@ -78,9 +78,6 @@ try {
  *    tracking things like crypto keys and access tokens.  If not specified,
  *    end-to-end crypto will be disabled.
  *
- * @param {string=} opts.defaultDeviceDisplayName Initial display name to set
- *    on new devices
- *
  * @param {Object=} opts.sessionStore A store to be used for end-to-end crypto
  *    session data. This should be a {@link
  *    module:store/session/webstorage~WebStorageSessionStore|WebStorageSessionStore},
@@ -109,7 +106,6 @@ function MatrixClient(opts) {
     this.store = opts.store || new StubStore();
 
     this.deviceId = opts.deviceId || null;
-    this.defaultDeviceDisplayName = opts.defaultDeviceDisplayName || "js-sdk device";
 
     var userId = (opts.userId || null);
     this.credentials = {
@@ -1750,14 +1746,10 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
 MatrixClient.prototype.login = function(loginType, data, callback) {
     var login_data = {
         type: loginType,
-        device_id: this.deviceId,
-        initial_device_display_name: this.defaultDeviceDisplayName,
     };
 
     // merge data into login_data
-    for (var k in data) {
-        if (data.hasOwnProperty(k)) { login_data[k] = data[k]; }
-    }
+    login_data.extend(data);
 
     return this._http.authedRequest(
         callback, "POST", "/login", undefined, login_data


### PR DESCRIPTION
login no longer relies on fields within MatrixClient, so we can move it down to BaseApis.

(includes changes from https://github.com/matrix-org/matrix-js-sdk/pull/168)