### PR TITLE
Remove m.new_device support

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -647,60 +647,6 @@ describe("MatrixClient crypto", function() {
             }).then(aliRecvMessage);
     });
 
-
-    it("Ali does a key query when she gets a new_device event", function() {
-        return q()
-            .then(() => aliTestClient.start())
-            .then(() => firstSync(aliTestClient))
-
-            // ali will only care about bob's new_device if she is tracking
-            // bob's devices, which she will do if we enable encryption
-            .then(aliEnablesEncryption)
-
-            .then(() => {
-                aliTestClient.expectKeyQuery({
-                    device_keys: {
-                        [aliUserId]: {},
-                        [bobUserId]: {},
-                    },
-                });
-                return aliTestClient.httpBackend.flush('/keys/query', 1);
-            })
-
-            // make sure that the initial key download has completed
-            // (downloadKeys will wait until it does)
-            .then(() => {
-                return aliTestClient.client.downloadKeys([bobUserId]);
-            })
-
-            .then(function() {
-                const syncData = {
-                    next_batch: '2',
-                    to_device: {
-                        events: [
-                            testUtils.mkEvent({
-                                content: {
-                                    device_id: 'TEST_DEVICE',
-                                    rooms: [],
-                                },
-                                sender: bobUserId,
-                                type: 'm.new_device',
-                            }),
-                        ],
-                    },
-                };
-                aliTestClient.httpBackend.when('GET', '/sync').respond(200, syncData);
-                return aliTestClient.httpBackend.flush('/sync', 1);
-            }).then(() => {
-                aliTestClient.expectKeyQuery({
-                    device_keys: {
-                        [bobUserId]: {},
-                    },
-                });
-                return aliTestClient.httpBackend.flush('/keys/query', 1);
-            });
-    });
-
     it("Ali does a key query when encryption is enabled", function() {
         // enabling encryption in the room should make alice download devices
         // for both members.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -155,8 +155,6 @@ function _registerEventHandlers(crypto, eventEmitter) {
             if (event.getType() == "m.room_key"
                     || event.getType() == "m.forwarded_room_key") {
                 crypto._onRoomKeyEvent(event);
-            } else if (event.getType() == "m.new_device") {
-                crypto._onNewDeviceEvent(event);
             } else if (event.getType() == "m.room_key_request") {
                 crypto._onRoomKeyRequestEvent(event);
             }
@@ -875,9 +873,6 @@ Crypto.prototype._onSyncCompleted = function(syncData) {
     if (!syncData.oldSyncToken) {
         console.log("Completed initial sync");
 
-        // an initialsync.
-        this._sendNewDeviceEvents();
-
         // if we have a deviceSyncToken, we can tell the deviceList to
         // invalidate devices which have changed since then.
         const oldSyncToken = this._sessionStore.getEndToEndDeviceSyncToken();
@@ -924,57 +919,6 @@ Crypto.prototype._onSyncCompleted = function(syncData) {
         _maybeUploadOneTimeKeys(this);
         this._processReceivedRoomKeyRequests();
     }
-};
-
-/**
- * Send m.new_device messages to any devices we share a room with.
- *
- * (TODO: we can get rid of this once a suitable number of homeservers and
- * clients support the more reliable device list update stream mechanism)
- *
- * @private
- */
-Crypto.prototype._sendNewDeviceEvents = function() {
-    if (this._sessionStore.getDeviceAnnounced()) {
-        return;
-    }
-
-    // we need to tell all the devices in all the rooms we are members of that
-    // we have arrived.
-    // build a list of rooms for each user.
-    const roomsByUser = {};
-    for (const room of this._getE2eRooms()) {
-        const members = room.getJoinedMembers();
-        for (let j = 0; j < members.length; j++) {
-            const m = members[j];
-            if (!roomsByUser[m.userId]) {
-                roomsByUser[m.userId] = [];
-            }
-            roomsByUser[m.userId].push(room.roomId);
-        }
-    }
-
-    // build a per-device message for each user
-    const content = {};
-    for (const userId in roomsByUser) {
-        if (!roomsByUser.hasOwnProperty(userId)) {
-            continue;
-        }
-        content[userId] = {
-            "*": {
-                device_id: this._deviceId,
-                rooms: roomsByUser[userId],
-            },
-        };
-    }
-
-    const self = this;
-    this._baseApis.sendToDevice(
-        "m.new_device", // OH HAI!
-        content,
-    ).done(function() {
-        self._sessionStore.setDeviceAnnounced();
-    });
 };
 
 /**
@@ -1082,34 +1026,6 @@ Crypto.prototype._onRoomMembership = function(event, member, oldMembership) {
     alg.onRoomMembership(event, member, oldMembership);
 };
 
-
-/**
- * Called when a new device announces itself
- *
- * @private
- * @param {module:models/event.MatrixEvent} event announcement event
- */
-Crypto.prototype._onNewDeviceEvent = function(event) {
-    const content = event.getContent();
-    const userId = event.getSender();
-    const deviceId = content.device_id;
-    const rooms = content.rooms;
-
-    if (!rooms || !deviceId) {
-        console.warn("new_device event missing keys");
-        return;
-    }
-
-    console.log("m.new_device event from " + userId + ":" + deviceId +
-                " for rooms " + rooms);
-
-    if (this.getStoredDevice(userId, deviceId)) {
-        console.log("Known device; ignoring");
-        return;
-    }
-
-    this._deviceList.invalidateUserDeviceList(userId);
-};
 
 /**
  * Called when we get an m.room_key_request event.

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -66,22 +66,6 @@ WebStorageSessionStore.prototype = {
     },
 
     /**
-     * Store a flag indicating that we have announced the new device.
-     */
-    setDeviceAnnounced: function() {
-        this.store.setItem(KEY_END_TO_END_ANNOUNCED, "true");
-    },
-
-    /**
-     * Check if the "device announced" flag is set
-     *
-     * @return {boolean} true if the "device announced" flag has been set.
-     */
-    getDeviceAnnounced: function() {
-        return this.store.getItem(KEY_END_TO_END_ANNOUNCED) == "true";
-    },
-
-    /**
      * Stores the known devices for a user.
      * @param {string} userId The user's ID.
      * @param {object} devices A map from device ID to keys for the device.
@@ -208,7 +192,6 @@ WebStorageSessionStore.prototype = {
 };
 
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
-const KEY_END_TO_END_ANNOUNCED = E2E_PREFIX + "announced";
 const KEY_END_TO_END_DEVICE_SYNC_TOKEN = E2E_PREFIX + "device_sync_token";
 const KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS = E2E_PREFIX + "device_tracking";
 


### PR DESCRIPTION
We now rely on the server to track new devices, and tell us about them when
users add them, rather than forcing devices to announce themselves (see
https://github.com/vector-im/riot-web/issues/2305 for the whole backstory
there).

The necessary support for that has now been in all the clients and the server
for several months (since March or so). I now want to get rid of the
localstorage store, which this code is relying on, so now seems like a good
time to get rid of it. Yay.