### PR TITLE
Record all e2e room settings in localstorage

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -822,10 +822,6 @@ Crypto.prototype.setRoomEncryption = function(roomId, config) {
         throw new Error("Unable to encrypt with " + config.algorithm);
     }
 
-    // remove spurious keys
-    config = {
-        algorithm: config.algorithm,
-    };
     this._sessionStore.storeEndToEndRoom(roomId, config);
 
     const alg = new AlgClass({


### PR DESCRIPTION
I can't quite remember what the logic behind only recording the algorithm in
localstorage was, but the upshot is that if you try to set any e2e config
options (such as the megolm rotation periods) via the room state, then the
state gets rejected and you can't send any events.