### PR TITLE
Fix sync breaking when an invalid filterId is in localStorage

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2395,7 +2395,26 @@ MatrixClient.prototype.getOrCreateFilter = function(filterName, filter) {
             }
             // debuglog("Existing filter ID %s: %s; new filter: %s",
             //          filterId, JSON.stringify(oldDef), JSON.stringify(newDef));
-            return;
+            self.store.setFilterIdByName(filterName, undefined);
+            return undefined;
+        }, function(error) {
+            // Synapse currently returns the following when the filter cannot be found:
+            // {
+            //     errcode: "M_UNKNOWN",
+            //     name: "M_UNKNOWN",
+            //     message: "No row found",
+            //     data: Object, httpStatus: 404
+            // }
+            if (error.httpStatus === 404 &&
+                (error.errcode === "M_UNKNOWN" || error.errcode === "M_NOT_FOUND")) {
+                // Clear existing filterId from localStorage
+                // if it no longer exists on the server
+                self.store.setFilterIdByName(filterName, undefined);
+                // Return a undefined value for existingId further down the promise chain
+                return undefined;
+            } else {
+                throw error;
+            }
         });
     }
 


### PR DESCRIPTION
 * if getFilter fails for a filterId, null out the localStorage id and redirect to the createFilter path. 

Currently it keeps retrying at `keepAlive` without invalidating: https://github.com/matrix-org/matrix-js-sdk/blob/master/lib/sync.js#L386 (Probably this should actually check whether it is an error that can be recovered through retry or not, rather than looping endlessly?) 

 * add spec

 * fix unit/matrix-client.spec.js http response not matching synapse
 Here is what a response looks like (note that httpStatus was missing from the mock response in the beforeEach() setup of the spec): 
```es6
{
  "errcode":"M_UNKNOWN",
  "name":"M_UNKNOWN",
  "message":"No row found",
  "data":{"errcode":"M_UNKNOWN","error":"No row found"},
  "httpStatus":404
}
```