### PR TITLE
Handle the first /sync failure differently.

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -545,13 +545,22 @@ SyncApi.prototype._sync = function(syncOptions) {
         console.error("/sync error %s", err);
         console.error(err);
 
-        debuglog("Starting keep-alive");
-        self._syncConnectionLost = true;
-        self._startKeepAlives().done(function() {
+        if (!self._syncConnectionLost) {
+            // This is the first failure, which may be spurious. To avoid unnecessary
+            // connection error warnings we simply retry the /sync immediately. Only
+            // if *that* one fails too do we say the connection has been lost.
+            // Should we emit a state like "MAYBE_CONNETION_LOST"?
+            self._syncConnectionLost = true;
             self._sync(syncOptions);
-        });
-        self._currentSyncRequest = null;
-        self._updateSyncState("ERROR", { error: err });
+        } else {
+            debuglog("Starting keep-alive");
+            self._syncConnectionLost = true;
+            self._startKeepAlives().done(function() {
+                self._sync(syncOptions);
+            });
+            self._currentSyncRequest = null;
+            self._updateSyncState("ERROR", { error: err });
+        }
     });
 };
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -549,6 +549,12 @@ SyncApi.prototype._sync = function(syncOptions) {
             // This is the first failure, which may be spurious. To avoid unnecessary
             // connection error warnings we simply retry the /sync immediately. Only
             // if *that* one fails too do we say the connection has been lost.
+            // Examples of when this may happen are:
+            //   - Restarting backend servers. (In an HA world backends may be
+            //     restarted all the time, and its easiest just to make the
+            //     client retry).
+            //   - Intermediate proxies restarting.
+            //   - Device network changes.
             // Should we emit a state like "MAYBE_CONNETION_LOST"?
             self._syncConnectionLost = true;
             self._sync(syncOptions);

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -332,8 +332,12 @@ describe("MatrixClient", function() {
             httpLookups = [];
             httpLookups.push(PUSH_RULES_RESPONSE);
             httpLookups.push(FILTER_RESPONSE);
+            // We fail twice since the SDK ignores the first error.
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NOPE_NOPE_NOPE" }
+            });
+            httpLookups.push({
+                method: "GET", path: "/sync", error: { errcode: "NOPE_NOPE_NOPE2" }
             });
             httpLookups.push({
                 method: "GET", path: "/sync", data: SYNC_DATA
@@ -355,8 +359,12 @@ describe("MatrixClient", function() {
 
         it("should transition SYNCING -> ERROR after a failed /sync", function(done) {
             var expectedStates = [];
+            // We fail twice since the SDK ignores the first error.
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
+            });
+            httpLookups.push({
+                method: "GET", path: "/sync", error: { errcode: "NONONONONO2" }
             });
 
             expectedStates.push(["PREPARED", null]);
@@ -396,6 +404,10 @@ describe("MatrixClient", function() {
 
         it("should transition ERROR -> ERROR if multiple /sync fails", function(done) {
             var expectedStates = [];
+            // We fail twice since the SDK ignores the first error.
+            httpLookups.push({
+                method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
+            });
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
             });


### PR DESCRIPTION
A `/sync` request may spuriously fail on occasion, without the "connection" actually being lost. To avoid spurious "Connection Lost" warning messages we ignore the first `/sync` and immediately retry, and only if that fails do we enter an ERROR state.


Is this sensible? Should we emit an event to indicate we *may* have lost a connection?