### PR TITLE
Make indexeddb startup faster

### DIFF
--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -133,13 +133,15 @@ LocalIndexedDBStoreBackend.prototype = {
             this.db.onversionchange = () => {
                 this.db.close();
             };
+
+            return this._init();
         });
     },
 
     /**
      * Having connected, load initial data from the database and prepare for use
      */
-    init: function() {
+    _init: function() {
         return q.all([
             this._loadAccountData(),
             this._loadSyncData(),

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -140,6 +140,7 @@ LocalIndexedDBStoreBackend.prototype = {
 
     /**
      * Having connected, load initial data from the database and prepare for use
+     * @return {Promise} Resolves on success
      */
     _init: function() {
         return q.all([

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -137,6 +137,24 @@ LocalIndexedDBStoreBackend.prototype = {
     },
 
     /**
+     * Having connected, load initial data from the database and prepare for use
+     */
+    init: function() {
+        return q.all([
+            this._loadAccountData(),
+            this._loadSyncData(),
+        ]).then(([accountData, syncData]) => {
+            this._syncAccumulator.accumulate({
+                next_batch: syncData.nextBatch,
+                rooms: syncData.roomsData,
+                account_data: {
+                    events: accountData,
+                },
+            });
+        });
+    },
+
+    /**
      * Clear the entire database. This should be used when logging out of a client
      * to prevent mixing data between accounts.
      * @return {Promise} Resolved when the database is cleared.
@@ -250,7 +268,7 @@ LocalIndexedDBStoreBackend.prototype = {
      * sync.
      * @return {Promise<Object[]>} A list of presence events in their raw form.
      */
-    loadUserPresenceEvents: function() {
+    getUserPresenceEvents: function() {
         return q.try(() => {
             const txn = this.db.transaction(["users"], "readonly");
             const store = txn.objectStore("users");
@@ -264,7 +282,7 @@ LocalIndexedDBStoreBackend.prototype = {
      * Load all the account data events from the database. This is not cached.
      * @return {Promise<Object[]>} A list of raw global account events.
      */
-    loadAccountData: function() {
+    _loadAccountData: function() {
         return q.try(() => {
             const txn = this.db.transaction(["accountData"], "readonly");
             const store = txn.objectStore("accountData");
@@ -278,7 +296,7 @@ LocalIndexedDBStoreBackend.prototype = {
      * Load the sync data from the database.
      * @return {Promise<Object>} An object with "roomsData" and "nextBatch" keys.
      */
-    loadSyncData: function() {
+    _loadSyncData: function() {
         return q.try(() => {
             const txn = this.db.transaction(["sync"], "readonly");
             const store = txn.objectStore("sync");

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -56,6 +56,13 @@ RemoteIndexedDBStoreBackend.prototype = {
     },
 
     /**
+     * Having connected, load initial data from the database and prepare for use
+     */
+    init: function() {
+        return this._doCmd('init');
+    },
+
+    /**
      * Clear the entire database. This should be used when logging out of a client
      * to prevent mixing data between accounts.
      * @return {Promise} Resolved when the database is cleared.
@@ -86,24 +93,8 @@ RemoteIndexedDBStoreBackend.prototype = {
      * Load all user presence events from the database. This is not cached.
      * @return {Promise<Object[]>} A list of presence events in their raw form.
      */
-    loadUserPresenceEvents: function() {
-        return this._doCmd('loadUserPresenceEvents');
-    },
-
-    /**
-     * Load all the account data events from the database. This is not cached.
-     * @return {Promise<Object[]>} A list of raw global account events.
-     */
-    loadAccountData: function() {
-        return this._doCmd('loadAccountData');
-    },
-
-    /**
-     * Load the sync data from the database.
-     * @return {Promise<Object>} An object with "roomsData" and "nextBatch" keys.
-     */
-    loadSyncData: function() {
-        return this._doCmd('loadSyncData');
+    getUserPresenceEvents: function() {
+        return this._doCmd('getUserPresenceEvents');
     },
 
     _doCmd: function(cmd, args) {

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -56,13 +56,6 @@ RemoteIndexedDBStoreBackend.prototype = {
     },
 
     /**
-     * Having connected, load initial data from the database and prepare for use
-     */
-    init: function() {
-        return this._doCmd('init');
-    },
-
-    /**
      * Clear the entire database. This should be used when logging out of a client
      * to prevent mixing data between accounts.
      * @return {Promise} Resolved when the database is cleared.

--- a/src/store/indexeddb-remote-worker.js
+++ b/src/store/indexeddb-remote-worker.js
@@ -45,6 +45,9 @@ class IndexedDbStoreWorker {
             case 'connect':
                 prom = this.backend.connect();
                 break;
+            case 'init':
+                prom = this.backend.init();
+                break;
             case 'clearDatabase':
                 prom = this.backend.clearDatabase().then((result) => {
                     // This returns special classes which can't be cloned
@@ -64,14 +67,8 @@ class IndexedDbStoreWorker {
                     return {};
                 });
                 break;
-            case 'loadUserPresenceEvents':
-                prom = this.backend.loadUserPresenceEvents();
-                break;
-            case 'loadAccountData':
-                prom = this.backend.loadAccountData();
-                break;
-            case 'loadSyncData':
-                prom = this.backend.loadSyncData();
+            case 'getUserPresenceEvents':
+                prom = this.backend.getUserPresenceEvents();
                 break;
         }
 

--- a/src/store/indexeddb-store-worker.js
+++ b/src/store/indexeddb-store-worker.js
@@ -66,9 +66,6 @@ class IndexedDBStoreWorker {
             case 'connect':
                 prom = this.backend.connect();
                 break;
-            case 'init':
-                prom = this.backend.init();
-                break;
             case 'clearDatabase':
                 prom = this.backend.clearDatabase().then((result) => {
                     // This returns special classes which can't be cloned

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -107,9 +107,7 @@ IndexedDBStore.prototype.startup = function() {
     if (this.startedUp) {
         return q();
     }
-    // FIXME: This is a bit dumb: we pull the sync data over from
-    // the web worker to then immediately push it back again without
-    // using it.
+
     return this.backend.connect().then(() => {
         return this.backend.init();
     }).then(() => {

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -109,8 +109,6 @@ IndexedDBStore.prototype.startup = function() {
     }
 
     return this.backend.connect().then(() => {
-        return this.backend.init();
-    }).then(() => {
         return this.backend.getUserPresenceEvents();
     }).then((userPresenceEvents) => {
         userPresenceEvents.forEach(([userId, rawEvent]) => {


### PR DESCRIPTION
Don't needlessly transfer data from the worker to the main script
only to immediately transfer it right back again.

This is based off https://github.com/matrix-org/matrix-js-sdk/pull/412