### PR TITLE
Update package.json for building browser-matrix without olm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "test": "istanbul cover --report cobertura --config .istanbul.yml -i \"lib/**/*.js\" jasmine-node -- spec --verbose --junitreport --captureExceptions",
     "check": "jasmine-node spec --verbose --junitreport --captureExceptions",
     "gendoc": "jsdoc -r lib -P package.json -R README.md -d .jsdoc",
-    "build": "jshint -c .jshint lib/ && browserify browser-index.js -o dist/browser-matrix-dev.js --ignore-missing",
+    "build": "jshint -c .jshint lib/ && browserify browser-index.js -o dist/browser-matrix-dev.js --ignore-missing && browserify browser-index --exclude='./lib/crypto/*' browser-index.js  -o dist/browser-matrix-dev-lite.js --ignore-missing",
     "watch": "watchify browser-index.js -o dist/browser-matrix-dev.js -v",
     "lint": "jshint -c .jshint lib spec && gjslint --unix_mode --disable 0131,0211,0200,0222,0212 --max_line_length 90 -r spec/ -r lib/",
-    "release": "npm run build && mkdir -p dist/$npm_package_version && uglifyjs -c -m -o dist/$npm_package_version/browser-matrix-$npm_package_version.min.js dist/browser-matrix-dev.js && cp dist/browser-matrix-dev.js dist/$npm_package_version/browser-matrix-$npm_package_version.js",
+    "release": "npm run build && mkdir -p dist/$npm_package_version && uglifyjs -c -m -o dist/$npm_package_version/browser-matrix-$npm_package_version.min.js dist/browser-matrix-dev.js && uglifyjs -c -m -o dist/$npm_package_version/browser-matrix-$npm_package_version-lite.min.js dist/browser-matrix-dev-lite.js && cp dist/browser-matrix-dev.js dist/$npm_package_version/browser-matrix-$npm_package_version.js && cp dist/browser-matrix-dev-lite.js dist/$npm_package_version/browser-matrix-$npm_package_version-lite.js",
     "prepublish": "git rev-parse HEAD > git-revision.txt",
     "version": "npm run release && git add dist/$npm_package_version"
   },


### PR DESCRIPTION
I tried checking out `v0.6.3` tag and release branch but I am unable to reproduce (?) the dist files currently bundled when running `npm run release` - so just the package.json update for now. 
### Respective file sizes

```
1.6M browser-matrix-0.6.3.js
885K browser-matrix-0.6.3.min.js
168K browser-matrix-0.6.3-lite.min.js
```
