### PR TITLE
Upload one-time keys on /sync rather than a timer

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -300,17 +300,15 @@ MatrixClient.prototype.getDeviceEd25519Key = function() {
 };
 
 /**
- * Upload the device keys to the homeserver and ensure that the
- * homeserver has enough one-time keys.
- * @param {number} maxKeys The maximum number of keys to generate
+ * Upload the device keys to the homeserver.
  * @return {object} A promise that will resolve when the keys are uploaded.
  */
-MatrixClient.prototype.uploadKeys = function(maxKeys) {
+MatrixClient.prototype.uploadKeys = function() {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
 
-    return this._crypto.uploadKeys(maxKeys);
+    return this._crypto.uploadDeviceKeys();
 };
 
 /**
@@ -2687,12 +2685,7 @@ MatrixClient.prototype.startClient = function(opts) {
     }
 
     if (this._crypto) {
-        this._crypto.uploadKeys(5).done();
-        const tenMinutes = 1000 * 60 * 10;
-        const self = this;
-        this._uploadIntervalID = global.setInterval(function() {
-            self._crypto.uploadKeys(5).done();
-        }, tenMinutes);
+        this._crypto.uploadDeviceKeys().done();
     }
 
     // periodically poll for turn servers if we support voip
@@ -2724,9 +2717,6 @@ MatrixClient.prototype.stopClient = function() {
     if (this._syncApi) {
         this._syncApi.stop();
         this._syncApi = null;
-    }
-    if (this._crypto) {
-        global.clearInterval(this._uploadIntervalID);
     }
     global.clearTimeout(this._checkTurnServersTimeoutID);
 };


### PR DESCRIPTION
Delay the upload of one-time keys until we have received a sync *without any to-device messages*. Doing so means that we can try to avoid throwing away our private keys just before we receive the to-device messages which use them.

Once we've decided to go ahead and upload them, we keep uploading them in batches of 5 until we get to the desired 50 keys on the server. We then periodically check that there are still enough on the server.

Fixes https://github.com/vector-im/riot-web/issues/2782.