### PR TITLE
Don't create Olm sessions proactively

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -453,18 +453,8 @@ MatrixClient.prototype.setRoomEncryption = function(roomId, config) {
     if (!this._crypto) {
         throw new Error("End-to-End encryption disabled");
     }
-
-    var roomMembers = [];
-    var room = this.getRoom(roomId);
-    if (!room) {
-        console.warn("Enabling encryption in unknown room " + roomId);
-    } else {
-       roomMembers = utils.map(room.getJoinedMembers(), function(u) {
-           return u.userId;
-       });
-    }
-
-    return this._crypto.setRoomEncryption(roomId, config, roomMembers);
+    this._crypto.setRoomEncryption(roomId, config);
+    return q();
 };
 
 /**

--- a/lib/crypto-algorithms/base.js
+++ b/lib/crypto-algorithms/base.js
@@ -20,8 +20,6 @@ limitations under the License.
  *
  * @module crypto-algorithms/base
  */
-var q = require("q");
-
 var utils = require("../utils");
 
 /**
@@ -62,20 +60,6 @@ var EncryptionAlgorithm = function(params) {
 };
 /** */
 module.exports.EncryptionAlgorithm = EncryptionAlgorithm;
-
-/**
- * Initialise this EncryptionAlgorithm instance for a particular room.
- *
- * <p>This will be called once per EncryptionAlgorithm, just after the
- * constructor is called.
- *
- * @param {string[]} roomMembers list of currently-joined users in the room
- * @return {module:client.Promise} Promise which resolves when setup is complete
- */
-EncryptionAlgorithm.prototype.initRoomEncryption = function(roomMembers) {
-    return q();
-};
-
 
 /**
  * Encrypt a message event

--- a/lib/crypto-algorithms/olm.js
+++ b/lib/crypto-algorithms/olm.js
@@ -41,19 +41,37 @@ var base = require("./base");
  */
 function OlmEncryption(params) {
     base.EncryptionAlgorithm.call(this, params);
+    this._sessionPrepared = false;
+    this._prepPromise = null;
 }
 utils.inherits(OlmEncryption, base.EncryptionAlgorithm);
 
 /**
- * @inheritdoc
+ * @private
+
  * @param {string[]} roomMembers list of currently-joined users in the room
  * @return {module:client.Promise} Promise which resolves when setup is complete
  */
-OlmEncryption.prototype.initRoomEncryption = function(roomMembers) {
-    var crypto = this._crypto;
-    return crypto.downloadKeys(roomMembers, true).then(function(res) {
-        return crypto.ensureOlmSessionsForUsers(roomMembers);
+OlmEncryption.prototype._ensureSession = function(roomMembers) {
+    if (this._prepPromise) {
+        // prep already in progress
+        return this._prepPromise;
+    }
+
+    if (this._sessionPrepared) {
+        // prep already done
+        return q();
+    }
+
+    var self = this;
+    this._prepPromise = self._crypto.downloadKeys(roomMembers, true).then(function(res) {
+        return self._crypto.ensureOlmSessionsForUsers(roomMembers);
+    }).then(function() {
+        self._sessionPrepared = true;
+    }).finally(function() {
+        self._prepPromise = null;
     });
+    return this._prepPromise;
 };
 
 /**
@@ -75,35 +93,35 @@ OlmEncryption.prototype.encryptMessage = function(room, eventType, content) {
         return u.userId;
     });
 
-    var participantKeys = [];
-    for (var i = 0; i < users.length; ++i) {
-        var userId = users[i];
-        var devices = this._crypto.getStoredDevicesForUser(userId);
-        for (var j = 0; j < devices.length; ++j) {
-            var deviceInfo = devices[j];
-            var key = deviceInfo.getIdentityKey();
-            if (key == this._olmDevice.deviceCurve25519Key) {
-                // don't bother setting up session to ourself
-                continue;
+    var self = this;
+    return this._ensureSession(users).then(function() {
+        var participantKeys = [];
+        for (var i = 0; i < users.length; ++i) {
+            var userId = users[i];
+            var devices = self._crypto.getStoredDevicesForUser(userId);
+            for (var j = 0; j < devices.length; ++j) {
+                var deviceInfo = devices[j];
+                var key = deviceInfo.getIdentityKey();
+                if (key == self._olmDevice.deviceCurve25519Key) {
+                    // don't bother setting up session to ourself
+                    continue;
+                }
+                if (deviceInfo.verified == DeviceVerification.BLOCKED) {
+                    // don't bother setting up sessions with blocked users
+                    continue;
+                }
+                participantKeys.push(key);
             }
-            if (deviceInfo.verified == DeviceVerification.BLOCKED) {
-                // don't bother setting up sessions with blocked users
-                continue;
-            }
-            participantKeys.push(key);
         }
-    }
 
-    return q(
-        olmlib.encryptMessageForDevices(
-            this._deviceId, this._olmDevice, participantKeys, {
+        return olmlib.encryptMessageForDevices(
+            self._deviceId, self._olmDevice, participantKeys, {
                 room_id: room.roomId,
                 type: eventType,
                 content: content,
             }
-        )
-    );
-
+        );
+    });
 };
 
 /**

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -557,11 +557,8 @@ Crypto.prototype.isSenderKeyVerified = function(userId, algorithm, sender_key) {
  *
  * @param {string} roomId The room ID to enable encryption in.
  * @param {object} config The encryption config for the room.
- * @param {string[]} roomMembers userIds of room members to start sessions with
- *
- * @return {module:client.Promise} A promise that will resolve when encryption is setup.
  */
-Crypto.prototype.setRoomEncryption = function(roomId, config, roomMembers) {
+Crypto.prototype.setRoomEncryption = function(roomId, config) {
     // if we already have encryption in this room, we should ignore this event
     // (for now at least. maybe we should alert the user somehow?)
     var existingConfig = this._sessionStore.getEndToEndRoom(roomId);
@@ -569,7 +566,7 @@ Crypto.prototype.setRoomEncryption = function(roomId, config, roomMembers) {
         if (JSON.stringify(existingConfig) != JSON.stringify(config)) {
             console.error("Ignoring m.room.encryption event which requests " +
                           "a change of config in " + roomId);
-            return q();
+            return;
         }
     }
 
@@ -592,7 +589,6 @@ Crypto.prototype.setRoomEncryption = function(roomId, config, roomMembers) {
         roomId: roomId,
     });
     this._roomAlgorithms[roomId] = alg;
-    return alg.initRoomEncryption(roomMembers);
 };
 
 


### PR DESCRIPTION
In what I hoped would be a five-minute refactor to help clean up an annoying not-really-used codepath, but turned into a bit of a hackathon on the tests, create Olm sessions lazily in Olm rooms, just as we do in megolm rooms, which allows us to avoid having to get the member list before configuring e2e in a room.