### PR TITLE
MatrixClient.getStoredDevicesForUser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -308,6 +308,8 @@ MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
 /**
  * List the stored device keys for a user id
  *
+ * @deprecated prefer {@link module:client#getStoredDevicesForUser}
+ *
  * @param {string} userId the user to list keys for.
  *
  * @return {object[]} list of devices with "id", "verified", "blocked",
@@ -319,6 +321,22 @@ MatrixClient.prototype.listDeviceKeys = function(userId) {
     }
     return this._crypto.listDeviceKeys(userId);
 };
+
+/**
+ * Get the stored device keys for a user id
+ *
+ * @param {string} userId the user to list keys for.
+ *
+ * @return {module:crypto-deviceinfo[]} list of devices
+ */
+MatrixClient.prototype.getStoredDevicesForUser = function(userId) {
+    if (this._crypto === null) {
+        throw new Error("End-to-end encryption disabled");
+    }
+    return this._crypto.getStoredDevicesForUser(userId);
+};
+
+
 
 /**
  * Mark the given device as verified

--- a/lib/crypto-deviceinfo.js
+++ b/lib/crypto-deviceinfo.js
@@ -113,6 +113,24 @@ DeviceInfo.prototype.getDisplayname = function() {
 };
 
 /**
+ * Returns true if this device is blocked
+ *
+ * @return {Boolean} true if blocked
+ */
+DeviceInfo.prototype.isBlocked = function() {
+    return this.verified == DeviceVerification.BLOCKED;
+};
+
+/**
+ * Returns true if this device is verified
+ *
+ * @return {Boolean} true if verified
+ */
+DeviceInfo.prototype.isVerified = function() {
+    return this.verified == DeviceVerification.VERIFIED;
+};
+
+/**
  * @enum
  */
 DeviceInfo.DeviceVerification = {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -385,8 +385,8 @@ Crypto.prototype.listDeviceKeys = function(userId) {
             result.push({
                 id: device.deviceId,
                 key: ed25519Key,
-                verified: Boolean(device.verified == DeviceVerification.VERIFIED),
-                blocked: Boolean(device.verified == DeviceVerification.BLOCKED),
+                verified: Boolean(device.isVerified()),
+                blocked: Boolean(device.isBlocked()),
                 display_name: device.getDisplayname(),
             });
         }


### PR DESCRIPTION
Implement MatrixClient.getStoredDevicesForUser which uses
Crypto.getStoredDevicesForUser, which is more powerful than listDeviceKeys, and
isn't deprecated.

Also a couple of accessors for DeviceInfo.