### PR TITLE
Rework device list tracking logic

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -60,6 +60,7 @@ TestClient.prototype.toString = function() {
  * @return {Promise}
  */
 TestClient.prototype.start = function() {
+    console.log(this + ': starting');
     this.httpBackend.when("GET", "/pushrules").respond(200, {});
     this.httpBackend.when("POST", "/filter").respond(200, { filter_id: "fid" });
     this.expectDeviceKeyUpload();

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -99,6 +99,14 @@ WebStorageSessionStore.prototype = {
         return getJsonItem(this.store, keyEndToEndDevicesForUser(userId));
     },
 
+    storeEndToEndDeviceTrackingStatus: function(statusMap) {
+        setJsonItem(this.store, KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS, statusMap);
+    },
+
+    getEndToEndDeviceTrackingStatus: function() {
+        return getJsonItem(this.store, KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS);
+    },
+
     /**
      * Store the sync token corresponding to the device list.
      *
@@ -202,6 +210,7 @@ WebStorageSessionStore.prototype = {
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_END_TO_END_ANNOUNCED = E2E_PREFIX + "announced";
 const KEY_END_TO_END_DEVICE_SYNC_TOKEN = E2E_PREFIX + "device_sync_token";
+const KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS = E2E_PREFIX + "device_tracking";
 
 function keyEndToEndDevicesForUser(userId) {
     return E2E_PREFIX + "devices/" + userId;


### PR DESCRIPTION
Yet another attempt at fixing https://github.com/vector-im/riot-web/issues/2305.

This now implements the algorithm described at http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#tracking-the-device-list-for-a-user:

* We now keep a flag to tell us which users' device lists we are tracking. That makes it much easier to figure out whether we should care about device-update notifications from /sync (thereby fixing https://github.com/vector-im/riot-web/issues/3588).

* We use the same flag to indicate whether the device list for a particular user is out of date. Previously we did this implicitly by only updating the stored sync token when the list had been updated, but that was somewhat complicated, and in any case didn't help in cases where we initiated the key download due to a user joining an encrypted room.

Also fixes https://github.com/vector-im/riot-web/issues/3310.