### PR TITLE
Keep the device-sync token more up-to-date

### DIFF
--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -294,6 +294,13 @@ export default class DeviceList {
             // nothing to do
             this._currentQueryDeferred.resolve();
             this._currentQueryDeferred = null;
+
+            // that means we're up-to-date with the lastKnownSyncToken.
+            const token = this.lastKnownSyncToken;
+            if (token !== null) {
+                this._sessionStore.storeEndToEndDeviceSyncToken(token);
+            }
+
             return;
         }
 
@@ -363,7 +370,7 @@ export default class DeviceList {
 
             return prom;
         }).then(() => {
-            if (token) {
+            if (token !== null) {
                 this._sessionStore.storeEndToEndDeviceSyncToken(token);
             }
             console.log('Completed key download for ' + downloadUsers);


### PR DESCRIPTION
Update the sync token whenever the device list is in sync. Fixes
https://github.com/vector-im/riot-web/issues/3127.