### PR TITLE
src/client.js: Fix incorrect roomId reference in VoIP glare code

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2829,7 +2829,7 @@ function setupCallEventHandler(client) {
             const existingCalls = utils.values(client.callList);
             for (i = 0; i < existingCalls.length; ++i) {
                 const thisCall = existingCalls[i];
-                if (call.room_id === thisCall.room_id &&
+                if (call.roomId === thisCall.roomId &&
                         thisCall.direction === 'outbound' &&
                         (["wait_local_media", "create_offer", "invite_sent"].indexOf(
                             thisCall.state) !== -1)) {


### PR DESCRIPTION
MatrixCall has a `roomId` property, but not a `room_id` property.