### PR TITLE
Revert "Use native Array.isArray when available."

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -204,8 +204,7 @@ module.exports.isFunction = function(value) {
  * @return {boolean} True if it is an array.
  */
 module.exports.isArray = function(value) {
-    return Array.isArray ? Array.isArray(value) :
-        Boolean(value && value.constructor === Array);
+    return Boolean(value && value.constructor === Array);
 };
 
 /**


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#282 - this should have been against develop