### PR TITLE
Update to fixed olmlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "uglifyjs": "^2.4.10"
   },
   "optionalDependencies": {
-    "olm": "https://matrix.org/packages/npm/olm/olm-1.0.0.tgz"
+    "olm": "https://matrix.org/packages/npm/olm/olm-1.1.0.tgz"
   }
 }


### PR DESCRIPTION
Olm 1.0.0 had broken OlmAccounts; upgrade to a more recent one.

When we try to restore the old OlmAccount, we'll get an error; detect this and
create a new OlmAccount.

Because we do this, we will see key changes on other devices; we want to
tolerate this, so we define a new algorithm tag,
m.olm.v2.curve25519-aes-sha2. If we see a device which previously didn't
support that algorithm, but now does, we tolerate a key change (but reset the
device to unverified).