### PR TITLE
crypto: remove duplicate code

### DIFF
--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -318,10 +318,10 @@ Crypto.prototype.downloadKeys = function(userIds, forceDownload) {
                 }
 
                 storage[deviceId] = userStore[deviceId].toStorage();
-                self._sessionStore.storeEndToEndDevicesForUser(
-                    userId, storage
-                );
             }
+            self._sessionStore.storeEndToEndDevicesForUser(
+                userId, storage
+            );
         }
         return stored;
     });


### PR DESCRIPTION
Only call SessionStore.storeEndToEndDevicesForUser once per user, rather than
once per device.

(Probably also fixes a bug where, when a user removes all devices, the store
isn't updated)