### PR TITLE
Fix issues with firefox private browsing

### DIFF
--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -72,9 +72,9 @@ export default class IndexedDBCryptoStore {
             };
 
             req.onblocked = () => {
-                reject(new Error(
-                    "unable to upgrade indexeddb because it is open elsewhere",
-                ));
+                console.log(
+                    `can't yet open IndexedDBCryptoStore because it is open elsewhere`,
+                );
             };
 
             req.onerror = (ev) => {
@@ -110,9 +110,9 @@ export default class IndexedDBCryptoStore {
             const req = this._indexedDB.deleteDatabase(this._dbName);
 
             req.onblocked = () => {
-                reject(new Error(
-                    "unable to delete indexeddb because it is open elsewhere",
-                ));
+                console.log(
+                    `can't yet delete IndexedDBCryptoStore because it is open elsewhere`,
+                );
             };
 
             req.onerror = (ev) => {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -116,9 +116,11 @@ export default class IndexedDBCryptoStore {
             };
 
             req.onerror = (ev) => {
-                reject(new Error(
-                    "unable to delete indexeddb: " + ev.target.error,
-                ));
+                // in firefox, with indexedDB disabled, this fails with a
+                // DOMError. We treat this as non-fatal, so that people can
+                // still use the app.
+                console.warn(`unable to delete IndexedDBCryptoStore: ${ev.target.error}`);
+                resolve();
             };
 
             req.onsuccess = () => {

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -40,6 +40,11 @@ const RemoteIndexedDBStoreBackend = function RemoteIndexedDBStoreBackend(
     };
 
     this._worker.onmessage = this._onWorkerMessage.bind(this);
+
+    // tell the worker the db name.
+    this._startPromise = this._doCmd('_setupWorker', [this._dbName]).then(() => {
+        console.log("IndexedDB worker is ready");
+    });
 };
 
 
@@ -50,10 +55,7 @@ RemoteIndexedDBStoreBackend.prototype = {
      * @return {Promise} Resolves if successfully connected.
      */
     connect: function() {
-        return this._doCmd('_setupWorker', [this._dbName]).then(() => {
-            console.log("IndexedDB worker is ready");
-            return this._doCmd('connect');
-        });
+        return this._startPromise.then(() => this._doCmd('connect'));
     },
 
     /**
@@ -62,7 +64,7 @@ RemoteIndexedDBStoreBackend.prototype = {
      * @return {Promise} Resolved when the database is cleared.
      */
     clearDatabase: function() {
-        return this._doCmd('clearDatabase');
+        return this._startPromise.then(() => this._doCmd('clearDatabase'));
     },
 
     /**


### PR DESCRIPTION
Treat errors when deleting indexeddb as non-fatal

also let the webworker be used for deleting the indexeddb without it having previously been used for syncing.

(part of the fix to https://github.com/vector-im/riot-web/issues/4340)