### PR TITLE
Load Olm from the global rather than requiring it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+unreleased changes
+==================
+
+ * BREAKING CHANGE: The SDK no longer ``require``s ``olm`` - instead it expects
+   libolm to be provided as an ``Olm`` global. This will only affect
+   applications which use end-to-end encryption. See the
+   [README](README.md#end-to-end-encryption-support) for details.
+
 Changes in [0.7.8](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.7.8) (2017-05-22)
 ================================================================================================
 [Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.7.8-rc.1...v0.7.8)

--- a/README.md
+++ b/README.md
@@ -236,6 +236,24 @@ host the API reference from the source files like this:
 
 Then visit ``http://localhost:8005`` to see the API docs.
 
+End-to-end encryption support
+=============================
+
+The SDK supports end-to-end encryption via the Olm and Megolm protocols, using
+[libolm](http://matrix.org/git/olm). It is left up to the application to make
+libolm available, via the ``Olm`` global.
+
+To enable support in a browser application:
+
+ * download the transpiled libolm (either via ``npm install olm``, or from
+   https://matrix.org/packages/npm/olm/).
+ * load ``olm.js`` as a ``<script>`` *before* ``browser-matrix.js``.
+ 
+To enable support in a node.js application:
+
+ * ``npm install olm``
+ * ``require('olm');`` *before* ``matrix-js-sdk``.
+
 Contributing
 ============
 *This section is for people who want to modify the SDK. If you just

--- a/package.json
+++ b/package.json
@@ -73,16 +73,9 @@
     "uglify-js": "^2.8.26",
     "watchify": "^3.2.1"
   },
-  "optionalDependencies": {
-    "olm": "https://matrix.org/packages/npm/olm/olm-2.2.1.tgz"
-  },
   "browserify": {
     "transform": [
-      "sourceify",
-      "browserify-shim"
+      "sourceify"
     ]
-  },
-  "browserify-shim": {
-    "olm": "global:Olm"
   }
 }

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -299,6 +299,10 @@ describe("MatrixClient", function() {
 
 
     describe("downloadKeys", function() {
+        if (!sdk.CRYPTO_ENABLED) {
+            return;
+        }
+
         it("should do an HTTP request and then store the keys", function(done) {
             const ed25519key = "7wG2lzAqbjcyEkOP7O4gU7ItYcn+chKzh5sT/5r2l78";
             // ed25519key = client.getDeviceEd25519Key();

--- a/src/client.js
+++ b/src/client.js
@@ -47,8 +47,7 @@ try {
     var Crypto = require("./crypto");
     CRYPTO_ENABLED = true;
 } catch (e) {
-    console.error("olm load error", e);
-    // Olm not installed.
+    console.warn("Unable to load crypto module: crypto will be disabled: " + e);
 }
 
 /**

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -20,11 +20,9 @@ limitations under the License.
  *
  * @module crypto/OlmDevice
  */
-const Olm = require("olm");
+const Olm = global.Olm;
 if (!Olm) {
-    // this happens if we were loaded via browserify and the Olm module was not
-    // loaded.
-    throw new Error("Olm is not defined");
+    throw new Error("global.Olm is not defined");
 }
 const utils = require("../utils");
 


### PR DESCRIPTION
This means that we can avoid confusing everybody in the world about how to
webpack js-sdk apps.