### PR TITLE
Fix member events breaking on timeline reset, 2

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -404,7 +404,7 @@ describe("Room", function() {
         it("should copy state from previous timeline", function() {
             room.addLiveEvents([events[0], events[1]]);
             expect(room.getLiveTimeline().getEvents().length).toEqual(2);
-            room.resetLiveTimeline();
+            room.resetLiveTimeline('sometoken', 'someothertoken');
 
             room.addLiveEvents([events[2]]);
             const oldState = room.getLiveTimeline().getState(EventTimeline.BACKWARDS);
@@ -417,7 +417,7 @@ describe("Room", function() {
         it("should reset the legacy timeline fields", function() {
             room.addLiveEvents([events[0], events[1]]);
             expect(room.timeline.length).toEqual(2);
-            room.resetLiveTimeline();
+            room.resetLiveTimeline('sometoken', 'someothertoken');
 
             room.addLiveEvents([events[2]]);
             const newLiveTimeline = room.getLiveTimeline();
@@ -451,7 +451,7 @@ describe("Room", function() {
             room.addLiveEvents([events[0]]);
             expect(room.timeline.length).toEqual(1);
             const firstLiveTimeline = room.getLiveTimeline();
-            room.resetLiveTimeline();
+            room.resetLiveTimeline('sometoken', 'someothertoken');
 
             const tl = room.getTimelineForEvent(events[0].getId());
             expect(tl).toBe(timelineSupport ? firstLiveTimeline : null);

--- a/src/client.js
+++ b/src/client.js
@@ -2089,7 +2089,7 @@ MatrixClient.prototype.resetNotifTimelineSet = function() {
     // know about /notifications, so we have no choice but to start paginating
     // from the current point in time.  This may well overlap with historical
     // notifs which are then inserted into the timeline by /sync responses.
-    this._notifTimelineSet.resetLiveTimeline('end', true);
+    this._notifTimelineSet.resetLiveTimeline('end', null);
 
     // we could try to paginate a single event at this point in order to get
     // a more valid pagination token, but it just ends up with an out of order

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -162,8 +162,8 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     // special because they will have listeners attached to monitor changes to
     // the current room state, so we move this RoomState from the end of the
     // current live timeline to the end of the new one and, if necessary,
-    // replace it with the fresh one created for the new timeline. We also make
-    // a copy for the start of the new timeline.
+    // replace it with a newly created one. We also make a copy for the start
+    // of the new timeline.
 
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || !forwardPaginationToken;

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -180,8 +180,6 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
         // we just stole it and put it on the new live timeline
         // (If we're resetting all timelines, don't bother because the old live
         // timeline is about to be thrown away anyway.
-        this._liveTimeline._startState = new RoomState(this._roomId);
-        this._liveTimeline._endState = new RoomState(this._roomId);
         const evMap = this._liveTimeline.getState(EventTimeline.FORWARDS).events;
         const events = [];
         for (const evtype in evMap) {
@@ -195,6 +193,8 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
                 events.push(evMap[evtype][stateKey]);
             }
         }
+        this._liveTimeline._startState = new RoomState(this._roomId);
+        this._liveTimeline._endState = new RoomState(this._roomId);
         this._liveTimeline.initialiseState(events);
 
         this._liveTimeline.setPaginationToken(

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -188,9 +188,10 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     newTimeline.initialiseState(events);
 
     const freshEndState = newTimeline._endState;
-    // Now clobber the end state with that from the previous live timeline.
-    // It will be identical except that we'll keep using the same RoomMember
-    // objects for the 'live' set of members with any listeners still attached
+    // Now clobber the end state of the new live timeline with that from the
+    // previous live timeline. It will be identical except that we'll keep
+    // using the same RoomMember objects for the 'live' set of members with any
+    // listeners still attached
     newTimeline._endState = this._liveTimeline._endState;
 
     // If we're not resetting all timelines, we need to fix up the old live timeline
@@ -200,6 +201,8 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
         // new live timeline.
         this._liveTimeline._endState = freshEndState;
 
+        // Now set the forward pagination token on the old live timeline
+        // so it can be forward-paginated.
         this._liveTimeline.setPaginationToken(
             forwardPaginationToken, EventTimeline.FORWARDS,
         );
@@ -210,6 +213,7 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     // stuck without realising that they *can* back-paginate.
     newTimeline.setPaginationToken(backPaginationToken, EventTimeline.BACKWARDS);
 
+    // Now we can swap the live timeline to the new one.
     this._liveTimeline = newTimeline;
     this.emit("Room.timelineReset", this.room, this, resetAllTimelines);
 };

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -20,7 +20,6 @@ limitations under the License.
 const EventEmitter = require("events").EventEmitter;
 const utils = require("../utils");
 const EventTimeline = require("./event-timeline");
-const RoomState = require("./room-state");
 
 // var DEBUG = false;
 const DEBUG = true;

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -20,6 +20,7 @@ limitations under the License.
 const EventEmitter = require("events").EventEmitter;
 const utils = require("../utils");
 const EventTimeline = require("./event-timeline");
+const RoomState = require("./room-state");
 
 // var DEBUG = false;
 const DEBUG = true;
@@ -154,7 +155,9 @@ EventTimelineSet.prototype.replaceEventId = function(oldEventId, newEventId) {
  *
  * @fires module:client~MatrixClient#event:"Room.timelineReset"
  */
-EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, forwardPaginationToken) {
+EventTimelineSet.prototype.resetLiveTimeline = function(
+    backPaginationToken, forwardPaginationToken,
+) {
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || !forwardPaginationToken;
 
@@ -194,7 +197,9 @@ EventTimelineSet.prototype.resetLiveTimeline = function(backPaginationToken, for
         }
         this._liveTimeline.initialiseState(events);
 
-        this._liveTimeline.setPaginationToken(forwardPaginationToken, EventTimeline.FORWARDS);
+        this._liveTimeline.setPaginationToken(
+            forwardPaginationToken, EventTimeline.FORWARDS,
+        );
     }
 
     // make sure we set the pagination token before firing timelineReset,

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -177,8 +177,10 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
         newTimeline = this.addTimeline();
     }
 
+    const oldTimeline = this._liveTimeline;
+
     // Collect the state events from the old timeline
-    const evMap = this._liveTimeline.getState(EventTimeline.FORWARDS).events;
+    const evMap = oldTimeline.getState(EventTimeline.FORWARDS).events;
     const events = [];
     for (const evtype in evMap) {
         if (!evMap.hasOwnProperty(evtype)) {
@@ -200,18 +202,18 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     // previous live timeline. It will be identical except that we'll keep
     // using the same RoomMember objects for the 'live' set of members with any
     // listeners still attached
-    newTimeline._endState = this._liveTimeline._endState;
+    newTimeline._endState = oldTimeline._endState;
 
     // If we're not resetting all timelines, we need to fix up the old live timeline
     if (!resetAllTimelines) {
         // Firstly, we just stole the old timeline's end state, so it needs a new one.
         // Just swap them around and give it the one we just generated for the
         // new live timeline.
-        this._liveTimeline._endState = freshEndState;
+        oldTimeline._endState = freshEndState;
 
         // Now set the forward pagination token on the old live timeline
         // so it can be forward-paginated.
-        this._liveTimeline.setPaginationToken(
+        oldTimeline.setPaginationToken(
             forwardPaginationToken, EventTimeline.FORWARDS,
         );
     }

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -157,6 +157,14 @@ EventTimelineSet.prototype.replaceEventId = function(oldEventId, newEventId) {
 EventTimelineSet.prototype.resetLiveTimeline = function(
     backPaginationToken, forwardPaginationToken,
 ) {
+    // Each EventTimeline has RoomState objects tracking the state at the start
+    // and end of that timeline. The copies at the end of the live timeline are
+    // special because they will have listeners attached to monitor changes to
+    // the current room state, so we move this RoomState from the end of the
+    // current live timeline to the end of the new one and, if necessary,
+    // replace it with the fresh one created for the new timeline. We also make
+    // a copy for the start of the new timeline.
+
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || !forwardPaginationToken;
 

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -193,12 +193,11 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     // objects for the 'live' set of members with any listeners still attached
     newTimeline._endState = this._liveTimeline._endState;
 
+    // If we're not resetting all timelines, we need to fix up the old live timeline
     if (!resetAllTimelines) {
-        // We just stole the old timeline's end state, so it needs a new one.
+        // Firstly, we just stole the old timeline's end state, so it needs a new one.
         // Just swap them around and give it the one we just generated for the
         // new live timeline.
-        // (If we're resetting all timelines, don't bother because the old live
-        // timeline is about to be thrown away anyway.
         this._liveTimeline._endState = freshEndState;
 
         this._liveTimeline.setPaginationToken(

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -210,7 +210,9 @@ Room.prototype.getLiveTimeline = function() {
  */
 Room.prototype.resetLiveTimeline = function(backPaginationToken, forwardPaginationToken) {
     for (let i = 0; i < this._timelineSets.length; i++) {
-        this._timelineSets[i].resetLiveTimeline(backPaginationToken, forwardPaginationToken);
+        this._timelineSets[i].resetLiveTimeline(
+            backPaginationToken, forwardPaginationToken,
+        );
     }
 
     this._fixUpLegacyTimelineFields();

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -205,12 +205,12 @@ Room.prototype.getLiveTimeline = function() {
  * <p>This is used when /sync returns a 'limited' timeline.
  *
  * @param {string=} backPaginationToken   token for back-paginating the new timeline
- * @param {boolean=} flush True to remove all events in all timelines. If false, only
- * the live timeline is reset.
+ * @param {string=} forwardPaginationToken token for forward-paginating the old live timeline,
+ * if absent or null, all timelines are reset.
  */
-Room.prototype.resetLiveTimeline = function(backPaginationToken, flush) {
+Room.prototype.resetLiveTimeline = function(backPaginationToken, forwardPaginationToken) {
     for (let i = 0; i < this._timelineSets.length; i++) {
-        this._timelineSets[i].resetLiveTimeline(backPaginationToken, flush);
+        this._timelineSets[i].resetLiveTimeline(backPaginationToken, forwardPaginationToken);
     }
 
     this._fixUpLegacyTimelineFields();

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -206,7 +206,9 @@ Room.prototype.getLiveTimeline = function() {
  *
  * @param {string=} backPaginationToken   token for back-paginating the new timeline
  * @param {string=} forwardPaginationToken token for forward-paginating the old live timeline,
- * if absent or null, all timelines are reset.
+ * if absent or null, all timelines are reset, removing old ones (including the previous live
+ * timeline which would otherwise be unable to paginate forwards without this token).
+ * Removing just the old live timeline whilst preserving previous ones is not supported.
  */
 Room.prototype.resetLiveTimeline = function(backPaginationToken, forwardPaginationToken) {
     for (let i = 0; i < this._timelineSets.length; i++) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -884,14 +884,10 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
             }
 
             if (limited) {
-                // save the old 'next_batch' token as the
-                // forward-pagination token for the previously-active
-                // timeline.
-                room.currentState.paginationToken = syncToken;
                 self._deregisterStateListeners(room);
                 room.resetLiveTimeline(
                     joinObj.timeline.prev_batch,
-                    self.opts.canResetEntireTimeline(room.roomId),
+                    self.opts.canResetEntireTimeline(room.roomId) ? null : syncToken,
                 );
 
                 // We have to assume any gap in any timeline is


### PR DESCRIPTION
Re-use the same RoomState from the old live timeline so we re-use
all the same member objects etc, so all the listeners stay attached