### PR TITLE
Fix jsdoc failure on async code

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "exorcist": "^0.4.0",
     "expect": "^1.20.2",
     "istanbul": "^0.4.5",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "^3.5.0",
     "lolex": "^1.5.2",
     "matrix-mock-request": "^1.2.0",
     "mocha": "^3.2.0",


### PR DESCRIPTION
We need jsdoc 3.5 to support the async/await syntax.