### PR TITLE
Wrong variable name is used.

### DIFF
--- a/examples/voip/browserTest.js
+++ b/examples/voip/browserTest.js
@@ -44,7 +44,7 @@ window.onload = function() {
     disableButtons(true, true, true);
 };
 
-matrixClient.on("sync", function(state, prevState, data) {
+client.on("sync", function(state, prevState, data) {
     switch (state) {
         case "PREPARED":
           syncComplete();


### PR DESCRIPTION
Ran into this while trying this out.It should be `|client.on("sync")`|` instead |matrixClient.on("sync")| .
tested it, works fine :)