### PR TITLE
Handle decryption of events after they arrive

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -463,38 +463,31 @@ MatrixClient.prototype.isRoomEncrypted = function(roomId) {
  * Decrypt a received event according to the algorithm specified in the event.
  *
  * @param {MatrixClient} client
- * @param {object} raw event
- *
- * @return {MatrixEvent}
+ * @param {MatrixEvent} event
  */
 function _decryptEvent(client, event) {
     if (!client._crypto) {
-        return _badEncryptedMessage(event, "**Encryption not enabled**");
+        _badEncryptedMessage(event, "**Encryption not enabled**");
+        return;
     }
 
-    var decryptionResult;
     try {
-        decryptionResult = client._crypto.decryptEvent(event);
+        client._crypto.decryptEvent(event);
     } catch (e) {
         if (!(e instanceof Crypto.DecryptionError)) {
             throw e;
         }
-        return _badEncryptedMessage(event, "**" + e.message + "**");
+        _badEncryptedMessage(event, "**" + e.message + "**");
+        return;
     }
-    return new MatrixEvent(
-        event, decryptionResult.payload,
-        decryptionResult.keysProved,
-        decryptionResult.keysClaimed
-    );
 }
 
 function _badEncryptedMessage(event, reason) {
-    return new MatrixEvent(event, {
+    event.setClearData({
         type: "m.room.message",
         content: {
             msgtype: "m.bad.encrypted",
             body: reason,
-            content: event.content,
         },
     });
 }
@@ -2829,10 +2822,11 @@ function _resolve(callback, defer, res) {
 
 function _PojoToMatrixEventMapper(client) {
     function mapper(plainOldJsObject) {
-        if (plainOldJsObject.type === "m.room.encrypted") {
-            return _decryptEvent(client, plainOldJsObject);
+        var event = new MatrixEvent(plainOldJsObject);
+        if (event.isEncrypted()) {
+            _decryptEvent(client, event);
         }
-        return new MatrixEvent(plainOldJsObject);
+        return event;
     }
     return mapper;
 }

--- a/lib/crypto/algorithms/base.js
+++ b/lib/crypto/algorithms/base.js
@@ -105,11 +105,16 @@ EncryptionAlgorithm.prototype.onNewDevice = function(userId, deviceId) {};
  *
  * @param {object} params parameters
  * @param {string} params.userId  The UserID for the local user
+ * @param {module:crypto} params.crypto crypto core
  * @param {module:crypto/OlmDevice} params.olmDevice olm.js wrapper
+ * @param {string=} params.roomId The ID of the room we will be receiving
+ *     from. Null for to-device events.
  */
 var DecryptionAlgorithm = function(params) {
     this._userId = params.userId;
+    this._crypto = params.crypto;
     this._olmDevice = params.olmDevice;
+    this._roomId = params.roomId;
 };
 /** */
 module.exports.DecryptionAlgorithm = DecryptionAlgorithm;

--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -451,7 +451,7 @@ utils.inherits(MegolmDecryption, base.DecryptionAlgorithm);
 /**
  * @inheritdoc
  *
- * @param {object} event raw event
+ * @param {MatrixEvent} event
  *
  * @return {null} The event referred to an unknown megolm session
  * @return {module:crypto.DecryptionResult} decryption result
@@ -460,7 +460,7 @@ utils.inherits(MegolmDecryption, base.DecryptionAlgorithm);
  *   problem decrypting the event
  */
 MegolmDecryption.prototype.decryptEvent = function(event) {
-    var content = event.content;
+    var content = event.getWireContent();
 
     if (!content.sender_key || !content.session_id ||
         !content.ciphertext
@@ -471,14 +471,15 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
     var res;
     try {
         res = this._olmDevice.decryptGroupMessage(
-            event.room_id, content.sender_key, content.session_id, content.ciphertext
+            event.getRoomId(), content.sender_key, content.session_id, content.ciphertext
         );
     } catch (e) {
         throw new base.DecryptionError(e);
     }
 
     if (res === null) {
-        return null;
+        // We've got a message for a session we don't have.
+        throw new base.DecryptionError("Unknown inbound session id");
     }
 
     var payload = JSON.parse(res.result);
@@ -486,17 +487,13 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
     // belt-and-braces check that the room id matches that indicated by the HS
     // (this is somewhat redundant, since the megolm session is scoped to the
     // room, so neither the sender nor a MITM can lie about the room_id).
-    if (payload.room_id !== event.room_id) {
+    if (payload.room_id !== event.getRoomId()) {
         throw new base.DecryptionError(
             "Message intended for room " + payload.room_id
         );
     }
 
-    return {
-        payload: payload,
-        keysClaimed: res.keysClaimed,
-        keysProved: res.keysProved,
-    };
+    event.setClearData(payload, res.keysClaimed, res.keysProved);
 };
 
 /**

--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -445,6 +445,10 @@ MegolmEncryption.prototype.onNewDevice = function(userId, deviceId) {
  */
 function MegolmDecryption(params) {
     base.DecryptionAlgorithm.call(this, params);
+
+    // events which we couldn't decrypt due to unknown sessions / indexes: map from
+    // senderKey|sessionId to list of MatrixEvents
+    this._pendingEvents = {};
 }
 utils.inherits(MegolmDecryption, base.DecryptionAlgorithm);
 
@@ -474,11 +478,15 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
             event.getRoomId(), content.sender_key, content.session_id, content.ciphertext
         );
     } catch (e) {
+        if (e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {
+            this._addEventToPendingList(event);
+        }
         throw new base.DecryptionError(e);
     }
 
     if (res === null) {
         // We've got a message for a session we don't have.
+        this._addEventToPendingList(event);
         throw new base.DecryptionError("Unknown inbound session id");
     }
 
@@ -494,6 +502,24 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
     }
 
     event.setClearData(payload, res.keysClaimed, res.keysProved);
+};
+
+
+/**
+ * Add an event to the list of those we couldn't decrypt the first time we
+ * saw them.
+ *
+ * @private
+ *
+ * @param {module:models/event.MatrixEvent} event
+ */
+MegolmDecryption.prototype._addEventToPendingList = function(event) {
+    var content = event.getWireContent();
+    var k = content.sender_key + "|" + content.session_id;
+    if (!this._pendingEvents[k]) {
+        this._pendingEvents[k] = [];
+    }
+    this._pendingEvents[k].push(event);
 };
 
 /**
@@ -517,6 +543,22 @@ MegolmDecryption.prototype.onRoomKeyEvent = function(event) {
         content.room_id, event.getSenderKey(), content.session_id,
         content.session_key, event.getKeysClaimed()
     );
+
+    var k = event.getSenderKey() + "|" + content.session_id;
+    var pending = this._pendingEvents[k];
+    if (pending) {
+        // have another go at decrypting events sent with this session.
+        delete this._pendingEvents[k];
+
+        for (var i = 0; i < pending.length; i++) {
+            try {
+                this.decryptEvent(pending[i]);
+                console.log("successful re-decryption of", pending[i]);
+            } catch (e) {
+                console.log("Still can't decrypt", pending[i], e.stack || e);
+            }
+        }
+    }
 };
 
 base.registerAlgorithm(

--- a/lib/crypto/algorithms/olm.js
+++ b/lib/crypto/algorithms/olm.js
@@ -151,15 +151,13 @@ utils.inherits(OlmDecryption, base.DecryptionAlgorithm);
 /**
  * @inheritdoc
  *
- * @param {object} event raw event
- *
- * @return {module:crypto.DecryptionResult} decryption result
+ * @param {MatrixEvent} event
  *
  * @throws {module:crypto/algorithms/base.DecryptionError} if there is a
  *   problem decrypting the event
  */
 OlmDecryption.prototype.decryptEvent = function(event) {
-    var content = event.content;
+    var content = event.getWireContent();
     var deviceKey = content.sender_key;
     var ciphertext = content.ciphertext;
 
@@ -178,7 +176,7 @@ OlmDecryption.prototype.decryptEvent = function(event) {
     } catch (e) {
         console.warn(
             "Failed to decrypt Olm event (id=" +
-                event.event_id + ") from " + deviceKey +
+                event.getId() + ") from " + deviceKey +
                 ": " + e.message
         );
         throw new base.DecryptionError("Bad Encrypted Message");
@@ -192,11 +190,11 @@ OlmDecryption.prototype.decryptEvent = function(event) {
         // older versions of riot did not set this field, so we cannot make
         // this check. TODO: kill this off once our users have updated
         console.warn(
-            "Olm event (id=" + event.event_id + ") contains no 'recipient' " +
+            "Olm event (id=" + event.getId() + ") contains no 'recipient' " +
              "property; cannot prevent unknown-key attack");
     } else if (payload.recipient != this._userId) {
         console.warn(
-            "Event " + event.event_id + ": Intended recipient " +
+            "Event " + event.getId() + ": Intended recipient " +
             payload.recipient + " does not match our id " + this._userId
         );
         throw new base.DecryptionError(
@@ -207,12 +205,12 @@ OlmDecryption.prototype.decryptEvent = function(event) {
     if (payload.recipient_keys === undefined) {
         // ditto
         console.warn(
-            "Olm event (id=" + event.event_id + ") contains no " +
+            "Olm event (id=" + event.getId() + ") contains no " +
             "'recipient_keys' property; cannot prevent unknown-key attack");
     } else if (payload.recipient_keys.ed25519 !=
                this._olmDevice.deviceEd25519Key) {
         console.warn(
-            "Event " + event.event_id + ": Intended recipient ed25519 key " +
+            "Event " + event.getId() + ": Intended recipient ed25519 key " +
             payload.recipient_keys.ed25519 + " did not match ours"
         );
         throw new base.DecryptionError("Message not intended for this device");
@@ -225,12 +223,12 @@ OlmDecryption.prototype.decryptEvent = function(event) {
     if (payload.sender === undefined) {
         // ditto
         console.warn(
-            "Olm event (id=" + event.event_id + ") contains no " +
+            "Olm event (id=" + event.getId() + ") contains no " +
             "'sender' property; cannot prevent unknown-key attack");
-    } else if (payload.sender != event.sender) {
+    } else if (payload.sender != event.getSender()) {
         console.warn(
-            "Event " + event.event_id + ": original sender " + payload.sender +
-            " does not match reported sender " + event.sender
+            "Event " + event.getId() + ": original sender " + payload.sender +
+            " does not match reported sender " + event.getSender()
         );
         throw new base.DecryptionError(
             "Message forwarded from " + payload.sender
@@ -238,9 +236,9 @@ OlmDecryption.prototype.decryptEvent = function(event) {
     }
 
     // Olm events intended for a room have a room_id.
-    if (payload.room_id !== event.room_id) {
+    if (payload.room_id !== event.getRoomId()) {
         console.warn(
-            "Event " + event.event_id + ": original room " + payload.room_id +
+            "Event " + event.getId() + ": original room " + payload.room_id +
             " does not match reported room " + event.room_id
         );
         throw new base.DecryptionError(
@@ -248,12 +246,7 @@ OlmDecryption.prototype.decryptEvent = function(event) {
         );
     }
 
-    return {
-        payload: payload,
-        sessionExists: true,
-        keysProved: {curve25519: deviceKey},
-        keysClaimed: payload.keys || {}
-    };
+    event.setClearData(payload, {curve25519: deviceKey}, payload.keys || {});
 };
 
 

--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -901,62 +901,16 @@ Crypto.prototype.encryptEventIfNeeded = function(event, room) {
 };
 
 /**
- * @typedef {Object} module:crypto.DecryptionResult
- *
- * @property {Object} payload decrypted payload (with properties 'type',
- *     'content').
- *
- * @property {Object<string, string>} keysClaimed keys that the sender of the
- *     event claims ownership of: map from key type to base64-encoded key
- *
- * @property {Object<string, string>} keysProved keys that the sender of the
- *     event is known to have ownership of: map from key type to base64-encoded
- *     key
- */
-
-/**
  * Decrypt a received event
  *
- * @param {object} event raw event
- *
- * @return {module:crypto.DecryptionResult} decryption result
+ * @param {MatrixEvent} event
  *
  * @raises {algorithms.DecryptionError} if there is a problem decrypting the event
  */
 Crypto.prototype.decryptEvent = function(event) {
-    var content = event.content;
-    var alg = this._getRoomDecryptor(event.room_id, content.algorithm);
-    var r = alg.decryptEvent(event);
-
-    if (r !== null) {
-        return r;
-    } else {
-        // We've got a message for a session we don't have.  Maybe the sender
-        // forgot to tell us about the session.  Remind the sender that we
-        // exist so that they might tell us about the session on their next
-        // send.
-        //
-        // (Alternatively, it might be that we are just looking at
-        // scrollback... at least we rate-limit the m.new_device events :/)
-        //
-        // XXX: this is a band-aid which masks symptoms of other bugs. It would
-        // be nice to get rid of it.
-        if (event.room_id !== undefined && event.sender !== undefined) {
-            var device_id = event.content.device_id;
-            if (device_id === undefined) {
-                // if the sending device didn't tell us its device_id, fall
-                // back to all devices.
-                device_id = null;
-            }
-            console.log(
-                "Unknown session decrypting event id " + event.event_id +
-                    ": sending m.new_device event"
-            );
-            this._sendPingToDevice(event.sender, device_id, event.room_id);
-        }
-
-        throw new algorithms.DecryptionError("Unknown inbound session id");
-    }
+    var content = event.getWireContent();
+    var alg = this._getRoomDecryptor(event.getRoomId(), content.algorithm);
+    alg.decryptEvent(event);
 };
 
 /**

--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -57,7 +57,10 @@ function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId) {
     this._olmDevice = new OlmDevice(sessionStore);
 
     // EncryptionAlgorithm instance for each room
-    this._roomAlgorithms = {};
+    this._roomEncryptors = {};
+
+    // map from algorithm to DecryptionAlgorithm instance, for each room
+    this._roomDecryptors = {};
 
     this._supportedAlgorithms = utils.keys(
         algorithms.DECRYPTION_CLASSES
@@ -705,7 +708,7 @@ Crypto.prototype.setRoomEncryption = function(roomId, config) {
         roomId: roomId,
         config: config,
     });
-    this._roomAlgorithms[roomId] = alg;
+    this._roomEncryptors[roomId] = alg;
 };
 
 
@@ -839,7 +842,7 @@ Crypto.prototype.ensureOlmSessionsForUsers = function(users) {
  * @return {bool} whether encryption is enabled.
  */
 Crypto.prototype.isRoomEncrypted = function(roomId) {
-    return Boolean(this._roomAlgorithms[roomId]);
+    return Boolean(this._roomEncryptors[roomId]);
 };
 
 /**
@@ -867,7 +870,7 @@ Crypto.prototype.encryptEventIfNeeded = function(event, room) {
 
     var roomId = event.getRoomId();
 
-    var alg = this._roomAlgorithms[roomId];
+    var alg = this._roomEncryptors[roomId];
     if (!alg) {
         // not encrypting messages in this room
 
@@ -922,14 +925,7 @@ Crypto.prototype.encryptEventIfNeeded = function(event, room) {
  */
 Crypto.prototype.decryptEvent = function(event) {
     var content = event.content;
-    var AlgClass = algorithms.DECRYPTION_CLASSES[content.algorithm];
-    if (!AlgClass) {
-        throw new algorithms.DecryptionError("Unable to decrypt " + content.algorithm);
-    }
-    var alg = new AlgClass({
-        userId: this._userId,
-        olmDevice: this._olmDevice,
-    });
+    var alg = this._getRoomDecryptor(event.room_id, content.algorithm);
     var r = alg.decryptEvent(event);
 
     if (r !== null) {
@@ -1054,7 +1050,7 @@ Crypto.prototype._onInitialSyncCompleted = function(rooms) {
         var room = rooms[i];
 
         // check for rooms with encryption enabled
-        var alg = this._roomAlgorithms[room.roomId];
+        var alg = this._roomEncryptors[room.roomId];
         if (!alg) {
             continue;
         }
@@ -1108,16 +1104,13 @@ Crypto.prototype._onInitialSyncCompleted = function(rooms) {
  */
 Crypto.prototype._onRoomKeyEvent = function(event) {
     var content = event.getContent();
-    var AlgClass = algorithms.DECRYPTION_CLASSES[content.algorithm];
-    if (!AlgClass) {
-        throw new algorithms.DecryptionError(
-            "Unable to handle keys for " + content.algorithm
-        );
+
+    if (!content.room_id || !content.algorithm) {
+        console.error("key event is missing fields");
+        return;
     }
-    var alg = new AlgClass({
-        userId: this._userId,
-        olmDevice: this._olmDevice,
-    });
+
+    var alg = this._getRoomDecryptor(content.room_id, content.algorithm);
     alg.onRoomKeyEvent(event);
 };
 
@@ -1141,7 +1134,7 @@ Crypto.prototype._onRoomMembership = function(event, member, oldMembership) {
 
     var roomId = member.roomId;
 
-    var alg = this._roomAlgorithms[roomId];
+    var alg = this._roomEncryptors[roomId];
     if (!alg) {
         // not encrypting in this room
         return;
@@ -1177,7 +1170,7 @@ Crypto.prototype._onNewDeviceEvent = function(event) {
     ).then(function() {
         for (var i = 0; i < rooms.length; i++) {
             var roomId = rooms[i];
-            var alg = self._roomAlgorithms[roomId];
+            var alg = self._roomEncryptors[roomId];
             if (!alg) {
                 // not encrypting in this room
                 continue;
@@ -1191,6 +1184,58 @@ Crypto.prototype._onNewDeviceEvent = function(event) {
             e
         );
     }).done();
+};
+
+/**
+ * Get a decryptor for a given room and algorithm.
+ *
+ * If we already have a decryptor for the given room and algorithm, return
+ * it. Otherwise try to instantiate it.
+ *
+ * @private
+ *
+ * @param {string?} roomId   room id for decryptor. If undefined, a temporary
+ * decryptor is instantiated.
+ *
+ * @param {string} algorithm  crypto algorithm
+ *
+ * @return {module:crypto.algorithms.base.DecryptionAlgorithm}
+ *
+ * @raises {module:crypto.algorithms.DecryptionError} if the algorithm is
+ * unknown
+ */
+Crypto.prototype._getRoomDecryptor = function(roomId, algorithm) {
+    var decryptors;
+    var alg;
+
+    roomId = roomId || null;
+    if (roomId) {
+        decryptors = this._roomDecryptors[roomId];
+        if (!decryptors) {
+            this._roomDecryptors[roomId] = decryptors = {};
+        }
+
+        alg = decryptors[algorithm];
+        if (alg) {
+            return alg;
+        }
+    }
+
+    var AlgClass = algorithms.DECRYPTION_CLASSES[algorithm];
+    if (!AlgClass) {
+        throw new algorithms.DecryptionError("Unable to decrypt " + algorithm);
+    }
+    alg = new AlgClass({
+        userId: this._userId,
+        crypto: this,
+        olmDevice: this._olmDevice,
+        roomId: roomId,
+    });
+
+    if (decryptors) {
+        decryptors[algorithm] = alg;
+    }
+    return alg;
 };
 
 

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -51,15 +51,6 @@ module.exports.EventStatus = {
  *
  * @param {Object} event The raw event to be wrapped in this DAO
  *
- * @param {Object=} clearEvent For encrypted events, the plaintext payload for
- * the event (typically containing <tt>type</tt> and <tt>content</tt> fields).
- *
- * @param {Object=} keysProved Keys owned by the sender of this event.
- *    See {@link module:models/event.MatrixEvent#getKeysProved}.
- *
- * @param {Object=} keysClaimed Keys the sender of this event claims.
- *    See {@link module:models/event.MatrixEvent#getKeysClaimed}.
- *
  * @prop {Object} event The raw (possibly encrypted) event. <b>Do not access
  * this property</b> directly unless you absolutely have to. Prefer the getter
  * methods defined on this class. Using the getter methods shields your app
@@ -75,19 +66,18 @@ module.exports.EventStatus = {
  * Default: true. <strong>This property is experimental and may change.</strong>
  */
 module.exports.MatrixEvent = function MatrixEvent(
-    event, clearEvent, keysProved, keysClaimed
+    event
 ) {
     this.event = event || {};
     this.sender = null;
     this.target = null;
     this.status = null;
     this.forwardLooking = true;
-
-    this._clearEvent = clearEvent || {};
     this._pushActions = null;
 
-    this._keysProved = keysProved || {};
-    this._keysClaimed = keysClaimed || {};
+    this._clearEvent = {};
+    this._keysProved = {};
+    this._keysClaimed = {};
 };
 
 module.exports.MatrixEvent.prototype = {
@@ -240,11 +230,35 @@ module.exports.MatrixEvent.prototype = {
     },
 
     /**
+     * Update the cleartext data on this event.
+     *
+     * (This is used after decrypting an event; it should not be used by applications).
+     *
+     * @internal
+     *
+     * @fires module:models/event.MatrixEvent#"Event.decrypted"
+     *
+     * @param {Object} clearEvent The plaintext payload for the event
+     *     (typically containing <tt>type</tt> and <tt>content</tt> fields).
+     *
+     * @param {Object=} keysProved Keys owned by the sender of this event.
+     *    See {@link module:models/event.MatrixEvent#getKeysProved}.
+     *
+     * @param {Object=} keysClaimed Keys the sender of this event claims.
+     *    See {@link module:models/event.MatrixEvent#getKeysClaimed}.
+     */
+    setClearData: function(clearEvent, keysProved, keysClaimed) {
+        this._clearEvent = clearEvent;
+        this._keysProved = keysProved || {};
+        this._keysClaimed = keysClaimed || {};
+    },
+
+    /**
      * Check if the event is encrypted.
      * @return {boolean} True if this event is encrypted.
      */
     isEncrypted: function() {
-        return Boolean(this._clearEvent.type);
+        return this.event.type === "m.room.encrypted";
     },
 
     /**

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -21,6 +21,10 @@ limitations under the License.
  * @module models/event
  */
 
+var EventEmitter = require("events").EventEmitter;
+
+var utils = require('../utils.js');
+
 /**
  * Enum for event statuses.
  * @readonly
@@ -79,8 +83,10 @@ module.exports.MatrixEvent = function MatrixEvent(
     this._keysProved = {};
     this._keysClaimed = {};
 };
+utils.inherits(module.exports.MatrixEvent, EventEmitter);
 
-module.exports.MatrixEvent.prototype = {
+
+utils.extend(module.exports.MatrixEvent.prototype, {
 
     /**
      * Get the event_id for this event.
@@ -251,6 +257,7 @@ module.exports.MatrixEvent.prototype = {
         this._clearEvent = clearEvent;
         this._keysProved = keysProved || {};
         this._keysClaimed = keysClaimed || {};
+        this.emit("Event.decrypted", this);
     },
 
     /**
@@ -367,7 +374,7 @@ module.exports.MatrixEvent.prototype = {
      setPushActions: function(pushActions) {
         this._pushActions = pushActions;
      },
-};
+});
 
 
 /* http://matrix.org/docs/spec/r0.0.1/client_server.html#redactions says:
@@ -408,3 +415,15 @@ var _REDACT_KEEP_CONTENT_MAP = {
                            },
     'm.room.aliases': {'aliases': 1},
 };
+
+
+
+
+/**
+ * Fires when an event is decrypted
+ *
+ * @event module:models/event.MatrixEvent#"Event.decrypted"
+ *
+ * @param {module:models/event.MatrixEvent} event
+ *    The matrix event which has been decrypted
+ */


### PR DESCRIPTION
If we don't have the crypto keys available to decrypt an event when it first arrives, add it to a list, so that we can have another go at decrypting it. We raise an event when this happens so that applications can handle it appropriately.

Also remove the workaround that sends m.new_device messages when we get an unknown session; it's just a bandaid which is obscuring more meaningful problems.

You might find it more digestible to look at each commit separately.

(There will be a react-sdk PR to follow)