### PR TITLE
Add ability to set a filter prior to the first /sync

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2511,6 +2511,9 @@ MatrixClient.prototype.getTurnServers = function() {
  *
  * @param {Number=} opts.pollTimeout The number of milliseconds to wait on /events.
  * Default: 30000 (30 seconds).
+ *
+ * @param {Filter=} opts.filter The filter to apply to /sync calls. This will override
+ * the opts.initialSyncLimit, which would normally result in a timeline limit filter.
  */
 MatrixClient.prototype.startClient = function(opts) {
     if (this.clientRunning) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -391,8 +391,13 @@ SyncApi.prototype.sync = function() {
     }
 
     function getFilter() {
-        var filter = new Filter(client.credentials.userId);
-        filter.setTimelineLimit(self.opts.initialSyncLimit);
+        var filter;
+        if (self.opts.filter) {
+            filter = self.opts.filter;
+        } else {
+            filter = new Filter(client.credentials.userId);
+            filter.setTimelineLimit(self.opts.initialSyncLimit);
+        }
 
         client.getOrCreateFilter(
             getFilterName(client.credentials.userId), filter


### PR DESCRIPTION
Useful for only syncing with a subset of joined rooms or only retrieving certain types of events.