### PR TITLE
Fix sender verification for megolm messages

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -412,7 +412,10 @@ Crypto.prototype.listDeviceKeys = function(userId) {
  * @return {module:crypto-deviceinfo?}
  */
 Crypto.prototype.getDeviceByIdentityKey = function(userId, algorithm, sender_key) {
-    if (algorithm !== olmlib.OLM_ALGORITHM) {
+    if (
+        algorithm !== olmlib.OLM_ALGORITHM &&
+        algorithm !== olmlib.MEGOLM_ALGORITHM
+    ) {
         // we only deal in olm keys
         return null;
     }
@@ -528,6 +531,19 @@ Crypto.prototype.getOlmSessionsForUser = function(userId) {
  * @return {boolean} true if the device is verified
  */
 Crypto.prototype.isSenderKeyVerified = function(userId, algorithm, sender_key) {
+
+    // sender_key is the curve25519 public key of the device, that the event
+    // purports to have been sent from. It's assumed that, by the time we get here,
+    // we have already checked that the event was, in fact, sent by that device.
+    //
+    // In the case of both olm and megolm, that is achieved primarily by the
+    // fact that sessions are indexed by the curve25519 key of the device that
+    // created the session, and we assume that only that device has the keys
+    // necessary to create valid messages in that session.
+    //
+    // So, all we need to do here is look up the device by sender and
+    // curve25519 key and determine the state of the verification flag.
+
     var device = this.getDeviceByIdentityKey(userId, algorithm, sender_key);
     if (!device) {
         return false;


### PR DESCRIPTION
Turns out all we need to do is to make sure we use the Olm device table when we
look up megolm senders.