### PR TITLE
E2E: Check devices to share keys with on each send

### DIFF
--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -38,12 +38,17 @@ var base = require("./base");
  * @property {Number} creationTime when the session was created (ms since the epoch)
  * @property {module:client.Promise?} sharePromise  If a share operation is in progress,
  *    a promise which resolves when it is complete.
+ *
+ * @property {object} sharedWithDevices
+ *    devices with which we have shared the session key
+ *        userId -> {deviceId -> msgindex}
  */
 function OutboundSessionInfo(sessionId) {
     this.sessionId = sessionId;
     this.useCount = 0;
     this.creationTime = new Date().getTime();
     this.sharePromise = null;
+    this.sharedWithDevices = {};
 }
 
 
@@ -90,11 +95,6 @@ function MegolmEncryption(params) {
     // case _outboundSession.sharePromise will be non-null.)
     this._outboundSession = null;
 
-    // devices which have joined since we last sent a message.
-    // userId -> {deviceId -> true}, or
-    // userId -> true
-    this._devicesPendingKeyShare = {};
-
     // default rotation periods
     this._sessionRotationPeriodMsgs = 100;
     this._sessionRotationPeriodMs = 7 * 24 * 3600 * 1000;
@@ -134,32 +134,55 @@ MegolmEncryption.prototype._ensureOutboundSession = function(room) {
         return session.sharePromise;
     }
 
-    // no share in progress: check for new devices
-    var shareMap = this._devicesPendingKeyShare;
-    this._devicesPendingKeyShare = {};
+    // no share in progress: check if we need to share with any devices
+    var prom = this._getDevicesInRoom(room).then(function(devicesInRoom) {
+        var shareMap = {};
 
-    // check each user is (still) a member of the room
-    for (var userId in shareMap) {
-        if (!shareMap.hasOwnProperty(userId)) {
-            continue;
+        for (var userId in devicesInRoom) {
+            if (!devicesInRoom.hasOwnProperty(userId)) {
+                continue;
+            }
+
+            var userDevices = devicesInRoom[userId];
+
+            for (var deviceId in userDevices) {
+                if (!userDevices.hasOwnProperty(deviceId)) {
+                    continue;
+                }
+
+                var deviceInfo = userDevices[deviceId];
+
+                if (deviceInfo.isBlocked()) {
+                    continue;
+                }
+
+                var key = deviceInfo.getIdentityKey();
+                if (key == self._olmDevice.deviceCurve25519Key) {
+                    // don't bother sending to ourself
+                    continue;
+                }
+
+                if (
+                    !session.sharedWithDevices[userId] ||
+                        session.sharedWithDevices[userId][deviceId] === undefined
+                ) {
+                    shareMap[userId] = shareMap[userId] || [];
+                    shareMap[userId].push(deviceInfo);
+                }
+            }
         }
 
-        // XXX what about rooms where invitees can see the content?
-        var member = room.getMember(userId);
-        if (member.membership !== "join") {
-            delete shareMap[userId];
-        }
-    }
-
-    session.sharePromise = this._shareKeyWithDevices(
-        session.sessionId, shareMap
-    ).finally(function() {
+        return self._shareKeyWithDevices(
+            session, shareMap
+        );
+    }).finally(function() {
         session.sharePromise = null;
     }).then(function() {
         return session;
     });
 
-    return session.sharePromise;
+    session.sharePromise = prom;
+    return prom;
 };
 
 /**
@@ -178,95 +201,53 @@ MegolmEncryption.prototype._prepareNewSession = function(room) {
         key.key, {ed25519: this._olmDevice.deviceEd25519Key}
     );
 
-    // we're going to share the key with all current members of the room,
-    // so we can reset this.
-    this._devicesPendingKeyShare = {};
-
-    var session = new OutboundSessionInfo(session_id);
-
-    var roomMembers = utils.map(room.getJoinedMembers(), function(u) {
-        return u.userId;
-    });
-
-    var shareMap = {};
-    for (var i = 0; i < roomMembers.length; i++) {
-        var userId = roomMembers[i];
-        shareMap[userId] = true;
-    }
-
-    var self = this;
-
-    // TODO: we need to give the user a chance to block any devices or users
-    // before we send them the keys; it's too late to download them here.
-    session.sharePromise = this._crypto.downloadKeys(
-        roomMembers, false
-    ).then(function(res) {
-        return self._shareKeyWithDevices(session_id, shareMap);
-    }).then(function() {
-        return session;
-    }).finally(function() {
-        session.sharePromise = null;
-    });
-
-    return session;
+    return new OutboundSessionInfo(session_id);
 };
 
 /**
  * @private
  *
- * @param {string} session_id
+ * @param {module:crypto/algorithms/megolm.OutboundSessionInfo} session
  *
- * @param {Object<string, Object<string, boolean>|boolean>} shareMap
- *    Map from userid to either: true (meaning this is a new user in the room,
- *    so all of his devices need the keys); or a map from deviceid to true
- *    (meaning this user has one or more new devices, which need the keys).
+ * @param {object<string, module:crypto/deviceinfo[]>} devicesByUser
+ *    map from userid to list of devices
  *
  * @return {module:client.Promise} Promise which resolves once the key sharing
  *     message has been sent.
  */
-MegolmEncryption.prototype._shareKeyWithDevices = function(session_id, shareMap) {
+MegolmEncryption.prototype._shareKeyWithDevices = function(session, devicesByUser) {
     var self = this;
 
-    var key = this._olmDevice.getOutboundGroupSessionKey(session_id);
+    var key = this._olmDevice.getOutboundGroupSessionKey(session.sessionId);
     var payload = {
         type: "m.room_key",
         content: {
             algorithm: olmlib.MEGOLM_ALGORITHM,
             room_id: this._roomId,
-            session_id: session_id,
+            session_id: session.sessionId,
             session_key: key.key,
             chain_index: key.chain_index,
         }
     };
 
-    // we downloaded the user's device list when they joined the room, or when
-    // the new device announced itself, so there is no need to do so now.
+    var contentMap = {};
 
-    return self._crypto.ensureOlmSessionsForUsers(
-        utils.keys(shareMap)
+    return olmlib.ensureOlmSessionsForDevices(
+        this._olmDevice, this._baseApis, devicesByUser
     ).then(function(devicemap) {
-        var contentMap = {};
         var haveTargets = false;
 
-        for (var userId in devicemap) {
-            if (!devicemap.hasOwnProperty(userId)) {
+        for (var userId in devicesByUser) {
+            if (!devicesByUser.hasOwnProperty(userId)) {
                 continue;
             }
 
-            var devicesToShareWith = shareMap[userId];
+            var devicesToShareWith = devicesByUser[userId];
             var sessionResults = devicemap[userId];
 
-            for (var deviceId in sessionResults) {
-                if (!sessionResults.hasOwnProperty(deviceId)) {
-                    continue;
-                }
-
-                if (devicesToShareWith === true) {
-                    // all devices
-                } else if (!devicesToShareWith[deviceId]) {
-                    // not a new device
-                    continue;
-                }
+            for (var i = 0; i < devicesToShareWith.length; i++) {
+                var deviceInfo = devicesToShareWith[i];
+                var deviceId = deviceInfo.deviceId;
 
                 var sessionResult = sessionResults[deviceId];
                 if (!sessionResult.sessionId) {
@@ -287,8 +268,6 @@ MegolmEncryption.prototype._shareKeyWithDevices = function(session_id, shareMap)
                 console.log(
                     "sharing keys with device " + userId + ":" + deviceId
                 );
-
-                var deviceInfo = sessionResult.device;
 
                 var encryptedContent = {
                     algorithm: olmlib.OLM_ALGORITHM,
@@ -321,6 +300,27 @@ MegolmEncryption.prototype._shareKeyWithDevices = function(session_id, shareMap)
 
         // TODO: retries
         return self._baseApis.sendToDevice("m.room.encrypted", contentMap);
+    }).then(function() {
+        // Add the devices we have shared with to session.sharedWithDevices.
+        //
+        // we deliberately iterate over devicesByUser (ie, the devices we
+        // attempted to share with) rather than the contentMap (those we did
+        // share with), because we don't want to try to claim a one-time-key
+        // for dead devices on every message.
+        for (var userId in devicesByUser) {
+            if (!devicesByUser.hasOwnProperty(userId)) {
+                continue;
+            }
+            if (!session.sharedWithDevices[userId]) {
+                session.sharedWithDevices[userId] = {};
+            }
+            var devicesToShareWith = devicesByUser[userId];
+            for (var i = 0; i < devicesToShareWith.length; i++) {
+                var deviceInfo = devicesToShareWith[i];
+                session.sharedWithDevices[userId][deviceInfo.deviceId] =
+                    key.chain_index;
+            }
+        }
     });
 };
 
@@ -369,20 +369,9 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
  * @param {string=} oldMembership  previous membership
  */
 MegolmEncryption.prototype.onRoomMembership = function(event, member, oldMembership) {
-    // if we haven't yet made a session, there's nothing to do here.
-    if (!this._outboundSession) {
-        return;
-    }
-
     var newMembership = member.membership;
 
-    if (newMembership === 'join') {
-        this._onNewRoomMember(member.userId);
-        return;
-    }
-
-    if (newMembership === 'invite' && oldMembership !== 'join') {
-        // we don't (yet) share keys with invited members, so nothing to do yet
+    if (newMembership === 'join' || newMembership === 'invite') {
         return;
     }
 
@@ -396,43 +385,25 @@ MegolmEncryption.prototype.onRoomMembership = function(event, member, oldMembers
 };
 
 /**
- * handle a new user joining a room
+ * Get the list of devices for all users in the room
  *
- * @param {string} userId   new member
- */
-MegolmEncryption.prototype._onNewRoomMember = function(userId) {
-    // make sure we have a list of this user's devices. We are happy to use a
-    // cached version here: we assume that if we already have a list of the
-    // user's devices, then we already share an e2e room with them, which means
-    // that they will have announced any new devices via an m.new_device.
-    this._crypto.downloadKeys([userId], false).done();
-
-    // also flag this user up for needing a keyshare.
-    this._devicesPendingKeyShare[userId] = true;
-};
-
-
-/**
- * @inheritdoc
+ * @param {module:models/room} room
  *
- * @param {string} userId    owner of the device
- * @param {string} deviceId  deviceId of the device
+ * @return {module:client.Promise} Promise which resolves to a map
+ *     from userId to deviceId to deviceInfo
  */
-MegolmEncryption.prototype.onNewDevice = function(userId, deviceId) {
-    var d = this._devicesPendingKeyShare[userId];
+MegolmEncryption.prototype._getDevicesInRoom = function(room) {
+    // XXX what about rooms where invitees can see the content?
+    var roomMembers = utils.map(room.getJoinedMembers(), function(u) {
+        return u.userId;
+    });
 
-    if (d === true) {
-        // we already want to share keys with all devices for this user
-        return;
-    }
-
-    if (!d) {
-        this._devicesPendingKeyShare[userId] = d = {};
-    }
-
-    d[deviceId] = true;
+    // We are happy to use a cached version here: we assume that if we already
+    // have a list of the user's devices, then we already share an e2e room
+    // with them, which means that they will have announced any new devices via
+    // an m.new_device.
+    return this._crypto.downloadKeys(roomMembers, false);
 };
-
 
 /**
  * Megolm decryption implementation

--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -407,7 +407,7 @@ function _storeDeviceKeys(_olmDevice, userStore, deviceResult) {
     var unsigned = deviceResult.unsigned || {};
 
     try {
-        _verifySignature(_olmDevice, deviceResult, userId, deviceId, signKey);
+        olmlib.verifySignature(_olmDevice, deviceResult, userId, deviceId, signKey);
     } catch (e) {
         console.log("Unable to verify signature on device " +
                     userId + ":" + deviceId + ":", e);
@@ -726,7 +726,8 @@ Crypto.prototype.setRoomEncryption = function(roomId, config) {
  */
 
 /**
- * Try to make sure we have established olm sessions for the given users.
+ * Try to make sure we have established olm sessions for all known devices for
+ * the given users.
  *
  * @param {string[]} users list of user ids
  *
@@ -735,19 +736,15 @@ Crypto.prototype.setRoomEncryption = function(roomId, config) {
  *    {@link module:crypto~OlmSessionResult}
  */
 Crypto.prototype.ensureOlmSessionsForUsers = function(users) {
-    var devicesWithoutSession = [
-        // [userId, deviceId, deviceInfo], ...
-    ];
-    var result = {};
+    var devicesByUser = {};
 
     for (var i = 0; i < users.length; ++i) {
         var userId = users[i];
-        result[userId] = {};
+        devicesByUser[userId] = [];
 
         var devices = this.getStoredDevicesForUser(userId) || [];
         for (var j = 0; j < devices.length; ++j) {
             var deviceInfo = devices[j];
-            var deviceId = deviceInfo.deviceId;
 
             var key = deviceInfo.getIdentityKey();
             if (key == this._olmDevice.deviceCurve25519Key) {
@@ -759,87 +756,13 @@ Crypto.prototype.ensureOlmSessionsForUsers = function(users) {
                 continue;
             }
 
-            var sessionId = this._olmDevice.getSessionIdForDevice(key);
-            if (sessionId === null) {
-                devicesWithoutSession.push([userId, deviceId, deviceInfo]);
-            }
-            result[userId][deviceId] = {
-                device: deviceInfo,
-                sessionId: sessionId,
-            };
+            devicesByUser[userId].push(deviceInfo);
         }
     }
 
-    if (devicesWithoutSession.length === 0) {
-        return q(result);
-    }
-
-    // TODO: this has a race condition - if we try to send another message
-    // while we are claiming a key, we will end up claiming two and setting up
-    // two sessions.
-    //
-    // That should eventually resolve itself, but it's poor form.
-
-    var self = this;
-    var oneTimeKeyAlgorithm = "signed_curve25519";
-    return this._baseApis.claimOneTimeKeys(
-        devicesWithoutSession, oneTimeKeyAlgorithm
-    ).then(function(res) {
-        for (var i = 0; i < devicesWithoutSession.length; ++i) {
-            var device = devicesWithoutSession[i];
-            var userId = device[0];
-            var deviceId = device[1];
-            var deviceInfo = device[2];
-
-            var userRes = res.one_time_keys[userId] || {};
-            var deviceRes = userRes[deviceId];
-            var oneTimeKey = null;
-            for (var keyId in deviceRes) {
-                if (keyId.indexOf(oneTimeKeyAlgorithm + ":") === 0) {
-                    oneTimeKey = deviceRes[keyId];
-                }
-            }
-
-            if (!oneTimeKey) {
-                console.warn(
-                    "No one-time keys (alg=" + oneTimeKeyAlgorithm +
-                        ") for device " + userId + ":" + deviceId
-                );
-                continue;
-            }
-
-            try {
-                _verifySignature(
-                    self._olmDevice, oneTimeKey, userId, deviceId,
-                    deviceInfo.getFingerprint()
-                );
-            } catch (e) {
-                console.log(
-                    "Unable to verify signature on one-time key for device " +
-                        userId + ":" + deviceId + ":", e
-                );
-                continue;
-            }
-
-            var sid;
-            try {
-                sid = self._olmDevice.createOutboundSession(
-                    deviceInfo.getIdentityKey(), oneTimeKey.key
-                );
-            } catch (e) {
-                // possibly a bad key
-                console.error("Error starting session with device " +
-                              userId + ":" + deviceId + ": " + e);
-                continue;
-            }
-
-            console.log("Started new sessionid " + sid +
-                        " for device " + userId + ":" + deviceId);
-
-            result[userId][deviceId].sessionId = sid;
-        }
-        return result;
-    });
+    return olmlib.ensureOlmSessionsForDevices(
+        this._olmDevice, this._baseApis, devicesByUser
+    );
 };
 
 /**
@@ -1211,40 +1134,6 @@ Crypto.prototype._signObject = function(obj) {
         this._olmDevice.sign(anotherjson.stringify(obj));
     obj.signatures = sigs;
 };
-
-/**
- * Verify the signature on an object
- *
- * @param {module:crypto/OlmDevice} olmDevice olm wrapper to use for verify op
- *
- * @param {Object} obj object to check signature on. Note that this will be
- * stripped of its 'signatures' and 'unsigned' properties.
- *
- * @param {string} signingUserId  ID of the user whose signature should be checked
- *
- * @param {string} signingDeviceId  ID of the device whose signature should be checked
- *
- * @param {string} signingKey   base64-ed ed25519 public key
- */
-function _verifySignature(olmDevice, obj, signingUserId, signingDeviceId, signingKey) {
-    var signKeyId = "ed25519:" + signingDeviceId;
-    var signatures = obj.signatures || {};
-    var userSigs = signatures[signingUserId] || {};
-    var signature = userSigs[signKeyId];
-    if (!signature) {
-        throw Error("No signature");
-    }
-
-    // prepare the canonical json: remove unsigned and signatures, and stringify with
-    // anotherjson
-    delete obj.unsigned;
-    delete obj.signatures;
-    var json = anotherjson.stringify(obj);
-
-    olmDevice.verifySignature(
-        signingKey, json, signature
-    );
-}
 
 /**
  * @see module:crypto/algorithms/base.DecryptionError

--- a/lib/crypto/olmlib.js
+++ b/lib/crypto/olmlib.js
@@ -20,6 +20,9 @@ limitations under the License.
  * Utilities common to olm encryption algorithms
  */
 
+var q = require('q');
+var anotherjson = require('another-json');
+
 var utils = require("../utils");
 
 /**
@@ -98,5 +101,168 @@ module.exports.encryptMessageForDevice = function(
 
     resultsObject[deviceKey] = olmDevice.encryptMessage(
         deviceKey, sessionId, JSON.stringify(payload)
+    );
+};
+
+/**
+ * Try to make sure we have established olm sessions for the given devices.
+ *
+ * @param {module:crypto/OlmDevice} olmDevice
+ *
+ * @param {module:base-apis~MatrixBaseApis} baseApis
+ *
+ * @param {object<string, module:crypto/deviceinfo[]>} devicesByUser
+ *    map from userid to list of devices
+ *
+ * @return {module:client.Promise} resolves once the sessions are complete, to
+ *    an Object mapping from userId to deviceId to
+ *    {@link module:crypto~OlmSessionResult}
+ */
+module.exports.ensureOlmSessionsForDevices = function(
+    olmDevice, baseApis, devicesByUser
+) {
+    var devicesWithoutSession = [
+        // [userId, deviceId], ...
+    ];
+    var result = {};
+
+    for (var userId in devicesByUser) {
+        if (!devicesByUser.hasOwnProperty(userId)) { continue; }
+        result[userId] = {};
+        var devices = devicesByUser[userId];
+        for (var j = 0; j < devices.length; j++) {
+            var deviceInfo = devices[j];
+            var deviceId = deviceInfo.deviceId;
+            var key = deviceInfo.getIdentityKey();
+            var sessionId = olmDevice.getSessionIdForDevice(key);
+            if (sessionId === null) {
+                devicesWithoutSession.push([userId, deviceId]);
+            }
+            result[userId][deviceId] = {
+                device: deviceInfo,
+                sessionId: sessionId,
+            };
+        }
+    }
+
+    if (devicesWithoutSession.length === 0) {
+        return q(result);
+    }
+
+    // TODO: this has a race condition - if we try to send another message
+    // while we are claiming a key, we will end up claiming two and setting up
+    // two sessions.
+    //
+    // That should eventually resolve itself, but it's poor form.
+
+    var oneTimeKeyAlgorithm = "signed_curve25519";
+    return baseApis.claimOneTimeKeys(
+        devicesWithoutSession, oneTimeKeyAlgorithm
+    ).then(function(res) {
+        for (var userId in devicesByUser) {
+            if (!devicesByUser.hasOwnProperty(userId)) { continue; }
+            var userRes = res.one_time_keys[userId] || {};
+            var devices = devicesByUser[userId];
+            for (var j = 0; j < devices.length; j++) {
+                var deviceInfo = devices[j];
+                var deviceId = deviceInfo.deviceId;
+                if (result[userId][deviceId].sessionId) {
+                    // we already have a result for this device
+                    continue;
+                }
+
+                var deviceRes = userRes[deviceId] || {};
+                var oneTimeKey = null;
+                for (var keyId in deviceRes) {
+                    if (keyId.indexOf(oneTimeKeyAlgorithm + ":") === 0) {
+                        oneTimeKey = deviceRes[keyId];
+                    }
+                }
+
+                if (!oneTimeKey) {
+                    console.warn(
+                        "No one-time keys (alg=" + oneTimeKeyAlgorithm +
+                            ") for device " + userId + ":" + deviceId
+                    );
+                    continue;
+                }
+
+                var sid = _verifyKeyAndStartSession(
+                    olmDevice, oneTimeKey, userId, deviceInfo
+                );
+                result[userId][deviceId].sessionId = sid;
+            }
+        }
+        return result;
+    });
+};
+
+
+function _verifyKeyAndStartSession(olmDevice, oneTimeKey, userId, deviceInfo) {
+    var deviceId = deviceInfo.deviceId;
+    try {
+        _verifySignature(
+            olmDevice, oneTimeKey, userId, deviceId,
+            deviceInfo.getFingerprint()
+        );
+    } catch (e) {
+        console.error(
+            "Unable to verify signature on one-time key for device " +
+                userId + ":" + deviceId + ":", e
+        );
+        return null;
+    }
+
+    var sid;
+    try {
+        sid = olmDevice.createOutboundSession(
+            deviceInfo.getIdentityKey(), oneTimeKey.key
+        );
+    } catch (e) {
+        // possibly a bad key
+        console.error("Error starting session with device " +
+                      userId + ":" + deviceId + ": " + e);
+        return null;
+    }
+
+    console.log("Started new sessionid " + sid +
+                " for device " + userId + ":" + deviceId);
+    return sid;
+}
+
+
+/**
+ * Verify the signature on an object
+ *
+ * @param {module:crypto/OlmDevice} olmDevice olm wrapper to use for verify op
+ *
+ * @param {Object} obj object to check signature on. Note that this will be
+ * stripped of its 'signatures' and 'unsigned' properties.
+ *
+ * @param {string} signingUserId  ID of the user whose signature should be checked
+ *
+ * @param {string} signingDeviceId  ID of the device whose signature should be checked
+ *
+ * @param {string} signingKey   base64-ed ed25519 public key
+ */
+var _verifySignature = module.exports.verifySignature = function(
+    olmDevice, obj, signingUserId, signingDeviceId, signingKey
+) {
+    var signKeyId = "ed25519:" + signingDeviceId;
+    var signatures = obj.signatures || {};
+    var userSigs = signatures[signingUserId] || {};
+    var signature = userSigs[signKeyId];
+    if (!signature) {
+        throw Error("No signature");
+    }
+
+    // prepare the canonical json: remove unsigned and signatures, and stringify with
+    // anotherjson
+    delete obj.unsigned;
+    delete obj.signatures;
+    var json = anotherjson.stringify(obj);
+
+    olmDevice.verifySignature(
+        signingKey, json, signature
     );
 };


### PR DESCRIPTION
Instead of trying to maintain a list of devices we need to share with, just check all the devices for all the users on each send.

This should fix https://github.com/vector-im/vector-web/issues/2568, and generally mean we're less likely to get out of sync.