### PR TITLE
Make it possible to use async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015"]
+    "presets": ["es2015"],
+    "plugins": [
+        "transform-async-to-generator",
+    ],
 }

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
     "browser-request": "^0.3.3",
     "content-type": "^1.0.2",
     "q": "^1.4.1",
+    "regenerator-runtime": "^0.10.5",
     "request": "^2.53.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-preset-es2015": "^6.18.0",
     "browserify": "^14.0.0",
     "browserify-shim": "^3.8.13",

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -16,6 +16,9 @@ limitations under the License.
 */
 "use strict";
 
+// make sure that the regenerator-runtime has been loaded
+import 'regenerator-runtime/runtime';
+
 /** The {@link module:models/event.MatrixEvent|MatrixEvent} class. */
 module.exports.MatrixEvent = require("./models/event").MatrixEvent;
 /** The {@link module:models/event.EventStatus|EventStatus} enum. */


### PR DESCRIPTION
Enables the babel plugin that transpiles async/await to generator functions,
and load the regenerator runtime so that generator functions work.