### PR TITLE
Don't emit ERROR until a keepalive poke fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Unreleased Changes
+==================
+
+Breaking Changes
+----------------
+ * Add a 'RECONNECTING' state to the sync states. This is an additional state
+   between 'SYNCING' and 'ERROR', so most clients should not notice.
+
 Changes in [0.6.2](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.6.2) (2016-10-05)
 ================================================================================================
 [Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.6.1...v0.6.2)

--- a/lib/client.js
+++ b/lib/client.js
@@ -2867,6 +2867,9 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * the server for updates. This may be called multiple times even if the state is
  * already ERROR. <i>This is the equivalent of "syncError" in the previous
  * API.</i></li>
+ * <li>RECONNECTING: The sync connedtion has dropped, but not in a way that should
+ * be considered erroneous.
+ * </li>
  * <li>STOPPED: The client has stopped syncing with server due to stopClient
  * being called.
  * </li>
@@ -2876,8 +2879,10 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  *                                          +---->STOPPED
  *                                          |
  *              +----->PREPARED -------> SYNCING <--+
- *              |        ^                  |       |
- *   null ------+        |  +---------------+       |
+ *              |        ^                  ^       |
+ *              |        |                  |       |
+ *              |        |                  V       |
+ *   null ------+        |  +-RECONNECTING<-+       |
  *              |        |  V                       |
  *              +------->ERROR ---------------------+
  *

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -351,7 +351,7 @@ module.exports.MatrixHttpApi.prototype = {
      */
     request: function(callback, method, path, queryParams, data, opts) {
         opts = opts || {};
-        var prefix = opts.prefix || this.opts.prefix;
+        var prefix = opts.prefix !== undefined ? opts.prefix : this.opts.prefix;
         var fullUri = this.opts.baseUrl + prefix + path;
 
         return this.requestOtherUrl(

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -856,10 +856,14 @@ SyncApi.prototype._startKeepAlives = function(delay) {
         clearTimeout(this._keepAliveTimer);
     }
     var self = this;
-    self._keepAliveTimer = setTimeout(
-        self._pokeKeepAlive.bind(self),
-        delay
-    );
+    if (delay > 0) {
+        self._keepAliveTimer = setTimeout(
+            self._pokeKeepAlive.bind(self),
+            delay
+        );
+    } else {
+        self._pokeKeepAlive();
+    }
     if (!this._connectionReturnedDefer) {
         this._connectionReturnedDefer = q.defer();
     }
@@ -899,17 +903,18 @@ SyncApi.prototype._pokeKeepAlive = function() {
             // responses fail, this will mean we don't hammer in a loop.
             self._keepAliveTimer = setTimeout(success, 2000);
         } else {
-            // If we haven't already marked this sync
-            // connection as gone-away, do so now and
-            // emit an error.
-            if (!self._syncConnectionLost) {
-                self._syncConnectionLost = true;
-                self._updateSyncState("ERROR", { error: err });
-            }
             self._keepAliveTimer = setTimeout(
                 self._pokeKeepAlive.bind(self),
                 5000 + Math.floor(Math.random() * 5000)
             );
+            // If we haven't already marked this sync
+            // connection as gone-away, do so now and
+            // emit an error.
+            // Note we do this after setting the timer:
+            // this lets the unit tests advance the mock
+            // clock when the get the error.
+            self._syncConnectionLost = true;
+            self._updateSyncState("ERROR", { error: err });
         }
     });
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -406,7 +406,7 @@ SyncApi.prototype.sync = function() {
 
             self._sync({ filterId: filterId });
         }, function(err) {
-            self._startKeepAlives(0).done(function() {
+            self._startKeepAlives().done(function() {
                 getFilter();
             });
             self._updateSyncState("ERROR", { error: err });
@@ -550,13 +550,14 @@ SyncApi.prototype._sync = function(syncOptions) {
         // lost yet: we only do this if a keepalive poke
         // fails, since long lived HTTP connections will
         // go away sometimes and we shouldn't treat this as
-        // erroneous.
-        // We sent the first keep alive immediately because
-        // of this.
-        self._startKeepAlives(0).done(function() {
+        // erroneous. We set the state to 'reconnecting'
+        // instead, so that clients can onserve this state
+        // if they wish.
+        self._startKeepAlives().done(function() {
             self._sync(syncOptions);
         });
         self._currentSyncRequest = null;
+        self._updateSyncState("RECONNECTING");
     });
 };
 
@@ -849,7 +850,7 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
  */
 SyncApi.prototype._startKeepAlives = function(delay) {
     if (delay === undefined) {
-        delay = 5000 + Math.floor(Math.random() * 5000);
+        delay = 2000 + Math.floor(Math.random() * 5000);
     }
 
     if (this._keepAliveTimer !== null) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -406,7 +406,7 @@ SyncApi.prototype.sync = function() {
 
             self._sync({ filterId: filterId });
         }, function(err) {
-            self._startKeepAlives().done(function() {
+            self._startKeepAlives(0).done(function() {
                 getFilter();
             });
             self._updateSyncState("ERROR", { error: err });
@@ -546,12 +546,17 @@ SyncApi.prototype._sync = function(syncOptions) {
         console.error(err);
 
         debuglog("Starting keep-alive");
-        self._syncConnectionLost = true;
-        self._startKeepAlives().done(function() {
+        // Note that we do *not* mark the sync connection as
+        // lost yet: we only do this if a keepalive poke
+        // fails, since long lived HTTP connections will
+        // go away sometimes and we shouldn't treat this as
+        // erroneous.
+        // We sent the first keep alive immediately because
+        // of this.
+        self._startKeepAlives(0).done(function() {
             self._sync(syncOptions);
         });
         self._currentSyncRequest = null;
-        self._updateSyncState("ERROR", { error: err });
     });
 };
 
@@ -874,9 +879,15 @@ SyncApi.prototype._pokeKeepAlive = function() {
         }
     }
 
-    this.client._http.requestWithPrefix(
-        undefined, "GET", "/_matrix/client/versions", undefined,
-        undefined, "", 15 * 1000
+    this.client._http.request(
+        undefined, // callback
+        "GET", "/_matrix/client/versions",
+        undefined, // queryParams
+        undefined, // data
+        {
+            prefix: '',
+            localTimeoutMs: 15 * 1000,
+        }
     ).done(function() {
         success();
     }, function(err) {
@@ -888,6 +899,13 @@ SyncApi.prototype._pokeKeepAlive = function() {
             // responses fail, this will mean we don't hammer in a loop.
             self._keepAliveTimer = setTimeout(success, 2000);
         } else {
+            // If we haven't already marked this sync
+            // connection as gone-away, do so now and
+            // emit an error.
+            if (!self._syncConnectionLost) {
+                self._syncConnectionLost = true;
+                self._updateSyncState("ERROR", { error: err });
+            }
             self._keepAliveTimer = setTimeout(
                 self._pokeKeepAlive.bind(self),
                 5000 + Math.floor(Math.random() * 5000)

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -253,6 +253,8 @@ describe("MatrixClient", function() {
                         true, "retryImmediately returned false"
                     );
                     jasmine.Clock.tick(1);
+                } else if (state === "RECONNECTING" && httpLookups.length > 0) {
+                    jasmine.Clock.tick(10000);
                 } else if (state === "SYNCING" && httpLookups.length === 0) {
                     client.removeListener("sync", syncListener);
                     done();
@@ -349,7 +351,8 @@ describe("MatrixClient", function() {
                 method: "GET", path: "/sync", data: SYNC_DATA
             });
 
-            expectedStates.push(["ERROR", null]);
+            expectedStates.push(["RECONNECTING", null]);
+            expectedStates.push(["ERROR", "RECONNECTING"]);
             expectedStates.push(["PREPARED", "ERROR"]);
             client.on("sync", syncChecker(expectedStates, done));
             client.startClient();
@@ -375,7 +378,8 @@ describe("MatrixClient", function() {
 
             expectedStates.push(["PREPARED", null]);
             expectedStates.push(["SYNCING", "PREPARED"]);
-            expectedStates.push(["ERROR", "SYNCING"]);
+            expectedStates.push(["RECONNECTING", "SYNCING"]);
+            expectedStates.push(["ERROR", "RECONNECTING"]);
             client.on("sync", syncChecker(expectedStates, done));
             client.startClient();
         });
@@ -423,7 +427,8 @@ describe("MatrixClient", function() {
 
             expectedStates.push(["PREPARED", null]);
             expectedStates.push(["SYNCING", "PREPARED"]);
-            expectedStates.push(["ERROR", "SYNCING"]);
+            expectedStates.push(["RECONNECTING", "SYNCING"]);
+            expectedStates.push(["ERROR", "RECONNECTING"]);
             expectedStates.push(["ERROR", "ERROR"]);
             client.on("sync", syncChecker(expectedStates, done));
             client.startClient();


### PR DESCRIPTION
This accomplishes the same as
https://github.com/matrix-org/matrix-js-sdk/pull/216/files, but
without the client waiting 110 seconds for a sync request to time
out. That is, don't display an error message a soon as a sync
request fails, since we should accept that sometimes long lived
HTTP connections will go away and that's fine.

Also:
 * Use request rather than deprecated requestWithPrefix
 * http-api: The empty string may be falsy, but it's a valid prefix
 * Update the tests to mock keepalive behaviour appropriately, and change one to assert it just keeps emiting ERROR events if it keeps failing, rather than specifically if subsequent sync requests fail.