### PR TITLE
Avoid NPE when no sessionStore is given

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -149,7 +149,7 @@ function MatrixClient(opts) {
     this._notifTimelineSet = null;
 
     this._crypto = null;
-    if (CRYPTO_ENABLED && opts.sessionStore !== null &&
+    if (CRYPTO_ENABLED && Boolean(opts.sessionStore) &&
             userId !== null && this.deviceId !== null) {
         this._crypto = new Crypto(
             this, this,


### PR DESCRIPTION
Fix the check on opts.sessionStore to check for undefined as well; fixes
"TypeError: Cannot read property 'getEndToEndAccount' of undefined"