### PR TITLE
Fix release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -217,6 +217,9 @@ fi
 rm "${release_text}"
 rm "${latest_changes}"
 
+# publish to npmjs
+npm publish
+
 if [ -z "$skip_jsdoc" ]; then
     echo "generating jsdocs"
     npm run gendoc
@@ -231,9 +234,6 @@ if [ -z "$skip_jsdoc" ]; then
     git add "$release"
     git commit --no-verify -m "Add jsdoc for $release" index.html "$release"
 fi
-
-# publish to npmjs
-npm publish
 
 # if it is a pre-release, leave it on the release branch for now.
 if [ $prerelease -eq 1 ]; then


### PR DESCRIPTION
Publish to npm before switching to the doc branch: previously we
published from master, but since we now now longer merge
pre-releases to master, publish from the release branch (just
not the doc branch because that won't work).