### PR TITLE
Initial framework for indexeddb-backed crypto store

### DIFF
--- a/browser-index.js
+++ b/browser-index.js
@@ -1,4 +1,13 @@
 var matrixcs = require("./lib/matrix");
 matrixcs.request(require("browser-request"));
+
+matrixcs.setCryptoStoreFactory(
+    function() {
+        return new matrixcs.IndexedDBCryptoStore(
+            global.indexedDB, "matrix-js-sdk:crypto"
+        );
+    }
+);
+
 module.exports = matrixcs; // keep export for browserify package deps
 global.matrixcs = matrixcs;

--- a/src/client.js
+++ b/src/client.js
@@ -156,8 +156,9 @@ function MatrixClient(opts) {
     this._notifTimelineSet = null;
 
     this._crypto = null;
+    this._cryptoStore = opts.cryptoStore;
     if (CRYPTO_ENABLED && Boolean(opts.sessionStore) &&
-            Boolean(opts.cryptoStore) &&
+            Boolean(this._cryptoStore) &&
             userId !== null && this.deviceId !== null) {
         this._crypto = new Crypto(
             this, this,
@@ -172,6 +173,25 @@ function MatrixClient(opts) {
 }
 utils.inherits(MatrixClient, EventEmitter);
 utils.extend(MatrixClient.prototype, MatrixBaseApis.prototype);
+
+/**
+ * Clear any data out of the persistent stores used by the client.
+ *
+ * @returns {Promise} Promise which resolves when the stores have been cleared.
+ */
+MatrixClient.prototype.clearStores = function() {
+    if (this._clientRunning) {
+        throw new Error("Cannot clear stores while client is running");
+    }
+
+    const promises = [];
+
+    promises.push(this.store.deleteAllData());
+    if (this._cryptoStore) {
+        promises.push(this._cryptoStore.deleteAllData());
+    }
+    return q.all(promises);
+};
 
 /**
  * Get the user-id of the logged-in user

--- a/src/client.js
+++ b/src/client.js
@@ -104,6 +104,9 @@ try {
  * disabled by default for compatibility with older clients - in particular to
  * maintain support for back-paginating the live timeline after a '/sync'
  * result with a gap.
+ *
+ * @param {module:crypto.store.base~CryptoStore} opts.cryptoStore
+ *    crypto store implementation.
  */
 function MatrixClient(opts) {
     MatrixBaseApis.call(this, opts);
@@ -154,6 +157,7 @@ function MatrixClient(opts) {
 
     this._crypto = null;
     if (CRYPTO_ENABLED && Boolean(opts.sessionStore) &&
+            Boolean(opts.cryptoStore) &&
             userId !== null && this.deviceId !== null) {
         this._crypto = new Crypto(
             this, this,

--- a/src/client.js
+++ b/src/client.js
@@ -160,6 +160,7 @@ function MatrixClient(opts) {
             opts.sessionStore,
             userId, this.deviceId,
             this.store,
+            opts.cryptoStore,
         );
 
         this.olmVersion = Crypto.getOlmVersion();

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 "use strict";
-
 
 /**
  * @module crypto
@@ -50,14 +50,18 @@ const DeviceList = require('./DeviceList').default;
  * @param {string} deviceId The identifier for this device.
  *
  * @param {Object} clientStore the MatrixClient data store.
+ *
+ * @param {module:crypto/store/base~CryptoStore} cryptoStore
+ *    storage for the crypto layer.
  */
 function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId,
-                clientStore) {
+                clientStore, cryptoStore) {
     this._baseApis = baseApis;
     this._sessionStore = sessionStore;
     this._userId = userId;
     this._deviceId = deviceId;
     this._clientStore = clientStore;
+    this._cryptoStore = cryptoStore;
 
     this._olmDevice = new OlmDevice(sessionStore);
     this._deviceList = new DeviceList(baseApis, sessionStore, this._olmDevice);

--- a/src/crypto/store/base.js
+++ b/src/crypto/store/base.js
@@ -1,0 +1,11 @@
+/**
+ * Internal module. Defintions for storage for the crypto module
+ *
+ * @module
+ */
+
+/**
+ * Abstraction of things that can store data required for end-to-end encryption
+ *
+ * @interface CryptoStore
+ */

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import q from 'q';
+
+/**
+ * Internal module. indexeddb storage for e2e.
+ *
+ * @module
+ */
+
+const VERSION = 1;
+
+/**
+ * @implements {module:crypto/store/base~CryptoStore}
+ */
+export default class IndexedDBCryptoStore {
+    constructor(indexedDB, dbName) {
+        if (!indexedDB) {
+            throw new Error("must pass indexedDB into IndexedDBCryptoStore");
+        }
+        this._indexedDB = indexedDB;
+        this._dbName = dbName;
+        this._dbPromise = null;
+    }
+
+    /**
+     * Ensure the database exists and is up-to-date
+     *
+     * @return {Promise} resolves to an instance of IDBDatabase when
+     * the database is ready
+     */
+    connect() {
+        if (this._dbPromise) {
+            return this._dbPromise;
+        }
+
+        this._dbPromise = new q.Promise((resolve, reject) => {
+            const req = this._indexedDB.open(this._dbName, VERSION);
+
+            req.onupgradeneeded = (ev) => {
+                const db = ev.target.result;
+                const oldVersion = ev.oldVersion;
+                console.log(
+                    `Upgrading IndexedDBCryptoStore from version ${oldVersion}`
+                    + ` to ${VERSION}`,
+                );
+                if (oldVersion < 1) { // The database did not previously exist.
+                    createDatabase(db);
+                }
+                // Expand as needed.
+            };
+
+            req.onblocked = () => {
+                reject(new Error(
+                    "unable to upgrade indexeddb because it is open elsewhere",
+                ));
+            };
+
+            req.onerror = (ev) => {
+                reject(new Error(
+                    "unable to connect to indexeddb: " + ev.target.error,
+                ));
+            };
+
+            req.onsuccess = (r) => {
+                resolve(r.target.result);
+            };
+        });
+        return this._dbPromise;
+    }
+}
+
+function createDatabase(db) {
+    const outgoingRoomKeyRequestsStore =
+        db.createObjectStore("outgoingRoomKeyRequests", { keyPath: "requestId" });
+
+    // we assume that the RoomKeyRequestBody will have room_id and session_id
+    // properties, to make the index efficient.
+    outgoingRoomKeyRequestsStore.createIndex("session",
+        ["requestBody.room_id", "requestBody.session_id"],
+    );
+
+    outgoingRoomKeyRequestsStore.createIndex("state", "state");
+}

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -88,6 +88,28 @@ export default class IndexedDBCryptoStore {
         });
         return this._dbPromise;
     }
+
+    /**
+     * Delete all data from this store.
+     *
+     * @returns {Promise} resolves when the store has been cleared.
+     */
+    deleteAllData() {
+        return new q.Promise((resolve, reject) => {
+            console.log(`Removing indexeddb instance: ${this._dbName}`);
+            const req = this._indexedDB.deleteDatabase(this._dbName);
+            req.onerror = (ev) => {
+                reject(new Error(
+                    "unable to delete indexeddb: " + ev.target.error,
+                ));
+            };
+
+            req.onsuccess = () => {
+                console.log(`Removed indexeddb instance: ${this._dbName}`);
+                resolve();
+            };
+        });
+    }
 }
 
 function createDatabase(db) {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -28,6 +28,12 @@ const VERSION = 1;
  * @implements {module:crypto/store/base~CryptoStore}
  */
 export default class IndexedDBCryptoStore {
+    /**
+     * Create a new IndexedDBCryptoStore
+     *
+     * @param {IDBFactory} indexedDB  global indexedDB instance
+     * @param {string} dbName   name of db to connect to
+     */
     constructor(indexedDB, dbName) {
         if (!indexedDB) {
             throw new Error("must pass indexedDB into IndexedDBCryptoStore");

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import q from 'q';
+
 /**
  * Internal module. in-memory storage for e2e.
  *
@@ -25,5 +27,14 @@ limitations under the License.
  */
 export default class MemoryCryptoStore {
     constructor() {
+    }
+
+    /**
+     * Delete all data from this store.
+     *
+     * @returns {Promise} Promise which resolves when the store has been cleared.
+     */
+    deleteAllData() {
+        return q();
     }
 }

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Internal module. in-memory storage for e2e.
+ *
+ * @module
+ */
+
+/**
+ * @implements {module:crypto/store/base~CryptoStore}
+ */
+export default class MemoryCryptoStore {
+    constructor() {
+    }
+}

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -135,7 +135,7 @@ let cryptoStoreFactory = () => new module.exports.MemoryCryptoStore;
 /**
  * Configure a different factory to be used for creating crypto stores
  *
- * @param {Function} fac  a funciton which will return a new
+ * @param {Function} fac  a function which will return a new
  *    {@link module:crypto.store.base~CryptoStore}.
  */
 module.exports.setCryptoStoreFactory = function(fac) {
@@ -157,7 +157,9 @@ module.exports.setCryptoStoreFactory = function(fac) {
  *
  * @param {module:crypto.store.base~CryptoStore=} opts.cryptoStore
  *    crypto store implementation. Calls the factory supplied to
- *    {@link setCryptoStoreFactory if unspecified}
+ *    {@link setCryptoStoreFactory} if unspecified; or if no factory has been
+ *    specified, uses a default implementation (indexeddb in the browser,
+ *    in-memory otherwise).
  *
  * @return {MatrixClient} A new matrix client.
  * @see {@link module:client~MatrixClient} for the full list of options for


### PR DESCRIPTION
Doesn't do anything useful yet - just demonstrates a framework for how I hope it will fit into the sdk.

The idea here is that you can configure a factory to build a crypto store whenever you call `createClient` (if you don't pass one in explicitly). The default is an in-memory store, but `browser-index.js` sets the factory to the indexeddb impl.