### PR TITLE
Spread out device verification work

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -131,7 +131,7 @@ function expectAliClaimKeys() {
     });
 
     // it can take a while to process the key query, so give it some extra
-    // time, and make sure the claim actually happens tather than ploughing on
+    // time, and make sure the claim actually happens rather than ploughing on
     // confusingly.
     return aliTestClient.httpBackend.flush("/keys/claim", 1, 20).then((r) => {
         expect(r).toEqual(1);

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -123,7 +123,7 @@ describe("MatrixClient room timelines", function() {
         client.startClient();
         httpBackend.flush("/pushrules").then(function() {
             return httpBackend.flush("/filter");
-        }).done(done);
+        }).nodeify(done);
     });
 
     afterEach(function() {


### PR DESCRIPTION
Avoid a big freeze when we process the results of a device query, by splitting
the work up by user.

Fixes https://github.com/vector-im/riot-web/issues/3158