### PR TITLE
Sanity-check response from /thirdparty/protocols

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1326,7 +1326,15 @@ MatrixBaseApis.prototype.getThirdpartyProtocols = function() {
     return this._http.authedRequestWithPrefix(
         undefined, "GET", "/thirdparty/protocols", undefined, undefined,
         httpApi.PREFIX_UNSTABLE,
-    );
+    ).then((response) => {
+        // sanity check
+        if (!response || typeof(response) !== 'object') {
+            throw new Error(
+                `/thirdparty/protocols did not return an object: ${response}`,
+            );
+        }
+        return response;
+    });
 };
 
 /**


### PR DESCRIPTION
Check that /thirdparty/protocols gives us an object (rather than a string, for
instance). I saw a test explode, apparently because it gave us a string. Which
is odd, but in general we ought to be sanity-checking the things coming back
from the server.