### PR TITLE
Save the completed flows

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -275,7 +275,8 @@ InteractiveAuth.prototype = {
                 // if the error didn't come with flows, completed flows or session ID,
                 // copy over the ones we have. Synapse sometimes sends responses without
                 // any UI auth data (eg. when polling for email validation, if the email
-                // has not yet been validated).
+                // has not yet been validated). This appears to be a Synapse bug, which
+                // we workaround here.
                 if (!error.data.flows && !error.data.completed && !error.data.session) {
                     error.data.flows = self._data.flows;
                     error.data.completed = self._data.completed;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -272,9 +272,10 @@ InteractiveAuth.prototype = {
                     // doesn't look like an interactive-auth failure. fail the whole lot.
                     throw error;
                 }
-                // if the error didn't come with flows or session ID,
+                // if the error didn't come with flows, completed flows or session ID,
                 // copy over the ones we have
                 if (!error.data.flows) error.data.flows = self._data.flows;
+                if (!error.data.completed) error.data.completed = self._data.completed;
                 if (!error.data.session) error.data.session = self._data.session;
                 self._data = error.data;
                 self._startNextAuthStage();

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -273,10 +273,14 @@ InteractiveAuth.prototype = {
                     throw error;
                 }
                 // if the error didn't come with flows, completed flows or session ID,
-                // copy over the ones we have
-                if (!error.data.flows) error.data.flows = self._data.flows;
-                if (!error.data.completed) error.data.completed = self._data.completed;
-                if (!error.data.session) error.data.session = self._data.session;
+                // copy over the ones we have. Synapse sometimes sends responses without
+                // any UI auth data (eg. when polling for email validation, if the email
+                // has not yet been validated).
+                if (!error.data.flows && !error.data.completed && !error.data.session) {
+                    error.data.flows = self._data.flows;
+                    error.data.completed = self._data.completed;
+                    error.data.session = self._data.session;
+                }
                 self._data = error.data;
                 self._startNextAuthStage();
             },


### PR DESCRIPTION
Otherwise we get very confused and go back to the start when given
a response with no flows etc.