### PR TITLE
Add x_show_msisdn parameter to register calls

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -170,6 +170,15 @@ MatrixBaseApis.prototype.register = function(
     if (guestAccessToken !== undefined && guestAccessToken !== null) {
         params.guest_access_token = guestAccessToken;
     }
+    // Temporary parameter added to make the register endpoint advertise
+    // msisdn flows. This exists because there are clients that break
+    // when given stages they don't recognise. This parameter will cease
+    // to be necessary once these old clients are gone.
+    // Only send it if we send any params at all (the password param is
+    // mandatory, so if we send any params, we'll send the password param)
+    if (password !== undefined && password !== null) {
+        params.x_show_msisdn = true;
+    }
 
     return this.registerRequest(params, undefined, callback);
 };


### PR DESCRIPTION
Request the msisdn stages in the register UI auth, as commented