### PR TITLE
Make indexeddb save after the first sync

### DIFF
--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -89,7 +89,7 @@ const IndexedDBStore = function IndexedDBStore(opts) {
     }
 
     this.startedUp = false;
-    this._syncTs = Date.now(); // updated when writes to the database are performed
+    this._syncTs = 0;
 
     // Records the last-modified-time of each user at the last point we saved
     // the database, such that we can derive the set if users that have been
@@ -123,7 +123,6 @@ IndexedDBStore.prototype.startup = function() {
             this._userModifiedMap[u.userId] = u.getLastModifiedTime();
             this.storeUser(u);
         });
-        this._syncTs = Date.now(); // pretend we've written so we don't rewrite
     });
 };
 
@@ -157,26 +156,30 @@ IndexedDBStore.prototype.deleteAllData = function() {
 IndexedDBStore.prototype.save = function() {
     const now = Date.now();
     if (now - this._syncTs > WRITE_DELAY_MS) {
-        this._syncTs = Date.now(); // set now to guard against multi-writes
-
-        // work out changed users (this doesn't handle deletions but you
-        // can't 'delete' users as they are just presence events).
-        const userTuples = [];
-        for (const u of this.getUsers()) {
-            if (this._userModifiedMap[u.userId] === u.getLastModifiedTime()) continue;
-            if (!u.events.presence) continue;
-
-            userTuples.push([u.userId, u.events.presence.event]);
-
-            // note that we've saved this version of the user
-            this._userModifiedMap[u.userId] = u.getLastModifiedTime();
-        }
-
-        return this.backend.syncToDatabase(userTuples).catch((err) => {
-            console.error("sync fail:", err);
-        });
+        return this._reallySave();
     }
     return q();
+};
+
+IndexedDBStore.prototype._reallySave = function() {
+    this._syncTs = Date.now(); // set now to guard against multi-writes
+
+    // work out changed users (this doesn't handle deletions but you
+    // can't 'delete' users as they are just presence events).
+    const userTuples = [];
+    for (const u of this.getUsers()) {
+        if (this._userModifiedMap[u.userId] === u.getLastModifiedTime()) continue;
+        if (!u.events.presence) continue;
+
+        userTuples.push([u.userId, u.events.presence.event]);
+
+        // note that we've saved this version of the user
+        this._userModifiedMap[u.userId] = u.getLastModifiedTime();
+    }
+
+    return this.backend.syncToDatabase(userTuples).catch((err) => {
+        console.error("sync fail:", err);
+    });
 };
 
 IndexedDBStore.prototype.setSyncData = function(syncData) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -620,11 +620,13 @@ SyncApi.prototype._sync = function(syncOptions) {
         // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
         if (!isCachedResponse) {
             self._updateSyncState("SYNCING", syncEventData);
+
+            // tell databases that everything is now in a consistent state and can be
+            // saved (no point doing so if we only have the data we just got out of the
+            // store).
+            client.store.save();
         }
 
-        // tell databases that everything is now in a consistent state and can be
-        // saved.
-        client.store.save();
 
         // Begin next sync
         self._sync(syncOptions);


### PR DESCRIPTION
Save the sync data to indexeddb after the first catch-up

Fixes vector-im/riot-web#3527

This is based off of https://github.com/matrix-org/matrix-js-sdk/pull/413