### PR TITLE
Fix early return in MatrixClient.setGuestAccess

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -426,8 +426,10 @@ describe("MatrixClient crypto", function() {
                 expect(bobDeviceKeys.keys["curve25519:" + bobDeviceId]).toBeTruthy();
                 bobDeviceKeys.keys["curve25519:" + bobDeviceId] += "abc";
 
-                return q.all(aliTestClient.client.downloadKeys([bobUserId]),
-                             expectAliQueryKeys());
+                return q.all([
+                    aliTestClient.client.downloadKeys([bobUserId]),
+                    expectAliQueryKeys(),
+                ]);
             })
             .then(function() {
                 // should get an empty list

--- a/src/client.js
+++ b/src/client.js
@@ -2153,7 +2153,7 @@ MatrixClient.prototype.setGuestAccess = function(roomId, opts) {
         });
     }
 
-    return q.all(readPromise, writePromise);
+    return q.all([readPromise, writePromise]);
 };
 
 // Registration/Login operations


### PR DESCRIPTION
(as well as a similar bug in the test suite)

Turns out that `q.all(a, b)` === `q.all([a])`, rather than `q.all([a,b])`: it
only waits for the *first* promise - which means that `client.setGuestAccess`
would swallow any errors returned from the API.