### PR TITLE
Don't leave the gh-pages branch checked out

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -238,6 +238,7 @@ fi
 # if it is a pre-release, leave it on the release branch for now.
 if [ $prerelease -eq 1 ]; then
     exit 0
+    git checkout "$rel_branch"
 fi
 
 # merge release branch to master

--- a/release.sh
+++ b/release.sh
@@ -237,8 +237,8 @@ fi
 
 # if it is a pre-release, leave it on the release branch for now.
 if [ $prerelease -eq 1 ]; then
-    exit 0
     git checkout "$rel_branch"
+    exit 0
 fi
 
 # merge release branch to master


### PR DESCRIPTION
After a pre-release, check out the release branch again rather
than leaving the working copy on the gh-pages branch