### PR TITLE
Fix member events breaking on timeline reset

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -155,7 +155,9 @@ EventTimelineSet.prototype.replaceEventId = function(oldEventId, newEventId) {
  *
  * @fires module:client~MatrixClient#event:"Room.timelineReset"
  */
-EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, flush, onNewLiveTimeline) {
+EventTimelineSet.prototype.resetLiveTimeline = function(
+    backPaginationToken, flush, onNewLiveTimeline,
+) {
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || flush;
 

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -150,10 +150,12 @@ EventTimelineSet.prototype.replaceEventId = function(oldEventId, newEventId) {
  *
  * @param {string=} backPaginationToken   token for back-paginating the new timeline
  * @param {?bool} flush  Whether to flush the non-live timelines too.
+ * @param {?function} onNewLiveTimeline Called with the new unfiltered, live timeline
+ * as soon as it's available. This can be used to set event listeners.
  *
  * @fires module:client~MatrixClient#event:"Room.timelineReset"
  */
-EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, flush) {
+EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, flush, onNewLiveTimeline) {
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || flush;
 
@@ -165,6 +167,12 @@ EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, flu
     } else {
         newTimeline = this.addTimeline();
     }
+
+    // Allow event listeners to be set up before we start injecting events
+    // as otherwise events will be missed: most importantly the RoomState.newMember
+    // events which are used to set up reEmit on Member events and only fired when
+    // room members are first created.
+    if (onNewLiveTimeline) onNewLiveTimeline(newTimeline);
 
     // initialise the state in the new timeline from our last known state
     const evMap = this._liveTimeline.getState(EventTimeline.FORWARDS).events;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -207,9 +207,16 @@ Room.prototype.getLiveTimeline = function() {
  * @param {string=} backPaginationToken   token for back-paginating the new timeline
  * @param {boolean=} flush True to remove all events in all timelines. If false, only
  * the live timeline is reset.
+ * @param {Object=} onNewLiveTimeline Function called with the new live timeline object
+ * once it has been created, but before it has had any event inserted into it. This can be
+ * used to add any event listeners.
  */
-Room.prototype.resetLiveTimeline = function(backPaginationToken, flush) {
-    for (let i = 0; i < this._timelineSets.length; i++) {
+Room.prototype.resetLiveTimeline = function(backPaginationToken, flush, onNewLiveTimeline) {
+    // The unfiltered timeline set (we pass the onNewLiveTimeline callback here)
+    this._timelineSets[0].resetLiveTimeline(backPaginationToken, flush, onNewLiveTimeline);
+
+    // any other timeline sets
+    for (let i = 1; i < this._timelineSets.length; i++) {
         this._timelineSets[i].resetLiveTimeline(backPaginationToken, flush);
     }
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -211,9 +211,13 @@ Room.prototype.getLiveTimeline = function() {
  * once it has been created, but before it has had any event inserted into it. This can be
  * used to add any event listeners.
  */
-Room.prototype.resetLiveTimeline = function(backPaginationToken, flush, onNewLiveTimeline) {
+Room.prototype.resetLiveTimeline = function(
+    backPaginationToken, flush, onNewLiveTimeline,
+) {
     // The unfiltered timeline set (we pass the onNewLiveTimeline callback here)
-    this._timelineSets[0].resetLiveTimeline(backPaginationToken, flush, onNewLiveTimeline);
+    this._timelineSets[0].resetLiveTimeline(
+        backPaginationToken, flush, onNewLiveTimeline,
+    );
 
     // any other timeline sets
     for (let i = 1; i < this._timelineSets.length; i++) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -126,6 +126,7 @@ SyncApi.prototype.createRoom = function(roomId) {
 
 /**
  * @param {Room} room
+ * @param {RoomState} currentState The current state of the room's live, unfiltered timeline
  * @private
  */
 SyncApi.prototype._registerStateListeners = function(room, currentState) {
@@ -893,8 +894,11 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
                     joinObj.timeline.prev_batch,
                     self.opts.canResetEntireTimeline(room.roomId),
                     (newLiveTimeline) => {
-                        self._registerStateListeners(room, newLiveTimeline.getState(EventTimeline.FORWARDS));
-                    }
+                        self._registerStateListeners(
+                            room,
+                            newLiveTimeline.getState(EventTimeline.FORWARDS),
+                        );
+                    },
                 );
 
                 // We have to assume any gap in any timeline is


### PR DESCRIPTION
We were re-adding the listeners too late as state is inserted into
the timeline as part of resetting it causing, among other things,
newMember events to fire. These would be missed, causing those new
RoomMember objects to not get their reEmit set up.

Fixes https://github.com/vector-im/riot-web/issues/4624