### PR TITLE
Fix params getting replaced on register calls

### DIFF
--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -136,10 +136,10 @@ MatrixBaseApis.prototype.register = function(
     var params = {
         auth: auth
     };
-    if (username !== undefined) { params.username = username; }
-    if (password !== undefined) { params.password = password; }
-    if (bindEmail !== undefined) { params.bind_email = bindEmail; }
-    if (guestAccessToken !== undefined) { params.guest_access_token = guestAccessToken; }
+    if (username !== undefined && username !== null) { params.username = username; }
+    if (password !== undefined && password !== null) { params.password = password; }
+    if (bindEmail !== undefined && bindEmail !== null) { params.bind_email = bindEmail; }
+    if (guestAccessToken !== undefined && guestAccessToken !== null) { params.guest_access_token = guestAccessToken; }
 
     return this.registerRequest(params, undefined, callback);
 };

--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -139,7 +139,9 @@ MatrixBaseApis.prototype.register = function(
     if (username !== undefined && username !== null) { params.username = username; }
     if (password !== undefined && password !== null) { params.password = password; }
     if (bindEmail !== undefined && bindEmail !== null) { params.bind_email = bindEmail; }
-    if (guestAccessToken !== undefined && guestAccessToken !== null) { params.guest_access_token = guestAccessToken; }
+    if (guestAccessToken !== undefined && guestAccessToken !== null) {
+        params.guest_access_token = guestAccessToken;
+    }
 
     return this.registerRequest(params, undefined, callback);
 };


### PR DESCRIPTION
The react-sdk sets guest access token to null sometimes, but we
previously added anything that was not 'undefined' to the params,
causing us to send parameters which overwrite the previous actual
parameters with the useless, {guest_access_token: null} which
caused registrations from an email link to break.

We should have no reason to send null, at least for these
particular params, so don't.