### PR TITLE
Make Olm work with browserified js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "check": "npm run buildtest && jasmine-node specbuild --verbose --junitreport --captureExceptions",
     "gendoc": "jsdoc -r lib -P package.json -R README.md -d .jsdoc",
     "start": "babel -s -w -d lib src",
-    "build": "babel -s -d lib src && rimraf dist && mkdir dist && browserify --exclude olm browser-index.js -o dist/browser-matrix.js --ignore-missing && uglifyjs -c -m -o dist/browser-matrix.min.js dist/browser-matrix.js",
+    "build": "babel -s -d lib src && rimraf dist && mkdir dist && browserify browser-index.js -o dist/browser-matrix.js && uglifyjs -c -m -o dist/browser-matrix.min.js dist/browser-matrix.js",
     "dist": "npm run build",
-    "watch": "watchify --exclude olm browser-index.js -o dist/browser-matrix-dev.js -v",
+    "watch": "watchify browser-index.js -o dist/browser-matrix-dev.js -v",
     "lint": "eslint --max-warnings 121 src spec",
     "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt"
   },
@@ -55,6 +55,7 @@
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "browserify": "^10.2.3",
+    "browserify-shim": "^3.8.13",
     "eslint": "^3.13.1",
     "eslint-config-google": "^0.7.1",
     "istanbul": "^0.3.13",
@@ -66,5 +67,11 @@
   },
   "optionalDependencies": {
     "olm": "https://matrix.org/packages/npm/olm/olm-2.2.1.tgz"
+  },
+  "browserify": {
+    "transform": "browserify-shim"
+  },
+  "browserify-shim": {
+    "olm": "global:Olm"
   }
 }

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -21,6 +21,11 @@ limitations under the License.
  * @module crypto/OlmDevice
  */
 const Olm = require("olm");
+if (!Olm) {
+    // this happens if we were loaded via browserify and the Olm module was not
+    // loaded.
+    throw new Error("Olm is not defined");
+}
 const utils = require("../utils");
 
 


### PR DESCRIPTION
We want to avoid distributing olm as part of the js-sdk, so we exclude it from
the browserified build. Previously this meant that you couldn't use olm this
way.

We can do better though: if the web page includes olm.js via a separate script
tag, that will set global.Olm, which we can get browserify to shim in.