### PR TITLE
Change interface of IndexedDBStore: hide internals

### DIFF
--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -234,7 +234,6 @@ IndexedDBStoreBackend.prototype = {
  *
  * @constructor
  * @extends MatrixInMemoryStore
- * loaded from IndexedDB and periodically saved to IndexedDB.
  * @param {Object} opts Options optject.
  * @param {Object} opts.indexedDB The Indexed DB interface e.g.
  * <code>window.indexedDB</code>

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -234,7 +234,7 @@ IndexedDBStoreBackend.prototype = {
  *
  * @constructor
  * @extends MatrixInMemoryStore
- * @param {Object} opts Options optject.
+ * @param {Object} opts Options object.
  * @param {Object} opts.indexedDB The Indexed DB interface e.g.
  * <code>window.indexedDB</code>
  * @param {string=} opts.dbName Optional database name. The same name must be used


### PR DESCRIPTION
Hide the IndexedDBBackend and SyncAccumulator objects and have
indexeddbstore instaniate them itself, rather than making the app
instantiate them. Pass the approipriate options through. This
gives us much more flexibility to move things around under the
hood.