### PR TITLE
Use native Array.isArray when available.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -204,7 +204,8 @@ module.exports.isFunction = function(value) {
  * @return {boolean} True if it is an array.
  */
 module.exports.isArray = function(value) {
-    return Boolean(value && value.constructor === Array);
+    return Array.isArray ? Array.isArray(value) :
+        Boolean(value && value.constructor === Array);
 };
 
 /**


### PR DESCRIPTION
I was trying to use the matrix-js-sdk inside Mozilla chat client (https://bugzilla.mozilla.org/show_bug.cgi?id=1199855) and for some reason the utils.isArray function fails (it seems that two different Array constructors are involved in the comparison). Using the native Array.isArray function solves the problem and it seems well supported in modern browsers:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray

Note that the definition of isArray is more sophisticated in Ecmascript 2015:
http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.3.2
http://www.ecma-international.org/ecma-262/6.0/#sec-isarray
