### PR TITLE
Automatically complete dummy auth

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -318,6 +318,13 @@ InteractiveAuth.prototype = {
         }
         this._currentStage = nextStage;
 
+        if (nextStage == 'm.login.dummy') {
+            this.submitAuthDict({
+                type: 'm.login.dummy',
+            });
+            return;
+        }
+
         if (this._data.errcode || this._data.error) {
             this._stateUpdatedCallback(nextStage, {
                 errcode: this._data.errcode || "",


### PR DESCRIPTION
Dummy auth flows, by definition, do not require a response from
the user, and so should just be completed automatically by
interactive-auth.

Fixes https://github.com/vector-im/riot-web/issues/3621