### PR TITLE
Fix npm@5 bug when doing npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dist": "npm run build",
     "watch": "watchify -d browser-index.js -o 'exorcist dist/browser-matrix.js.map > dist/browser-matrix.js' -v",
     "lint": "eslint --max-warnings 113 src spec",
-    "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt"
+    "prepare": "npm run build && git rev-parse HEAD > git-revision.txt"
   },
   "repository": {
     "url": "https://github.com/matrix-org/matrix-js-sdk"


### PR DESCRIPTION
NPM@5.x droped support of prepublish for npm install. prepare replaces prepublish. See https://github.com/npm/npm/issues/10074