### PR TITLE
Don't log the entire /sync response

### DIFF
--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -276,7 +276,7 @@ IndexedDBStore.prototype.startup = function() {
     }).then((values) => {
         const [users, accountData, syncData] = values;
         console.log(
-            "Loaded data from database: sync from ", syncData,
+            "Loaded data from database: sync from ", syncData.nextBatch,
             " -- Reticulating splines...",
         );
         users.forEach((u) => {


### PR DESCRIPTION
The console will maintain a strong ref to this object, which may exacerbate
memory leaks.