### PR TITLE
release.sh: Bail early if there are uncommitted changes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -32,6 +32,18 @@ if [ "$ret" -eq 0 ]; then
     exit
 fi
 
+git diff-index --quiet --cached HEAD || ret=$?
+if [ "$ret" -eq 1 ]; then
+    echo "this git checkout has staged (uncommitted) changes. Refusing to release."
+    exit
+fi
+
+git diff-files --quiet || ret=$?
+if [ "$ret" -eq 1 ]; then
+    echo "this git checkout has uncommitted changes. Refusing to release."
+    exit
+fi
+
 skip_changelog=
 skip_jsdoc=
 changelog_file="CHANGELOG.md"

--- a/release.sh
+++ b/release.sh
@@ -32,6 +32,7 @@ if [ "$ret" -eq 0 ]; then
     exit
 fi
 
+ret=0
 git diff-index --quiet --cached HEAD || ret=$?
 if [ "$ret" -eq 1 ]; then
     echo "this git checkout has staged (uncommitted) changes. Refusing to release."

--- a/release.sh
+++ b/release.sh
@@ -32,15 +32,12 @@ if [ "$ret" -eq 0 ]; then
     exit
 fi
 
-ret=0
-git diff-index --quiet --cached HEAD || ret=$?
-if [ "$ret" -eq 1 ]; then
+if ! git diff-index --quiet --cached HEAD; then
     echo "this git checkout has staged (uncommitted) changes. Refusing to release."
     exit
 fi
 
-git diff-files --quiet || ret=$?
-if [ "$ret" -eq 1 ]; then
+if ! git diff-files --quiet; then
     echo "this git checkout has uncommitted changes. Refusing to release."
     exit
 fi


### PR DESCRIPTION
This catches both things that are visible on `git diff` as well as staged (added) files. Cargo-culted from http://stackoverflow.com/questions/2657935/checking-for-a-dirty-index-or-untracked-files-with-git and manually tested both scenarios.