### PR TITLE
Implement sharing of megolm keys

### DIFF
--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -89,6 +89,7 @@ export {EncryptionAlgorithm}; // https://github.com/jsdoc3/jsdoc/issues/1272
 /**
  * base type for decryption implementations
  *
+ * @alias module:crypto/algorithms/base.DecryptionAlgorithm
  * @param {object} params parameters
  * @param {string} params.userId  The UserID for the local user
  * @param {module:crypto} params.crypto crypto core
@@ -144,7 +145,7 @@ class DecryptionAlgorithm {
     /**
      * Determine if we have the keys necessary to respond to a room key request
      *
-     * @param {module:crypto#RoomKeyRequest} keyRequest
+     * @param {module:crypto~IncomingRoomKeyRequest} keyRequest
      * @return {boolean} true if we have the keys and could (theoretically) share
      *  them; else false.
      */
@@ -155,7 +156,7 @@ class DecryptionAlgorithm {
     /**
      * Send the response to a room key request
      *
-     * @param {module:crypto#RoomKeyRequest} keyRequest
+     * @param {module:crypto~IncomingRoomKeyRequest} keyRequest
      */
     shareKeysWithDevice(keyRequest) {
         throw new Error("shareKeysWithDevice not supported for this DecryptionAlgorithm");

--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -89,12 +89,11 @@ export {EncryptionAlgorithm}; // https://github.com/jsdoc3/jsdoc/issues/1272
 /**
  * base type for decryption implementations
  *
- * @alias module:crypto/algorithms/base.DecryptionAlgorithm
- *
  * @param {object} params parameters
  * @param {string} params.userId  The UserID for the local user
  * @param {module:crypto} params.crypto crypto core
  * @param {module:crypto/OlmDevice} params.olmDevice olm.js wrapper
+ * @param {module:base-apis~MatrixBaseApis} baseApis base matrix api interface
  * @param {string=} params.roomId The ID of the room we will be receiving
  *     from. Null for to-device events.
  */
@@ -103,6 +102,7 @@ class DecryptionAlgorithm {
         this._userId = params.userId;
         this._crypto = params.crypto;
         this._olmDevice = params.olmDevice;
+        this._baseApis = params.baseApis;
         this._roomId = params.roomId;
     }
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -662,7 +662,9 @@ MegolmDecryption.prototype.onRoomKeyEvent = function(event) {
     this._retryDecryption(senderKey, sessionId);
 };
 
-
+/**
+ * @inheritdoc
+ */
 MegolmDecryption.prototype.hasKeysForKeyRequest = function(keyRequest) {
     const body = keyRequest.requestBody;
 
@@ -674,7 +676,9 @@ MegolmDecryption.prototype.hasKeysForKeyRequest = function(keyRequest) {
     );
 };
 
-
+/**
+ * @inheritdoc
+ */
 MegolmDecryption.prototype.shareKeysWithDevice = function(keyRequest) {
     const userId = keyRequest.userId;
     const deviceId = keyRequest.deviceId;

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -663,6 +663,89 @@ MegolmDecryption.prototype.onRoomKeyEvent = function(event) {
 };
 
 
+MegolmDecryption.prototype.hasKeysForKeyRequest = function(keyRequest) {
+    const body = keyRequest.requestBody;
+
+    return this._olmDevice.hasInboundSessionKeys(
+        body.room_id,
+        body.sender_key,
+        body.session_id,
+        // TODO: ratchet index
+    );
+};
+
+
+MegolmDecryption.prototype.shareKeysWithDevice = function(keyRequest) {
+    const userId = keyRequest.userId;
+    const deviceId = keyRequest.deviceId;
+    const deviceInfo = this._crypto.getStoredDevice(userId, deviceId);
+    const body = keyRequest.requestBody;
+
+    olmlib.ensureOlmSessionsForDevices(
+        this._olmDevice, this._baseApis, {
+            [userId]: [deviceInfo],
+        },
+    ).then((devicemap) => {
+        const olmSessionResult = devicemap[userId][deviceId];
+        if (!olmSessionResult.sessionId) {
+            // no session with this device, probably because there
+            // were no one-time keys.
+            //
+            // ensureOlmSessionsForUsers has already done the logging,
+            // so just skip it.
+            return;
+        }
+
+        console.log(
+            "sharing keys for session " + body.sender_key + "|"
+            + body.session_id + " with device "
+            + userId + ":" + deviceId,
+        );
+
+        const key = this._olmDevice.getInboundGroupSessionKey(
+            body.room_id, body.sender_key, body.session_id,
+        );
+
+        const payload = {
+            type: "m.forwarded_room_key",
+            content: {
+                algorithm: olmlib.MEGOLM_ALGORITHM,
+                room_id: body.room_id,
+                sender_key: body.sender_key,
+                session_id: body.session_id,
+                session_key: key.key,
+                chain_index: key.chain_index,
+            },
+        };
+
+        const encryptedContent = {
+            algorithm: olmlib.OLM_ALGORITHM,
+            sender_key: this._olmDevice.deviceCurve25519Key,
+            ciphertext: {},
+        };
+
+        olmlib.encryptMessageForDevice(
+            encryptedContent.ciphertext,
+            this._userId,
+            this._deviceId,
+            this._olmDevice,
+            userId,
+            deviceInfo,
+            payload,
+        );
+
+        const contentMap = {
+            [userId]: {
+                [deviceId]: encryptedContent,
+            },
+        };
+
+        // TODO: retries
+        return this._baseApis.sendToDevice("m.room.encrypted", contentMap);
+    }).done();
+};
+
+
 /**
  * @inheritdoc
  *

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1277,8 +1277,8 @@ Crypto.prototype._signObject = function(obj) {
  * @property {string} userId    user requesting the key
  * @property {string} deviceId  device requesting the key
  * @property {string} requestId unique id for the request
- * @property {RoomKeyRequestBody} requestBody
- * @property {Function} share  callback which, when called, will ask
+ * @property {module:crypto~RoomKeyRequestBody} requestBody
+ * @property {function()} share  callback which, when called, will ask
  *    the relevant crypto algorithm implementation to share the keys for
  *    this request.
  */

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1238,6 +1238,7 @@ Crypto.prototype._getRoomDecryptor = function(roomId, algorithm) {
         userId: this._userId,
         crypto: this,
         olmDevice: this._olmDevice,
+        baseApis: this._baseApis,
         roomId: roomId,
     });
 


### PR DESCRIPTION
This builds on previously-landed code (specifically #449) to implement sharing of megolm keys.

When we get a request from one of our other devices we check (via the existing hook https://github.com/matrix-org/matrix-js-sdk/blob/665ed057e364ec54f20513c489749cc1e985fbac/src/crypto/index.js#L1158) whether we have the keys for that session. If the device is verified, or the user accepts the request, we then send an m.forwarded_room_key event with the keys to the session.