### PR TITLE
realtime-callbacks: pass `global` as `this`

### DIFF
--- a/src/realtime-callbacks.js
+++ b/src/realtime-callbacks.js
@@ -168,7 +168,7 @@ function _runCallbacks() {
     for (let i = 0; i < callbacksToRun.length; i++) {
         cb = callbacksToRun[i];
         try {
-            cb.func.apply(null, cb.params);
+            cb.func.apply(global, cb.params);
         } catch (e) {
             console.error("Uncaught exception in callback function",
                           e.stack || e);


### PR DESCRIPTION
We had a test for this, but apparently it wasn't testing it right...