### PR TITLE
always play audio out of the remoteAudioElement if it exists.

### DIFF
--- a/lib/webrtc/call.js
+++ b/lib/webrtc/call.js
@@ -293,9 +293,11 @@ MatrixCall.prototype.setRemoteVideoElement = function(element) {
 /**
  * Set the remote <code>&lt;audio&gt;</code> DOM element. If this call is active,
  * the first received audio-only stream will be rendered to it immediately.
+ * The audio will *not* be rendered from the remoteVideoElement.
  * @param {Element} element The <code>&lt;video&gt;</code> DOM element.
  */
 MatrixCall.prototype.setRemoteAudioElement = function(element) {
+    this.remoteVideoElement.muted = true;
     this.remoteAudioElement = element;
     _tryPlayRemoteAudioStream(this);
 };
@@ -794,6 +796,7 @@ MatrixCall.prototype._onAddStream = function(event) {
     if (s.getVideoTracks().length > 0) {
         this.type = 'video';
         this.remoteAVStream = s;
+        this.remoteAStream = s;
     } else {
         this.type = 'voice';
         this.remoteAStream = s;
@@ -819,6 +822,7 @@ MatrixCall.prototype._onAddStream = function(event) {
 
     if (this.type === 'video') {
         _tryPlayRemoteStream(this);
+        _tryPlayRemoteAudioStream(this);
     }
     else {
         _tryPlayRemoteAudioStream(this);


### PR DESCRIPTION
fixes https://github.com/vector-im/vector-web/issues/1271 and https://github.com/vector-im/vector-web/issues/621