### PR TITLE
Add getEmailSid

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -218,6 +218,8 @@ InteractiveAuth.prototype = {
     /**
      * Gets the sid for the email validation session
      * Specific to m.login.email.identity
+     *
+     * @returns {string} The sid of the email auth session
      */
     getEmailSid: function() {
         return this._emailSid;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -216,6 +216,14 @@ InteractiveAuth.prototype = {
     },
 
     /**
+     * Gets the sid for the email validation session
+     * Specific to m.login.email.identity
+     */
+    getEmailSid: function() {
+        return this._emailSid;
+    },
+
+    /**
      * Sets the sid for the email validation session
      * This must be set in order to successfully poll for completion
      * of the email validation.


### PR DESCRIPTION
Other places sometimes need to re-use the email sid to send proof
of ownership of a email address to somewhere else.