### PR TITLE
Add debug methods to get the state of OlmSessions

### DIFF
--- a/lib/OlmDevice.js
+++ b/lib/OlmDevice.js
@@ -316,6 +316,38 @@ OlmDevice.prototype.getSessionIdForDevice = function(theirDeviceIdentityKey) {
 };
 
 /**
+ * Get information on the active Olm sessions for a device.
+ * <p>
+ * Returns an array, with an entry for each active session. The first entry in
+ * the result will be the one used for outgoing messages. Each entry contains
+ * the keys 'hasReceivedMessage' (true if the session has received an incoming
+ * message and is therefore past the pre-key stage), and 'sessionId'.
+ *
+ * @param {string} deviceIdentityKey Curve25519 identity key for the device
+ * @return {Array.<{sessionId: string, hasReceivedMessage: Boolean}>}
+ */
+OlmDevice.prototype.getSessionInfoForDevice = function(deviceIdentityKey) {
+    var sessionIds = this.getSessionIdsForDevice(deviceIdentityKey);
+    sessionIds.sort();
+
+    var info = [];
+
+    function getSessionInfo(session) {
+        return {
+            hasReceivedMessage: session.has_received_message()
+        };
+    }
+
+    for (var i = 0; i < sessionIds.length; i++) {
+        var sessionId = sessionIds[i];
+        var res = this._getSession(deviceIdentityKey, sessionId, getSessionInfo);
+        res.sessionId = sessionId;
+        info.push(res);
+    }
+    return info;
+};
+
+/**
  * Encrypt an outgoing message using an existing session
  *
  * @param {string} theirDeviceIdentityKey Curve25519 identity key for the

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -489,6 +489,36 @@ Crypto.prototype.setDeviceVerification = function(userId, deviceId, verified, bl
 
 
 /**
+ * Get information on the active olm sessions with a user
+ * <p>
+ * Returns a map from device id to an object with keys 'deviceIdKey' (the
+ * device's curve25519 identity key) and 'sessions' (an array of objects in the
+ * same format as that returned by {@link module:OlmDevice#getSessionInfoForDevice}).
+ * <p>
+ * This method is provided for debugging purposes.
+ *
+ * @param {string} userId id of user to inspect
+ *
+ * @return {Object.<string, {deviceIdKey: string, sessions: object[]}>}
+ */
+Crypto.prototype.getOlmSessionsForUser = function(userId) {
+    var devices = this.getStoredDevicesForUser(userId);
+    var result = {};
+    for (var j = 0; j < devices.length; ++j) {
+        var device = devices[j];
+        var deviceKey = device.getIdentityKey();
+        var sessions = this._olmDevice.getSessionInfoForDevice(deviceKey);
+
+        result[device.deviceId] = {
+            deviceIdKey: deviceKey,
+            sessions: sessions,
+        };
+    }
+    return result;
+};
+
+
+/**
  * Identify a device by curve25519 identity key and determine its verification state
  *
  * @param {string} userId     owner of the device


### PR DESCRIPTION
I've been trying to track down issues with the OlmSessions getting out of sync
between two devices. To help with this, add a method which can be used from the
JS console to inspect the state of OlmSessions.

(Requires https://github.com/matrix-org/olm-backup/pull/15 to actually work)