### PR TITLE
Allow clients the ability to set a default local timeout

### DIFF
--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -45,6 +45,10 @@ var utils = require("./utils");
  *
  * @param {string} opts.accessToken The access_token for this user.
  *
+ * @param {Number=} opts.localTimeoutMs Optional. The default maximum amount of
+ * time to wait before timing out HTTP requests. If not specified, there is no
+ * timeout.
+ *
  * @param {Object} opts.queryParams Optional. Extra query parameters to append
  * to all requests with this client. Useful for application services which require
  * <code>?user_id=</code>.

--- a/lib/base-apis.js
+++ b/lib/base-apis.js
@@ -63,7 +63,8 @@ function MatrixBaseApis(opts) {
         request: opts.request,
         prefix: httpApi.PREFIX_R0,
         onlyData: true,
-        extraParams: opts.queryParams
+        extraParams: opts.queryParams,
+        localTimeoutMs: opts.localTimeoutMs
     };
     this._http = new httpApi.MatrixHttpApi(this, httpOpts);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -94,6 +94,9 @@ try {
  * to all requests with this client. Useful for application services which require
  * <code>?user_id=</code>.
  *
+ * @param {Number=} opts.localTimeoutMs Optional. The default maximum amount of
+ * time to wait before timing out HTTP requests. If not specified, there is no timeout.
+ *
  * @param {boolean} [opts.timelineSupport = false] Set to true to enable
  * improved timeline support ({@link
  * module:client~MatrixClient#getEventTimeline getEventTimeline}). It is

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -596,7 +596,7 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {object=} opts.headers  extra request headers
      *
      * @param {number=} opts.localTimeoutMs client-side timeout for the
-     *    request. No timeout if undefined.
+     *    request. Default timeout if undefined.
      *
      * @param {function=} opts.bodyParser function to parse the body of the
      *    response before passing it to the promise and callback.

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -596,7 +596,7 @@ module.exports.MatrixHttpApi.prototype = {
      * @param {object=} opts.headers  extra request headers
      *
      * @param {number=} opts.localTimeoutMs client-side timeout for the
-     *    request. Default timeout if undefined.
+     *    request. Default timeout if falsy.
      *
      * @param {function=} opts.bodyParser function to parse the body of the
      *    response before passing it to the promise and callback.

--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -70,8 +70,10 @@ module.exports.PREFIX_MEDIA_R0 = "/_matrix/media/r0";
  *
  * @param {string} opts.accessToken The access_token to send with requests. Can be
  * null to not send an access token.
- * @param {Object} opts.extraParams Optional. Extra query parameters to send on
+ * @param {Object=} opts.extraParams Optional. Extra query parameters to send on
  * requests.
+ * @param {Number=} opts.localTimeoutMs The default maximum amount of time to wait
+ * before timing out the request. If not specified, there is no timeout.
  */
 module.exports.MatrixHttpApi = function MatrixHttpApi(event_emitter, opts) {
     utils.checkObjectHasKeys(opts, ["baseUrl", "request", "prefix"]);
@@ -626,7 +628,7 @@ module.exports.MatrixHttpApi.prototype = {
         var timeoutId;
         var timedOut = false;
         var req;
-        var localTimeoutMs = opts.localTimeoutMs;
+        var localTimeoutMs = opts.localTimeoutMs || this.opts.localTimeoutMs;
         if (localTimeoutMs) {
             timeoutId = callbacks.setTimeout(function() {
                 timedOut = true;


### PR DESCRIPTION
Will be used to fix matrix-org/matrix-appservice-irc#328