### PR TITLE
Use babel transform-runtime instead of regenerator-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,13 @@
 {
     "presets": ["es2015"],
     "plugins": [
+        // this transforms async functions into generator functions, which
+        // are then made to use the regenerator module by babel's
+        // transform-regnerator plugin (which is enabled by es2015.
         "transform-async-to-generator",
+
+        // This makes sure that the regenerator runtime is available to
+        // the transpiled code.
+        "transform-runtime",
     ],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     "plugins": [
         // this transforms async functions into generator functions, which
         // are then made to use the regenerator module by babel's
-        // transform-regnerator plugin (which is enabled by es2015.
+        // transform-regnerator plugin (which is enabled by es2015).
         "transform-async-to-generator",
 
         // This makes sure that the regenerator runtime is available to

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "bluebird": "^3.5.0",
     "browser-request": "^0.3.3",
     "content-type": "^1.0.2",
-    "regenerator-runtime": "^0.10.5",
     "request": "^2.53.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "browserify": "^14.0.0",
     "browserify-shim": "^3.8.13",

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -16,9 +16,6 @@ limitations under the License.
 */
 "use strict";
 
-// make sure that the regenerator-runtime has been loaded
-import 'regenerator-runtime/runtime';
-
 /** The {@link module:models/event.MatrixEvent|MatrixEvent} class. */
 module.exports.MatrixEvent = require("./models/event").MatrixEvent;
 /** The {@link module:models/event.EventStatus|EventStatus} enum. */


### PR DESCRIPTION
Attempting to use the regnerator-runtime ourselves led to a fight with riot-web about whether `global.regeneratorRuntime` could be defined. By using the transform-runtime plugin, references to `global.regeneratorRuntime` which are created by the transform-regenerator plugin are turned into references to an imported module, which works much better.

(The full tragic tale went as follows:

- riot-web uses transform-runtime, which adds an import of `regenerator-runtime` to index.js
- `regenerator-runtime`:
   - loads `regenerator-runtime/runtime`, which defines `global.regeneratorRuntime`
   - then clears the global property and returns the regeneratorRuntime object as the exported value from the module
- later, the js-sdk tried to import `regenerator-runtime/runtime`, which then did nothing because the module had already been loaded once.

For added fun, this only manifested itself when riot-web and js-sdk shared an instance of the `regenerator-runtime` package, which happens on proper builds, but not a normal development setup.)