### PR TITLE
Add m.login.email.identity support to UI auth

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -135,7 +136,7 @@ MatrixBaseApis.prototype.register = function(
     sessionId, auth, bindEmail, guestAccessToken,
     callback,
 ) {
-    if (auth === undefined) {
+    if (auth === undefined || auth === null) {
         auth = {};
     }
     if (sessionId) {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -220,6 +220,8 @@ InteractiveAuth.prototype = {
      * This must be set in order to successfully poll for completion
      * of the email validation.
      * Specific to m.login.email.identity
+     *
+     * @param {string} sid The sid for the email validation session
      */
     setEmailSid: function(sid) {
         this._emailSid = sid;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -56,7 +56,9 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  *     called when the status of the UI auth changes, ie. when the state of
  *     an auth stage changes of when the auth flow moves to a new stage.
  *     The arguments are: the login type (eg m.login.password); and an object
- *     specific to the login type.
+ *     specific to the login type. These are:
+ *         m.login.email.identity:
+ *          * emailSid: string, the sid of the active email auth session
  *
  * @param {object?} opts.inputs Inputs provided by the user and used by different
  *     stages of the auto process. The inputs provided will affect what flow is chosen.

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -248,6 +248,9 @@ InteractiveAuth.prototype = {
         if (!ignoreFailure) {
             prom = prom.catch(this._completionDeferred.reject);
         } else {
+            // We ignore all failures here (even non-UI auth related ones)
+            // since we don't want to suddenly fail if the internet connection
+            // had a blip whilst we were polling
             prom = prom.catch((error) => {
                 console.log("Ignoring error from UI auth: " + error);
             });

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -300,6 +300,14 @@ InteractiveAuth.prototype = {
 
     /**
      * Pick one of the flows from the returned list
+     * If a flow using all of the inputs is found, it will
+     * be returned, otherwise, null will be returned.
+     *
+     * Only flows using all given inputs are chosen because it
+     * is likley to be surprising if the user provides a
+     * credential and it is not used. For example, for registration,
+     * this could result in the email not being used which would leave
+     * the account with no means to reset a password.
      *
      * @private
      * @return {object} flow

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -265,10 +265,6 @@ InteractiveAuth.prototype = {
         if (!nextStage) {
             throw new Error("No incomplete flows from the server");
         }
-        if (nextStage == this._currentStage) {
-            // we've already started: don't re-start it
-            return;
-        }
         this._currentStage = nextStage;
 
         if (this._data.errcode || this._data.error) {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -92,7 +92,8 @@ function InteractiveAuth(opts) {
     this._matrixClient = opts.matrixClient;
     this._data = opts.authData || {};
     this._requestCallback = opts.doRequest;
-    this._stateUpdatedCallback = opts.stateUpdated;
+    // startAuthStage included for backwards compat
+    this._stateUpdatedCallback = opts.stateUpdated || opts.startAuthStage;
     this._completionDeferred = null;
     this._inputs = opts.inputs || {};
 

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -241,8 +241,10 @@ InteractiveAuth.prototype = {
                     // doesn't look like an interactive-auth failure. fail the whole lot.
                     throw error;
                 }
-                // if the error didn't come with flows, copy over the ones we have
+                // if the error didn't come with flows or session ID,
+                // copy over the ones we have
                 if (!error.data.flows) error.data.flows = self._data.flows;
+                if (!error.data.session) error.data.session = self._data.session;
                 self._data = error.data;
                 self._startNextAuthStage();
             },

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -241,7 +241,9 @@ InteractiveAuth.prototype = {
                     // doesn't look like an interactive-auth failure. fail the whole lot.
                     throw error;
                 }
-                if (errorFlows) self._data = error.data;
+                // if the error didn't come with flows, copy over the ones we have
+                if (!error.data.flows) error.data.flows = self._data.flows;
+                self._data = error.data;
                 self._startNextAuthStage();
             },
         );

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -165,6 +165,12 @@ InteractiveAuth.prototype = {
         return this._data ? this._data.session : undefined;
     },
 
+    /**
+     * get the client secret used for validation sessions
+     * with the ID server.
+     *
+     * @return {string} client secret
+     */
     getClientSecret: function() {
         return this._clientSecret;
     },
@@ -209,6 +215,12 @@ InteractiveAuth.prototype = {
         this._doRequest(auth, ignoreFailure);
     },
 
+    /**
+     * Sets the sid for the email validation session
+     * This must be set in order to successfully poll for completion
+     * of the email validation.
+     * Specific to m.login.email.identity
+     */
     setEmailSid: function(sid) {
         this._emailSid = sid;
     },

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -70,8 +70,6 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  * @param {string?} opts.inputs.phoneNumber A phone number. If supplied, a flow
  *     using phone number validation will be chosen.
  *
- * @param {function(object)?} opts.makeRegistrationUrl A function that makes a registration URL
- *
  * @param {string?} opts.sessionId If resuming an existing interactive auth session,
  *     the sessionId of that session.
  *
@@ -89,11 +87,11 @@ function InteractiveAuth(opts) {
     this._stateUpdatedCallback = opts.stateUpdated;
     this._completionDeferred = null;
     this._inputs = opts.inputs || {};
-    this._makeRegistrationUrl = opts.makeRegistrationUrl;
 
     if (opts.sessionId) this._data.session = opts.sessionId;
     this._clientSecret = opts.clientSecret || this._matrixClient.generateClientSecret();
     this._emailSid = opts.emailSid;
+    if (this._emailSid === undefined) this._emailSid = null;
 
     this._currentStage = null;
 }
@@ -158,6 +156,10 @@ InteractiveAuth.prototype = {
         return this._data ? this._data.session : undefined;
     },
 
+    getClientSecret: function() {
+        return this._clientSecret;
+    },
+
     /**
      * get the server params for a given stage
      *
@@ -196,6 +198,10 @@ InteractiveAuth.prototype = {
         utils.extend(auth, authData);
 
         this._doRequest(auth, ignoreFailure);
+    },
+
+    setEmailSid: function(sid) {
+        this._emailSid = sid;
     },
 
     /**
@@ -273,48 +279,9 @@ InteractiveAuth.prototype = {
 
         const stageStatus = {};
         if (nextStage == EMAIL_STAGE_TYPE) {
-            stageStatus.busy = true;
+            stageStatus.emailSid = this._emailSid;
         }
         this._stateUpdatedCallback(nextStage, stageStatus);
-
-        // Do stage-specific things to start the stage. These would be
-        // an obvious thing to stick in a different file / function if there
-        // were more of them.
-        if (nextStage == EMAIL_STAGE_TYPE) {
-            if (this._emailSid) {
-                this.poll();
-            } else {
-                this._requestEmailToken().catch(
-                    this._completionDeferred.reject,
-                ).finally(() => {
-                    this._stateUpdatedCallback(nextStage, { busy: false });
-                }).done();
-            }
-        }
-    },
-
-    /*
-     * Requests a verification token by email.
-     * Specific to m.login.email.identity, and would be
-     * an obvious thing to move out to stage-specific
-     * modules if worthwhile.
-     */
-    _requestEmailToken() {
-        const nextLink = this._makeRegistrationUrl({
-            client_secret: this._clientSecret,
-            hs_url: this._matrixClient.getHomeserverUrl(),
-            is_url: this._matrixClient.getIdentityServerUrl(),
-            session_id: this.getSessionId(),
-        });
-
-        return this._matrixClient.requestRegisterEmailToken(
-            this._inputs.emailAddress,
-            this._clientSecret,
-            1, // TODO: Multiple send attempts?
-            nextLink,
-        ).then((result) => {
-            this._emailSid = result.sid;
-        });
     },
 
     /**

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -222,12 +222,13 @@ InteractiveAuth.prototype = {
                 self._completionDeferred.resolve(result);
             }, function(error) {
                 // sometimes UI auth errors don't come with flows
-                const haveFlows = Boolean(self._data.flows) || Boolean(error.data.flows);
+                const errorFlows = error.data ? error.data.flows : null;
+                const haveFlows = Boolean(self._data.flows) || Boolean(errorFlows);
                 if (error.httpStatus !== 401 || !error.data || !haveFlows) {
                     // doesn't look like an interactive-auth failure. fail the whole lot.
                     throw error;
                 }
-                if (error.data.flows) self._data = error.data;
+                if (errorFlows) self._data = error.data;
                 self._startNextAuthStage();
             },
         );

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -285,7 +285,7 @@ InteractiveAuth.prototype = {
                 this.poll();
             } else {
                 this._requestEmailToken().catch(
-                    this._completionDeferred.reject
+                    this._completionDeferred.reject,
                 ).finally(() => {
                     this._stateUpdatedCallback(nextStage, { busy: false });
                 }).done();

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -56,7 +56,13 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  *     called when the status of the UI auth changes, ie. when the state of
  *     an auth stage changes of when the auth flow moves to a new stage.
  *     The arguments are: the login type (eg m.login.password); and an object
- *     specific to the login type. These are:
+ *     which is either an error or an informational object specific to the
+ *     login type. If the 'errcode' key is defined, the object is an error,
+ *     and has keys:
+ *         errcode: string, the textual error code, eg. M_UNKNOWN
+ *         error: string, human readable string describing the error
+ *
+ *     The login type specific objects are as follows:
  *         m.login.email.identity:
  *          * emailSid: string, the sid of the active email auth session
  *


### PR DESCRIPTION
Extends the interactive-auth to support m.login.email.identity
This also includes the ability to resume a UI auth session given
the appropriate information (ie. to resume the auth flow having
clicked a link in a verification email) and supports polling for
the auth session having been completed elsewhere.