### PR TITLE
Remove babel-polyfill

### DIFF
--- a/browser-index.js
+++ b/browser-index.js
@@ -1,5 +1,3 @@
-require("babel-polyfill");
-
 var matrixcs = require("./lib/matrix");
 matrixcs.request(require("browser-request"));
 module.exports = matrixcs; // keep export for browserify package deps

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-require("babel-polyfill");
-
 var matrixcs = require("./lib/matrix");
 matrixcs.request(require("request"));
 module.exports = matrixcs;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   ],
   "dependencies": {
     "another-json": "^0.2.0",
-    "babel-polyfill": "^6.20.0",
     "browser-request": "^0.3.3",
     "browserify": "^10.2.3",
     "q": "^1.4.1",


### PR DESCRIPTION
react-sdk's tests are failing because babel-polyfill is being
pulled in twice.

As per https://babeljs.io/docs/usage/polyfill/ babel-polyfill is
"intended to be used in an application rather than a library/tool".
From a library, we're limited to things that don't modify globals,
since the js env is not ours to start screwing around with.