### PR TITLE
Make the tests work without olm

### DIFF
--- a/spec/unit/crypto.spec.js
+++ b/spec/unit/crypto.spec.js
@@ -1,13 +1,16 @@
 
 "use strict";
-const Crypto = require("../../lib/crypto");
+
 const sdk = require("../..");
+let Crypto;
+if (sdk.CRYPTO_ENABLED) {
+    Crypto = require("../../lib/crypto");
+}
 
 describe("Crypto", function() {
     if (!sdk.CRYPTO_ENABLED) {
         return;
     }
-
     it("Crypto exposes the correct olm library version", function() {
         expect(Crypto.getOlmVersion()[0]).toEqual(2);
     });


### PR DESCRIPTION
Olm is an optional dependency, so the tests should work without it.