### PR TITLE
crypto/algorithms/base.js: Convert to es6

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -567,7 +567,7 @@ function _decryptEvent(client, event) {
         console.warn(
             `Error decrypting event (id=${event.getId()}): ${e}`,
         );
-        if (!(e instanceof Crypto.DecryptionError)) {
+        if (e.name !== "DecryptionError") {
             throw e;
         }
         _badEncryptedMessage(event, e.message);

--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -13,14 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-"use strict";
 
 /**
  * Internal module. Defines the base classes of the encryption implementations
  *
- * @module crypto/algorithms/base
+ * @module
  */
-const utils = require("../../utils");
 
 /**
  * map of registered encryption algorithm classes. A map from string to {@link
@@ -28,7 +26,7 @@ const utils = require("../../utils");
  *
  * @type {Object.<string, function(new: module:crypto/algorithms/base.EncryptionAlgorithm)>}
  */
-module.exports.ENCRYPTION_CLASSES = {};
+export const ENCRYPTION_CLASSES = {};
 
 /**
  * map of registered encryption algorithm classes. Map from string to {@link
@@ -36,12 +34,11 @@ module.exports.ENCRYPTION_CLASSES = {};
  *
  * @type {Object.<string, function(new: module:crypto/algorithms/base.DecryptionAlgorithm)>}
  */
-module.exports.DECRYPTION_CLASSES = {};
+export const DECRYPTION_CLASSES = {};
 
 /**
  * base type for encryption implementations
  *
- * @constructor
  * @alias module:crypto/algorithms/base.EncryptionAlgorithm
  *
  * @param {object} params parameters
@@ -53,45 +50,45 @@ module.exports.DECRYPTION_CLASSES = {};
  * @param {string} params.roomId  The ID of the room we will be sending to
  * @param {object} params.config  The body of the m.room.encryption event
  */
-const EncryptionAlgorithm = function(params) {
-    this._userId = params.userId;
-    this._deviceId = params.deviceId;
-    this._crypto = params.crypto;
-    this._olmDevice = params.olmDevice;
-    this._baseApis = params.baseApis;
-    this._roomId = params.roomId;
-};
-/** */
-module.exports.EncryptionAlgorithm = EncryptionAlgorithm;
+class EncryptionAlgorithm {
+    constructor(params) {
+        this._userId = params.userId;
+        this._deviceId = params.deviceId;
+        this._crypto = params.crypto;
+        this._olmDevice = params.olmDevice;
+        this._baseApis = params.baseApis;
+        this._roomId = params.roomId;
+    }
 
-/**
- * Encrypt a message event
- *
- * @method module:crypto/algorithms/base.EncryptionAlgorithm#encryptMessage
- * @abstract
- *
- * @param {module:models/room} room
- * @param {string} eventType
- * @param {object} plaintext event content
- *
- * @return {module:client.Promise} Promise which resolves to the new event body
- */
+    /**
+     * Encrypt a message event
+     *
+     * @method module:crypto/algorithms/base.EncryptionAlgorithm.encryptMessage
+     * @abstract
+     *
+     * @param {module:models/room} room
+     * @param {string} eventType
+     * @param {object} plaintext event content
+     *
+     * @return {module:client.Promise} Promise which resolves to the new event body
+     */
 
-/**
- * Called when the membership of a member of the room changes.
- *
- * @param {module:models/event.MatrixEvent} event  event causing the change
- * @param {module:models/room-member} member  user whose membership changed
- * @param {string=} oldMembership  previous membership
- */
-EncryptionAlgorithm.prototype.onRoomMembership = function(
-    event, member, oldMembership,
-) {};
+    /**
+     * Called when the membership of a member of the room changes.
+     *
+     * @param {module:models/event.MatrixEvent} event  event causing the change
+     * @param {module:models/room-member} member  user whose membership changed
+     * @param {string=} oldMembership  previous membership
+     * @public
+     */
+     onRoomMembership(event, member, oldMembership) {
+     }
+}
+export {EncryptionAlgorithm}; // https://github.com/jsdoc3/jsdoc/issues/1272
 
 /**
  * base type for decryption implementations
  *
- * @constructor
  * @alias module:crypto/algorithms/base.DecryptionAlgorithm
  *
  * @param {object} params parameters
@@ -101,55 +98,55 @@ EncryptionAlgorithm.prototype.onRoomMembership = function(
  * @param {string=} params.roomId The ID of the room we will be receiving
  *     from. Null for to-device events.
  */
-const DecryptionAlgorithm = function(params) {
-    this._userId = params.userId;
-    this._crypto = params.crypto;
-    this._olmDevice = params.olmDevice;
-    this._roomId = params.roomId;
-};
-/** */
-module.exports.DecryptionAlgorithm = DecryptionAlgorithm;
+class DecryptionAlgorithm {
+    constructor(params) {
+        this._userId = params.userId;
+        this._crypto = params.crypto;
+        this._olmDevice = params.olmDevice;
+        this._roomId = params.roomId;
+    }
 
-/**
- * Decrypt an event
- *
- * @method module:crypto/algorithms/base.DecryptionAlgorithm#decryptEvent
- * @abstract
- *
- * @param {object} event raw event
- *
- * @return {null} if the event referred to an unknown megolm session
- * @return {module:crypto.DecryptionResult} decryption result
- *
- * @throws {module:crypto/algorithms/base.DecryptionError} if there is a
- *   problem decrypting the event
- */
+    /**
+     * Decrypt an event
+     *
+     * @method module:crypto/algorithms/base.DecryptionAlgorithm#decryptEvent
+     * @abstract
+     *
+     * @param {object} event raw event
+     *
+     * @return {null} if the event referred to an unknown megolm session
+     * @return {module:crypto.DecryptionResult} decryption result
+     *
+     * @throws {module:crypto/algorithms/base.DecryptionError} if there is a
+     *   problem decrypting the event
+     */
 
-/**
- * Handle a key event
- *
- * @method module:crypto/algorithms/base.DecryptionAlgorithm#onRoomKeyEvent
- *
- * @param {module:models/event.MatrixEvent} params event key event
- */
-DecryptionAlgorithm.prototype.onRoomKeyEvent = function(params) {
-    // ignore by default
-};
+    /**
+     * Handle a key event
+     *
+     * @method module:crypto/algorithms/base.DecryptionAlgorithm#onRoomKeyEvent
+     *
+     * @param {module:models/event.MatrixEvent} params event key event
+     */
+    onRoomKeyEvent(params) {
+        // ignore by default
+    }
 
-/**
- * Import a room key
- *
- * @param {module:crypto/OlmDevice.MegolmSessionData} session
- */
-DecryptionAlgorithm.prototype.importRoomKey = function(session) {
-    // ignore by default
-};
+    /**
+     * Import a room key
+     *
+     * @param {module:crypto/OlmDevice.MegolmSessionData} session
+     */
+    importRoomKey(session) {
+        // ignore by default
+    }
+}
+export {DecryptionAlgorithm}; // https://github.com/jsdoc3/jsdoc/issues/1272
 
 /**
  * Exception thrown when decryption fails
  *
  * @alias module:crypto/algorithms/base.DecryptionError
- * @constructor
  * @param {string} msg user-visible message describing the problem
  *
  * @param {Object=} details key/value pairs reported in the logs but not shown
@@ -157,50 +154,51 @@ DecryptionAlgorithm.prototype.importRoomKey = function(session) {
  *
  * @extends Error
  */
-const DecryptionError = function(msg, details) {
-    this.name = 'DecryptionError';
-    this.message = msg;
-    this.details = details;
-};
-utils.inherits(DecryptionError, Error);
-
-/** override the string used when logging
- *
- * @returns {String}
- */
-DecryptionError.prototype.toString = function() {
-    let result = this.name + '[msg: ' + this.message;
-
-    if (this.details) {
-        result += ', ' +
-            Object.keys(this.details).map(
-                (k) => k + ': ' + this.details[k],
-            ).join(', ');
+class DecryptionError extends Error {
+    constructor(msg, details) {
+        super(msg);
+        this.name = 'DecryptionError';
+        this.details = details;
     }
 
-    result += ']';
+    /**
+     * override the string used when logging
+     *
+     * @returns {String}
+     */
+    toString() {
+        let result = this.name + '[msg: ' + this.message;
 
-    return result;
-};
+        if (this.details) {
+            result += ', ' +
+                Object.keys(this.details).map(
+                    (k) => k + ': ' + this.details[k],
+                ).join(', ');
+        }
 
-module.exports.DecryptionError = DecryptionError;
+        result += ']';
+
+        return result;
+    }
+}
+export {DecryptionError}; // https://github.com/jsdoc3/jsdoc/issues/1272
 
 /**
  * Exception thrown specifically when we want to warn the user to consider
  * the security of their conversation before continuing
  *
- * @constructor
  * @param {string} msg message describing the problem
  * @param {Object} devices userId -> {deviceId -> object}
  *      set of unknown devices per user we're warning about
  * @extends Error
  */
-module.exports.UnknownDeviceError = function(msg, devices) {
-    this.name = "UnknownDeviceError";
-    this.message = msg;
-    this.devices = devices;
-};
-utils.inherits(module.exports.UnknownDeviceError, Error);
+export class UnknownDeviceError extends Error {
+    constructor(msg, devices) {
+        super(msg);
+        this.name = "UnknownDeviceError";
+        this.devices = devices;
+    }
+}
 
 /**
  * Registers an encryption/decryption class for a particular algorithm
@@ -215,7 +213,7 @@ utils.inherits(module.exports.UnknownDeviceError, Error);
  *     module:crypto/algorithms/base.DecryptionAlgorithm|DecryptionAlgorithm}
  *     implementation
  */
-module.exports.registerAlgorithm = function(algorithm, encryptor, decryptor) {
-    module.exports.ENCRYPTION_CLASSES[algorithm] = encryptor;
-    module.exports.DECRYPTION_CLASSES[algorithm] = decryptor;
-};
+export function registerAlgorithm(algorithm, encryptor, decryptor) {
+    ENCRYPTION_CLASSES[algorithm] = encryptor;
+    DECRYPTION_CLASSES[algorithm] = decryptor;
+}

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1121,11 +1121,6 @@ Crypto.prototype._signObject = function(obj) {
     obj.signatures = sigs;
 };
 
-/**
- * @see module:crypto/algorithms/base.DecryptionError
- */
-Crypto.DecryptionError = algorithms.DecryptionError;
-
 
 /** */
 module.exports = Crypto;


### PR DESCRIPTION
Convert base to an es6 module with es6 classes, for clarity and to help with
jsdoccing.

Complications are:

* jsdoc gets confused by `export class`, so the exports are separated.

* turns out that extending Error is a bit difficult, so instanceof doesn't work
  on derived Error classes. This only really affects us in one place (app-side
  code shouldn't be doing instanceofs anyway), so just use `name` instead.