### PR TITLE
Avoid throwing an unhandled error when the indexeddb is deleted

### DIFF
--- a/src/crypto/OutgoingRoomKeyRequestManager.js
+++ b/src/crypto/OutgoingRoomKeyRequestManager.js
@@ -96,6 +96,7 @@ export default class OutgoingRoomKeyRequestManager {
      * Called when the client is stopped. Stops any running background processes.
      */
     stop() {
+        console.log('stopping OutgoingRoomKeyRequestManager');
         // stop the timer on the next run
         this._clientRunning = false;
     }
@@ -229,6 +230,12 @@ export default class OutgoingRoomKeyRequestManager {
 
             this._sendOutgoingRoomKeyRequests().finally(() => {
                 this._sendOutgoingRoomKeyRequestsRunning = false;
+            }).catch((e) => {
+                // this should only happen if there is an indexeddb error,
+                // in which case we're a bit stuffed anyway.
+                console.warn(
+                    `error in OutgoingRoomKeyRequestManager: ${e}`,
+                );
             }).done();
         };
 

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -91,9 +91,11 @@ export default class IndexedDBCryptoStore {
                 // attempts to delete the database will block (and subsequent
                 // attempts to re-create it will also block).
                 db.onversionchange = (ev) => {
+                    console.log(`versionchange for indexeddb ${this._dbName}: closing`);
                     db.close();
                 };
 
+                console.log(`connected to indexeddb ${this._dbName}`);
                 resolve(db);
             };
         });


### PR DESCRIPTION
Hopefully this will fix the vector-web test failures (the
OutgoingRoomRequestManager throws an exception because the indexeddb is being
deleted just as it's getting started).