### PR TITLE
Remove testUtils.failTest

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -414,7 +414,7 @@ describe("MatrixClient crypto", function() {
         q()
             .then(bobUploadsDeviceKeys)
             .then(aliDownloadsKeys)
-            .catch(testUtils.failTest).done(done);
+            .nodeify(done);
     });
 
     it("Ali gets keys with an invalid signature", function(done) {
@@ -433,7 +433,7 @@ describe("MatrixClient crypto", function() {
                 // should get an empty list
                 expect(aliTestClient.client.listDeviceKeys(bobUserId)).toEqual([]);
             })
-            .catch(testUtils.failTest).done(done);
+            .nodeify(done);
     });
 
     it("Ali gets keys with an incorrect userId", function(done) {
@@ -472,7 +472,7 @@ describe("MatrixClient crypto", function() {
             // should get an empty list
             expect(aliTestClient.client.listDeviceKeys(bobUserId)).toEqual([]);
             expect(aliTestClient.client.listDeviceKeys(eveUserId)).toEqual([]);
-        }).catch(testUtils.failTest).done(done);
+        }).nodeify(done);
     });
 
     it("Ali gets keys with an incorrect deviceId", function(done) {
@@ -508,7 +508,7 @@ describe("MatrixClient crypto", function() {
         ).then(function() {
             // should get an empty list
             expect(aliTestClient.client.listDeviceKeys(bobUserId)).toEqual([]);
-        }).catch(testUtils.failTest).done(done);
+        }).nodeify(done);
     });
 
 
@@ -540,7 +540,7 @@ describe("MatrixClient crypto", function() {
             .then(aliEnablesEncryption)
             .then(aliSendsFirstMessage)
             .then(bobRecvMessage)
-            .catch(testUtils.failTest).done(done);
+            .nodeify(done);
     });
 
     it("Bob receives a message with a bogus sender", function(done) {
@@ -597,7 +597,7 @@ describe("MatrixClient crypto", function() {
                 bobTestClient.httpBackend.flush();
                 return deferred.promise;
             })
-            .catch(testUtils.failTest).done(done);
+            .nodeify(done);
     });
 
     it("Ali blocks Bob's device", function(done) {
@@ -629,7 +629,7 @@ describe("MatrixClient crypto", function() {
             .then(bobRecvMessage)
             .then(aliSendsMessage)
             .then(bobRecvMessage)
-            .catch(testUtils.failTest).done(done);
+            .nodeify(done);
     });
 
     it("Bob replies to the message", function() {

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -465,10 +465,10 @@ describe("MatrixClient crypto", function() {
             return {device_keys: result};
         });
 
-        q.all(
+        q.all([
             aliTestClient.client.downloadKeys([bobUserId, eveUserId]),
             aliTestClient.httpBackend.flush("/keys/query", 1),
-        ).then(function() {
+        ]).then(function() {
             // should get an empty list
             expect(aliTestClient.client.listDeviceKeys(bobUserId)).toEqual([]);
             expect(aliTestClient.client.listDeviceKeys(eveUserId)).toEqual([]);
@@ -502,10 +502,10 @@ describe("MatrixClient crypto", function() {
             return {device_keys: result};
         });
 
-        q.all(
+        q.all([
             aliTestClient.client.downloadKeys([bobUserId]),
             aliTestClient.httpBackend.flush("/keys/query", 1),
-        ).then(function() {
+        ]).then(function() {
             // should get an empty list
             expect(aliTestClient.client.listDeviceKeys(bobUserId)).toEqual([]);
         }).nodeify(done);
@@ -529,7 +529,7 @@ describe("MatrixClient crypto", function() {
             .then(() => firstSync(aliTestClient))
             .then(aliEnablesEncryption)
             .then(aliSendsFirstMessage)
-            .catch(testUtils.failTest).nodeify(done);
+            .nodeify(done);
     });
 
     it("Bob receives a message", function(done) {

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -130,7 +130,7 @@ describe("getEventTimeline support", function() {
         }).nodeify(done);
     });
 
-    it("timeline support works when enabled", function(done) {
+    it("timeline support works when enabled", function() {
         client = sdk.createClient({
             baseUrl: baseUrl,
             userId: userId,
@@ -138,16 +138,16 @@ describe("getEventTimeline support", function() {
             timelineSupport: true,
         });
 
-        startClient(httpBackend, client,
-        ).then(function() {
-            const room = client.getRoom(roomId);
-            const timelineSet = room.getTimelineSets()[0];
-            expect(function() {
-                client.getEventTimeline(timelineSet, "event");
-            }).toNotThrow();
-        }).nodeify(done);
-
-        httpBackend.flush().catch(utils.failTest);
+        return q.all([
+            startClient(httpBackend, client).then(function() {
+                const room = client.getRoom(roomId);
+                const timelineSet = room.getTimelineSets()[0];
+                expect(function() {
+                    client.getEventTimeline(timelineSet, "event");
+                }).toNotThrow();
+            }),
+            httpBackend.flush(),
+        ]);
     });
 
 
@@ -251,7 +251,7 @@ describe("MatrixClient event timelines", function() {
     });
 
     describe("getEventTimeline", function() {
-        it("should create a new timeline for new events", function(done) {
+        it("should create a new timeline for new events", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
             httpBackend.when("GET", "/rooms/!foo%3Abar/context/event1%3Abar")
@@ -269,22 +269,23 @@ describe("MatrixClient event timelines", function() {
                     };
                 });
 
-            client.getEventTimeline(timelineSet, "event1:bar").then(function(tl) {
-                expect(tl.getEvents().length).toEqual(4);
-                for (let i = 0; i < 4; i++) {
-                    expect(tl.getEvents()[i].event).toEqual(EVENTS[i]);
-                    expect(tl.getEvents()[i].sender.name).toEqual(userName);
-                }
-                expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
-                    .toEqual("start_token");
-                expect(tl.getPaginationToken(EventTimeline.FORWARDS))
-                    .toEqual("end_token");
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                client.getEventTimeline(timelineSet, "event1:bar").then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(4);
+                    for (let i = 0; i < 4; i++) {
+                        expect(tl.getEvents()[i].event).toEqual(EVENTS[i]);
+                        expect(tl.getEvents()[i].sender.name).toEqual(userName);
+                    }
+                    expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toEqual("start_token");
+                    expect(tl.getPaginationToken(EventTimeline.FORWARDS))
+                        .toEqual("end_token");
+                }),
+                httpBackend.flush(),
+            ]);
         });
 
-        it("should return existing timeline for known events", function(done) {
+        it("should return existing timeline for known events", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
             httpBackend.when("GET", "/sync").respond(200, {
@@ -303,17 +304,20 @@ describe("MatrixClient event timelines", function() {
                 },
             });
 
-            httpBackend.flush("/sync").then(function() {
-                return client.getEventTimeline(timelineSet, EVENTS[0].event_id);
-            }).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[1].event).toEqual(EVENTS[0]);
-                expect(tl.getEvents()[1].sender.name).toEqual(userName);
-                expect(tl.getPaginationToken(EventTimeline.BACKWARDS)).toEqual("f_1_1");
-                // expect(tl.getPaginationToken(EventTimeline.FORWARDS)).toEqual("s_5_4");
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                httpBackend.flush("/sync").then(function() {
+                    return client.getEventTimeline(timelineSet, EVENTS[0].event_id);
+                }).then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[1].event).toEqual(EVENTS[0]);
+                    expect(tl.getEvents()[1].sender.name).toEqual(userName);
+                    expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toEqual("f_1_1");
+                    // expect(tl.getPaginationToken(EventTimeline.FORWARDS))
+                    //    .toEqual("s_5_4");
+                }),
+                httpBackend.flush(),
+            ]);
         });
 
         it("should update timelines where they overlap a previous /sync", function() {
@@ -371,7 +375,7 @@ describe("MatrixClient event timelines", function() {
         });
 
         it("should join timelines where they overlap a previous /context",
-          function(done) {
+          function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
 
@@ -431,41 +435,42 @@ describe("MatrixClient event timelines", function() {
 
             let tl0;
             let tl3;
-            client.getEventTimeline(timelineSet, EVENTS[0].event_id,
-            ).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(1);
-                tl0 = tl;
-                return client.getEventTimeline(timelineSet, EVENTS[2].event_id);
-            }).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(1);
-                return client.getEventTimeline(timelineSet, EVENTS[3].event_id);
-            }).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(1);
-                tl3 = tl;
-                return client.getEventTimeline(timelineSet, EVENTS[1].event_id);
-            }).then(function(tl) {
-                // we expect it to get merged in with event 2
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[0].event).toEqual(EVENTS[1]);
-                expect(tl.getEvents()[1].event).toEqual(EVENTS[2]);
-                expect(tl.getNeighbouringTimeline(EventTimeline.BACKWARDS))
-                    .toBe(tl0);
-                expect(tl.getNeighbouringTimeline(EventTimeline.FORWARDS))
-                    .toBe(tl3);
-                expect(tl0.getPaginationToken(EventTimeline.BACKWARDS))
-                    .toEqual("start_token0");
-                expect(tl0.getPaginationToken(EventTimeline.FORWARDS))
-                    .toBe(null);
-                expect(tl3.getPaginationToken(EventTimeline.BACKWARDS))
-                    .toBe(null);
-                expect(tl3.getPaginationToken(EventTimeline.FORWARDS))
-                    .toEqual("end_token3");
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                client.getEventTimeline(timelineSet, EVENTS[0].event_id,
+                ).then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(1);
+                    tl0 = tl;
+                    return client.getEventTimeline(timelineSet, EVENTS[2].event_id);
+                }).then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(1);
+                    return client.getEventTimeline(timelineSet, EVENTS[3].event_id);
+                }).then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(1);
+                    tl3 = tl;
+                    return client.getEventTimeline(timelineSet, EVENTS[1].event_id);
+                }).then(function(tl) {
+                    // we expect it to get merged in with event 2
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[0].event).toEqual(EVENTS[1]);
+                    expect(tl.getEvents()[1].event).toEqual(EVENTS[2]);
+                    expect(tl.getNeighbouringTimeline(EventTimeline.BACKWARDS))
+                        .toBe(tl0);
+                    expect(tl.getNeighbouringTimeline(EventTimeline.FORWARDS))
+                        .toBe(tl3);
+                    expect(tl0.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toEqual("start_token0");
+                    expect(tl0.getPaginationToken(EventTimeline.FORWARDS))
+                        .toBe(null);
+                    expect(tl3.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toBe(null);
+                    expect(tl3.getPaginationToken(EventTimeline.FORWARDS))
+                        .toEqual("end_token3");
+                }),
+                httpBackend.flush(),
+            ]);
         });
 
-        it("should fail gracefully if there is no event field", function(done) {
+        it("should fail gracefully if there is no event field", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
             // we fetch event 0, then 2, then 3, and finally 1. 1 is returned
@@ -481,20 +486,21 @@ describe("MatrixClient event timelines", function() {
                     };
                 });
 
-            client.getEventTimeline(timelineSet, "event1",
-            ).then(function(tl) {
-                // could do with a fail()
-                expect(true).toBeFalsy();
-            }).catch(function(e) {
-                expect(String(e)).toMatch(/'event'/);
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                client.getEventTimeline(timelineSet, "event1",
+                ).then(function(tl) {
+                    // could do with a fail()
+                    expect(true).toBeFalsy();
+                }, function(e) {
+                    expect(String(e)).toMatch(/'event'/);
+                }),
+                httpBackend.flush(),
+            ]);
         });
     });
 
     describe("paginateEventTimeline", function() {
-        it("should allow you to paginate backwards", function(done) {
+        it("should allow you to paginate backwards", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
 
@@ -525,27 +531,28 @@ describe("MatrixClient event timelines", function() {
                 });
 
             let tl;
-            client.getEventTimeline(timelineSet, EVENTS[0].event_id,
-            ).then(function(tl0) {
-                tl = tl0;
-                return client.paginateEventTimeline(tl, {backwards: true});
-            }).then(function(success) {
-                expect(success).toBeTruthy();
-                expect(tl.getEvents().length).toEqual(3);
-                expect(tl.getEvents()[0].event).toEqual(EVENTS[2]);
-                expect(tl.getEvents()[1].event).toEqual(EVENTS[1]);
-                expect(tl.getEvents()[2].event).toEqual(EVENTS[0]);
-                expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
-                    .toEqual("start_token1");
-                expect(tl.getPaginationToken(EventTimeline.FORWARDS))
-                    .toEqual("end_token0");
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                client.getEventTimeline(timelineSet, EVENTS[0].event_id,
+                ).then(function(tl0) {
+                    tl = tl0;
+                    return client.paginateEventTimeline(tl, {backwards: true});
+                }).then(function(success) {
+                    expect(success).toBeTruthy();
+                    expect(tl.getEvents().length).toEqual(3);
+                    expect(tl.getEvents()[0].event).toEqual(EVENTS[2]);
+                    expect(tl.getEvents()[1].event).toEqual(EVENTS[1]);
+                    expect(tl.getEvents()[2].event).toEqual(EVENTS[0]);
+                    expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toEqual("start_token1");
+                    expect(tl.getPaginationToken(EventTimeline.FORWARDS))
+                        .toEqual("end_token0");
+                }),
+                httpBackend.flush(),
+            ]);
         });
 
 
-        it("should allow you to paginate forwards", function(done) {
+        it("should allow you to paginate forwards", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
 
@@ -576,24 +583,25 @@ describe("MatrixClient event timelines", function() {
                 });
 
             let tl;
-            client.getEventTimeline(timelineSet, EVENTS[0].event_id,
-            ).then(function(tl0) {
-                tl = tl0;
-                return client.paginateEventTimeline(
-                    tl, {backwards: false, limit: 20});
-            }).then(function(success) {
-                expect(success).toBeTruthy();
-                expect(tl.getEvents().length).toEqual(3);
-                expect(tl.getEvents()[0].event).toEqual(EVENTS[0]);
-                expect(tl.getEvents()[1].event).toEqual(EVENTS[1]);
-                expect(tl.getEvents()[2].event).toEqual(EVENTS[2]);
-                expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
-                    .toEqual("start_token0");
-                expect(tl.getPaginationToken(EventTimeline.FORWARDS))
-                    .toEqual("end_token1");
-            }).nodeify(done);
-
-            httpBackend.flush().catch(utils.failTest);
+            return q.all([
+                client.getEventTimeline(timelineSet, EVENTS[0].event_id,
+                ).then(function(tl0) {
+                    tl = tl0;
+                    return client.paginateEventTimeline(
+                        tl, {backwards: false, limit: 20});
+                }).then(function(success) {
+                    expect(success).toBeTruthy();
+                    expect(tl.getEvents().length).toEqual(3);
+                    expect(tl.getEvents()[0].event).toEqual(EVENTS[0]);
+                    expect(tl.getEvents()[1].event).toEqual(EVENTS[1]);
+                    expect(tl.getEvents()[2].event).toEqual(EVENTS[2]);
+                    expect(tl.getPaginationToken(EventTimeline.BACKWARDS))
+                        .toEqual("start_token0");
+                    expect(tl.getPaginationToken(EventTimeline.FORWARDS))
+                        .toEqual("end_token1");
+                }),
+                httpBackend.flush(),
+            ]);
         });
     });
 
@@ -628,62 +636,66 @@ describe("MatrixClient event timelines", function() {
             });
         });
 
-        it("should work when /send returns before /sync", function(done) {
+        it("should work when /send returns before /sync", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
 
-            client.sendTextMessage(roomId, "a body", TXN_ID).then(function(res) {
-                expect(res.event_id).toEqual(event.event_id);
-                return client.getEventTimeline(timelineSet, event.event_id);
-            }).then(function(tl) {
-                // 2 because the initial sync contained an event
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[1].getContent().body).toEqual("a body");
+            return q.all([
+                client.sendTextMessage(roomId, "a body", TXN_ID).then(function(res) {
+                    expect(res.event_id).toEqual(event.event_id);
+                    return client.getEventTimeline(timelineSet, event.event_id);
+                }).then(function(tl) {
+                    // 2 because the initial sync contained an event
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[1].getContent().body).toEqual("a body");
 
-                // now let the sync complete, and check it again
-                return q.all([
-                    httpBackend.flush("/sync", 1),
-                    utils.syncPromise(client),
-                ]);
-            }).then(function() {
-                return client.getEventTimeline(timelineSet, event.event_id);
-            }).then(function(tl) {
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[1].event).toEqual(event);
-            }).nodeify(done);
+                    // now let the sync complete, and check it again
+                    return q.all([
+                        httpBackend.flush("/sync", 1),
+                        utils.syncPromise(client),
+                    ]);
+                }).then(function() {
+                    return client.getEventTimeline(timelineSet, event.event_id);
+                }).then(function(tl) {
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[1].event).toEqual(event);
+                }),
 
-            httpBackend.flush("/send/m.room.message/" + TXN_ID, 1).catch(utils.failTest);
+                httpBackend.flush("/send/m.room.message/" + TXN_ID, 1),
+            ]);
         });
 
-        it("should work when /send returns after /sync", function(done) {
+        it("should work when /send returns after /sync", function() {
             const room = client.getRoom(roomId);
             const timelineSet = room.getTimelineSets()[0];
 
-            // initiate the send, and set up checks to be done when it completes
-            // - but note that it won't complete until after the /sync does, below.
-            client.sendTextMessage(roomId, "a body", TXN_ID).then(function(res) {
-                console.log("sendTextMessage completed");
-                expect(res.event_id).toEqual(event.event_id);
-                return client.getEventTimeline(timelineSet, event.event_id);
-            }).then(function(tl) {
-                console.log("getEventTimeline completed (2)");
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[1].getContent().body).toEqual("a body");
-            }).nodeify(done);
+            return q.all([
+                // initiate the send, and set up checks to be done when it completes
+                // - but note that it won't complete until after the /sync does, below.
+                client.sendTextMessage(roomId, "a body", TXN_ID).then(function(res) {
+                    console.log("sendTextMessage completed");
+                    expect(res.event_id).toEqual(event.event_id);
+                    return client.getEventTimeline(timelineSet, event.event_id);
+                }).then(function(tl) {
+                    console.log("getEventTimeline completed (2)");
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[1].getContent().body).toEqual("a body");
+                }),
 
-            q.all([
-                httpBackend.flush("/sync", 1),
-                utils.syncPromise(client),
-            ]).then(function() {
-                return client.getEventTimeline(timelineSet, event.event_id);
-            }).then(function(tl) {
-                console.log("getEventTimeline completed (1)");
-                expect(tl.getEvents().length).toEqual(2);
-                expect(tl.getEvents()[1].event).toEqual(event);
+                q.all([
+                    httpBackend.flush("/sync", 1),
+                    utils.syncPromise(client),
+                ]).then(function() {
+                    return client.getEventTimeline(timelineSet, event.event_id);
+                }).then(function(tl) {
+                    console.log("getEventTimeline completed (1)");
+                    expect(tl.getEvents().length).toEqual(2);
+                    expect(tl.getEvents()[1].event).toEqual(event);
 
-                // now let the send complete.
-                return httpBackend.flush("/send/m.room.message/" + TXN_ID, 1);
-            }).catch(utils.failTest);
+                    // now let the send complete.
+                    return httpBackend.flush("/send/m.room.message/" + TXN_ID, 1);
+                }),
+            ]);
         });
     });
 

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -127,7 +127,7 @@ describe("getEventTimeline support", function() {
             expect(function() {
                 client.getEventTimeline(timelineSet, "event");
             }).toThrow();
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 
     it("timeline support works when enabled", function(done) {
@@ -145,7 +145,7 @@ describe("getEventTimeline support", function() {
             expect(function() {
                 client.getEventTimeline(timelineSet, "event");
             }).toNotThrow();
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
 
         httpBackend.flush().catch(utils.failTest);
     });
@@ -220,7 +220,7 @@ describe("getEventTimeline support", function() {
             expect(room.timeline[0].event).toEqual(EVENTS[0]);
             expect(room.timeline[1].event).toEqual(EVENTS[1]);
             expect(room.oldState.paginationToken).toEqual("pagin_end");
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 });
 
@@ -279,7 +279,7 @@ describe("MatrixClient event timelines", function() {
                     .toEqual("start_token");
                 expect(tl.getPaginationToken(EventTimeline.FORWARDS))
                     .toEqual("end_token");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -311,7 +311,7 @@ describe("MatrixClient event timelines", function() {
                 expect(tl.getEvents()[1].sender.name).toEqual(userName);
                 expect(tl.getPaginationToken(EventTimeline.BACKWARDS)).toEqual("f_1_1");
                 // expect(tl.getPaginationToken(EventTimeline.FORWARDS)).toEqual("s_5_4");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -460,7 +460,7 @@ describe("MatrixClient event timelines", function() {
                     .toBe(null);
                 expect(tl3.getPaginationToken(EventTimeline.FORWARDS))
                     .toEqual("end_token3");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -487,7 +487,7 @@ describe("MatrixClient event timelines", function() {
                 expect(true).toBeFalsy();
             }).catch(function(e) {
                 expect(String(e)).toMatch(/'event'/);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -539,7 +539,7 @@ describe("MatrixClient event timelines", function() {
                     .toEqual("start_token1");
                 expect(tl.getPaginationToken(EventTimeline.FORWARDS))
                     .toEqual("end_token0");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -591,7 +591,7 @@ describe("MatrixClient event timelines", function() {
                     .toEqual("start_token0");
                 expect(tl.getPaginationToken(EventTimeline.FORWARDS))
                     .toEqual("end_token1");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush().catch(utils.failTest);
         });
@@ -650,7 +650,7 @@ describe("MatrixClient event timelines", function() {
             }).then(function(tl) {
                 expect(tl.getEvents().length).toEqual(2);
                 expect(tl.getEvents()[1].event).toEqual(event);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush("/send/m.room.message/" + TXN_ID, 1).catch(utils.failTest);
         });
@@ -669,7 +669,7 @@ describe("MatrixClient event timelines", function() {
                 console.log("getEventTimeline completed (2)");
                 expect(tl.getEvents().length).toEqual(2);
                 expect(tl.getEvents()[1].getContent().body).toEqual("a body");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             q.all([
                 httpBackend.flush("/sync", 1),
@@ -750,6 +750,6 @@ describe("MatrixClient event timelines", function() {
             const room = client.getRoom(roomId);
             const tl = room.getLiveTimeline();
             expect(tl.getEvents().length).toEqual(1);
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 });

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -79,7 +79,7 @@ describe("MatrixClient", function() {
 
                 const uploads = client.getCurrentUploads();
                 expect(uploads.length).toEqual(0);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush();
         });
@@ -99,7 +99,7 @@ describe("MatrixClient", function() {
                 rawResponse: false,
             }).then(function(response) {
                 expect(response.content_uri).toEqual("uri");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush();
         });
@@ -125,7 +125,7 @@ describe("MatrixClient", function() {
                 expect(error.httpStatus).toEqual(400);
                 expect(error.errcode).toEqual("M_SNAFU");
                 expect(error.message).toEqual("broken");
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush();
         });
@@ -149,7 +149,7 @@ describe("MatrixClient", function() {
 
                 const uploads = client.getCurrentUploads();
                 expect(uploads.length).toEqual(0);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             const r = client.cancelUpload(prom);
             expect(r).toBe(true);
@@ -381,7 +381,7 @@ describe("MatrixClient", function() {
                     algorithms: ["2"],
                     unsigned: { "ghi": "def" },
                 });
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
 
             httpBackend.flush();
         });
@@ -398,7 +398,7 @@ describe("MatrixClient", function() {
 
             client.deleteDevice(
                 "my_device", auth,
-            ).catch(utils.failTest).done(done);
+            ).nodeify(done);
 
             httpBackend.flush();
         });

--- a/spec/integ/matrix-client-retrying.spec.js
+++ b/spec/integ/matrix-client-retrying.spec.js
@@ -94,7 +94,7 @@ describe("MatrixClient retrying", function() {
             client.cancelPendingEvent(ev1);
             expect(ev1.status).toEqual(EventStatus.CANCELLED);
             expect(tl.length).toEqual(0);
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 
     describe("resending", function() {

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -297,7 +297,7 @@ describe("megolm", function() {
         aliceTestClient.stop();
     });
 
-    it("Alice receives a megolm message", function(done) {
+    it("Alice receives a megolm message", function() {
         return aliceTestClient.start().then(() => {
             return createOlmSession(testOlmAccount, aliceTestClient);
         }).then((p2pSession) => {
@@ -342,10 +342,10 @@ describe("megolm", function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
-        }).nodeify(done);
+        });
     });
 
-    it("Alice receives a megolm message before the session keys", function(done) {
+    it("Alice receives a megolm message before the session keys", function() {
         // https://github.com/vector-im/riot-web/issues/2273
         let roomKeyEncrypted;
 
@@ -405,10 +405,10 @@ describe("megolm", function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
-        }).nodeify(done);
+        });
     });
 
-    it("Alice gets a second room_key message", function(done) {
+    it("Alice gets a second room_key message", function() {
         return aliceTestClient.start().then(() => {
             return createOlmSession(testOlmAccount, aliceTestClient);
         }).then((p2pSession) => {
@@ -476,10 +476,10 @@ describe("megolm", function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
-        }).nodeify(done);
+        });
     });
 
-    it('Alice sends a megolm message', function(done) {
+    it('Alice sends a megolm message', function() {
         let p2pSession;
 
         return aliceTestClient.start().then(() => {
@@ -556,10 +556,10 @@ describe("megolm", function() {
                 aliceTestClient.client.resendEvent(pendingMsg, room),
                 aliceTestClient.httpBackend.flush(),
             ]);
-        }).nodeify(done);
+        });
     });
 
-    it("Alice shouldn't do a second /query for non-e2e-capable devices", function(done) {
+    it("Alice shouldn't do a second /query for non-e2e-capable devices", function() {
         return aliceTestClient.start().then(function() {
             const syncResponse = getSyncResponse(['@bob:xyz']);
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
@@ -591,11 +591,11 @@ describe("megolm", function() {
                 aliceTestClient.client.sendTextMessage(ROOM_ID, 'test'),
                 aliceTestClient.httpBackend.flush(),
             ]);
-        }).nodeify(done);
+        });
     });
 
 
-    it("We shouldn't attempt to send to blocked devices", function(done) {
+    it("We shouldn't attempt to send to blocked devices", function() {
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);
@@ -638,10 +638,10 @@ describe("megolm", function() {
                 aliceTestClient.client.sendTextMessage(ROOM_ID, 'test'),
                 aliceTestClient.httpBackend.flush(),
             ]);
-        }).nodeify(done);
+        });
     });
 
-    it("We should start a new megolm session when a device is blocked", function(done) {
+    it("We should start a new megolm session when a device is blocked", function() {
         let p2pSession;
         let megolmSessionId;
 
@@ -726,11 +726,11 @@ describe("megolm", function() {
                 aliceTestClient.client.sendTextMessage(ROOM_ID, 'test2'),
                 aliceTestClient.httpBackend.flush(),
             ]);
-        }).nodeify(done);
+        });
     });
 
     // https://github.com/vector-im/riot-web/issues/2676
-    it("Alice should send to her other devices", function(done) {
+    it("Alice should send to her other devices", function() {
         // for this test, we make the testOlmAccount be another of Alice's devices.
         // it ought to get included in messages Alice sends.
 
@@ -834,12 +834,12 @@ describe("megolm", function() {
         }).then(function() {
             expect(decrypted.type).toEqual('m.room.message');
             expect(decrypted.content.body).toEqual('test');
-        }).nodeify(done);
+        });
     });
 
 
     it('Alice should wait for device list to complete when sending a megolm message',
-    function(done) {
+    function() {
         let p2pSession;
         let inboundGroupSession;
 
@@ -913,7 +913,7 @@ describe("megolm", function() {
             return aliceTestClient.httpBackend.flush();
         }).then(function() {
             return q.all([downloadPromise, sendPromise]);
-        }).nodeify(done);
+        });
     });
 
 
@@ -1039,7 +1039,7 @@ describe("megolm", function() {
            });
        });
 
-    it("Alice exports megolm keys and imports them to a new device", function(done) {
+    it("Alice exports megolm keys and imports them to a new device", function() {
         let messageEncrypted;
 
         return aliceTestClient.start().then(() => {
@@ -1119,6 +1119,6 @@ describe("megolm", function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
-        }).nodeify(done);
+        });
     });
 });

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -182,35 +182,6 @@ module.exports.mkMessage = function(opts) {
 
 
 /**
- * make the test fail, with the given exception
- *
- * <p>This is useful for use with integration tests which use asyncronous
- * methods: it can be added as a 'catch' handler in a promise chain.
- *
- * @param {Error} err   exception to be reported
- *
- * @deprecated
- * It turns out there are easier ways of doing this. Just use nodeify():
- *
- * it("should not throw", function(done) {
- *    asynchronousMethod().then(function() {
- *       // some tests
- *    }).nodeify(done);
- * });
- *
- * @example
- * it("should not throw", function(done) {
- *    asynchronousMethod().then(function() {
- *       // some tests
- *    }).nodeify(done);
- * });
- */
-module.exports.failTest = function(err) {
-    expect(true).toBe(false, "Testfunc threw: " + err.stack);
-};
-
-
-/**
  * A mock implementation of webstorage
  *
  * @constructor

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -202,7 +202,7 @@ module.exports.mkMessage = function(opts) {
  * it("should not throw", function(done) {
  *    asynchronousMethod().then(function() {
  *       // some tests
- *    }).catch(utils.failTest).done(done);
+ *    }).nodeify(done);
  * });
  */
 module.exports.failTest = function(err) {

--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -88,7 +88,7 @@ describe("InteractiveAuth", function() {
             expect(res).toBe(requestRes);
             expect(doRequest.calls.length).toEqual(1);
             expect(stateUpdated.calls.length).toEqual(1);
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 
     it("should make a request if no authdata is provided", function(done) {
@@ -151,6 +151,6 @@ describe("InteractiveAuth", function() {
             expect(res).toBe(requestRes);
             expect(doRequest.calls.length).toEqual(2);
             expect(stateUpdated.calls.length).toEqual(1);
-        }).catch(utils.failTest).done(done);
+        }).nodeify(done);
     });
 });

--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -179,7 +179,7 @@ describe("TimelineWindow", function() {
             timelineWindow.load(undefined, 2).then(function() {
                 const expectedEvents = liveTimeline.getEvents().slice(1);
                 expect(timelineWindow.getEvents()).toEqual(expectedEvents);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("should initialise from a specific event", function(done) {
@@ -198,7 +198,7 @@ describe("TimelineWindow", function() {
             timelineWindow.load(eventId, 3).then(function() {
                 const expectedEvents = timeline.getEvents();
                 expect(timelineWindow.getEvents()).toEqual(expectedEvents);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("canPaginate should return false until load has returned",
@@ -229,7 +229,7 @@ describe("TimelineWindow", function() {
                     .toBe(true);
                 expect(timelineWindow.canPaginate(EventTimeline.FORWARDS))
                     .toBe(true);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
     });
 
@@ -277,7 +277,7 @@ describe("TimelineWindow", function() {
                 return timelineWindow.paginate(EventTimeline.BACKWARDS, 2);
             }).then(function(success) {
                 expect(success).toBe(false);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("should advance into next timeline", function(done) {
@@ -322,7 +322,7 @@ describe("TimelineWindow", function() {
                 return timelineWindow.paginate(EventTimeline.FORWARDS, 2);
             }).then(function(success) {
                 expect(success).toBe(false);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("should retreat into previous timeline", function(done) {
@@ -367,7 +367,7 @@ describe("TimelineWindow", function() {
                 return timelineWindow.paginate(EventTimeline.BACKWARDS, 2);
             }).then(function(success) {
                 expect(success).toBe(false);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("should make forward pagination requests", function(done) {
@@ -399,7 +399,7 @@ describe("TimelineWindow", function() {
                 expect(success).toBe(true);
                 const expectedEvents = timeline.getEvents().slice(0, 5);
                 expect(timelineWindow.getEvents()).toEqual(expectedEvents);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
 
@@ -432,7 +432,7 @@ describe("TimelineWindow", function() {
                 expect(success).toBe(true);
                 const expectedEvents = timeline.getEvents().slice(1, 6);
                 expect(timelineWindow.getEvents()).toEqual(expectedEvents);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
 
         it("should limit the number of unsuccessful pagination requests",
@@ -471,7 +471,7 @@ describe("TimelineWindow", function() {
                     .toBe(false);
                 expect(timelineWindow.canPaginate(EventTimeline.FORWARDS))
                     .toBe(true);
-            }).catch(utils.failTest).done(done);
+            }).nodeify(done);
         });
     });
 });


### PR DESCRIPTION
This was a helper function I wrote for testing asynchronous tests before I knew better. It turns out there are better ways of doing what it did badly:

 * using `nodeify` to turn promise results into nodejs-style callbacks, which is what `done` wants
 * or, now that we use mocha rather than jasmine, just returning a promise from the test function.

`failTest` obfuscates the actual source of the failure, so let's kill it off.