### PR TITLE
Fix some races in the tests

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -187,3 +187,16 @@ TestClient.prototype.getSigningKey = function() {
     const keyId = 'ed25519:' + this.deviceId;
     return this.deviceKeys.keys[keyId];
 };
+
+/**
+ * flush a single /sync request, and wait for the syncing event
+ *
+ * @returns {Promise} promise which completes once the sync has been flushed
+ */
+TestClient.prototype.flushSync = function() {
+    console.log(`${this}: flushSync`);
+    return q.all([
+        this.httpBackend.flush('/sync', 1),
+        testUtils.syncPromise(this.client),
+    ]);
+};

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -25,6 +25,10 @@ limitations under the License.
 
 "use strict";
 import 'source-map-support/register';
+
+// load olm before the sdk if possible
+import '../olm-loader';
+
 import expect from 'expect';
 const sdk = require("../..");
 const q = require("q");
@@ -375,9 +379,7 @@ function firstSync(testClient) {
     };
 
     testClient.httpBackend.when("GET", "/sync").respond(200, syncData);
-    return testClient.httpBackend.flush("/sync", 1).then(() => {
-        return testUtils.syncPromise(testClient.client);
-    });
+    return testClient.flushSync();
 }
 
 

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -641,9 +641,10 @@ describe("MatrixClient event timelines", function() {
                 expect(tl.getEvents()[1].getContent().body).toEqual("a body");
 
                 // now let the sync complete, and check it again
-                return httpBackend.flush("/sync", 1);
-            }).then(function() {
-                return utils.syncPromise(client);
+                return q.all([
+                    httpBackend.flush("/sync", 1),
+                    utils.syncPromise(client),
+                ]);
             }).then(function() {
                 return client.getEventTimeline(timelineSet, event.event_id);
             }).then(function(tl) {
@@ -670,9 +671,10 @@ describe("MatrixClient event timelines", function() {
                 expect(tl.getEvents()[1].getContent().body).toEqual("a body");
             }).catch(utils.failTest).done(done);
 
-            httpBackend.flush("/sync", 1).then(function() {
-                return utils.syncPromise(client);
-            }).then(function() {
+            q.all([
+                httpBackend.flush("/sync", 1),
+                utils.syncPromise(client),
+            ]).then(function() {
                 return client.getEventTimeline(timelineSet, event.event_id);
             }).then(function(tl) {
                 console.log("getEventTimeline completed (1)");

--- a/spec/integ/matrix-client-opts.spec.js
+++ b/spec/integ/matrix-client-opts.spec.js
@@ -6,6 +6,7 @@ const HttpBackend = require("../mock-request");
 const utils = require("../test-utils");
 
 import expect from 'expect';
+import q from 'q';
 
 describe("MatrixClient opts", function() {
     const baseUrl = "http://localhost.or.something";
@@ -113,9 +114,10 @@ describe("MatrixClient opts", function() {
             httpBackend.flush("/pushrules", 1).then(function() {
                 return httpBackend.flush("/filter", 1);
             }).then(function() {
-                return httpBackend.flush("/sync", 1);
-            }).then(function() {
-                return utils.syncPromise(client);
+                return q.all([
+                    httpBackend.flush("/sync", 1),
+                    utils.syncPromise(client),
+                ]);
             }).done(function() {
                 expect(expectedEventTypes.length).toEqual(
                     0, "Expected to see event types: " + expectedEventTypes,

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -337,9 +337,7 @@ describe("megolm", function() {
             };
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush("/sync", 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
@@ -387,9 +385,7 @@ describe("megolm", function() {
             };
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush("/sync", 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
@@ -404,9 +400,7 @@ describe("megolm", function() {
             };
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush("/sync", 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
@@ -474,9 +468,10 @@ describe("megolm", function() {
             };
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse2);
 
-            return aliceTestClient.httpBackend.flush("/sync", 2);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            // flush both syncs
+            return aliceTestClient.flushSync().then(() => {
+                return aliceTestClient.flushSync();
+            });
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
@@ -504,9 +499,7 @@ describe("megolm", function() {
             syncResponse.to_device = { events: [olmEvent] };
 
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush('/sync', 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             // start out with the device unknown - the send should be rejected.
             aliceTestClient.httpBackend.when('POST', '/keys/query').respond(
@@ -571,9 +564,7 @@ describe("megolm", function() {
             const syncResponse = getSyncResponse(['@bob:xyz']);
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
 
-            return aliceTestClient.httpBackend.flush('/sync', 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             console.log("Forcing alice to download our device keys");
 
@@ -620,9 +611,7 @@ describe("megolm", function() {
             syncResponse.to_device = { events: [olmEvent] };
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
 
-            return aliceTestClient.httpBackend.flush('/sync', 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             console.log('Forcing alice to download our device keys');
 
@@ -673,9 +662,7 @@ describe("megolm", function() {
             syncResponse.to_device = { events: [olmEvent] };
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
 
-            return aliceTestClient.httpBackend.flush('/sync', 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             console.log("Fetching bob's devices and marking known");
 
@@ -904,9 +891,7 @@ describe("megolm", function() {
             syncResponse.to_device = { events: [olmEvent] };
 
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush('/sync', 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             console.log('Forcing alice to download our device keys');
 
@@ -938,9 +923,7 @@ describe("megolm", function() {
            return aliceTestClient.start().then(() => {
                aliceTestClient.httpBackend.when('GET', '/sync').respond(
                    200, getSyncResponse(['@bob:xyz', '@chris:abc']));
-               return aliceTestClient.httpBackend.flush('/sync', 1);
-           }).then(() => {
-               return testUtils.syncPromise(aliceTestClient.client);
+               return aliceTestClient.flushSync();
            }).then(() => {
                // to make sure the initial device queries are flushed out, we
                // attempt to send a message.
@@ -979,9 +962,10 @@ describe("megolm", function() {
                        changed: ['@chris:abc'],
                    },
                });
-               return aliceTestClient.httpBackend.flush('/sync', 2);
-           }).then(() => {
-               return testUtils.syncPromise(aliceTestClient.client);
+               // flush both syncs
+               return aliceTestClient.flushSync().then(() => {
+                   return aliceTestClient.flushSync();
+               });
            }).then(() => {
                // check that we don't yet have a request for chris's devices.
                aliceTestClient.httpBackend.when('POST', '/keys/query', {
@@ -1006,7 +990,7 @@ describe("megolm", function() {
                      .getEndToEndDeviceTrackingStatus()['@chris:abc'];
                if (chrisStat != 1 && chrisStat != 2) {
                    throw new Error('Unexpected status for chris: wanted 1 or 2, got ' +
-                                   bobStat);
+                                   chrisStat);
                }
 
                // now add an expectation for a query for bob's devices, and let
@@ -1098,9 +1082,7 @@ describe("megolm", function() {
             };
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush("/sync", 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
@@ -1132,9 +1114,7 @@ describe("megolm", function() {
             };
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
-            return aliceTestClient.httpBackend.flush("/sync", 1);
-        }).then(function() {
-            return testUtils.syncPromise(aliceTestClient.client);
+            return aliceTestClient.flushSync();
         }).then(function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];


### PR DESCRIPTION
There is a common pattern in the tests which is, when we want to mock a /sync,
to flush it, and then, in the next tick of the promise loop, to wait for the
syncing event. However, this is racy: there is no guarantee that the syncing
event will not happen before the next tick of the promise loop.

Instead, we should set the expectation of the syncing event, then do the flush.
(Technically we only need to wait for the syncing event, but by waiting for
both we'll catch any errors thrown by the flush, and make sure we don't have
any outstanding flushes before proceeding).

Add a utility method to TestClient to do the above, and use it where we have a
TestClient.

(Also fixes a couple of other minor buglets in the tests).