### PR TITLE
Make bits of the js-sdk api asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+Unreleased changes
+==================
+
+BREAKING CHANGE
+---------------
+
+In order to support a move to a more scalable storage backend, we need to make
+a number of the APIs related end-to-end encryption asynchronous.
+
+This release of the JS-SDK includes the following changes which will affect
+applications which support end-to-end encryption:
+
+1. `MatrixClient` now provides a new (asynchronous) method,
+   `initCrypto`. Applications which support end-to-end encryption must call
+   this method (and wait for it to complete) before calling `startClient`, to
+   give the crypto layer a chance to initialise.
+
+2. The following APIs have been changed to return promises:
+
+   * `MatrixClient.getStoredDevicesForUser`
+   * `MatrixClient.getStoredDevice`
+   * `MatrixClient.setDeviceVerified`
+   * `MatrixClient.setDeviceBlocked`
+   * `MatrixClient.setDeviceKnown`
+   * `MatrixClient.getEventSenderDeviceInfo`
+   * `MatrixClient.isEventSenderVerified`
+   * `MatrixClient.importRoomKeys`
+
+   Applications using the results of any of the above methods will need to be
+   updated to wait for the result of the promise.
+
+
+3. `MatrixClient.listDeviceKeys` has been removed altogether. It's been
+   deprecated for some time. Applications using it should insted be changed to
+   use `MatrixClient.getStoredDevices`, which is similar but returns its results
+   in a slightly different format.
+
+
 Changes in [0.7.13](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.7.13) (2017-06-22)
 ==================================================================================================
 [Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.7.12...v0.7.13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ applications which support end-to-end encryption:
 
 
 3. `MatrixClient.listDeviceKeys` has been removed altogether. It's been
-   deprecated for some time. Applications using it should insted be changed to
+   deprecated for some time. Applications using it should instead be changed to
    use `MatrixClient.getStoredDevices`, which is similar but returns its results
    in a slightly different format.
 

--- a/README.md
+++ b/README.md
@@ -245,21 +245,27 @@ The SDK supports end-to-end encryption via the Olm and Megolm protocols, using
 [libolm](http://matrix.org/git/olm). It is left up to the application to make
 libolm available, via the ``Olm`` global.
 
-If the ``Olm`` global is not available, the SDK will show a warning:
+It is also necessry to call ``matrixClient.initCrypto()`` after creating a new
+``MatrixClient`` (but **before** calling ``matrixClient.startClient()``) to
+initialise the crypto layer.
+
+If the ``Olm`` global is not available, the SDK will show a warning, as shown
+below; ``initCrypto()`` will also fail.
 
 ```
 Unable to load crypto module: crypto will be disabled: Error: global.Olm is not defined
 ```
 
-The SDK will continue to work for unencrypted rooms, but it will not support
-the E2E parts of the Matrix specification.
+If the crypto layer is not (successfully) initialised, the SDK will continue to
+work for unencrypted rooms, but it will not support the E2E parts of the Matrix
+specification.
 
-To enable E2E support in a browser application:
+To provide the Olm library in a browser application:
 
  * download the transpiled libolm (from https://matrix.org/packages/npm/olm/).
  * load ``olm.js`` as a ``<script>`` *before* ``browser-matrix.js``.
  
-To enable E2E support in a node.js application:
+To provide the Olm library in a node.js application:
 
  * ``npm install https://matrix.org/packages/npm/olm/olm-2.2.2.tgz``
    (replace the URL with the latest version you want to use from

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -388,11 +388,14 @@ describe("MatrixClient crypto", function() {
         return;
     }
 
-    beforeEach(function() {
+    beforeEach(async function() {
         testUtils.beforeEach(this); // eslint-disable-line no-invalid-this
 
         aliTestClient = new TestClient(aliUserId, aliDeviceId, aliAccessToken);
+        await aliTestClient.client.initCrypto();
+
         bobTestClient = new TestClient(bobUserId, bobDeviceId, bobAccessToken);
+        await bobTestClient.client.initCrypto();
 
         aliMessages = [];
         bobMessages = [];

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -305,6 +305,10 @@ describe("MatrixClient", function() {
             return;
         }
 
+        beforeEach(function() {
+            return client.initCrypto();
+        });
+
         it("should do an HTTP request and then store the keys", function(done) {
             const ed25519key = "7wG2lzAqbjcyEkOP7O4gU7ItYcn+chKzh5sT/5r2l78";
             // ed25519key = client.getDeviceEd25519Key();

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -280,12 +280,13 @@ describe("megolm", function() {
         return claimResponse;
     }
 
-    beforeEach(function() {
+    beforeEach(async function() {
         testUtils.beforeEach(this); // eslint-disable-line no-invalid-this
 
         aliceTestClient = new TestClient(
             "@alice:localhost", "xzcvb", "akjgkrgjs",
         );
+        await aliceTestClient.client.initCrypto();
 
         testOlmAccount = new Olm.Account();
         testOlmAccount.create();
@@ -1079,10 +1080,10 @@ describe("megolm", function() {
             aliceTestClient = new TestClient(
                 "@alice:localhost", "device2", "access_token2",
             );
-
-            aliceTestClient.client.importRoomKeys(exported);
-
-            return aliceTestClient.start();
+            return aliceTestClient.client.initCrypto().then(() => {
+                aliceTestClient.client.importRoomKeys(exported);
+                return aliceTestClient.start();
+            });
         }).then(function() {
             const syncResponse = {
                 next_batch: 1,

--- a/src/client.js
+++ b/src/client.js
@@ -371,7 +371,8 @@ MatrixClient.prototype.initCrypto = async function() {
 
     await crypto.init();
 
-    // if crypto initialisation was sucessful, tell it to attach its event handlers.
+    // if crypto initialisation was successful, tell it to attach its event
+    // handlers.
     crypto.registerEventHandlers(this);
     this._crypto = crypto;
 };

--- a/src/client.js
+++ b/src/client.js
@@ -428,30 +428,13 @@ MatrixClient.prototype.downloadKeys = function(userIds, forceDownload) {
 };
 
 /**
- * List the stored device keys for a user id
- *
- * @deprecated prefer {@link module:client#getStoredDevicesForUser}
- *
- * @param {string} userId the user to list keys for.
- *
- * @return {object[]} list of devices with "id", "verified", "blocked",
- *    "key", and "display_name" parameters.
- */
-MatrixClient.prototype.listDeviceKeys = function(userId) {
-    if (this._crypto === null) {
-        throw new Error("End-to-end encryption disabled");
-    }
-    return this._crypto.listDeviceKeys(userId);
-};
-
-/**
  * Get the stored device keys for a user id
  *
  * @param {string} userId the user to list keys for.
  *
- * @return {module:crypto-deviceinfo[]} list of devices
+ * @return {Promise<module:crypto-deviceinfo[]>} list of devices
  */
-MatrixClient.prototype.getStoredDevicesForUser = function(userId) {
+MatrixClient.prototype.getStoredDevicesForUser = async function(userId) {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
@@ -464,9 +447,9 @@ MatrixClient.prototype.getStoredDevicesForUser = function(userId) {
  * @param {string} userId the user to list keys for.
  * @param {string} deviceId unique identifier for the device
  *
- * @return {?module:crypto-deviceinfo} device or null
+ * @return {Promise<?module:crypto-deviceinfo>} device or null
  */
-MatrixClient.prototype.getStoredDevice = function(userId, deviceId) {
+MatrixClient.prototype.getStoredDevice = async function(userId, deviceId) {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
@@ -482,13 +465,15 @@ MatrixClient.prototype.getStoredDevice = function(userId, deviceId) {
  * @param {boolean=} verified whether to mark the device as verified. defaults
  *   to 'true'.
  *
+ * @returns {Promise}
+ *
  * @fires module:client~event:MatrixClient"deviceVerificationChanged"
  */
 MatrixClient.prototype.setDeviceVerified = function(userId, deviceId, verified) {
     if (verified === undefined) {
         verified = true;
     }
-    _setDeviceVerification(this, userId, deviceId, verified, null);
+    return _setDeviceVerification(this, userId, deviceId, verified, null);
 };
 
 /**
@@ -500,13 +485,15 @@ MatrixClient.prototype.setDeviceVerified = function(userId, deviceId, verified) 
  * @param {boolean=} blocked whether to mark the device as blocked. defaults
  *   to 'true'.
  *
+ * @returns {Promise}
+ *
  * @fires module:client~event:MatrixClient"deviceVerificationChanged"
  */
 MatrixClient.prototype.setDeviceBlocked = function(userId, deviceId, blocked) {
     if (blocked === undefined) {
         blocked = true;
     }
-    _setDeviceVerification(this, userId, deviceId, null, blocked);
+    return _setDeviceVerification(this, userId, deviceId, null, blocked);
 };
 
 /**
@@ -518,16 +505,20 @@ MatrixClient.prototype.setDeviceBlocked = function(userId, deviceId, blocked) {
  * @param {boolean=} known whether to mark the device as known. defaults
  *   to 'true'.
  *
+ * @returns {Promise}
+ *
  * @fires module:client~event:MatrixClient"deviceVerificationChanged"
  */
 MatrixClient.prototype.setDeviceKnown = function(userId, deviceId, known) {
     if (known === undefined) {
         known = true;
     }
-    _setDeviceVerification(this, userId, deviceId, null, null, known);
+    return _setDeviceVerification(this, userId, deviceId, null, null, known);
 };
 
-function _setDeviceVerification(client, userId, deviceId, verified, blocked, known) {
+async function _setDeviceVerification(
+    client, userId, deviceId, verified, blocked, known,
+) {
     if (!client._crypto) {
         throw new Error("End-to-End encryption disabled");
     }
@@ -568,9 +559,9 @@ MatrixClient.prototype.getGlobalBlacklistUnverifiedDevices = function() {
  *
  * @param {MatrixEvent} event event to be checked
  *
- * @return {module:crypto/deviceinfo?}
+ * @return {Promise<module:crypto/deviceinfo?>}
  */
-MatrixClient.prototype.getEventSenderDeviceInfo = function(event) {
+MatrixClient.prototype.getEventSenderDeviceInfo = async function(event) {
     if (!this._crypto) {
         return null;
     }
@@ -586,8 +577,8 @@ MatrixClient.prototype.getEventSenderDeviceInfo = function(event) {
  * @return {boolean} true if the sender of this event has been verified using
  * {@link module:client~MatrixClient#setDeviceVerified|setDeviceVerified}.
  */
-MatrixClient.prototype.isEventSenderVerified = function(event) {
-    const device = this.getEventSenderDeviceInfo(event);
+MatrixClient.prototype.isEventSenderVerified = async function(event) {
+    const device = await this.getEventSenderDeviceInfo(event);
     if (!device) {
         return false;
     }
@@ -641,7 +632,7 @@ MatrixClient.prototype.exportRoomKeys = function() {
  *
  * @param {Object[]} keys a list of session export objects
  */
-MatrixClient.prototype.importRoomKeys = function(keys) {
+MatrixClient.prototype.importRoomKeys = async function(keys) {
     if (!this._crypto) {
         throw new Error("End-to-end encryption disabled");
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -37,13 +37,14 @@ import OutgoingRoomKeyRequestManager from './OutgoingRoomKeyRequestManager';
 /**
  * Cryptography bits
  *
+ * This module is internal to the js-sdk; the public API is via MatrixClient.
+ *
  * @constructor
  * @alias module:crypto
  *
- * @param {module:base-apis~MatrixBaseApis} baseApis base matrix api interface
+ * @internal
  *
- * @param {external:EventEmitter} eventEmitter event source where we can register
- *    for event notifications
+ * @param {module:base-apis~MatrixBaseApis} baseApis base matrix api interface
  *
  * @param {module:store/session/webstorage~WebStorageSessionStore} sessionStore
  *    Store to be used for end-to-end crypto session data
@@ -57,7 +58,7 @@ import OutgoingRoomKeyRequestManager from './OutgoingRoomKeyRequestManager';
  * @param {module:crypto/store/base~CryptoStore} cryptoStore
  *    storage for the crypto layer.
  */
-function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId,
+function Crypto(baseApis, sessionStore, userId, deviceId,
                 clientStore, cryptoStore) {
     this._baseApis = baseApis;
     this._sessionStore = sessionStore;
@@ -85,8 +86,9 @@ function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId,
         algorithms.DECRYPTION_CLASSES,
     );
 
-    // build our device keys: these will later be uploaded
     this._deviceKeys = {};
+
+    // build our device keys: these will later be uploaded
     this._deviceKeys["ed25519:" + this._deviceId] =
         this._olmDevice.deviceEd25519Key;
     this._deviceKeys["curve25519:" + this._deviceId] =
@@ -125,13 +127,24 @@ function Crypto(baseApis, eventEmitter, sessionStore, userId, deviceId,
             this._userId, myDevices,
         );
     }
-
-    _registerEventHandlers(this, eventEmitter);
 }
 utils.inherits(Crypto, EventEmitter);
 
+/**
+ * Initialise the crypto module so that it is ready for use
+ */
+Crypto.prototype.init = async function() {
+};
 
-function _registerEventHandlers(crypto, eventEmitter) {
+/**
+ * Tell the crypto module to register for MatrixClient events which it needs to
+ * listen for
+ *
+ * @param {external:EventEmitter} eventEmitter event source where we can register
+ *    for event notifications
+ */
+Crypto.prototype.registerEventHandlers = function(eventEmitter) {
+    const crypto = this;
     eventEmitter.on("sync", function(syncState, oldState, data) {
         try {
             if (syncState === "SYNCING") {
@@ -173,7 +186,8 @@ function _registerEventHandlers(crypto, eventEmitter) {
             console.error("Error handling crypto event:", e);
         }
     });
-}
+};
+
 
 /** Start background processes related to crypto */
 Crypto.prototype.start = function() {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -410,49 +410,6 @@ Crypto.prototype.getStoredDevice = function(userId, deviceId) {
 };
 
 /**
- * List the stored device keys for a user id
- *
- * @deprecated prefer {@link module:crypto#getStoredDevicesForUser}
- *
- * @param {string} userId the user to list keys for.
- *
- * @return {object[]} list of devices with "id", "verified", "blocked",
- *    "key", and "display_name" parameters.
- */
-Crypto.prototype.listDeviceKeys = function(userId) {
-    const devices = this.getStoredDevicesForUser(userId) || [];
-
-    const result = [];
-
-    for (let i = 0; i < devices.length; ++i) {
-        const device = devices[i];
-        const ed25519Key = device.getFingerprint();
-        if (ed25519Key) {
-            result.push({
-                id: device.deviceId,
-                key: ed25519Key,
-                verified: Boolean(device.isVerified()),
-                blocked: Boolean(device.isBlocked()),
-                display_name: device.getDisplayName(),
-            });
-        }
-    }
-
-    // sort by deviceid
-    result.sort(function(a, b) {
-        if (a.deviceId < b.deviceId) {
-            return -1;
-        }
-        if (a.deviceId > b.deviceId) {
-            return 1;
-        }
-        return 0;
-    });
-
-    return result;
-};
-
-/**
  * Update the blocked/verified state of the given device
  *
  * @param {string} userId owner of the device


### PR DESCRIPTION
We're going to need to make a bunch of these APIs asynchronous, so that we can do indexeddb stuff within them.

Add MatrixClient.initCrypto: initialising the crypto layer needs to become
asynchronous. Rather than making `sdk.createClient` asynchronous, which would
break every single app in the world, add `initCrypto`, which will only break
those attempting to do e2e (and in a way which will fall back to only
supporting unencrypted events).

Make the following return Promises:

* `MatrixClient.getStoredDevicesForUser`
* `MatrixClient.getStoredDevice`
* `MatrixClient.setDeviceVerified`
* `MatrixClient.setDeviceBlocked`
* `MatrixClient.setDeviceKnown`
* `MatrixClient.getEventSenderDeviceInfo`
* `MatrixClient.isEventSenderVerified`
* `MatrixClient.importRoomKeys`

Remove `listDeviceKeys` altogether: it's been deprecated for ages, and
since applications are going to have to be changed anyway, they might as
well use its replacement (`getStoredDevices`).

The changes required to react-sdk are in https://github.com/matrix-org/matrix-react-sdk/pull/1233.