### PR TITLE
Add API for POST /user_directory/search

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1,4 +1,4 @@
-    /*
+/*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -691,8 +691,11 @@ MatrixBaseApis.prototype.setRoomDirectoryVisibilityAppService =
 MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
     const body = {
         search_term: opts.term,
-        limit: opts.limit,
     };
+
+    if (opts.limit !== undefined) {
+        body.limit = opts.limit;
+    }
 
     return this._http.authedRequest(
         undefined, "POST", "/user_directory/search", undefined, body,

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -685,13 +685,13 @@ MatrixBaseApis.prototype.setRoomDirectoryVisibilityAppService =
  * Query the user directory with a term matching user IDs, display names and domains.
  * @param {object} opts options
  * @param {string} opts.term the term with which to search.
- * @param {number=} opts.limit the maximum number of results to return. Defaults to 20.
+ * @param {number=} opts.limit the maximum number of results to return. Defaults to 10.
  * @return {module:client.Promise} Resolves: an array of results.
  */
 MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
     const body = {
         search_term: opts.term,
-        limit: opts.limit || 20,
+        limit: opts.limit,
     };
 
     return this._http.authedRequest(

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -685,7 +685,8 @@ MatrixBaseApis.prototype.setRoomDirectoryVisibilityAppService =
  * Query the user directory with a term matching user IDs, display names and domains.
  * @param {object} opts options
  * @param {string} opts.term the term with which to search.
- * @param {number=} opts.limit the maximum number of results to return. Defaults to 10.
+ * @param {number} opts.limit the maximum number of results to return. The server will
+ *                 apply a limit if unspecified.
  * @return {module:client.Promise} Resolves: an array of results.
  */
 MatrixBaseApis.prototype.searchUserDirectory = function(opts) {

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1,4 +1,4 @@
-/*
+    /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 
@@ -675,6 +675,27 @@ MatrixBaseApis.prototype.setRoomDirectoryVisibilityAppService =
     });
     return this._http.authedRequest(
         callback, "PUT", path, undefined, { "visibility": visibility },
+    );
+};
+
+// User Directory Operations
+// =========================
+
+/**
+ * Query the user directory with a term matching user IDs, display names and domains.
+ * @param {object} opts options
+ * @param {string} opts.term the term with which to search.
+ * @param {number=} opts.limit the maximum number of results to return. Defaults to 20.
+ * @return {module:client.Promise} Resolves: an array of results.
+ */
+MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
+    const body = {
+        search_term: opts.term,
+        limit: opts.limit || 20,
+    };
+
+    return this._http.authedRequest(
+        undefined, "POST", "/user_directory/search", undefined, body,
     );
 };
 


### PR DESCRIPTION
This takes a JSON body of the form:
```json
{
    "term": "search term",
    "limit": 42,
}
```
where "term" is the term to match against user IDs, display names and domains and "limit" is the maximum number of results to return.

The response body looks like
```json
{
    "results ": [
        { "user_id": "@someid:mydomain.com", "display_name": "Some Name", "avatar_url": "mx://..." },
        ...
    ],
    "limited": false
}
```
where "limited" indicates whether the "limit" was used to truncate the list.