### PR TITLE
Reinstate device blocking for simple Olm

### DIFF
--- a/lib/crypto-algorithms/olm.js
+++ b/lib/crypto-algorithms/olm.js
@@ -24,6 +24,9 @@ var q = require('q');
 
 var utils = require("../utils");
 var olmlib = require("../olmlib");
+var DeviceInfo = require("../crypto-deviceinfo");
+var DeviceVerification = DeviceInfo.DeviceVerification;
+
 
 var base = require("./base");
 
@@ -77,21 +80,17 @@ OlmEncryption.prototype.encryptMessage = function(room, eventType, content) {
         var userId = users[i];
         var devices = this._crypto.getStoredDevicesForUser(userId);
         for (var j = 0; j < devices.length; ++j) {
-            var dev = devices[j];
-            if (dev.blocked) {
+            var deviceInfo = devices[j];
+            var key = deviceInfo.getIdentityKey();
+            if (key == this._olmDevice.deviceCurve25519Key) {
+                // don't bother setting up session to ourself
                 continue;
             }
-
-            for (var keyId in dev.keys) {
-                if (keyId.indexOf("curve25519:") === 0) {
-                    var key = dev.keys[keyId];
-
-                    // don't send to ourselves.
-                    if (key != this._olmDevice.deviceCurve25519Key) {
-                        participantKeys.push(key);
-                    }
-                }
+            if (deviceInfo.verified == DeviceVerification.BLOCKED) {
+                // don't bother setting up sessions with blocked users
+                continue;
             }
+            participantKeys.push(key);
         }
     }
 

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -2,7 +2,9 @@
 var sdk = require("../..");
 var q = require("q");
 var HttpBackend = require("../mock-request");
-var utils = require("../test-utils");
+var utils = require("../../lib/utils");
+var test_utils = require("../test-utils");
+
 function MockStorageApi() {
     this.data = {};
 }
@@ -119,7 +121,7 @@ function expectBobKeyUpload() {
 }
 
 function bobUploadsKeys() {
-    bobClient.uploadKeys(5).catch(utils.failTest);
+    bobClient.uploadKeys(5).catch(test_utils.failTest);
     return expectBobKeyUpload();
 }
 
@@ -194,7 +196,7 @@ function aliEnablesEncryption() {
     // can't query keys before bob has uploaded them
     expect(bobOneTimeKeys).toBeDefined();
 
-    aliQueryKeys().catch(utils.failTest);
+    aliQueryKeys().catch(test_utils.failTest);
     aliHttpBackend.when("POST", "/keys/claim").respond(200, function(path, content) {
         expect(content.one_time_keys[bobUserId][bobDeviceId]).toEqual("curve25519");
         for (var keyId in bobOneTimeKeys) {
@@ -223,7 +225,7 @@ function aliEnablesEncryption() {
 }
 
 function bobEnablesEncryption() {
-    bobQueryKeys().catch(utils.failTest);
+    bobQueryKeys().catch(test_utils.failTest);
     return bobClient.setRoomEncryption(roomId, {
         algorithm: "m.olm.v1.curve25519-aes-sha2",
     }).then(function(res) {
@@ -237,6 +239,7 @@ function bobEnablesEncryption() {
 function aliSendsMessage() {
     return sendMessage(aliHttpBackend, aliClient).then(function(content) {
         aliMessages.push(content);
+        expect(utils.keys(content.ciphertext)).toEqual([bobDeviceCurve25519Key]);
         var ciphertext = content.ciphertext[bobDeviceCurve25519Key];
         expect(ciphertext).toBeDefined();
     });
@@ -247,6 +250,7 @@ function bobSendsMessage() {
         bobMessages.push(content);
         var aliKeyId = "curve25519:" + aliDeviceId;
         var aliDeviceCurve25519Key = aliDeviceKeys.keys[aliKeyId];
+        expect(utils.keys(content.ciphertext)).toEqual([aliDeviceCurve25519Key]);
         var ciphertext = content.ciphertext[aliDeviceCurve25519Key];
         expect(ciphertext).toBeDefined();
         return ciphertext;
@@ -293,7 +297,7 @@ function recvMessage(httpBackend, client, message) {
     syncData.rooms.join[roomId] = {
         timeline: {
             events: [
-                utils.mkEvent({
+                test_utils.mkEvent({
                     type: "m.room.encrypted",
                     room: roomId,
                     content: message
@@ -331,7 +335,7 @@ function recvMessage(httpBackend, client, message) {
 
 
 function aliStartClient() {
-    expectAliKeyUpload().catch(utils.failTest);
+    expectAliKeyUpload().catch(test_utils.failTest);
     startClient(aliHttpBackend, aliClient);
     return aliHttpBackend.flush().then(function() {
         console.log("Ali client started");
@@ -339,7 +343,7 @@ function aliStartClient() {
 }
 
 function bobStartClient() {
-    expectBobKeyUpload().catch(utils.failTest);
+    expectBobKeyUpload().catch(test_utils.failTest);
     startClient(bobHttpBackend, bobClient);
     return bobHttpBackend.flush().then(function() {
         console.log("Bob client started");
@@ -368,11 +372,11 @@ function startClient(httpBackend, client) {
     syncData.rooms.join[roomId] = {
         state: {
             events: [
-                utils.mkMembership({
+                test_utils.mkMembership({
                     mship: "join",
                     user: aliUserId,
                 }),
-                utils.mkMembership({
+                test_utils.mkMembership({
                     mship: "join",
                     user: bobUserId,
                 }),
@@ -397,7 +401,7 @@ describe("MatrixClient crypto", function() {
         aliLocalStore = new MockStorageApi();
         aliStorage = new sdk.WebStorageSessionStore(aliLocalStore);
         bobStorage = new sdk.WebStorageSessionStore(new MockStorageApi());
-        utils.beforeEach(this);
+        test_utils.beforeEach(this);
 
         aliHttpBackend = new HttpBackend();
         aliClient = sdk.createClient({
@@ -436,14 +440,14 @@ describe("MatrixClient crypto", function() {
     it("Bob uploads without one-time keys and with one-time keys", function(done) {
         q()
             .then(bobUploadsKeys)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Ali downloads Bobs keys", function(done) {
         q()
             .then(bobUploadsKeys)
             .then(aliDownloadsKeys)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Ali gets keys with an invalid signature", function(done) {
@@ -461,7 +465,7 @@ describe("MatrixClient crypto", function() {
                 // should get an empty list
                 expect(aliClient.listDeviceKeys(bobUserId)).toEqual([]);
             })
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Ali enables encryption", function(done) {
@@ -469,7 +473,7 @@ describe("MatrixClient crypto", function() {
             .then(bobUploadsKeys)
             .then(aliStartClient)
             .then(aliEnablesEncryption)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Ali sends a message", function(done) {
@@ -478,7 +482,7 @@ describe("MatrixClient crypto", function() {
             .then(aliStartClient)
             .then(aliEnablesEncryption)
             .then(aliSendsMessage)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Bob receives a message", function(done) {
@@ -489,7 +493,21 @@ describe("MatrixClient crypto", function() {
             .then(aliSendsMessage)
             .then(bobStartClient)
             .then(bobRecvMessage)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
+    });
+
+    it("Ali blocks Bob's device", function(done) {
+        q()
+            .then(bobUploadsKeys)
+            .then(aliStartClient)
+            .then(aliEnablesEncryption)
+            .then(function() {
+                aliClient.setDeviceBlocked(bobUserId, bobDeviceId, true);
+                return sendMessage(aliHttpBackend, aliClient);
+            }).then(function(sentContent) {
+                // no unblocked devices, so the ciphertext should be empty
+                expect(sentContent.ciphertext).toEqual({});
+            }).catch(test_utils.failTest).done(done);
     });
 
     it("Bob receives two pre-key messages", function(done) {
@@ -502,7 +520,7 @@ describe("MatrixClient crypto", function() {
             .then(bobRecvMessage)
             .then(aliSendsMessage)
             .then(bobRecvMessage)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 
     it("Bob replies to the message", function(done) {
@@ -517,6 +535,6 @@ describe("MatrixClient crypto", function() {
             .then(bobSendsMessage).then(function(ciphertext) {
                 expect(ciphertext.type).toEqual(1);
             }).then(aliRecvMessage)
-            .catch(utils.failTest).done(done);
+            .catch(test_utils.failTest).done(done);
     });
 });


### PR DESCRIPTION
Commit 4cde51b3 broke device blocking such that we were encrypting for all
devices, including blocked ones. Reinstate it, and add a test.