### PR TITLE
Inspect the state of the timeline to possibly resolve with less event loops in theory

### DIFF
--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -12,6 +12,22 @@ import expect from 'expect';
 const ROOM_ID = "roomId";
 const USER_ID = "userId";
 
+function createTimelineSet() {
+    // XXX: this is a horrid hack
+    return {
+        room: {
+            roomId: ROOM_ID,
+            getUnfilteredTimelineSet: function() {
+                return this;
+            },
+        },
+        getTimelineForEvent: function() {
+            return this.timeline;
+        },
+        timeline: null, // Must be set after creation
+    };
+}
+
 /*
  * create a timeline with a bunch (default 3) events.
  * baseIndex is 1 by default.
@@ -24,13 +40,9 @@ function createTimeline(numEvents, baseIndex) {
         baseIndex = 1;
     }
 
-    // XXX: this is a horrid hack
-    const timelineSet = { room: { roomId: ROOM_ID }};
-    timelineSet.room.getUnfilteredTimelineSet = function() {
-        return timelineSet;
-    };
-
+    const timelineSet = createTimelineSet();
     const timeline = new EventTimeline(timelineSet);
+    timelineSet.timeline = timeline;
 
     // add the events after the baseIndex first
     addEventsToTimeline(timeline, numEvents - baseIndex, false);
@@ -153,7 +165,8 @@ describe("TimelineWindow", function() {
     let timelineSet;
     let client;
     function createWindow(timeline, opts) {
-        timelineSet = {};
+        timelineSet = createTimelineSet();
+        timelineSet.timeline = timeline;
         client = {};
         client.getEventTimeline = function(timelineSet0, eventId0) {
             expect(timelineSet0).toBe(timelineSet);
@@ -186,7 +199,7 @@ describe("TimelineWindow", function() {
             const timeline = createTimeline();
             const eventId = timeline.getEvents()[1].getId();
 
-            const timelineSet = {};
+            const timelineSet = createTimelineSet();
             const client = {};
             client.getEventTimeline = function(timelineSet0, eventId0) {
                 expect(timelineSet0).toBe(timelineSet);
@@ -209,7 +222,7 @@ describe("TimelineWindow", function() {
 
             const eventId = timeline.getEvents()[1].getId();
 
-            const timelineSet = {};
+            const timelineSet = createTimelineSet();
             const client = {};
 
             const timelineWindow = new TimelineWindow(client, timelineSet);

--- a/src/timeline-window.js
+++ b/src/timeline-window.js
@@ -109,17 +109,25 @@ TimelineWindow.prototype.load = function(initialEventId, initialWindowSize) {
     // We avoid delaying the resolution of the promise by a reactor tick if
     // we already have the data we need, which is important to keep room-switching
     // feeling snappy.
-    //
-    // TODO: ideally we'd spot getEventTimeline returning a resolved promise and
-    // skip straight to the find-event loop.
     if (initialEventId) {
+        // Attempt to find an event timeline synchronously
+        const tl = this._timelineSet.getTimelineForEvent(initialEventId);
+        if (tl) {
+            // make sure that our window includes the event
+            for (let i = 0; i < tl.getEvents().length; i++) {
+                if (tl.getEvents()[i].getId() == initialEventId) {
+                    initFields(tl, i);
+                    return q();
+                }
+            }
+        }
         return this._client.getEventTimeline(this._timelineSet, initialEventId)
             .then(function(tl) {
                 // make sure that our window includes the event
                 for (let i = 0; i < tl.getEvents().length; i++) {
                     if (tl.getEvents()[i].getId() == initialEventId) {
                         initFields(tl, i);
-                        return;
+                        return q();
                     }
                 }
                 throw new Error("getEventTimeline result didn't include requested event");


### PR DESCRIPTION
If we already have a timeline for an event, don't do an async call, just use the timeline found directly.

This is the alternative to https://github.com/matrix-org/matrix-js-sdk/pull/458 which will immediately check if a promise is resolved.

Instead, this patch will check if there is a timeline for the event synchronously and then use that to instantiate the timeline window.