### PR TITLE
Use the device change notifications interface

### DIFF
--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -347,7 +347,11 @@ describe("MatrixClient", function() {
             */
 
             httpBackend.when("POST", "/keys/query").check(function(req) {
-                expect(req.data).toEqual({device_keys: {boris: {}, chaz: {}}});
+                expect(req.data).toEqual({device_keys: {
+                    '@alice:localhost': {},
+                    'boris': {},
+                    'chaz': {},
+                }});
             }).respond(200, {
                 device_keys: {
                     boris: borisKeys,

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1082,6 +1082,28 @@ MatrixBaseApis.prototype.claimOneTimeKeys = function(devices, key_algorithm) {
     );
 };
 
+/**
+ * Ask the server for a list of users who have changed their device lists
+ * between a pair of sync tokens
+ *
+ * @param {string} oldToken
+ * @param {string} newToken
+ *
+ * @return {module:client.Promise} Resolves: result object. Rejects: with
+ *     an error response ({@link module:http-api.MatrixError}).
+ */
+MatrixBaseApis.prototype.getKeyChanges = function(oldToken, newToken) {
+    const qps = {
+        from: oldToken,
+        to: newToken,
+    };
+
+    return this._http.authedRequestWithPrefix(
+        undefined, "GET", "/keys/changes", qps, undefined,
+        httpApi.PREFIX_UNSTABLE,
+    );
+};
+
 
 // Identity Server Operations
 // ==========================

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1018,20 +1018,35 @@ MatrixBaseApis.prototype.uploadKeysRequest = function(content, opts, callback) {
  *
  * @param {string[]} userIds  list of users to get keys for
  *
- * @param {module:client.callback=} callback
+ * @param {Object=} opts
+ *
+ * @param {string=} opts.token   sync token to pass in the query request, to help
+ *   the HS give the most recent results
  *
  * @return {module:client.Promise} Resolves: result object. Rejects: with
  *     an error response ({@link module:http-api.MatrixError}).
  */
-MatrixBaseApis.prototype.downloadKeysForUsers = function(userIds, callback) {
-    const downloadQuery = {};
-
-    for (let i = 0; i < userIds.length; ++i) {
-        downloadQuery[userIds[i]] = {};
+MatrixBaseApis.prototype.downloadKeysForUsers = function(userIds, opts) {
+    if (utils.isFunction(opts)) {
+        // opts used to be 'callback'.
+        throw new Error(
+            'downloadKeysForUsers no longer accepts a callback parameter',
+        );
     }
-    const content = {device_keys: downloadQuery};
+    opts = opts || {};
+
+    const content = {
+        device_keys: {},
+    };
+    if ('token' in opts) {
+        content.token = opts.token;
+    }
+    userIds.forEach((u) => {
+        content.device_keys[u] = {};
+    });
+
     return this._http.authedRequestWithPrefix(
-        callback, "POST", "/keys/query", undefined, content,
+        undefined, "POST", "/keys/query", undefined, content,
         httpApi.PREFIX_UNSTABLE,
     );
 };

--- a/src/client.js
+++ b/src/client.js
@@ -2638,8 +2638,6 @@ MatrixClient.prototype.startClient = function(opts) {
         };
     }
 
-    this._clientOpts = opts;
-
     if (this._crypto) {
         this._crypto.uploadKeys(5).done();
         const tenMinutes = 1000 * 60 * 10;
@@ -2657,6 +2655,13 @@ MatrixClient.prototype.startClient = function(opts) {
         console.error("Still have sync object whilst not running: stopping old one");
         this._syncApi.stop();
     }
+
+    // shallow-copy the opts dict before modifying and storing it
+    opts = Object.assign({}, opts);
+
+    opts.crypto = this._crypto;
+    this._clientOpts = opts;
+
     this._syncApi = new SyncApi(this, opts);
     this._syncApi.sync();
 };
@@ -3040,12 +3045,26 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * </ul>
  *
  * @event module:client~MatrixClient#"sync"
+ *
  * @param {string} state An enum representing the syncing state. One of "PREPARED",
  * "SYNCING", "ERROR", "STOPPED".
+ *
  * @param {?string} prevState An enum representing the previous syncing state.
  * One of "PREPARED", "SYNCING", "ERROR", "STOPPED" <b>or null</b>.
+ *
  * @param {?Object} data Data about this transition.
+ *
  * @param {MatrixError} data.err The matrix error if <code>state=ERROR</code>.
+ *
+ * @param {String} data.oldSyncToken The 'since' token passed to /sync.
+ *    <code>null</code> for the first successful sync since this client was
+ *    started. Only present if <code>state=PREPARED</code> or
+ *    <code>state=SYNCING</code>.
+ *
+ * @param {String} data.nextSyncToken The 'next_batch' result from /sync, which
+ *    will become the 'since' token for the next call to /sync. Only present if
+ *    <code>state=PREPARED</code> or <code>state=SYNCING</code>.
+ *
  * @example
  * matrixClient.on("sync", function(state, prevState, data) {
  *   switch (state) {

--- a/src/client.js
+++ b/src/client.js
@@ -158,6 +158,7 @@ function MatrixClient(opts) {
             this, this,
             opts.sessionStore,
             userId, this.deviceId,
+            this.store,
         );
 
         this.olmVersion = Crypto.getOlmVersion();

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -326,6 +326,10 @@ export default class DeviceList {
                 this._sessionStore.storeEndToEndDevicesForUser(
                     userId, storage,
                 );
+
+                if (token) {
+                    this._sessionStore.storeEndToEndDeviceSyncToken(token);
+                }
             }
         });
     }

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -41,6 +41,8 @@ export default class DeviceList {
 
         // userId -> promise
         this._keyDownloadsInProgressByUser = {};
+
+        this.lastKnownSyncToken = null;
     }
 
     /**
@@ -288,8 +290,13 @@ export default class DeviceList {
     _doKeyDownloadForUsers(downloadUsers) {
         console.log('Starting key download for ' + downloadUsers);
 
+        const token = this.lastKnownSyncToken;
+        const opts = {};
+        if (token) {
+            opts.token = token;
+        }
         return this._baseApis.downloadKeysForUsers(
-            downloadUsers,
+            downloadUsers, opts,
         ).then((res) => {
             const dk = res.device_keys || {};
 

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -25,7 +25,6 @@ import q from 'q';
 
 import DeviceInfo from './deviceinfo';
 import olmlib from './olmlib';
-import utils from '../utils';
 
 /**
  * @alias module:crypto/DeviceList
@@ -36,10 +35,11 @@ export default class DeviceList {
         this._sessionStore = sessionStore;
         this._olmDevice = olmDevice;
 
+        // users with outdated device lists
         // userId -> true
         this._pendingUsersWithNewDevices = {};
 
-        // userId -> [promise, ...]
+        // userId -> promise
         this._keyDownloadsInProgressByUser = {};
     }
 
@@ -53,45 +53,30 @@ export default class DeviceList {
      * module:crypto/deviceinfo|DeviceInfo}.
      */
     downloadKeys(userIds, forceDownload) {
-        const self = this;
-
         // promises we need to wait for while the download happens
         const promises = [];
 
-        // list of userids we need to download keys for
-        let downloadUsers = [];
-
-        function perUserCatch(u) {
-            return function(e) {
-                console.warn('Error downloading keys for user ' + u + ':', e);
-            };
-        }
-
-        if (forceDownload) {
-            downloadUsers = userIds;
-        } else {
-            for (let i = 0; i < userIds.length; ++i) {
-                const u = userIds[i];
-
-                const inprogress = this._keyDownloadsInProgressByUser[u];
-                if (inprogress) {
-                    // wait for the download to complete
-                    promises.push(q.any(inprogress).catch(perUserCatch(u)));
-                } else if (!this.getStoredDevicesForUser(u)) {
-                    downloadUsers.push(u);
+        let needsFlush = false;
+        userIds.forEach((u) => {
+            if (this._keyDownloadsInProgressByUser[u]) {
+                // just wait for the existing download to complete
+                promises.push(this._keyDownloadsInProgressByUser[u]);
+            } else {
+                if (forceDownload || !this.getStoredDevicesForUser(u)) {
+                    this.invalidateUserDeviceList(u);
+                }
+                if (this._pendingUsersWithNewDevices[u]) {
+                    needsFlush = true;
                 }
             }
+        });
+
+        if (needsFlush) {
+            promises.push(this.flushNewDeviceRequests(true));
         }
 
-        if (downloadUsers.length > 0) {
-            const r = this._doKeyDownloadForUsers(downloadUsers);
-            downloadUsers.map(function(u) {
-                promises.push(r[u].catch(perUserCatch(u)));
-            });
-        }
-
-        return q.all(promises).then(function() {
-            return self._getDevicesFromStore(userIds);
+        return q.all(promises).then(() => {
+            return this._getDevicesFromStore(userIds);
         });
     }
 
@@ -210,134 +195,124 @@ export default class DeviceList {
      * @param {String} userId
      */
     invalidateUserDeviceList(userId) {
+        if (typeof userId !== 'string') {
+            throw new Error('userId must be a string; was '+userId);
+        }
         this._pendingUsersWithNewDevices[userId] = true;
     }
 
     /**
-     * Start device queries for any users who sent us an m.new_device recently
+     * Start device queries for any users with outdated device lists
+     *
+     * We tolerate multiple concurrent device queries, but only one query per
+     * user.
+     *
+     * If any users already have downloads in progress, they are ignored -
+     * they will be refreshed when the current download completes anyway.
+     *
+     * The returned promise resolves immediately if there are no users with
+     * outdated device lists, or if all users with outdated device lists already
+     * have a query in progress.
+     *
+     * Otherwise, a new query request is made, and the promise resolves or
+     * once that query completes. If the query fails, the promise will reject
+     * if rejectOnFailure was truthy, otherwise it will still resolve.
+     *
+     * @param {Boolean?} rejectOnFailure  true to make the returned promise
+     *   reject if the device list query fails.
+     *
+     * @return {Promise}
      */
-    flushNewDeviceRequests() {
-        const users = Object.keys(this._pendingUsersWithNewDevices);
+    flushNewDeviceRequests(rejectOnFailure) {
+        const users = Object.keys(this._pendingUsersWithNewDevices).filter(
+            (u) => !this._keyDownloadsInProgressByUser[u],
+        );
 
         if (users.length === 0) {
-            return;
+            return q();
         }
 
-        const r = this._doKeyDownloadForUsers(users);
+        let prom = this._doKeyDownloadForUsers(users).then(() => {
+            users.forEach((u) => {
+                delete this._keyDownloadsInProgressByUser[u];
+            });
 
-        // we've kicked off requests to these users: remove their
-        // pending flag for now.
-        this._pendingUsersWithNewDevices = {};
+            // flush out any more requests that were blocked up while that
+            // was going on, but let the initial promise complete now.
+            //
+            this.flushNewDeviceRequests().done();
+        }, (e) => {
+            console.error(
+                'Error updating device key cache for ' + users + ":", e,
+            );
 
-        users.map((u) => {
-            r[u] = r[u].catch((e) => {
-                console.error(
-                    'Error updating device keys for user ' + u + ':', e,
-                );
-
-                // reinstate the pending flags on any users which failed; this will
-                // mean that we will do another download in the future, but won't
-                // tight-loop.
-                //
+            // reinstate the pending flags on any users which failed; this will
+            // mean that we will do another download in the future, but won't
+            // tight-loop.
+            //
+            users.forEach((u) => {
+                delete this._keyDownloadsInProgressByUser[u];
                 this._pendingUsersWithNewDevices[u] = true;
             });
+
+            // TODO: schedule a retry.
+            throw e;
         });
 
-        q.all(Object.values(r)).done();
+        users.forEach((u) => {
+            delete this._pendingUsersWithNewDevices[u];
+            this._keyDownloadsInProgressByUser[u] = prom;
+        });
+
+        if (!rejectOnFailure) {
+            // normally we just want to swallow the exception - we've already
+            // logged it futher up.
+            prom = prom.catch((e) => {});
+        }
+        return prom;
     }
 
     /**
      * @param {string[]} downloadUsers list of userIds
      *
-     * @return {Object} a map from userId to a promise for a result for that user
+     * @return {Promise}
      */
     _doKeyDownloadForUsers(downloadUsers) {
-        const self = this;
-
         console.log('Starting key download for ' + downloadUsers);
 
-        const deferMap = {};
-        const promiseMap = {};
-
-        downloadUsers.map(function(u) {
-            const deferred = q.defer();
-            const promise = deferred.promise.finally(function() {
-                const inProgress = self._keyDownloadsInProgressByUser[u];
-                utils.removeElement(inProgress, function(e) {
-                    return e === promise;
-                });
-                if (inProgress.length === 0) {
-                    // no more downloads for this user; remove the element
-                    delete self._keyDownloadsInProgressByUser[u];
-                }
-            });
-
-            if (!self._keyDownloadsInProgressByUser[u]) {
-                self._keyDownloadsInProgressByUser[u] = [];
-            }
-            self._keyDownloadsInProgressByUser[u].push(promise);
-
-            deferMap[u] = deferred;
-            promiseMap[u] = promise;
-        });
-
-        this._baseApis.downloadKeysForUsers(
+        return this._baseApis.downloadKeysForUsers(
             downloadUsers,
-        ).done(function(res) {
+        ).then((res) => {
             const dk = res.device_keys || {};
 
-            for (let i = 0; i < downloadUsers.length; ++i) {
-                const userId = downloadUsers[i];
-                var deviceId;
-
+            for (const userId of downloadUsers) {
                 console.log('got keys for ' + userId + ':', dk[userId]);
-
-                if (!dk[userId]) {
-                    // no result for this user
-                    const err = 'Unknown';
-                    // TODO: do something with res.failures
-                    deferMap[userId].reject(err);
-                    continue;
-                }
 
                 // map from deviceid -> deviceinfo for this user
                 const userStore = {};
-                const devs = self._sessionStore.getEndToEndDevicesForUser(userId);
+                const devs = this._sessionStore.getEndToEndDevicesForUser(userId);
                 if (devs) {
-                    for (deviceId in devs) {
-                        if (devs.hasOwnProperty(deviceId)) {
-                            const d = DeviceInfo.fromStorage(devs[deviceId], deviceId);
-                            userStore[deviceId] = d;
-                        }
-                    }
+                    Object.keys(devs).forEach((deviceId) => {
+                        const d = DeviceInfo.fromStorage(devs[deviceId], deviceId);
+                        userStore[deviceId] = d;
+                    });
                 }
 
                 _updateStoredDeviceKeysForUser(
-                    self._olmDevice, userId, userStore, dk[userId],
-                    );
+                    this._olmDevice, userId, userStore, dk[userId] || {},
+                );
 
                 // update the session store
                 const storage = {};
-                for (deviceId in userStore) {
-                    if (!userStore.hasOwnProperty(deviceId)) {
-                        continue;
-                    }
-
+                Object.keys(userStore).forEach((deviceId) => {
                     storage[deviceId] = userStore[deviceId].toStorage();
-                }
-                self._sessionStore.storeEndToEndDevicesForUser(
+                });
+
+                this._sessionStore.storeEndToEndDevicesForUser(
                     userId, storage,
-                    );
-
-                deferMap[userId].resolve();
+                );
             }
-        }, function(err) {
-            downloadUsers.map(function(u) {
-                deferMap[u].reject(err);
-            });
         });
-
-        return promiseMap;
     }
 }
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -708,7 +708,7 @@ Crypto.prototype._onInitialSyncCompleted = function(rooms) {
     this._initialSyncCompleted = true;
 
     // catch up on any m.new_device events which arrived during the initial sync.
-    this._deviceList.flushNewDeviceRequests().done();
+    this._deviceList.refreshOutdatedDeviceLists().done();
 
     if (this._sessionStore.getDeviceAnnounced()) {
         return;
@@ -845,7 +845,7 @@ Crypto.prototype._onNewDeviceEvent = function(event) {
     // we delay handling these until the intialsync has completed, so that we
     // can do all of them together.
     if (this._initialSyncCompleted) {
-        this._deviceList.flushNewDeviceRequests().done();
+        this._deviceList.refreshOutdatedDeviceLists().done();
     }
 };
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -708,7 +708,7 @@ Crypto.prototype._onInitialSyncCompleted = function(rooms) {
     this._initialSyncCompleted = true;
 
     // catch up on any m.new_device events which arrived during the initial sync.
-    this._deviceList.flushNewDeviceRequests();
+    this._deviceList.flushNewDeviceRequests().done();
 
     if (this._sessionStore.getDeviceAnnounced()) {
         return;
@@ -845,7 +845,7 @@ Crypto.prototype._onNewDeviceEvent = function(event) {
     // we delay handling these until the intialsync has completed, so that we
     // can do all of them together.
     if (this._initialSyncCompleted) {
-        this._deviceList.flushNewDeviceRequests();
+        this._deviceList.flushNewDeviceRequests().done();
     }
 };
 

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -100,6 +100,27 @@ WebStorageSessionStore.prototype = {
     },
 
     /**
+     * Store the sync token corresponding to the device list.
+     *
+     * This is used when starting the client, to get a list of the users who
+     * have changed their device list since the list time we were running.
+     *
+     * @param {String?} token
+     */
+    storeEndToEndDeviceSyncToken: function(token) {
+        setJsonItem(this.store, KEY_END_TO_END_DEVICE_SYNC_TOKEN, token);
+    },
+
+    /**
+     * Get the sync token corresponding to the device list.
+     *
+     * @return {String?} token
+     */
+    getEndToEndDeviceSyncToken: function() {
+        return getJsonItem(this.store, KEY_END_TO_END_DEVICE_SYNC_TOKEN);
+    },
+
+    /**
      * Store a session between the logged-in user and another device
      * @param {string} deviceKey The public key of the other device.
      * @param {string} sessionId The ID for this end-to-end session.
@@ -180,6 +201,7 @@ WebStorageSessionStore.prototype = {
 
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_END_TO_END_ANNOUNCED = E2E_PREFIX + "announced";
+const KEY_END_TO_END_DEVICE_SYNC_TOKEN = E2E_PREFIX + "device_sync_token";
 
 function keyEndToEndDevicesForUser(userId) {
     return E2E_PREFIX + "devices/" + userId;
@@ -199,6 +221,8 @@ function keyEndToEndRoom(roomId) {
 
 function getJsonItem(store, key) {
     try {
+        // if the key is absent, store.getItem() returns null, and
+        // JSON.parse(null) === null, so this returns null.
         return JSON.parse(store.getItem(key));
     } catch (e) {
         debuglog("Failed to get key %s: %s", key, e);


### PR DESCRIPTION
Listen to the notifications from /sync to tell us when a user's devices are out
of date. We're leaving the `m.new_device` stuff in place for now, for
compatibility with old homeservers/clients.

Builds on https://github.com/matrix-org/matrix-js-sdk/pull/347.

Fixes (together with the server-side support) https://github.com/vector-im/riot-web/issues/2305.