### PR TITLE
Further reorganising of indexeddb sync code

### DIFF
--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -134,8 +134,9 @@ describe("MatrixClient", function() {
             "getRoom", "getRooms", "getUser", "getSyncToken", "scrollback",
             "save", "setSyncToken", "storeEvents", "storeRoom", "storeUser",
             "getFilterIdByName", "setFilterIdByName", "getFilter", "storeFilter",
-            "getSyncAccumulator", "startup", "deleteAllData",
+            "getSyncAccumulator", "startup", "deleteAllData", "setSyncData",
         ].reduce((r, k) => { r[k] = expect.createSpy(); return r; }, {});
+        store.getSavedSync = expect.createSpy().andReturn(q(null));
         client = new MatrixClient({
             baseUrl: "https://my.home.server",
             idBaseUrl: identityServerUrl,

--- a/src/client.js
+++ b/src/client.js
@@ -164,8 +164,6 @@ function MatrixClient(opts) {
 
         this.olmVersion = Crypto.getOlmVersion();
     }
-
-    this._syncAccumulator = this.store.getSyncAccumulator();
 }
 utils.inherits(MatrixClient, EventEmitter);
 utils.extend(MatrixClient.prototype, MatrixBaseApis.prototype);
@@ -2789,7 +2787,6 @@ MatrixClient.prototype.startClient = function(opts) {
     opts = Object.assign({}, opts);
 
     opts.crypto = this._crypto;
-    opts.syncAccumulator = this._syncAccumulator;
     opts.canResetEntireTimeline = (roomId) => {
         if (!this._canResetTimelineCallback) {
             return false;

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -288,17 +288,27 @@ IndexedDBStore.prototype.startup = function() {
         });
         this._syncTs = Date.now(); // pretend we've written so we don't rewrite
         this.setSyncToken(syncData.nextBatch);
-        this._setSyncData(syncData.nextBatch, syncData.roomsData, accountData);
+        this.setSyncData({
+            next_batch: syncData.nextBatch,
+            rooms: syncData.roomsData,
+            account_data: {
+                events: accountData,
+            },
+        });
     });
 };
 
 /**
- * Return the accumulator which will have the initial /sync data when startup()
- * is called.
- * @return {SyncAccumulator}
+ * @return {Promise} Resolves with a sync response to restore the
+ * client state to where it was at the last save, or null if there
+ * is no saved sync data.
  */
-IndexedDBStore.prototype.getSyncAccumulator = function() {
-    return this._syncAccumulator;
+IndexedDBStore.prototype.getSavedSync = function() {
+    const data = this._syncAccumulator.getJSON();
+    if (!data.nextBatch) return q(null);
+    // We must deep copy the stored data so that the /sync processing code doesn't
+    // corrupt the internal state of the sync accumulator (it adds non-clonable keys)
+    return q(utils.deepCopy(data));
 };
 
 /**
@@ -327,14 +337,8 @@ IndexedDBStore.prototype.save = function() {
     return q();
 };
 
-IndexedDBStore.prototype._setSyncData = function(nextBatch, roomsData, accountData) {
-    this._syncAccumulator.accumulate({
-        next_batch: nextBatch,
-        rooms: roomsData,
-        account_data: {
-            events: accountData,
-        },
-    });
+IndexedDBStore.prototype.setSyncData = function(syncData) {
+    this._syncAccumulator.accumulate(syncData);
 };
 
 IndexedDBStore.prototype._syncToDatabase = function() {

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -279,6 +279,8 @@ module.exports.MatrixInMemoryStore.prototype = {
 
     /**
      * setSyncData does nothing as there is no backing data store.
+     *
+     * @param {Object} syncData The sync data
      */
     setSyncData: function(syncData) {},
 

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -298,6 +298,15 @@ module.exports.MatrixInMemoryStore.prototype = {
     },
 
     /**
+     * @return {Promise} Resolves with a sync response to restore the
+     * client state to where it was at the last save, or null if there
+     * is no saved sync data.
+     */
+    getSavedSync: function() {
+        return q(null);
+    },
+
+    /**
      * Delete all data from this store.
      * @return {Promise} An immediately resolved promise.
      */

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -278,17 +278,14 @@ module.exports.MatrixInMemoryStore.prototype = {
     },
 
     /**
+     * setSyncData does nothing as there is no backing data store.
+     */
+    setSyncData: function(syncData) {},
+
+    /**
      * Save does nothing as there is no backing data store.
      */
     save: function() {},
-
-    /**
-     * Returns nothing as this store does not accumulate /sync data.
-     * @return {?SyncAccumulator} null
-     */
-    getSyncAccumulator: function() {
-        return null;
-    },
 
     /**
      * Startup does nothing as this store doesn't require starting up.

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -203,6 +203,15 @@ StubStore.prototype = {
     },
 
     /**
+     * @return {Promise} Resolves with a sync response to restore the
+     * client state to where it was at the last save, or null if there
+     * is no saved sync data.
+     */
+    getSavedSync: function() {
+        return q(null);
+    },
+
+    /**
      * Delete all data from this store. Does nothing since this store
      * doesn't store anything.
      * @return {Promise} An immediately resolved promise.

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -184,6 +184,8 @@ StubStore.prototype = {
 
     /**
      * setSyncData does nothing as there is no backing data store.
+     *
+     * @param {Object} syncData The sync data
      */
     setSyncData: function(syncData) {},
 

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -183,17 +183,14 @@ StubStore.prototype = {
     },
 
     /**
+     * setSyncData does nothing as there is no backing data store.
+     */
+    setSyncData: function(syncData) {},
+
+    /**
      * Save does nothing as there is no backing data store.
      */
     save: function() {},
-
-    /**
-     * Returns nothing as this store does not accumulate /sync data.
-     * @return {?SyncAccumulator} null
-     */
-    getSyncAccumulator: function() {
-        return null;
-    },
 
     /**
      * Startup does nothing.

--- a/src/sync.js
+++ b/src/sync.js
@@ -60,8 +60,6 @@ function debuglog() {
  * @param {MatrixClient} client The matrix client instance to use.
  * @param {Object} opts Config options
  * @param {module:crypto=} opts.crypto Crypto manager
- * kept up-to-date. If one is supplied, the response to getJSON() will be used
- * initially.
  * @param {Function=} opts.canResetEntireTimeline A function which is called
  * with a room ID and returns a boolean. It should return 'true' if the SDK can
  * SAFELY remove events from this room. It may not be safe to remove events if


### PR DESCRIPTION
 * Make sync communicate with the sync accumulator via the store
 * Consequently get rid of getSyncAccumulator as it's now
   unnecessary.
 * Make the bit that gets the saved sync response async, because
   we'll need it to be when it's coming over postMessage from a
   webworker.

Based off of https://github.com/matrix-org/matrix-js-sdk/pull/406