### PR TITLE
Fix uploadContent for node.js

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -134,6 +134,8 @@ module.exports.MatrixHttpApi.prototype = {
                 cb(new Error('Timeout'));
             };
 
+            // set an initial timeout of 30s; we'll advance it each time we get
+            // a progress notification
             xhr.timeout_timer = callbacks.setTimeout(timeout_fn, 30000);
 
             xhr.onreadystatechange = function() {
@@ -191,8 +193,8 @@ module.exports.MatrixHttpApi.prototype = {
             promise = this.authedRequest(
                 callback, "POST", "/upload", queryParams, file.stream, {
                     prefix: "/_matrix/media/v1",
-                    localTimeoutMs: 30000,
                     headers: {"Content-Type": file.type},
+                    json: false,
                 }
             );
         }
@@ -538,7 +540,7 @@ module.exports.MatrixHttpApi.prototype = {
                     withCredentials: false,
                     qs: queryParams,
                     body: data,
-                    json: true,
+                    json: opts.json === undefined ? true : opts.json,
                     timeout: localTimeoutMs,
                     headers: opts.headers || {},
                     _matrix_opts: this.opts


### PR DESCRIPTION
9e89e71e broke uploadContent, making it set 'json=true' on the request, so that we would try to turn raw content into JSON. It also misguidedly set a client-side timeout of 30s.

Fix that, and add some tests to check `uploadContent` works.

In mock-request: distinguish between an expectation (`ExpectedRequest`) and an actual request (`Request`). Add support for checking the headers, and the request options in general, to `Request`.