### PR TITLE
Adds MatrixClient.prototype.mxcUrlToAlternateHttp

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1868,6 +1868,28 @@ MatrixClient.prototype.mxcUrlToHttp =
 };
 
 /**
+ * Turn an MXC URL into an HTTP one, using an alternative media server URL.
+ * <strong>This method is experimental and may change.</strong>
+ * @param {string} baseUrl The URL of the homeserver acting as the media server.
+ * @param {string} mxcUrl The MXC URL
+ * @param {Number} width The desired width of the thumbnail.
+ * @param {Number} height The desired height of the thumbnail.
+ * @param {string} resizeMethod The thumbnail resize method to use, either
+ * "crop" or "scale".
+ * @param {Boolean} allowDirectLinks If true, return any non-mxc URLs
+ * directly. Fetching such URLs will leak information about the user to
+ * anyone they share a room with. If false, will return null for such URLs.
+ * @return {?string} the avatar URL or null.
+ * @see {@link mxcUrlToHttp}.
+ */
+MatrixClient.prototype.mxcUrlToAlternateHttp =
+        function(baseUrl, mxcUrl, width, height, resizeMethod, allowDirectLinks) {
+    return contentRepo.getHttpUriForMxc(
+        baseUrl, mxcUrl, width, height, resizeMethod, allowDirectLinks
+    );
+};
+
+/**
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: TODO
  * @return {module:http-api.MatrixError} Rejects: with an error response.


### PR DESCRIPTION
I needed to push this somewhere - it might not need to be merged.

This allows specification of an alternate media repo that is not the `baseurl` of the client. The IRC bridge could need this for such configurations.

See https://github.com/matrix-org/matrix-appservice-irc/pull/201