### PR TITLE
Add setRoomDirectoryVisibilityAppService

### DIFF
--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -570,6 +570,30 @@ MatrixBaseApis.prototype.setRoomDirectoryVisibility =
     );
 };
 
+/**
+ * Set the visbility of a room bridged to a 3rd party network in
+ * the current HS's room directory.
+ * @param {string} networkId the network ID of the 3rd party
+ *                 instance under which this room is published under.
+ * @param {string} roomId
+ * @param {string} visibility "public" to make the room visible
+ *                 in the public directory, or "private" to make
+ *                 it invisible.
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: result object
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.setRoomDirectoryVisibilityAppService =
+                                function(networkId, roomId, visibility, callback) {
+    var path = utils.encodeUri("/directory/list/appservice/$networkId/$roomId", {
+        $networkId: networkId,
+        $roomId: roomId
+    });
+    return this._http.authedRequest(
+        callback, "PUT", path, undefined, { "visibility": visibility }
+    );
+};
+
 
 // Media operations
 // ================


### PR DESCRIPTION
Add a function for setting the publicity of a room that is bridged to a 3rd party network. This change reflects the second bullet point of matrix-org/synapse#1676