### PR TITLE
Indicate syncState ERROR after many failed /syncs

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -39,8 +39,6 @@ const DEBUG = true;
 // to determine the max time we're willing to wait.
 const BUFFER_PERIOD_MS = 80 * 1000;
 
-// Number of consecutive failed /sync requests
-let failedSyncCount = 0;
 // Number of consecutive failed syncs that will lead to a syncState of ERROR as opposed
 // to RECONNECTING. This is needed to inform the client of server issues when the
 // keepAlive is successful but the server /sync fails.
@@ -96,6 +94,7 @@ function SyncApi(client, opts) {
     this._keepAliveTimer = null;
     this._connectionReturnedDefer = null;
     this._notifEvents = []; // accumulator of sync events in the current sync response
+    this._failedSyncCount = 0; // Number of consecutive failed /sync requests
 
     if (client.getNotifTimelineSet()) {
         reEmit(client, client.getNotifTimelineSet(),
@@ -582,6 +581,9 @@ SyncApi.prototype._sync = function(syncOptions) {
         // polling with the same token.
         client.store.setSyncToken(data.next_batch);
 
+        // Reset after a successful sync
+        self._failedSyncCount = 0;
+
         try {
             self._processSyncResponse(syncToken, data);
         } catch (e) {
@@ -616,10 +618,8 @@ SyncApi.prototype._sync = function(syncOptions) {
         // saved.
         client.store.save();
 
+        // Begin next sync
         self._sync(syncOptions);
-
-        // Reset after a successful sync
-        failedSyncCount = 0;
     }, function(err) {
         if (!self._running) {
             debuglog("Sync no longer running: exiting");
@@ -633,8 +633,8 @@ SyncApi.prototype._sync = function(syncOptions) {
         console.error("/sync error %s", err);
         console.error(err);
 
-        failedSyncCount++;
-        console.log('Number of consecutive failed sync requests:', failedSyncCount);
+        self._failedSyncCount++;
+        console.log('Number of consecutive failed sync requests:', self._failedSyncCount);
 
         debuglog("Starting keep-alive");
         // Note that we do *not* mark the sync connection as
@@ -650,7 +650,8 @@ SyncApi.prototype._sync = function(syncOptions) {
         self._currentSyncRequest = null;
         // Transition from RECONNECTING to ERROR after a given number of failed syncs
         self._updateSyncState(
-            failedSyncCount > FAILED_SYNC_ERROR_THRESHOLD ? "ERROR" : "RECONNECTING",
+            self._failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
+                "ERROR" : "RECONNECTING",
         );
     });
 };


### PR DESCRIPTION
when a /sync leads to an error, increase a counter and use the counter to decide which state to be in when starting keepAlives. If the count is above a certain threshold (arbitrary 3 chosen here), switch from RECONNECTING to ERROR to show that the server is facing difficulties that aren't affeting is ability to return on /versions.

Attempts to fix https://github.com/vector-im/riot-web/issues/3336