### PR TITLE
Fix checkTurnServers leak on logout

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2543,6 +2543,7 @@ MatrixClient.prototype.stopClient = function() {
     if (this._crypto) {
         global.clearInterval(this._uploadIntervalID);
     }
+    global.clearTimeout(this._checkTurnServersTimeoutID);
 };
 
 function setupCallEventHandler(client) {
@@ -2762,13 +2763,15 @@ function checkTurnServers(client) {
             };
             client._turnServers = [servers];
             // re-fetch when we're about to reach the TTL
-            setTimeout(function() { checkTurnServers(client); },
-                (res.ttl || (60 * 60)) * 1000 * 0.9
-            );
+            client._checkTurnServersTimeoutID =
+                setTimeout(function() { checkTurnServers(client); },
+                           (res.ttl || (60 * 60)) * 1000 * 0.9
+                          );
         }
     }, function(err) {
         console.error("Failed to get TURN URIs");
-        setTimeout(function() { checkTurnServers(client); }, 60000);
+        client._checkTurnServersTimeoutID =
+            setTimeout(function() { checkTurnServers(client); }, 60000);
     });
 }
 


### PR DESCRIPTION
Remember to cancel the checkTurnServers callback when we stop the client.