### PR TITLE
Show warnings on to-device decryption fail

### DIFF
--- a/lib/crypto/algorithms/olm.js
+++ b/lib/crypto/algorithms/olm.js
@@ -191,6 +191,7 @@ OlmDecryption.prototype.decryptEvent = function(event) {
             console.log("created new inbound sesion");
         } catch (e) {
             // Failed to decrypt with a new session.
+            console.warn("Failed to decrypt message with new session", e);
         }
     }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -631,6 +631,17 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
             .map(client.getEventMapper())
             .forEach(
                 function(toDeviceEvent) {
+                    var content = toDeviceEvent.getContent();
+                    if (
+                        toDeviceEvent.getType() == "m.room.message" &&
+                            content.msgtype == "m.bad.encrypted"
+                    ) {
+                        console.warn(
+                            "Unable to decrypt to-device event: " + content.body
+                        );
+                        return;
+                    }
+
                     client.emit("toDeviceEvent", toDeviceEvent);
                 }
             );


### PR DESCRIPTION
If we can't decrypt a to-device message, show a warning about it, rather than swallowing the error.