### PR TITLE
Install source-map-support in each test

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jasmine-node": "^1.14.5",
     "jsdoc": "^3.4.0",
     "rimraf": "^2.5.4",
+    "source-map-support": "^0.4.11",
     "sourceify": "^0.1.0",
     "uglifyjs": "^2.4.10",
     "watchify": "^3.2.1"

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -24,6 +24,7 @@ limitations under the License.
  */
 
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const q = require("q");
 const utils = require("../../lib/utils");

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const HttpBackend = require("../mock-request");
 const utils = require("../test-utils");

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const q = require("q");
 const sdk = require("../..");
 const HttpBackend = require("../mock-request");

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const HttpBackend = require("../mock-request");
 const publicGlobals = require("../../lib/matrix");

--- a/spec/integ/matrix-client-opts.spec.js
+++ b/spec/integ/matrix-client-opts.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const MatrixClient = sdk.MatrixClient;
 const HttpBackend = require("../mock-request");

--- a/spec/integ/matrix-client-retrying.spec.js
+++ b/spec/integ/matrix-client-retrying.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const HttpBackend = require("../mock-request");
 const utils = require("../test-utils");

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const EventStatus = sdk.EventStatus;
 const HttpBackend = require("../mock-request");

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const HttpBackend = require("../mock-request");
 const utils = require("../test-utils");

--- a/spec/integ/megolm.spec.js
+++ b/spec/integ/megolm.spec.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 "use strict";
 
+import 'source-map-support/register';
 
 let Olm = null;
 try {

--- a/spec/unit/content-repo.spec.js
+++ b/spec/unit/content-repo.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const ContentRepo = require("../../lib/content-repo");
 const testUtils = require("../test-utils");
 

--- a/spec/unit/crypto.spec.js
+++ b/spec/unit/crypto.spec.js
@@ -1,5 +1,6 @@
 
 "use strict";
+import 'source-map-support/register';
 const Crypto = require("../../lib/crypto");
 const sdk = require("../..");
 

--- a/spec/unit/event-timeline.spec.js
+++ b/spec/unit/event-timeline.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const EventTimeline = sdk.EventTimeline;
 const utils = require("../test-utils");

--- a/spec/unit/filter.spec.js
+++ b/spec/unit/filter.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const Filter = sdk.Filter;
 const utils = require("../test-utils");

--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 "use strict";
 
+import 'source-map-support/register';
 const q = require("q");
 const sdk = require("../..");
 const utils = require("../test-utils");

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const q = require("q");
 const sdk = require("../..");
 const MatrixClient = sdk.MatrixClient;

--- a/spec/unit/pushprocessor.spec.js
+++ b/spec/unit/pushprocessor.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const PushProcessor = require("../../lib/pushprocessor");
 const utils = require("../test-utils");
 

--- a/spec/unit/realtime-callbacks.spec.js
+++ b/spec/unit/realtime-callbacks.spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import 'source-map-support/register';
 const callbacks = require("../../lib/realtime-callbacks");
 const testUtils = require("../test-utils.js");
 

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const RoomMember = sdk.RoomMember;
 const utils = require("../test-utils");

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const RoomState = sdk.RoomState;
 const RoomMember = sdk.RoomMember;

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const Room = sdk.Room;
 const RoomState = sdk.RoomState;

--- a/spec/unit/scheduler.spec.js
+++ b/spec/unit/scheduler.spec.js
@@ -1,6 +1,7 @@
 // This file had a function whose name is all caps, which displeases eslint
 /* eslint new-cap: "off" */
 
+import 'source-map-support/register';
 const q = require("q");
 const sdk = require("../..");
 const MatrixScheduler = sdk.MatrixScheduler;

--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const q = require("q");
 const sdk = require("../..");
 const EventTimeline = sdk.EventTimeline;

--- a/spec/unit/user.spec.js
+++ b/spec/unit/user.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const sdk = require("../..");
 const User = sdk.User;
 const utils = require("../test-utils");

--- a/spec/unit/utils.spec.js
+++ b/spec/unit/utils.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+import 'source-map-support/register';
 const utils = require("../../lib/utils");
 const testUtils = require("../test-utils");
 


### PR DESCRIPTION
This makes exception traces use the source map, which is much more helpful when
debugging.