### PR TITLE
Don't be SYNCING until updating from the server

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -605,7 +605,9 @@ SyncApi.prototype._sync = function(syncOptions) {
         }
 
         // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
-        self._updateSyncState("SYNCING", syncEventData);
+        if (!isCachedResponse) {
+            self._updateSyncState("SYNCING", syncEventData);
+        }
 
         // tell databases that everything is now in a consistent state and can be
         // saved.


### PR DESCRIPTION
Syncing should probably mean the stream is up to date and
streaming messages in real-time from the server, which is not the
case if we've only loaded the cached response. Stay PREPARED until
we actually get the latest from the server.