### PR TITLE
Stop peeking when a matrix client is stopped

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2888,6 +2888,9 @@ MatrixClient.prototype.stopClient = function() {
         this._syncApi.stop();
         this._syncApi = null;
     }
+    if (this._peekSync) {
+        this._peekSync.stopPeeking();
+    }
     global.clearTimeout(this._checkTurnServersTimeoutID);
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -329,6 +329,10 @@ SyncApi.prototype._peekPoll = function(roomId, token) {
         timeout: 30 * 1000,
         from: token,
     }, undefined, 50 * 1000).done(function(res) {
+        if (self._peekRoomId !== roomId) {
+            debuglog("Stopped peeking in room %s", roomId);
+            return;
+        }
         // We have a problem that we get presence both from /events and /sync
         // however, /sync only returns presence for users in rooms
         // you're actually joined to.


### PR DESCRIPTION
Otherwise we get very confused when the peek poll returns after
the client is stopped.