### PR TITLE
Make it easier for SDK users to wrap prevailing the 'request' function

### DIFF
--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -83,6 +83,13 @@ module.exports.request = function(r) {
 };
 
 /**
+ * Return the currently-set request function.
+ */
+module.exports.getRequest = function() {
+    return request;
+};
+
+/**
  * Construct a Matrix Client. Similar to {@link module:client~MatrixClient}
  * except that the 'request', 'store' and 'scheduler' dependencies are satisfied.
  * @param {(Object|string)} opts The configuration options for this client. If

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -90,6 +90,19 @@ module.exports.getRequest = function() {
 };
 
 /**
+ * Apply wrapping code around the request function. The wrapper function is
+ * installed as the new request handler, and when invoked it is passed the
+ * previous value, along with the options and callback arguments.
+ * @param {requestWrapperFunction} wrapper The wrapping function.
+ */
+module.exports.wrapRequest = function(wrapper) {
+    var origRequest = request;
+    request = function(options, callback) {
+        return wrapper(origRequest, options, callback);
+    };
+};
+
+/**
  * Construct a Matrix Client. Similar to {@link module:client~MatrixClient}
  * except that the 'request', 'store' and 'scheduler' dependencies are satisfied.
  * @param {(Object|string)} opts The configuration options for this client. If
@@ -133,6 +146,16 @@ module.exports.createClient = function(opts) {
  * @param {boolean} opts.json True if this is a JSON request.
  * @param {Object} opts._matrix_opts The underlying options set for
  * {@link MatrixHttpApi}.
+ * @param {requestCallback} callback The request callback.
+ */
+
+/**
+ * A wrapper for the request function interface.
+ * @callback requestWrapperFunction
+ * @param {requestFunction} origRequest The underlying request function being
+ * wrapped
+ * @param {Object} opts The options for this HTTP request, given in the same
+ * form as {@link requestFunction}.
  * @param {requestCallback} callback The request callback.
  */
 

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -84,6 +84,7 @@ module.exports.request = function(r) {
 
 /**
  * Return the currently-set request function.
+ * @return {requestFunction} The current request function.
  */
 module.exports.getRequest = function() {
     return request;


### PR DESCRIPTION
SDK provides a way to set a new `request` function but doesn't make it easy to enquire what the current value is, meaning that if two layers of code both try to set it, they'll collide and one of them will lose. E.g. a current precedent 

https://github.com/matrix-org/matrix-appservice-bridge/blob/master/lib/components/client-factory.js#L39

Nicer would be if user code could obtain the currently-prevailing `request` function, apply some wrapping around it, and set that back, meaning that two pieces of code don't have to collide, and both of their effects will apply.

Right now there's no easy way to ask the SDK what its current `request` function is, requiring such evil hackery as

https://github.com/matrix-org/matrix-appservice-bridge/commit/91f12676629af1b1879c2312bbe217396a0100e1#diff-5af80589062bd33c63fc43ce54295651R42

to obtain it.

This PR adds a function `sdk.getRequest()` which returns the prevailing `request` function, allowing such user code be written in a neater, less-fragile way.

This PR also adds a function `sdk.wrapRequest()` that further neatens the process, allowing user code to provide a wrapper that receives the previous `request` function in the chain.