### PR TITLE
Implement API for setting RM

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -470,6 +470,33 @@ MatrixBaseApis.prototype.roomInitialSync = function(roomId, limit, callback) {
     );
 };
 
+/**
+ * Set a marker to represent which event the user was last reading in a room. This can
+ * be retrieved from room account data and displayed as a horizontal line in the client
+ * that is visually distinct to the position of the user's own read receipt.
+ * @param {string} roomId ID of the room that has been read
+ * @param {string} rmEventId ID of the event that has been read
+ * @param {string} rrEventId ID of the event tracked by the read receipt. This is here
+ * for convenience because the RR and the RM are commonly updated at the same time as
+ * each other. Optional.
+ * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.setRoomReadMarkers = function(roomId, rmEventId, rrEventId) {
+    const path = utils.encodeUri("/rooms/$roomId/read_marker", {
+        $roomId: roomId,
+    });
+
+    const content = {
+        "m.read_marker": rmEventId,
+        "m.read": rrEventId,
+    };
+
+    return this._http.authedRequest(
+        null, "POST", path, undefined, content,
+    );
+};
+
 
 // Room Directory operations
 // =========================

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -483,12 +483,12 @@ MatrixBaseApis.prototype.roomInitialSync = function(roomId, limit, callback) {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixBaseApis.prototype.setRoomReadMarkers = function(roomId, rmEventId, rrEventId) {
-    const path = utils.encodeUri("/rooms/$roomId/read_marker", {
+    const path = utils.encodeUri("/rooms/$roomId/read_markers", {
         $roomId: roomId,
     });
 
     const content = {
-        "m.read_marker": rmEventId,
+        "m.fully_read": rmEventId,
         "m.read": rrEventId,
     };
 

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -471,16 +471,16 @@ MatrixBaseApis.prototype.roomInitialSync = function(roomId, limit, callback) {
 };
 
 /**
- * Set a marker to represent which event the user was last reading in a room. This can
- * be retrieved from room account data and displayed as a horizontal line in the client
- * that is visually distinct to the position of the user's own read receipt.
+ * Set a marker to indicate the point in a room before which the user has read every
+ * event. This can be retrieved from room account data (the event type is `m.fully_read`)
+ * and displayed as a horizontal line in the timeline that is visually distinct to the
+ * position of the user's own read receipt.
  * @param {string} roomId ID of the room that has been read
  * @param {string} rmEventId ID of the event that has been read
  * @param {string} rrEventId ID of the event tracked by the read receipt. This is here
  * for convenience because the RR and the RM are commonly updated at the same time as
  * each other. Optional.
- * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
- * @return {module:http-api.MatrixError} Rejects: with an error response.
+ * @return {module:client.Promise} Resolves: the empty object, {}.
  */
 MatrixBaseApis.prototype.setRoomReadMarkers = function(roomId, rmEventId, rrEventId) {
     const path = utils.encodeUri("/rooms/$roomId/read_markers", {

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -482,7 +482,8 @@ MatrixBaseApis.prototype.roomInitialSync = function(roomId, limit, callback) {
  * each other. Optional.
  * @return {module:client.Promise} Resolves: the empty object, {}.
  */
-MatrixBaseApis.prototype.setRoomReadMarkers = function(roomId, rmEventId, rrEventId) {
+MatrixBaseApis.prototype.setRoomReadMarkersHttpRequest =
+                                function(roomId, rmEventId, rrEventId) {
     const path = utils.encodeUri("/rooms/$roomId/read_markers", {
         $roomId: roomId,
     });

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -493,7 +493,7 @@ MatrixBaseApis.prototype.setRoomReadMarkers = function(roomId, rmEventId, rrEven
     };
 
     return this._http.authedRequest(
-        null, "POST", path, undefined, content,
+        undefined, "POST", path, undefined, content,
     );
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -1210,10 +1210,10 @@ MatrixClient.prototype.sendReadReceipt = function(event, callback) {
  * @param {string} eventId ID of the event that has been read
  * @param {string} rrEvent the event tracked by the read receipt. This is here for
  * convenience because the RR and the RM are commonly updated at the same time as each
- * other. Optional.
+ * other. The local echo of this receipt will be done if set. Optional.
  * @return {module:client.Promise} Resolves: the empty object, {}.
  */
-MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
+MatrixClient.prototype.setRoomReadMarkers = function(roomId, eventId, rrEvent) {
     const rmEventId = eventId;
     let rrEventId;
 
@@ -1226,7 +1226,7 @@ MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
         }
     }
 
-    return this.setRoomReadMarkers(roomId, rmEventId, rrEventId);
+    return this.setRoomReadMarkersHttpRequest(roomId, rmEventId, rrEventId);
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -843,40 +843,6 @@ MatrixClient.prototype.setRoomAccountData = function(roomId, eventType,
 };
 
 /**
- * Set a marker to represent which event the user was last reading in a room. This can
- * be retrieved from room account data and displayed as a horizontal line in the client
- * that is visually distinct to the position of the user's own read receipt.
- * @param {string} roomId ID of the room that has been read
- * @param {string} eventId ID of the event that has been read
- * @param {string} rrEvent the event tracked by the read receipt. This is here for
- * convenience because the RR and the RM are commonly updated at the same time as each
- * other. Optional.
- * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
- * @return {module:http-api.MatrixError} Rejects: with an error response.
- */
-MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
-    const path = utils.encodeUri("/rooms/$roomId/read_marker", {
-        $roomId: roomId,
-    });
-    const content = {
-        "m.read_marker": eventId,
-    };
-
-    // Add the optional RR update, do local echo like `sendReceipt`
-    if (rrEvent) {
-        content["m.read"] = rrEvent.getId();
-        const room = this.getRoom(roomId);
-        if (room) {
-            room._addLocalEchoReceipt(this.credentials.userId, rrEvent, "m.read");
-        }
-    }
-
-    return this._http.authedRequest(
-        null, "POST", path, undefined, content,
-    );
-};
-
-/**
  * Set a user's power level.
  * @param {string} roomId
  * @param {string} userId
@@ -1235,6 +1201,39 @@ MatrixClient.prototype.sendReadReceipt = function(event, callback) {
     return this.sendReceipt(event, "m.read", callback);
 };
 
+/**
+ * Set a marker to represent which event the user was last reading in a room. This can
+ * be retrieved from room account data and displayed as a horizontal line in the client
+ * that is visually distinct to the position of the user's own read receipt.
+ * @param {string} roomId ID of the room that has been read
+ * @param {string} eventId ID of the event that has been read
+ * @param {string} rrEvent the event tracked by the read receipt. This is here for
+ * convenience because the RR and the RM are commonly updated at the same time as each
+ * other. Optional.
+ * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
+    const path = utils.encodeUri("/rooms/$roomId/read_marker", {
+        $roomId: roomId,
+    });
+    const content = {
+        "m.read_marker": eventId,
+    };
+
+    // Add the optional RR update, do local echo like `sendReceipt`
+    if (rrEvent) {
+        content["m.read"] = rrEvent.getId();
+        const room = this.getRoom(roomId);
+        if (room) {
+            room._addLocalEchoReceipt(this.credentials.userId, rrEvent, "m.read");
+        }
+    }
+
+    return this._http.authedRequest(
+        null, "POST", path, undefined, content,
+    );
+};
 
 /**
  * Get a preview of the given URL as of (roughly) the given point in time,

--- a/src/client.js
+++ b/src/client.js
@@ -1202,16 +1202,16 @@ MatrixClient.prototype.sendReadReceipt = function(event, callback) {
 };
 
 /**
- * Set a marker to represent which event the user was last reading in a room. This can
- * be retrieved from room account data and displayed as a horizontal line in the client
- * that is visually distinct to the position of the user's own read receipt.
+ * Set a marker to indicate the point in a room before which the user has read every
+ * event. This can be retrieved from room account data (the event type is `m.fully_read`)
+ * and displayed as a horizontal line in the timeline that is visually distinct to the
+ * position of the user's own read receipt.
  * @param {string} roomId ID of the room that has been read
  * @param {string} eventId ID of the event that has been read
  * @param {string} rrEvent the event tracked by the read receipt. This is here for
  * convenience because the RR and the RM are commonly updated at the same time as each
  * other. Optional.
- * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
- * @return {module:http-api.MatrixError} Rejects: with an error response.
+ * @return {module:client.Promise} Resolves: the empty object, {}.
  */
 MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
     const rmEventId = eventId;

--- a/src/client.js
+++ b/src/client.js
@@ -843,21 +843,18 @@ MatrixClient.prototype.setRoomAccountData = function(roomId, eventType,
 };
 
 /**
+ * Set a marker to represent which event the user was last reading in a room. This can
+ * be retrieved from room account data and displayed as a horizontal line in the client
+ * that is visually distinct to the position of the user's own read receipt.
  * @param {string} roomId ID of the room that has been read
  * @param {string} eventId ID of the event that has been read
  * @param {string} rrEvent the event tracked by the read receipt. This is here for
  * convenience because the RR and the RM are commonly updated at the same time as each
  * other. Optional.
- * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
+ * @return {module:client.Promise} Resolves: (@see module:http-api.authedRequest)
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent, callback) {
-    if (typeof rrEventId === 'function') {
-        callback = rrEvent;
-        rrEvent = undefined;
-    }
-
+MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
     const path = utils.encodeUri("/rooms/$roomId/read_marker", {
         $roomId: roomId,
     });
@@ -875,7 +872,7 @@ MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent, ca
     }
 
     return this._http.authedRequest(
-        callback, "POST", path, undefined, content,
+        null, "POST", path, undefined, content,
     );
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -1214,25 +1214,19 @@ MatrixClient.prototype.sendReadReceipt = function(event, callback) {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.setRoomReadMarker = function(roomId, eventId, rrEvent) {
-    const path = utils.encodeUri("/rooms/$roomId/read_marker", {
-        $roomId: roomId,
-    });
-    const content = {
-        "m.read_marker": eventId,
-    };
+    const rmEventId = eventId;
+    let rrEventId;
 
     // Add the optional RR update, do local echo like `sendReceipt`
     if (rrEvent) {
-        content["m.read"] = rrEvent.getId();
+        rrEventId = rrEvent.getId();
         const room = this.getRoom(roomId);
         if (room) {
             room._addLocalEchoReceipt(this.credentials.userId, rrEvent, "m.read");
         }
     }
 
-    return this._http.authedRequest(
-        null, "POST", path, undefined, content,
-    );
+    return this.setRoomReadMarkers(roomId, rmEventId, rrEventId);
 };
 
 /**


### PR DESCRIPTION
This is now stored on the server with similar treatment to RRs. The server will only store the specified eventId as the current read marker for a room if the event is ahead in the stream when compared to the existing RM. The exception is when the RM has never been set for this room for this user, in which case the event ID will be stored as the RM without any comparison.

This API also allows for an optional RR event ID to be sent in the same request. This is because it might be the common case for some clients to update the RM at the same time as updating the RR.

See design: https://docs.google.com/document/d/1UWqdS-e1sdwkLDUY0wA4gZyIkRp-ekjsLZ8k6g_Zvso/edit

See server-side PR: https://github.com/matrix-org/synapse/pull/2120