### PR TITLE
Share the current ratchet with new members

### DIFF
--- a/lib/crypto/algorithms/base.js
+++ b/lib/crypto/algorithms/base.js
@@ -79,8 +79,12 @@ module.exports.EncryptionAlgorithm = EncryptionAlgorithm;
  *
  * @param {module:models/event.MatrixEvent} event  event causing the change
  * @param {module:models/room-member} member  user whose membership changed
+ * @param {string=} oldMembership  previous membership
  */
-EncryptionAlgorithm.prototype.onRoomMembership = function(event, member) {};
+EncryptionAlgorithm.prototype.onRoomMembership = function(
+    event, member, oldMembership
+) {};
+
 
 /**
  * base type for decryption implementations

--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -41,6 +41,11 @@ function MegolmEncryption(params) {
     this._prepPromise = null;
     this._outboundSessionId = null;
     this._discardNewSession = false;
+
+    // users who have joined since we last sent a message.
+    // userId -> true
+    this._usersPendingKeyShare = {};
+    this._sharePromise = null;
 }
 utils.inherits(MegolmEncryption, base.EncryptionAlgorithm);
 
@@ -49,20 +54,70 @@ utils.inherits(MegolmEncryption, base.EncryptionAlgorithm);
  *
  * @param {module:models/room} room
  *
- * @return {module:client.Promise} Promise which resolves when setup is
- *   complete.
+ * @return {module:client.Promise} Promise which resolves to the megolm
+ *   sessionId when setup is complete.
  */
 MegolmEncryption.prototype._ensureOutboundSession = function(room) {
+    var self = this;
+
     if (this._prepPromise) {
         // prep already in progress
         return this._prepPromise;
     }
 
-    if (this._outboundSessionId) {
-        // prep already done
-        return q(this._outboundSessionId);
+    var sessionId = this._outboundSessionId;
+
+    // need to make a brand new session?
+    if (!sessionId) {
+        this._prepPromise = this._prepareNewSession(room).
+            finally(function() {
+                self._prepPromise = null;
+            });
+        return this._prepPromise;
     }
 
+    if (this._sharePromise) {
+        // key share already in progress
+        return this._sharePromise;
+    }
+
+    // prep already done, but check for new users
+    var shareMap = this._usersPendingKeyShare;
+    this._usersPendingKeyShare = {};
+
+    // check each user is (still) a member of the room
+    for (var userId in shareMap) {
+        if (!shareMap.hasOwnProperty(userId)) {
+            continue;
+        }
+
+        // XXX what about rooms where invitees can see the content?
+        var member = room.getMember(userId);
+        if (member.membership !== "join") {
+            delete shareMap[userId];
+        }
+    }
+
+    this._sharePromise = this._shareKeyWithUsers(
+        sessionId, shareMap
+    ).finally(function() {
+        self._sharePromise = null;
+    }).then(function() {
+        return sessionId;
+    });
+
+    return this._sharePromise;
+};
+
+/**
+ * @private
+ *
+ * @param {module:models/room} room
+ *
+ * @return {module:client.Promise} Promise which resolves to the megolm
+ *   sessionId when setup is complete.
+ */
+MegolmEncryption.prototype._prepareNewSession = function(room) {
     var session_id = this._olmDevice.createOutboundGroupSession();
     var key = this._olmDevice.getOutboundGroupSessionKey(session_id);
 
@@ -71,60 +126,28 @@ MegolmEncryption.prototype._ensureOutboundSession = function(room) {
         key.key, key.chain_index
     );
 
-    // send the keys to each (unblocked) device in the room.
-    var payload = {
-        type: "m.room_key",
-        content: {
-            algorithm: olmlib.MEGOLM_ALGORITHM,
-            room_id: this._roomId,
-            session_id: session_id,
-            session_key: key.key,
-            chain_index: key.chain_index,
-        }
-    };
+    // we're going to share the key with all current members of the room,
+    // so we can reset this.
+    this._usersPendingKeyShare = {};
 
     var roomMembers = utils.map(room.getJoinedMembers(), function(u) {
         return u.userId;
     });
 
+    var shareMap = {};
+    for (var i = 0; i < roomMembers.length; i++) {
+        var userId = roomMembers[i];
+        shareMap[userId] = true;
+    }
+
     var self = this;
 
     // TODO: we need to give the user a chance to block any devices or users
     // before we send them the keys; it's too late to download them here.
-    this._prepPromise = this._crypto.downloadKeys(
+    return this._crypto.downloadKeys(
         roomMembers, false
     ).then(function(res) {
-        return self._crypto.ensureOlmSessionsForUsers(roomMembers);
-    }).then(function(devicemap) {
-        var contentMap = {};
-
-        for (var userId in devicemap) {
-            if (!devicemap.hasOwnProperty(userId)) {
-                continue;
-            }
-
-            contentMap[userId] = {};
-
-            var devices = devicemap[userId];
-
-            for (var deviceId in devices) {
-                if (!devices.hasOwnProperty(deviceId)) {
-                    continue;
-                }
-
-                var deviceInfo = devices[deviceId].device;
-                contentMap[userId][deviceId] =
-                    olmlib.encryptMessageForDevices(
-                        self._deviceId,
-                        self._olmDevice,
-                        [deviceInfo.getIdentityKey()],
-                        payload
-                    );
-            }
-        }
-
-        // TODO: retries
-        return self._baseApis.sendToDevice("m.room.encrypted", contentMap);
+        return self._shareKeyWithUsers(session_id, shareMap);
     }).then(function() {
         if (self._discardNewSession) {
             // we've had cause to reset the session_id since starting this process.
@@ -137,11 +160,80 @@ MegolmEncryption.prototype._ensureOutboundSession = function(room) {
         }
         return session_id;
     }).finally(function() {
-        self._prepPromise = null;
         self._discardNewSession = false;
     });
+};
 
-    return this._prepPromise;
+/**
+ * @private
+ *
+ * @param {string} session_id
+ * @param {Object<string, boolean>} shareMap
+ *
+ * @return {module:client.Promise} Promise which resolves once the key sharing
+ *     message has been sent.
+ */
+MegolmEncryption.prototype._shareKeyWithUsers = function(session_id, shareMap) {
+    var self = this;
+
+    var key = this._olmDevice.getOutboundGroupSessionKey(session_id);
+    var payload = {
+        type: "m.room_key",
+        content: {
+            algorithm: olmlib.MEGOLM_ALGORITHM,
+            room_id: this._roomId,
+            session_id: session_id,
+            session_key: key.key,
+            chain_index: key.chain_index,
+        }
+    };
+
+    return self._crypto.ensureOlmSessionsForUsers(
+        utils.keys(shareMap)
+    ).then(function(devicemap) {
+        var contentMap = {};
+        var haveTargets = false;
+
+        for (var userId in devicemap) {
+            if (!devicemap.hasOwnProperty(userId)) {
+                continue;
+            }
+
+            var deviceInfos = devicemap[userId];
+
+            for (var deviceId in deviceInfos) {
+                if (!deviceInfos.hasOwnProperty(deviceId)) {
+                    continue;
+                }
+
+                console.log(
+                    "sharing keys with device " + userId + ":" + deviceId
+                );
+
+                var deviceInfo = deviceInfos[deviceId].device;
+
+                if (!contentMap[userId]) {
+                    contentMap[userId] = {};
+                }
+
+                contentMap[userId][deviceId] =
+                    olmlib.encryptMessageForDevices(
+                        self._deviceId,
+                        self._olmDevice,
+                        [deviceInfo.getIdentityKey()],
+                        payload
+                    );
+                haveTargets = true;
+            }
+        }
+
+        if (!haveTargets) {
+            return q();
+        }
+
+        // TODO: retries
+        return self._baseApis.sendToDevice("m.room.encrypted", contentMap);
+    });
 };
 
 /**
@@ -182,26 +274,34 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
  *
  * @param {module:models/event.MatrixEvent} event  event causing the change
  * @param {module:models/room-member} member  user whose membership changed
+ * @param {string=} oldMembership  previous membership
  */
-MegolmEncryption.prototype.onRoomMembership = function(event, member) {
-    // start a new outbound session whenever someone joins or leaves the room.
-    //
-    // technically we don't need to reset on all membership transitions (eg,
-    // leave->ban), but we might as well.
+MegolmEncryption.prototype.onRoomMembership = function(event, member, oldMembership) {
+    var newMembership = member.membership;
 
-    // when people join the room, we could get away with sharing the current
-    // state of the ratchet with them; however, it's somewhat easier for now
-    // just to reset the session and start a new one.
+    if (newMembership === 'join') {
+        // new member in the room.
+        this._usersPendingKeyShare[member.userId] = true;
+        return;
+    }
 
+    if (newMembership === 'invite' && oldMembership !== 'join') {
+        // we don't (yet) share keys with invited members, so nothing to do yet
+        return;
+    }
+
+    // otherwise we assume the user is leaving, and start a new outbound session.
     if (this._outboundSessionId) {
         console.log("Discarding outbound megolm session due to change in " +
-                    "membership of " + member.userId);
+                    "membership of " + member.userId + " (" + oldMembership +
+                    "->" + newMembership + ")");
         this._outboundSessionId = null;
     }
 
     if (this._prepPromise) {
         console.log("Discarding as-yet-incomplete megolm session due to " +
-                    "change in membership of " + member.userId);
+                    "change in membership of " + member.userId + " (" +
+                    oldMembership + "->" + newMembership + ")");
         this._discardNewSession = true;
     }
 };

--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -841,8 +841,9 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
  * @private
  * @param {module:models/event.MatrixEvent} event  event causing the change
  * @param {module:models/room-member} member  user whose membership changed
+ * @param {string=} oldMembership  previous membership
  */
-Crypto.prototype._onRoomMembership = function(event, member) {
+Crypto.prototype._onRoomMembership = function(event, member, oldMembership) {
 
     // this event handler is registered on the *client* (as opposed to the
     // room member itself), which means it is only called on changes to the
@@ -859,7 +860,7 @@ Crypto.prototype._onRoomMembership = function(event, member) {
         return;
     }
 
-    alg.onRoomMembership(event, member);
+    alg.onRoomMembership(event, member, oldMembership);
 };
 
 /**

--- a/lib/models/room-member.js
+++ b/lib/models/room-member.js
@@ -80,11 +80,11 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
     this.name = calculateDisplayName(this, event, roomState);
     if (oldMembership !== this.membership) {
         this._updateModifiedTime();
-        this.emit("RoomMember.membership", event, this);
+        this.emit("RoomMember.membership", event, this, oldMembership);
     }
     if (oldName !== this.name) {
         this._updateModifiedTime();
-        this.emit("RoomMember.name", event, this);
+        this.emit("RoomMember.name", event, this, oldName);
     }
 };
 
@@ -255,6 +255,8 @@ module.exports = RoomMember;
  * @event module:client~MatrixClient#"RoomMember.name"
  * @param {MatrixEvent} event The matrix event which caused this event to fire.
  * @param {RoomMember} member The member whose RoomMember.name changed.
+ * @param {string?} oldName The previous name. Null if the member didn't have a
+ *    name previously.
  * @example
  * matrixClient.on("RoomMember.name", function(event, member){
  *   var newName = member.name;
@@ -266,8 +268,10 @@ module.exports = RoomMember;
  * @event module:client~MatrixClient#"RoomMember.membership"
  * @param {MatrixEvent} event The matrix event which caused this event to fire.
  * @param {RoomMember} member The member whose RoomMember.membership changed.
+ * @param {string?} oldMembership The previous membership state. Null if it's a
+ *    new member.
  * @example
- * matrixClient.on("RoomMember.membership", function(event, member){
+ * matrixClient.on("RoomMember.membership", function(event, member, oldMembership){
  *   var newState = member.membership;
  * });
  */


### PR DESCRIPTION
When a new member joins the room, we don't need to reset the megolm session;
instead we can just share the current state with the new user.