### PR TITLE
Fix potential 30s delay on reconnect

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -66,7 +66,6 @@ function SyncApi(client, opts) {
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
     this.opts = opts;
     this._peekRoomId = null;
-    this._syncConnectionLost = false;
     this._currentSyncRequest = null;
     this._syncState = null;
     this._running = false;
@@ -491,7 +490,7 @@ SyncApi.prototype._sync = function(syncOptions) {
         qps._cacheBuster = Date.now();
     }
 
-    if (self._syncConnectionLost) {
+    if (this.getSyncState() == 'ERROR' || this.getSyncState() == 'RECONNECTING') {
         // we think the connection is dead. If it comes back up, we won't know
         // about it till /sync returns. If the timeout= is high, this could
         // be a long time. Set it to 0 when doing retries so we don't have to wait
@@ -507,8 +506,6 @@ SyncApi.prototype._sync = function(syncOptions) {
     );
 
     this._currentSyncRequest.done(function(data) {
-        self._syncConnectionLost = false;
-
         // set the sync token NOW *before* processing the events. We do this so
         // if something barfs on an event we can skip it rather than constantly
         // polling with the same token.
@@ -908,13 +905,12 @@ SyncApi.prototype._pokeKeepAlive = function() {
                 self._pokeKeepAlive.bind(self),
                 5000 + Math.floor(Math.random() * 5000)
             );
-            // If we haven't already marked this sync
-            // connection as gone-away, do so now and
-            // emit an error.
+            // A keepalive has failed, so we emit the
+            // error state (whether or not this is the
+            // first failure).
             // Note we do this after setting the timer:
             // this lets the unit tests advance the mock
             // clock when the get the error.
-            self._syncConnectionLost = true;
             self._updateSyncState("ERROR", { error: err });
         }
     });


### PR DESCRIPTION
After a connection glitch we would normally sync with zero timeout
so the connection comes back faster, but we didn't if the first
keepalive succeeds since we never marked the connection as failed.
This makes the behaviour more consistent.

Also get rid of the connectionLost flag which was only used in
one place anyway.