### PR TITLE
Use `ciphertext` instead of `body` in megolm events

### DIFF
--- a/lib/crypto-algorithms/megolm.js
+++ b/lib/crypto-algorithms/megolm.js
@@ -182,7 +182,7 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
         var encryptedContent = {
             algorithm: olmlib.MEGOLM_ALGORITHM,
             sender_key: self._olmDevice.deviceCurve25519Key,
-            body: ciphertext,
+            ciphertext: ciphertext,
             session_id: session_id,
         };
 
@@ -251,14 +251,14 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
                 content.session_id);
 
     if (!content.sender_key || !content.session_id ||
-        !content.body
+        !content.ciphertext
        ) {
         throw new base.DecryptionError("Missing fields in input");
     }
 
     try {
         var res = this._olmDevice.decryptGroupMessage(
-            event.room_id, content.sender_key, content.session_id, content.body
+            event.room_id, content.sender_key, content.session_id, content.ciphertext
         );
         return JSON.parse(res);
     } catch (e) {


### PR DESCRIPTION
Apparently `body` is going to be special.