### PR TITLE
use device_one_time_keys_count transmitted by /sync

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -524,43 +524,6 @@ describe("MatrixClient crypto", function() {
             });
     });
 
-    it("React on device_one_time_keys send by /sync", function() {
-        // Send a response which causes a key upload
-        const syncDataEmpty = {
-            next_batch: "d",
-            device_one_time_keys_count: {
-                signed_curve25519: 0,
-            },
-        };
-        const syncDataFull = {
-            next_batch: "e",
-            device_one_time_keys_count: {
-                signed_curve25519: 70,
-            },
-        };
-
-        bobTestClient.httpBackend.when("GET", "/sync").respond(200, syncDataEmpty);
-        return Promise.resolve()
-            .then(() => bobTestClient.start())
-            .then(() => bobTestClient.awaitOneTimeKeyUpload())
-            .then((keys) => {
-                expect(Object.keys(keys).length).toEqual(5);
-                expect(Object.keys(bobTestClient.deviceKeys).length).toNotEqual(0);
-
-                bobTestClient.httpBackend.when("POST", "/keys/upload")
-                    .respond(200, (path, content) => {
-                        // This endpoint should now not be called anymore
-                        expect(2).toEqual(3);
-                    });
-                bobTestClient.httpBackend.when("GET", "/sync").respond(200, syncDataFull);
-            })
-            .then(() => bobTestClient.httpBackend.flush('/sync', 2).then((flushed) => {
-                expect(flushed).toEqual(2);
-            }))
-            .done();
-            // As the key store assumes to be full there should be two syncs in a row
-    });
-
     it("Ali sends a message", function(done) {
         Promise.resolve()
             .then(() => aliTestClient.start())

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -690,7 +690,7 @@ describe("MatrixClient crypto", function() {
             });
     });
 
-    it("React on device_one_time_keys send by /sync", function(done) {
+    it("React on device_one_time_keys send by /sync", function() {
         // Send a response which causes a key upload
         const self = aliTestClient;
         const httpBackend = self.httpBackend;
@@ -730,13 +730,21 @@ describe("MatrixClient crypto", function() {
                     expect(content.one_time_keys).toNotEqual({});
                     console.log('received %i one-time keys',
                                 Object.keys(content.one_time_keys).length);
-                    return {};
+                    // cancel futher calls by telling the client
+                    // we have more than we need
+                    return {
+                       device_one_time_keys_count: {
+                           signed_curve25519: 70,
+                       },
+                    };
                 }))
             .then(() => httpBackend.flushAllExpected())
             .then((flushed) => {
                 // 1x /keys/upload
                 expect(flushed).toEqual(1);
-                done();
-            });
+                // ignore all following request
+            })
+            .then(() => self.client.stopClient())
+            .then(() => httpBackend.flush());
     });
 });

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -529,20 +529,19 @@ describe("MatrixClient crypto", function() {
         const syncDataEmpty = {
             next_batch: "d",
             device_one_time_keys_count: {
-                signed_curve25519: 0
+                signed_curve25519: 0,
             },
         };
         const syncDataFull = {
             next_batch: "e",
             device_one_time_keys_count: {
-                signed_curve25519: 70
+                signed_curve25519: 70,
             },
         };
 
         bobTestClient.httpBackend.when("GET", "/sync").respond(200, syncDataEmpty);
         return Promise.resolve()
             .then(() => bobTestClient.start())
-            .then(() => bobTestClient.flushSync())
             .then(() => bobTestClient.awaitOneTimeKeyUpload())
             .then((keys) => {
                 expect(Object.keys(keys).length).toEqual(5);
@@ -551,11 +550,14 @@ describe("MatrixClient crypto", function() {
                 bobTestClient.httpBackend.when("POST", "/keys/upload")
                     .respond(200, (path, content) => {
                         // This endpoint should now not be called anymore
-                        expect(2).toBe(3);
+                        expect(2).toEqual(3);
                     });
-                bobTestClient.httpBackend.when("GET", "/sync").respond(200, syncFull);
+                bobTestClient.httpBackend.when("GET", "/sync").respond(200, syncDataFull);
             })
-            .then(() => bobTestClient.httpBackend.flush('/sync', 2));
+            .then(() => bobTestClient.httpBackend.flush('/sync', 2).then((flushed) => {
+                expect(flushed).toEqual(2);
+            }))
+            .done();
             // As the key store assumes to be full there should be two syncs in a row
     });
 

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -723,60 +723,6 @@ describe("MatrixClient syncing", function() {
         });
     });
 
-    describe("device_one_time_keys", function() {
-        if (!sdk.CRYPTO_ENABLED) {
-            return;
-        }
-
-        it("React on device_one_time_keys send by /sync", function() {
-            // Send a response which causes a key upload
-            const syncDataEmpty = {
-                next_batch: "d",
-                device_one_time_keys_count: {
-                    signed_curve25519: 0,
-                },
-            };
-            const syncDataFull = {
-                next_batch: "e",
-                device_one_time_keys_count: {
-                    signed_curve25519: 70,
-                },
-            };
-
-            client.startClient();
-            httpBackend.flushAllExpected();
-
-            // enqueue expectations:
-            // * Sync with empty one_time_keys => upload keys
-            // * Sync with more then needed keys => no request
-            // * Sync with empty one_time_keys => upload keys
-            httpBackend.when("GET", "/sync")
-                .respond(200, syncDataEmpty);
-            httpBackend.when("POST", "/keys/upload")
-                .respond(200, (path, content) => {
-                    expect(content.one_time_keys).toBeTruthy();
-                    expect(content.one_time_keys).toNotEqual({});
-                    console.log('received %i one-time keys',
-                                Object.keys(content.one_time_keys).length);
-                });
-            httpBackend.when("GET", "/sync")
-                .respond(200, syncDataFull);
-            httpBackend.when("GET", "/sync")
-                .respond(200, syncDataEmpty);
-            httpBackend.when("POST", "/keys/upload")
-                .respond(200, (path, content) => {
-                    expect(content.one_time_keys).toBeTruthy();
-                    expect(content.one_time_keys).toNotEqual({});
-                    console.log('received %i one-time keys',
-                                Object.keys(content.one_time_keys).length);
-                });
-            httpBackend.flushAllExpected().then((flushed) => {
-                // flush 3 /sync und 2 /keys/upload
-                expect(flushed).toEqual(5);
-            });
-        });
-    });
-
     /**
      * waits for the MatrixClient to emit one or more 'sync' events.
      *

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -301,8 +301,8 @@ function _maybeUploadOneTimeKeys(crypto) {
     crypto._oneTimeKeyCheckInProgress = true;
     Promise.resolve().then(() => {
         if (crypto._currentKeyCount !== undefined) {
-            // this._currentKeyCount and the handling got postponed. Use this value
-            // instead of asking the server for the current key count
+            // this._currentKeyCount got set and the handling got postponed.
+            // Use this value instead of asking the server for the current key count
             return Promise.resolve(crypto._currentKeyCount);
         }
         // ask the server how many keys we have

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -319,11 +319,12 @@ function _maybeUploadOneTimeKeys(crypto) {
         crypto._olmDevice.generateOneTimeKeys(keysThisLoop);
         return _uploadOneTimeKeys(crypto).then((res) => {
             if (res.one_time_key_counts && res.one_time_key_counts.signed_curve25519) {
-                // if the response contains a more up2date value use this
+                // if the response contains a more up to date value use this
                 // for the next loop
                 return uploadLoop(res.one_time_key_counts.signed_curve25519);
             } else {
-                return uploadLoop(keyCount + keysThisLoop);
+                throw new Error("response for uploading keys does not contain "
+                              + "one_time_key_counts.signed_curve25519");
             }
         });
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -278,12 +278,7 @@ function _maybeUploadOneTimeKeys(crypto) {
         now - crypto._lastOneTimeKeyCheck < uploadPeriod
        ) {
         // we've done a key upload recently.
-        if (crypto._currentKeyCount === undefined) {
-            // there was no /sync-response which sets this value so we return here.
-            // This is to be backwards compatible for servers which do not respond
-            // this value.
-            return;
-        }
+        return;
     }
 
     crypto._lastOneTimeKeyCheck = now;

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -247,14 +247,16 @@ Crypto.prototype.uploadDeviceKeys = function() {
 };
 
 /**
- * Stores the current key count which will be handled postponed (in a call of
- * _onSyncCompleted)
+ * Stores the current one_time_key count which will be handled later (in a call of
+ * _onSyncCompleted). The count is e.g. coming from a /sync response.
  *
- * @param {Number} currentKeyCount to be stored and handled later
+ * @param {Number} currentCount The current count of one_time_keys to be stored
  */
-Crypto.prototype.updateCurrentKeyCount = function(currentKeyCount) {
-    if (isFinite(currentKeyCount)) {
-        this._currentKeyCount = currentKeyCount;
+Crypto.prototype.updateOneTimeKeyCount = function(currentCount) {
+    if (isFinite(currentCount)) {
+        this._oneTimeKeyCount = currentCount;
+    } else {
+        throw new TypeError("Parameter for updateOneTimeKeyCount has to be a number");
     }
 };
 
@@ -295,7 +297,7 @@ function _maybeUploadOneTimeKeys(crypto) {
     // So we need some kind of enginering compromise to balance all of
     // these factors.
 
-    // We then check how many keys we can store in the Account object.
+    // Check how many keys we can store in the Account object.
     const maxOneTimeKeys = crypto._olmDevice.maxNumberOfOneTimeKeys();
     // Try to keep at most half that number on the server. This leaves the
     // rest of the slots free to hold keys that have been claimed from the
@@ -305,31 +307,33 @@ function _maybeUploadOneTimeKeys(crypto) {
     // out stale private keys that won't receive a message.
     const keyLimit = Math.floor(maxOneTimeKeys / 2);
 
-    function uploadLoop(numberToGenerate) {
-        if (numberToGenerate <= 0) {
+    function uploadLoop(keyCount) {
+        if (keyLimit <= keyCount) {
             // If we don't need to generate any more keys then we are done.
             return;
         }
 
-        const keysThisLoop = Math.min(numberToGenerate, maxKeysPerCycle);
+        const keysThisLoop = Math.min(keyLimit - keyCount, maxKeysPerCycle);
 
         // Ask olm to generate new one time keys, then upload them to synapse.
         crypto._olmDevice.generateOneTimeKeys(keysThisLoop);
         return _uploadOneTimeKeys(crypto).then((res) => {
-            const keyCount = res.one_time_key_counts.signed_curve25519 || 0;
-            if (keyCount != 0) {
-                return uploadLoop(Math.max(keyLimit - keyCount, 0));
+            if (res.one_time_key_counts && res.one_time_key_counts.signed_curve25519) {
+                // if the response contains a more up2date value use this
+                // for the next loop
+                return uploadLoop(res.one_time_key_counts.signed_curve25519);
+            } else {
+                return uploadLoop(keyCount + keysThisLoop);
             }
-            return uploadLoop(numberToGenerate - keysThisLoop);
         });
     }
 
     crypto._oneTimeKeyCheckInProgress = true;
     Promise.resolve().then(() => {
-        if (crypto._currentKeyCount !== undefined) {
-            // this._currentKeyCount got set and the handling got postponed.
-            // Use this value instead of asking the server for the current key count
-            return Promise.resolve(crypto._currentKeyCount);
+        if (crypto._oneTimeKeyCount !== undefined) {
+            // We already have the current one_time_key count from a /sync response.
+            // Use this value instead of asking the server for the current key count.
+            return Promise.resolve(crypto._oneTimeKeyCount);
         }
         // ask the server how many keys we have
         return crypto._baseApis.uploadKeysRequest({}, {
@@ -338,18 +342,17 @@ function _maybeUploadOneTimeKeys(crypto) {
             return res.one_time_key_counts.signed_curve25519 || 0;
         });
     }).then((keyCount) => {
-        // We work out how many new keys we need to create to top up the server
+        // Start the uploadLoop with the current keyCount. The function checks if
+        // we need to upload new keys or not.
         // If there are too many keys on the server then we don't need to
         // create any more keys.
-        const numberToGenerate = Math.max(keyLimit - keyCount, 0);
-
-        return uploadLoop(numberToGenerate);
+        return uploadLoop(keyCount);
     }).catch((e) => {
         console.error("Error uploading one-time keys", e.stack || e);
     }).finally(() => {
-        // reset _currentKeyCount to prevent start uploading based on old data.
+        // reset _oneTimeKeyCount to prevent start uploading based on old data.
         // it will be set again on the next /sync-response
-        crypto._currentKeyCount = undefined;
+        crypto._oneTimeKeyCount = undefined;
         crypto._oneTimeKeyCheckInProgress = false;
     }).done();
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -691,6 +691,7 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
     //    account_data: { events: [] },
     //    device_lists: { changed: ["@user:server", ... ]},
     //    to_device: { events: [] },
+    //    device_one_time_keys_count: { signed_curve25519: 42 } },
     //    rooms: {
     //      invite: {
     //        $roomid: {
@@ -981,6 +982,13 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
         data.device_lists.changed.forEach((u) => {
             this.opts.crypto.userDeviceListChanged(u);
         });
+    }
+
+    // Handle one_time_keys_count
+    if (this.opts.crypto && data.device_one_time_keys_count &&
+            data.device_one_time_keys_count.signed_curve25519) {
+        const currentCount = data.device_one_time_keys_count.signed_curve25519;
+        this.opts.crypto.updateCurrentKeyCount(currentCount);
     }
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -691,7 +691,7 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
     //    account_data: { events: [] },
     //    device_lists: { changed: ["@user:server", ... ]},
     //    to_device: { events: [] },
-    //    device_one_time_keys_count: { signed_curve25519: 42 } },
+    //    device_one_time_keys_count: { signed_curve25519: 42 },
     //    rooms: {
     //      invite: {
     //        $roomid: {
@@ -985,9 +985,8 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
     }
 
     // Handle one_time_keys_count
-    if (this.opts.crypto && data.device_one_time_keys_count &&
-            data.device_one_time_keys_count.signed_curve25519) {
-        const currentCount = data.device_one_time_keys_count.signed_curve25519;
+    if (this.opts.crypto && data.device_one_time_keys_count) {
+        const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
         this.opts.crypto.updateCurrentKeyCount(currentCount);
     }
 };

--- a/src/sync.js
+++ b/src/sync.js
@@ -987,7 +987,7 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
     // Handle one_time_keys_count
     if (this.opts.crypto && data.device_one_time_keys_count) {
         const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
-        this.opts.crypto.updateCurrentKeyCount(currentCount);
+        this.opts.crypto.updateOneTimeKeyCount(currentCount);
     }
 };
 


### PR DESCRIPTION
As of matrix-org/synapse#2237 the server sends `"device_one_time_keys_count"` as part of the `/sync`-response.

But currently this is nowhere used.
This PR changes this.

Another change: While uploading `one_time_keys` now the response will be used to measure how many keys to upload are left over. Especially useful when trying to abort uploading in tests.

Signed-off-by: Matthias Kesler <krombel@krombel.de>