### PR TITLE
Support for warning users when unknown devices show up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
     - node # Latest stable version of nodejs.
+script:
+    - npm run lint
+    - npm run test

--- a/docs/warning-on-unverified-devices.txt
+++ b/docs/warning-on-unverified-devices.txt
@@ -1,0 +1,31 @@
+Random notes from Matthew on the two possible approaches for warning users about unexpected
+unverified devices popping up in their rooms....
+
+Original idea...
+================
+
+Warn when an existing user adds an unknown device to a room.
+
+Warn when a user joins the room with unverified or unknown devices.
+
+Warn when you initial sync if the room has any unverified devices in it.
+ ^ this is good enough if we're doing local storage.
+ OR, better:
+Warn when you initial sync if the room has any new undefined devices since you were last there.
+ => This means persisting the rooms that devices are in, across initial syncs.
+
+
+Updated idea...
+===============
+
+Warn when the user tries to send a message:
+  - If the room has unverified devices which the user has not yet been told about in the context of this room
+    ...or in the context of this user?  currently all verification is per-user, not per-room.
+    ...this should be good enough.
+
+  - so track whether we have warned the user or not about unverified devices - blocked, unverified, verified, unverified_warned.
+    throw an error when trying to encrypt if there are pure unverified devices there
+    app will have to search for the devices which are pure unverified to warn about them - have to do this from MembersList anyway?
+      - or megolm could warn which devices are causing the problems.
+
+Why do we wait to establish outbound sessions?  It just makes a horrible pause when we first try to send a message... but could otherwise unnecessarily consume resources?

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -l
 
+set -x
+
 export NVM_DIR="/home/jenkins/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm use 6
-npm install
+
+nvm use 6 || exit $?
+npm install || exit $?
 
 RC=0
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist": "npm run build",
     "watch": "watchify --exclude olm browser-index.js -o dist/browser-matrix-dev.js -v",
     "lint": "eslint --max-warnings 122 src spec",
-    "prepublish": "npm run lint && npm run build && git rev-parse HEAD > git-revision.txt"
+    "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt"
   },
   "repository": {
     "url": "https://github.com/matrix-org/matrix-js-sdk"

--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -158,6 +158,21 @@ module.exports.DecryptionError = function(msg) {
 utils.inherits(module.exports.DecryptionError, Error);
 
 /**
+ * Exception thrown specifically when we want to warn the user to consider
+ * the security of their conversation before continuing
+ *
+ * @constructor
+ * @param {string} msg message describing the problem
+ * @extends Error
+ */
+module.exports.UnknownDeviceError = function(msg, devices) {
+    this.name = "UnknownDeviceError";
+    this.message = msg;
+    this.devices = devices;
+};
+utils.inherits(module.exports.UnknownDeviceError, Error);
+
+/**
  * Registers an encryption/decryption class for a particular algorithm
  *
  * @param {string} algorithm algorithm tag to register for

--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -163,6 +163,8 @@ utils.inherits(module.exports.DecryptionError, Error);
  *
  * @constructor
  * @param {string} msg message describing the problem
+ * @param {Object} devices userId -> {deviceId -> object}
+ *      set of unknown devices per user we're warning about
  * @extends Error
  */
 module.exports.UnknownDeviceError = function(msg, devices) {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -388,6 +388,10 @@ MegolmEncryption.prototype._shareKeyWithDevices = function(session, devicesByUse
 MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
     const self = this;
     return this._getDevicesInRoom(room).then(function(devicesInRoom) {
+        // check if any of these devices are not yet known to the user.
+        // if so, warn the user so they can verify or ignore.
+        self._checkForUnknownDevices(devicesInRoom);
+
         return self._ensureOutboundSession(devicesInRoom);
     }).then(function(session) {
         const payloadJson = {
@@ -416,6 +420,38 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
 };
 
 /**
+ * Checks the devices we're about to send to and see if any are entirely
+ * unknown to the user.  If so, warn the user, and mark them as known to
+ * give the user a chance to go verify them before re-sending this message.
+ */
+MegolmEncryption.prototype._checkForUnknownDevices = function(devicesInRoom) {
+    const unknownDevices = {};
+
+    Object.keys(devicesInRoom).forEach(userId=>{
+        Object.keys(devicesInRoom[userId]).forEach(deviceId=>{
+            const device = devicesInRoom[userId][deviceId];
+            if (device.isUnverified() && !device.isKnown()) {
+                // mark the devices as known to the user, given we're about to
+                // yell at them.
+                //this._crypto.setDeviceVerification(userId, device.deviceId,
+                //                                   undefined, undefined, true);
+                if (!unknownDevices[userId]) {
+                    unknownDevices[userId] = {};
+                }
+                unknownDevices[userId][deviceId] = device;
+            }
+        });
+    });
+
+    if (Object.keys(unknownDevices).length) {
+        // it'd be kind to pass unknownDevices up to the user in this error
+        throw new base.UnknownDeviceError(
+            "This room contains unknown devices which have not been verified. " +
+            "We strongly recommend you verify them before continuing.", unknownDevices);
+    }
+};
+
+/**
  * Get the list of unblocked devices for all users in the room
  *
  * @param {module:models/room} room
@@ -433,6 +469,9 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
     // have a list of the user's devices, then we already share an e2e room
     // with them, which means that they will have announced any new devices via
     // an m.new_device.
+    //
+    // XXX: what if the cache is stale, and the user left the room we had in common
+    // and then added new devices before joining this one? --Matthew
     return this._crypto.downloadKeys(roomMembers, false).then(function(devices) {
         // remove any blocked devices
         for (const userId in devices) {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -423,12 +423,15 @@ MegolmEncryption.prototype.encryptMessage = function(room, eventType, content) {
  * Checks the devices we're about to send to and see if any are entirely
  * unknown to the user.  If so, warn the user, and mark them as known to
  * give the user a chance to go verify them before re-sending this message.
+ *
+ * @param {Object} devicesInRoom userId -> {deviceId -> object}
+ *   devices we should shared the session with.
  */
 MegolmEncryption.prototype._checkForUnknownDevices = function(devicesInRoom) {
     const unknownDevices = {};
 
-    Object.keys(devicesInRoom).forEach(userId=>{
-        Object.keys(devicesInRoom[userId]).forEach(deviceId=>{
+    Object.keys(devicesInRoom).forEach((userId)=>{
+        Object.keys(devicesInRoom[userId]).forEach((deviceId)=>{
             const device = devicesInRoom[userId][deviceId];
             if (device.isUnverified() && !device.isKnown()) {
                 // mark the devices as known to the user, given we're about to

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -433,8 +433,8 @@ MegolmEncryption.prototype._checkForUnknownDevices = function(devicesInRoom) {
             if (device.isUnverified() && !device.isKnown()) {
                 // mark the devices as known to the user, given we're about to
                 // yell at them.
-                //this._crypto.setDeviceVerification(userId, device.deviceId,
-                //                                   undefined, undefined, true);
+                this._crypto.setDeviceVerification(userId, device.deviceId,
+                                                  undefined, undefined, true);
                 if (!unknownDevices[userId]) {
                     unknownDevices[userId] = {};
                 }

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -434,10 +434,6 @@ MegolmEncryption.prototype._checkForUnknownDevices = function(devicesInRoom) {
         Object.keys(devicesInRoom[userId]).forEach((deviceId)=>{
             const device = devicesInRoom[userId][deviceId];
             if (device.isUnverified() && !device.isKnown()) {
-                // mark the devices as known to the user, given we're about to
-                // yell at them.
-                this._crypto.setDeviceVerification(userId, device.deviceId,
-                                                  undefined, undefined, true);
                 if (!unknownDevices[userId]) {
                     unknownDevices[userId] = {};
                 }

--- a/src/crypto/deviceinfo.js
+++ b/src/crypto/deviceinfo.js
@@ -86,6 +86,7 @@ DeviceInfo.prototype.toStorage = function() {
         algorithms: this.algorithms,
         keys: this.keys,
         verified: this.verified,
+        known: this.known,
         unsigned: this.unsigned,
     };
 };

--- a/src/crypto/deviceinfo.js
+++ b/src/crypto/deviceinfo.js
@@ -34,7 +34,11 @@ limitations under the License.
   *      &lt;key type&gt;:&lt;id&gt; -> &lt;base64-encoded key&gt;>
   *
   * @property {module:crypto/deviceinfo.DeviceVerification} verified
-  *     whether the device has been verified by the user
+  *     whether the device has been verified/blocked by the user
+  *
+  * @property {boolean} known
+  *     whether the user knows of this device's existence (useful when warning
+  *     the user that a user has added new devices)
   *
   * @property {Object} unsigned  additional data from the homeserver
   *
@@ -50,6 +54,7 @@ function DeviceInfo(deviceId) {
     this.algorithms = [];
     this.keys = {};
     this.verified = DeviceVerification.UNVERIFIED;
+    this.known = false;
     this.unsigned = {};
 }
 
@@ -128,6 +133,24 @@ DeviceInfo.prototype.isBlocked = function() {
  */
 DeviceInfo.prototype.isVerified = function() {
     return this.verified == DeviceVerification.VERIFIED;
+};
+
+/**
+ * Returns true if this device is unverified
+ *
+ * @return {Boolean} true if unverified
+ */
+DeviceInfo.prototype.isUnverified = function() {
+    return this.verified == DeviceVerification.UNVERIFIED;
+};
+
+/**
+ * Returns true if the user knows about this device's existence
+ *
+ * @return {Boolean} true if known
+ */
+DeviceInfo.prototype.isKnown = function() {
+    return this.known == true;
 };
 
 /**

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -684,8 +684,12 @@ Crypto.prototype.getDeviceByIdentityKey = function(userId, algorithm, sender_key
  *
  * @param {?boolean} blocked whether to mark the device as blocked. Null to
  *      leave unchanged.
+ *
+ * @param {?boolean} known whether to mark that the user has been made aware of
+ *      the existence of this device. Null to leave unchanged
  */
-Crypto.prototype.setDeviceVerification = function(userId, deviceId, verified, blocked) {
+Crypto.prototype.setDeviceVerification = function(userId, deviceId, verified,
+                                                  blocked, known) {
     const devices = this._sessionStore.getEndToEndDevicesForUser(userId);
     if (!devices || !devices[deviceId]) {
         throw new Error("Unknown device " + userId + ":" + deviceId);
@@ -706,10 +710,16 @@ Crypto.prototype.setDeviceVerification = function(userId, deviceId, verified, bl
         verificationStatus = DeviceVerification.UNVERIFIED;
     }
 
-    if (dev.verified === verificationStatus) {
+    let knownStatus = dev.known;
+    if (known !== null) {
+        knownStatus = known;
+    }
+
+    if (dev.verified === verificationStatus && dev.known === knownStatus) {
         return;
     }
     dev.verified = verificationStatus;
+    dev.known = knownStatus;
     this._sessionStore.storeEndToEndDevicesForUser(userId, devices);
 };
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -96,6 +96,7 @@ function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId) {
             keys: this._deviceKeys,
             algorithms: this._supportedAlgorithms,
             verified: DeviceVerification.VERIFIED,
+            known: true,
         };
 
         myDevices[this._deviceId] = deviceInfo;


### PR DESCRIPTION
This adds a new crypto.DeviceInfo field called `known` which tracks whether the user has ever been made aware of a device's existence.

If the user tries to send a message into a room with unknown devices present, it throws a custom exception to the app with the details of the devices so the app can warn the user.  It also marks the devices as `known` given the user now knows they exist.

`known` is implemented as a flag on DeviceInfo rather than part of the verification enum as it's slightly semantically distinct from the concept of whether a device is verified or blocked (although it's questionable as to how a user would be able to verify or block a device without knowing it existed!).

The first draft of this tried to track `m.new_device` events as they came in, and warn the user if they referred to devices which the user hadn't seen before - however, this felt prone to races between correlating new-devices and room membership, downloading the actual device info, and the user speaking.  Hopefully this simpler approach doesn't fall foul of the racing concerns mentioned on the original bug.

Hopefully goes some way towards fixing vector-im/riot-web#2143

Twinned with https://github.com/matrix-org/matrix-react-sdk/pull/635.