### PR TITLE
Revert "Handle the first /sync failure differently."

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -545,28 +545,13 @@ SyncApi.prototype._sync = function(syncOptions) {
         console.error("/sync error %s", err);
         console.error(err);
 
-        if (!self._syncConnectionLost) {
-            // This is the first failure, which may be spurious. To avoid unnecessary
-            // connection error warnings we simply retry the /sync immediately. Only
-            // if *that* one fails too do we say the connection has been lost.
-            // Examples of when this may happen are:
-            //   - Restarting backend servers. (In an HA world backends may be
-            //     restarted all the time, and its easiest just to make the
-            //     client retry).
-            //   - Intermediate proxies restarting.
-            //   - Device network changes.
-            // Should we emit a state like "MAYBE_CONNETION_LOST"?
-            self._syncConnectionLost = true;
+        debuglog("Starting keep-alive");
+        self._syncConnectionLost = true;
+        self._startKeepAlives().done(function() {
             self._sync(syncOptions);
-        } else {
-            debuglog("Starting keep-alive");
-            self._syncConnectionLost = true;
-            self._startKeepAlives().done(function() {
-                self._sync(syncOptions);
-            });
-            self._currentSyncRequest = null;
-            self._updateSyncState("ERROR", { error: err });
-        }
+        });
+        self._currentSyncRequest = null;
+        self._updateSyncState("ERROR", { error: err });
     });
 };
 

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -332,12 +332,8 @@ describe("MatrixClient", function() {
             httpLookups = [];
             httpLookups.push(PUSH_RULES_RESPONSE);
             httpLookups.push(FILTER_RESPONSE);
-            // We fail twice since the SDK ignores the first error.
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NOPE_NOPE_NOPE" }
-            });
-            httpLookups.push({
-                method: "GET", path: "/sync", error: { errcode: "NOPE_NOPE_NOPE2" }
             });
             httpLookups.push({
                 method: "GET", path: "/sync", data: SYNC_DATA
@@ -359,12 +355,8 @@ describe("MatrixClient", function() {
 
         it("should transition SYNCING -> ERROR after a failed /sync", function(done) {
             var expectedStates = [];
-            // We fail twice since the SDK ignores the first error.
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
-            });
-            httpLookups.push({
-                method: "GET", path: "/sync", error: { errcode: "NONONONONO2" }
             });
 
             expectedStates.push(["PREPARED", null]);
@@ -404,10 +396,6 @@ describe("MatrixClient", function() {
 
         it("should transition ERROR -> ERROR if multiple /sync fails", function(done) {
             var expectedStates = [];
-            // We fail twice since the SDK ignores the first error.
-            httpLookups.push({
-                method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
-            });
             httpLookups.push({
                 method: "GET", path: "/sync", error: { errcode: "NONONONONO" }
             });


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#216