### PR TITLE
Allows to start client with initialSyncLimit = 0

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -60,7 +60,7 @@ function debuglog() {
 function SyncApi(client, opts) {
     this.client = client;
     opts = opts || {};
-    opts.initialSyncLimit = opts.initialSyncLimit || 8;
+    opts.initialSyncLimit = (opts.initialSyncLimit === undefined ? 8 : opts.initialSyncLimit);
     opts.resolveInvitesToProfiles = opts.resolveInvitesToProfiles || false;
     opts.pollTimeout = opts.pollTimeout || (30 * 1000);
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";


### PR DESCRIPTION
If no "old" timeline data is required when starting the client, it should be possible to set initialSyncLimit to 0 when calling startClient. See http://bit.ly/2f49Kbs for corresponding discussion.