### PR TITLE
Add `getDate` function to MatrixEvent

### DIFF
--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -78,6 +78,7 @@ module.exports.MatrixEvent = function MatrixEvent(
     this.status = null;
     this.forwardLooking = true;
     this._pushActions = null;
+    this._date = this.event.origin_server_ts ? new Date(this.event.origin_server_ts) : null;
 
     this._clearEvent = {};
     this._keysProved = {};
@@ -140,6 +141,15 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      */
     getTs: function() {
         return this.event.origin_server_ts;
+    },
+
+    /**
+     * Get a Date instance created in the constructor with the event timestamp
+     * as input.
+     * @return {Date} The event date, e.g. <code>new Date(1433502692297)</code>
+     */
+    getDate: function() {
+        return this._date;
     },
 
     /**

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -145,8 +145,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
     },
 
     /**
-     * Get a Date instance created in the constructor with the event timestamp
-     * as input.
+     * Get the timestamp of this event, as a Date object.
      * @return {Date} The event date, e.g. <code>new Date(1433502692297)</code>
      */
     getDate: function() {

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -78,7 +78,8 @@ module.exports.MatrixEvent = function MatrixEvent(
     this.status = null;
     this.forwardLooking = true;
     this._pushActions = null;
-    this._date = this.event.origin_server_ts ? new Date(this.event.origin_server_ts) : null;
+    this._date = this.event.origin_server_ts ?
+        new Date(this.event.origin_server_ts) : null;
 
     this._clearEvent = {};
     this._keysProved = {};

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -386,9 +386,12 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      },
 
      /**
-      * Recalculate properties based on the `event` property.
+      * Replace the `event` property and recalculate any properties based on it.
       */
-     handleRemoteEcho: function() {
+     handleRemoteEcho: function(event) {
+        this.event = event;
+        // successfully sent.
+        this.status = null;
         this._date = new Date(this.event.origin_server_ts);
      }
 });

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -387,6 +387,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
 
      /**
       * Replace the `event` property and recalculate any properties based on it.
+      * @param {Object} event the object to assign to the `event` property
       */
      handleRemoteEcho: function(event) {
         this.event = event;

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -384,6 +384,13 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      setPushActions: function(pushActions) {
         this._pushActions = pushActions;
      },
+
+     /**
+      * Recalculate properties based on the `event` property.
+      */
+     handleRemoteEcho: function() {
+        this._date = new Date(this.event.origin_server_ts);
+     }
 });
 
 

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -675,6 +675,7 @@ Room.prototype._handleRemoteEcho = function(remoteEvent, localEvent) {
     // replace the event source (this will preserve the plaintext payload if
     // any, which is good, because we don't want to try decoding it again).
     localEvent.event = remoteEvent.event;
+    localEvent.handleRemoteEcho();
 
     // successfully sent.
     localEvent.status = null;

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -674,11 +674,7 @@ Room.prototype._handleRemoteEcho = function(remoteEvent, localEvent) {
 
     // replace the event source (this will preserve the plaintext payload if
     // any, which is good, because we don't want to try decoding it again).
-    localEvent.event = remoteEvent.event;
-    localEvent.handleRemoteEcho();
-
-    // successfully sent.
-    localEvent.status = null;
+    localEvent.handleRemoteEcho(remoteEvent.event);
 
     for (var i = 0; i < this._timelineSets.length; i++) {
         var timelineSet = this._timelineSets[i];


### PR DESCRIPTION
This is useful because clients may often wish to construct Date instances using `getTs
()`, but `origin_server_ts` should never change and thus a Date instance can be created at construction time.