### PR TITLE
Fix bug in verifying megolm event senders

### DIFF
--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -501,7 +501,7 @@ MegolmDecryption.prototype.decryptEvent = function(event) {
         );
     }
 
-    event.setClearData(payload, res.keysClaimed, res.keysProved);
+    event.setClearData(payload, res.keysProved, res.keysClaimed);
 };
 
 


### PR DESCRIPTION
1a03e534bda introduced a bug which mixed up the keys_proved and the
keys_claimed. Switch them around again so that megolm messages are correctly
tied back to the sending device.