### PR TITLE
Start a new megolm session when devices are blacklisted

### DIFF
--- a/lib/crypto/algorithms/megolm.js
+++ b/lib/crypto/algorithms/megolm.js
@@ -36,8 +36,6 @@ var base = require("./base");
  * @property {string} sessionId
  * @property {Number} useCount     number of times this session has been used
  * @property {Number} creationTime when the session was created (ms since the epoch)
- * @property {module:client.Promise?} sharePromise  If a share operation is in progress,
- *    a promise which resolves when it is complete.
  *
  * @property {object} sharedWithDevices
  *    devices with which we have shared the session key
@@ -47,7 +45,6 @@ function OutboundSessionInfo(sessionId) {
     this.sessionId = sessionId;
     this.useCount = 0;
     this.creationTime = new Date().getTime();
-    this.sharePromise = null;
     this.sharedWithDevices = {};
 }
 
@@ -79,6 +76,45 @@ OutboundSessionInfo.prototype.needsRotation = function(
 
 
 /**
+ * Determine if this session has been shared with devices which it shouldn't
+ * have been.
+ *
+ * @param {Object} devicesInRoom userId -> {deviceId -> object}
+ *   devices we should shared the session with.
+ *
+ * @return {Boolean} true if we have shared the session with devices which aren't
+ * in devicesInRoom.
+ */
+OutboundSessionInfo.prototype.sharedWithTooManyDevices = function(
+    devicesInRoom
+) {
+
+    for (var userId in this.sharedWithDevices) {
+        if (!this.sharedWithDevices.hasOwnProperty(userId)) { continue; }
+
+        if (!devicesInRoom.hasOwnProperty(userId)) {
+            console.log("Starting new session because we shared with " + userId);
+            return true;
+        }
+
+        for (var deviceId in this.sharedWithDevices[userId]) {
+            if (!this.sharedWithDevices[userId].hasOwnProperty(deviceId)) {
+                continue;
+            }
+
+            if (!devicesInRoom[userId].hasOwnProperty(deviceId)) {
+                console.log(
+                    "Starting new session because we shared with " +
+                        userId + ":" + deviceId
+                );
+                return true;
+            }
+        }
+    }
+};
+
+
+/**
  * Megolm encryption implementation
  *
  * @constructor
@@ -90,10 +126,12 @@ OutboundSessionInfo.prototype.needsRotation = function(
 function MegolmEncryption(params) {
     base.EncryptionAlgorithm.call(this, params);
 
-    // OutboundSessionInfo. Null if we haven't yet started setting one up. Note
-    // that even if this is non-null, it may not be ready for use (in which
-    // case _outboundSession.sharePromise will be non-null.)
-    this._outboundSession = null;
+    // the most recent attempt to set up a session. This is used to serialise
+    // the session setups, so that we have a race-free view of which session we
+    // are using, and which devices we have shared the keys with. It resolves
+    // with an OutboundSessionInfo (or undefined, for the first message in the
+    // room).
+    this._setupPromise = q();
 
     // default rotation periods
     this._sessionRotationPeriodMsgs = 100;
@@ -117,25 +155,37 @@ utils.inherits(MegolmEncryption, base.EncryptionAlgorithm);
  * @return {module:client.Promise} Promise which resolves to the
  *    OutboundSessionInfo when setup is complete.
  */
-MegolmEncryption.prototype._ensureOutboundSession = function(room) {
+MegolmEncryption.prototype._ensureOutboundSession = function(devicesInRoom) {
     var self = this;
 
-    var session = this._outboundSession;
+    var session;
 
-    // need to make a brand new session?
-    if (!session || session.needsRotation(self._sessionRotationPeriodMsgs,
-                                          self._sessionRotationPeriodMs)
-       ) {
-        this._outboundSession = session = this._prepareNewSession(room);
-    }
+    // takes the previous OutboundSessionInfo, and considers whether to create
+    // a new one. Also shares the key with any (new) devices in the room.
+    // Updates `session` to hold the final OutboundSessionInfo.
+    //
+    // returns a promise which resolves once the keyshare is successful.
+    function prepareSession(oldSession) {
+        session = oldSession;
 
-    if (session.sharePromise) {
-        // key share already in progress
-        return session.sharePromise;
-    }
+        // need to make a brand new session?
+        if (session && session.needsRotation(self._sessionRotationPeriodMsgs,
+                                             self._sessionRotationPeriodMs)
+           ) {
+            console.log("Starting new megolm session because we need to rotate.");
+            session = null;
+        }
 
-    // no share in progress: check if we need to share with any devices
-    var prom = this._getDevicesInRoom(room).then(function(devicesInRoom) {
+        // determine if we have shared with anyone we shouldn't have
+        if (session && session.sharedWithTooManyDevices(devicesInRoom)) {
+            session = null;
+        }
+
+        if (!session) {
+            session = self._prepareNewSession();
+        }
+
+        // now check if we need to share with any devices
         var shareMap = {};
 
         for (var userId in devicesInRoom) {
@@ -151,10 +201,6 @@ MegolmEncryption.prototype._ensureOutboundSession = function(room) {
                 }
 
                 var deviceInfo = userDevices[deviceId];
-
-                if (deviceInfo.isBlocked()) {
-                    continue;
-                }
 
                 var key = deviceInfo.getIdentityKey();
                 if (key == self._olmDevice.deviceCurve25519Key) {
@@ -175,24 +221,27 @@ MegolmEncryption.prototype._ensureOutboundSession = function(room) {
         return self._shareKeyWithDevices(
             session, shareMap
         );
-    }).finally(function() {
-        session.sharePromise = null;
-    }).then(function() {
-        return session;
-    });
+    }
 
-    session.sharePromise = prom;
-    return prom;
+    // helper which returns the session prepared by prepareSession
+    function returnSession() { return session; }
+
+    // first wait for the previous share to complete
+    var prom = this._setupPromise.then(prepareSession);
+
+    // _setupPromise resolves to `session` whether or not the share succeeds
+    this._setupPromise = prom.then(returnSession, returnSession);
+
+    // but we return a promise which only resolves if the share was successful.
+    return prom.then(returnSession);
 };
 
 /**
  * @private
  *
- * @param {module:models/room} room
- *
  * @return {module:crypto/algorithms/megolm.OutboundSessionInfo} session
  */
-MegolmEncryption.prototype._prepareNewSession = function(room) {
+MegolmEncryption.prototype._prepareNewSession = function() {
     var session_id = this._olmDevice.createOutboundGroupSession();
     var key = this._olmDevice.getOutboundGroupSessionKey(session_id);
 
@@ -335,7 +384,9 @@ MegolmEncryption.prototype._shareKeyWithDevices = function(session, devicesByUse
  */
 MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
     var self = this;
-    return this._ensureOutboundSession(room).then(function(session) {
+    return this._getDevicesInRoom(room).then(function(devicesInRoom) {
+        return self._ensureOutboundSession(devicesInRoom);
+    }).then(function(session) {
         var payloadJson = {
             room_id: self._roomId,
             type: eventType,
@@ -362,30 +413,7 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
 };
 
 /**
- * @inheritdoc
- *
- * @param {module:models/event.MatrixEvent} event  event causing the change
- * @param {module:models/room-member} member  user whose membership changed
- * @param {string=} oldMembership  previous membership
- */
-MegolmEncryption.prototype.onRoomMembership = function(event, member, oldMembership) {
-    var newMembership = member.membership;
-
-    if (newMembership === 'join' || newMembership === 'invite') {
-        return;
-    }
-
-    // otherwise we assume the user is leaving, and start a new outbound session.
-    console.log("Discarding outbound megolm session due to change in " +
-                "membership of " + member.userId + " (" + oldMembership +
-                "->" + newMembership + ")");
-
-    // this ensures that we will start a new session on the next message.
-    this._outboundSession = null;
-};
-
-/**
- * Get the list of devices for all users in the room
+ * Get the list of unblocked devices for all users in the room
  *
  * @param {module:models/room} room
  *
@@ -402,7 +430,26 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
     // have a list of the user's devices, then we already share an e2e room
     // with them, which means that they will have announced any new devices via
     // an m.new_device.
-    return this._crypto.downloadKeys(roomMembers, false);
+    return this._crypto.downloadKeys(roomMembers, false).then(function(devices) {
+        // remove any blocked devices
+        for (var userId in devices) {
+            if (!devices.hasOwnProperty(userId)) {
+                continue;
+            }
+
+            var userDevices = devices[userId];
+            for (var deviceId in userDevices) {
+                if (!userDevices.hasOwnProperty(deviceId)) {
+                    continue;
+                }
+                if (userDevices[deviceId].isBlocked()) {
+                    delete userDevices[deviceId];
+                }
+            }
+        }
+
+        return devices;
+    });
 };
 
 /**


### PR DESCRIPTION
If we have shared the session with a device which is subsequently blacklisted,
we need to start a new session for the next message.

Rather than doing this proactively (which would be subject to false-positives
and require slightly awkward tracking of who we had shared the session with),
we check the list of who we have shared the session with on each send, and
start a new session if any of them are blocked.

Fixes https://github.com/vector-im/riot-web/issues/2146.