### PR TITLE
Edit Event Support (experimental)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -968,6 +968,26 @@ MatrixClient.prototype.sendTextMessage = function(roomId, body, txnId, callback)
 
 /**
  * @param {string} roomId
+ * @param {string} targetId
+ * @param {string} body
+ * @param {string} txnId Optional.
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.sendTextMessageEdit = function(roomId, targetId, body, txnId, callback) {
+    var content = {
+         msgtype: "m.text",
+         body: body,
+         target_id: targetId
+    };
+    return this.sendEvent(
+        roomId, "m.room.edit", content, txnId, callback
+    );
+};
+
+/**
+ * @param {string} roomId
  * @param {string} body
  * @param {string} txnId Optional.
  * @param {module:client.callback} callback Optional.
@@ -1035,6 +1055,28 @@ MatrixClient.prototype.sendHtmlMessage = function(roomId, body, htmlBody, callba
         formatted_body: htmlBody
     };
     return this.sendMessage(roomId, content, callback);
+};
+
+/**
+ * @param {string} roomId
+ * @param {string} targetId
+ * @param {string} body
+ * @param {string} htmlBody
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.sendHtmlMessageEdit = function(roomId, targetId, body, htmlBody, txnId, callback) {
+    var content = {
+        msgtype: "m.text",
+        format: "org.matrix.custom.html",
+        body: body,
+        formatted_body: htmlBody,
+        target_id: targetId
+    };
+    return this.sendEvent(
+        roomId, "m.room.edit", content, txnId, callback
+    );
 };
 
 /**

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -148,7 +148,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {Object} The event content JSON, or an empty object.
      */
     getContent: function() {
-        return this._clearEvent.content || this.event.content || {};
+        return this.event.edit ? this.event.edit.content : this._clearEvent.content || this.event.content || {};
     },
 
     /**
@@ -306,6 +306,10 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         return this.event.unsigned || {};
     },
 
+    isEdited: function() {
+        return !!this.event.edit;
+    },
+
     /**
      * Update the content of an event in the same way it would be by the server
      * if it were redacted before it was sent to us
@@ -347,6 +351,14 @@ utils.extend(module.exports.MatrixEvent.prototype, {
             }
         }
     },
+
+    makeEdit: function(mxEvent) {
+        if (!mxEvent.event) {
+            throw new Error("invalid editEvent in makeEdit");
+        }
+        this.event.edit = mxEvent.event;
+    },
+
 
     /**
      * Check if this event has been redacted

--- a/lib/models/room.js
+++ b/lib/models/room.js
@@ -229,6 +229,15 @@ Room.prototype._fixUpLegacyTimelineFields = function() {
 };
 
 /**
+ * Return whether message editing is enabled for this room
+ * @return {boolean} if edit_enabled is set true for the room
+ */
+Room.prototype.isEditEnabled = function() {
+    var lastEditModeEvent = this.currentState.getStateEvents('m.room.edit_mode').splice(-1)[0];
+    return !!(lastEditModeEvent && lastEditModeEvent.event.content.edit_enabled === true);
+};
+
+/**
  * Return the timeline sets for this room.
  * @return {EventTimelineSet[]} array of timeline sets for this room
  */
@@ -547,6 +556,8 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
         // NB: We continue to add the redaction event to the timeline so
         // clients can say "so and so redacted an event" if they wish to. Also
         // this may be needed to trigger an update.
+    } else if (event.getType() === "m.room.edit") {
+        this._addEditEvent(event, false);
     }
 
     if (event.getUnsigned().transaction_id) {
@@ -638,7 +649,28 @@ Room.prototype.addPendingEvent = function(event, txnId) {
         }
     }
 
+    if (event.getType() === "m.room.edit") {
+        this._addEditEvent(event, true);
+    }
+
     this.emit("Room.localEchoUpdated", event, this, null, null);
+};
+
+Room.prototype._addEditEvent = function(event, pending) {
+    var targetId = event.event.content.target_id;
+    if (!targetId || !event.event.content.body) {
+        return console.log("Invalid m.room.edit event.., skipping", event);
+    }
+    var targetEvent = this.getUnfilteredTimelineSet().findEventById(targetId);
+    if (targetEvent) {
+        if (pending) {
+            targetEvent.status = 'hasPendingEdit'
+        } else {
+            targetEvent.status = event.status
+        }
+        targetEvent.makeEdit(event, pending);
+        this.emit("Room.edit", targetEvent, this);
+    }
 };
 
 /**


### PR DESCRIPTION
This doesn't follow a particular Spec for edit events at the moment which I assume might not come until the Google Doc discussion related to: https://github.com/matrix-org/synapse/pull/1633 ? 

But at least provides some preliminary functionality which allows the matrix-react-sdk (https://github.com/matrix-org/matrix-react-sdk/pull/588) and vector-web (https://github.com/vector-im/riot-web/pull/2725) PR's to function.  