### PR TITLE
Store account data in the same way as room data

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -544,6 +544,9 @@ SyncApi.prototype._sync = function(syncOptions) {
             this._currentSyncRequest = q.resolve({
                 next_batch: data.nextBatch,
                 rooms: data.roomsData,
+                account_data: {
+                    events: data.accountData,
+                },
             });
             isCachedResponse = true;
         }
@@ -576,7 +579,7 @@ SyncApi.prototype._sync = function(syncOptions) {
         // accumulated data. We don't want to accumulate the same thing twice, so
         // only accumulate if this isn't a cached response.
         if (self.opts.syncAccumulator && !isCachedResponse) {
-            self.opts.syncAccumulator.accumulateRooms(data);
+            self.opts.syncAccumulator.accumulate(data);
         }
 
         // emit synced events


### PR DESCRIPTION
Previously, we treated the `MatrixEvents` that were in `this.accountData` in
`MatrixInMemoryStore` as the ground truth and saved those to disk and restored
them back upon load. This did not consider that there are **no emitted events**
when they are restored. Riot-Web was listening for a specific account data
event in order to dynamically update the theme. When the page was reloaded, we
dutifully put the right event in `MatrixInMemoryStore`, but failed to emit an
event to tell Riot-Web this. This led to vector-im/riot-web#3247

This patch fixes it by treating the `/sync` response as the ground truth and
ignoring `this.accountData` entirely. This means that upon load, we will be
injecting an `account_data` key into the initial `/sync` response. This will
cause it to be added to `this.accountData` in the store AND cause the event to
be emitted.

Manually tested and it does indeed fix it.