### PR TITLE
'babel' is not a babel package anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "request": "^2.53.0"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "istanbul": "^0.3.13",


### PR DESCRIPTION
and so is just redundant as you have babel-cli which is what you
actually want.