### PR TITLE
Increase BUFFER_PERIOD_MS from 80s to 20mins

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -37,7 +37,9 @@ const DEBUG = true;
 // beyond that and wedge forever, so we need to track how long we are willing
 // to keep open the connection. This constant is *ADDED* to the timeout= value
 // to determine the max time we're willing to wait.
-const BUFFER_PERIOD_MS = 80 * 1000;
+//
+// Increased from 80s to 20mins to fix https://github.com/vector-im/riot-web/issues/2737
+const BUFFER_PERIOD_MS = (60 * 20) * 1000;
 
 function getFilterName(userId, suffix) {
     // scope this on the user ID because people may login on many accounts


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/2737

Seems to work - I forced Chome into a heavily throttled state during /sync (1-10kb/s).
![2017-03-15-135556_427x45_scrot](https://cloud.githubusercontent.com/assets/6750344/23951910/9c21c62a-0987-11e7-8881-b99ac56f4d62.png)
