### PR TITLE
Refactor handling of crypto events for async

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "babel -s -d lib src && rimraf dist && mkdir dist && browserify -d browser-index.js | exorcist dist/browser-matrix.js.map > dist/browser-matrix.js && uglifyjs -c -m -o dist/browser-matrix.min.js --source-map dist/browser-matrix.min.js.map --in-source-map dist/browser-matrix.js.map dist/browser-matrix.js",
     "dist": "npm run build",
     "watch": "watchify -d browser-index.js -o 'exorcist dist/browser-matrix.js.map > dist/browser-matrix.js' -v",
-    "lint": "eslint --max-warnings 110 src spec",
+    "lint": "eslint --max-warnings 109 src spec",
     "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt"
   },
   "repository": {

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -595,19 +595,9 @@ describe("MatrixClient crypto", function() {
 
                     expect(event.isEncrypted()).toBeTruthy();
 
-                    // it will still be encrypted at first - wait for it to be decrypted.
-                    expect(event.getType()).toEqual("m.room.encrypted");
-                    expect(event.isBeingDecrypted()).toBe(true);
-
-                    console.log(
-                        `bob waiting for event to be decrypted`,
-                    );
-                    event.once('Event.decrypted', (ev) => {
-                        expect(ev).toBe(event);
-                        expect(event.getType()).toEqual("m.room.message");
-                        expect(event.getContent().msgtype).toEqual("m.bad.encrypted");
-                        deferred.resolve();
-                    });
+                    expect(event.getType()).toEqual("m.room.message");
+                    expect(event.getContent().msgtype).toEqual("m.bad.encrypted");
+                    deferred.resolve();
                 };
 
                 bobTestClient.client.once("event", onEvent);

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -5,6 +5,7 @@ const HttpBackend = require("matrix-mock-request");
 const utils = require("../test-utils");
 
 import expect from 'expect';
+import Promise from 'bluebird';
 
 describe("MatrixClient events", function() {
     const baseUrl = "http://localhost.or.something";
@@ -101,7 +102,7 @@ describe("MatrixClient events", function() {
         };
 
         it("should emit events from both the first and subsequent /sync calls",
-        function(done) {
+        function() {
             httpBackend.when("GET", "/sync").respond(200, SYNC_DATA);
             httpBackend.when("GET", "/sync").respond(200, NEXT_SYNC_DATA);
 
@@ -130,11 +131,13 @@ describe("MatrixClient events", function() {
 
             client.startClient();
 
-            httpBackend.flushAllExpected().done(function() {
+            return Promise.all([
+                utils.syncPromise(client),
+                httpBackend.flushAllExpected(),
+            ]).then(() => {
                 expect(expectedEvents.length).toEqual(
                     0, "Failed to see all events from /sync calls",
                 );
-                done();
             });
         });
 

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -132,7 +132,10 @@ describe("MatrixClient events", function() {
             client.startClient();
 
             return Promise.all([
-                utils.syncPromise(client),
+                // wait for two SYNCING events
+                utils.syncPromise(client).then(() => {
+                    return utils.syncPromise(client);
+                }),
                 httpBackend.flushAllExpected(),
             ]).then(() => {
                 expect(expectedEvents.length).toEqual(

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -175,17 +175,6 @@ Crypto.prototype.registerEventHandlers = function(eventEmitter) {
             console.error("Error handling toDeviceEvent:", e);
         }
     });
-
-    eventEmitter.on("event", function(event) {
-        try {
-            if (!event.isState() || event.getType() != "m.room.encryption") {
-                return;
-            }
-            crypto._onCryptoEvent(event);
-        } catch (e) {
-            console.error("Error handling crypto event:", e);
-        }
-    });
 };
 
 
@@ -841,10 +830,9 @@ Crypto.prototype.cancelRoomKeyRequest = function(requestBody) {
 /**
  * handle an m.room.encryption event
  *
- * @private
  * @param {module:models/event.MatrixEvent} event encryption event
  */
-Crypto.prototype._onCryptoEvent = function(event) {
+Crypto.prototype.onCryptoEvent = async function(event) {
     const roomId = event.getRoomId();
     const content = event.getContent();
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -52,11 +52,11 @@ function getFilterName(userId, suffix) {
     return "FILTER_SYNC_" + userId + (suffix ? "_" + suffix : "");
 }
 
-function debuglog() {
+function debuglog(...params) {
     if (!DEBUG) {
         return;
     }
-    console.log(...arguments);
+    console.log(...params);
 }
 
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -603,39 +603,36 @@ SyncApi.prototype._sync = function(syncOptions) {
             return Promise.resolve(data);
         }
     }).done((data) => {
-        try {
-            self._processSyncResponse(syncToken, data);
-        } catch (e) {
+        self._processSyncResponse(syncToken, data).catch((e) => {
             // log the exception with stack if we have it, else fall back
             // to the plain description
             console.error("Caught /sync error", e.stack || e);
-        }
+        }).then(() => {
+            // emit synced events
+            const syncEventData = {
+                oldSyncToken: syncToken,
+                nextSyncToken: data.next_batch,
+                catchingUp: self._catchingUp,
+            };
 
-        // emit synced events
-        const syncEventData = {
-            oldSyncToken: syncToken,
-            nextSyncToken: data.next_batch,
-            catchingUp: self._catchingUp,
-        };
+            if (!syncOptions.hasSyncedBefore) {
+                self._updateSyncState("PREPARED", syncEventData);
+                syncOptions.hasSyncedBefore = true;
+            }
 
-        if (!syncOptions.hasSyncedBefore) {
-            self._updateSyncState("PREPARED", syncEventData);
-            syncOptions.hasSyncedBefore = true;
-        }
+            // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
+            if (!isCachedResponse) {
+                self._updateSyncState("SYNCING", syncEventData);
 
-        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
-        if (!isCachedResponse) {
-            self._updateSyncState("SYNCING", syncEventData);
+                // tell databases that everything is now in a consistent state and can be
+                // saved (no point doing so if we only have the data we just got out of the
+                // store).
+                client.store.save();
+            }
 
-            // tell databases that everything is now in a consistent state and can be
-            // saved (no point doing so if we only have the data we just got out of the
-            // store).
-            client.store.save();
-        }
-
-
-        // Begin next sync
-        self._sync(syncOptions);
+            // Begin next sync
+            self._sync(syncOptions);
+        });
     }, function(err) {
         if (!self._running) {
             debuglog("Sync no longer running: exiting");
@@ -680,7 +677,7 @@ SyncApi.prototype._sync = function(syncOptions) {
  *    sync request.
  * @param {Object} data The response from /sync
  */
-SyncApi.prototype._processSyncResponse = function(syncToken, data) {
+SyncApi.prototype._processSyncResponse = async function(syncToken, data) {
     const client = this.client;
     const self = this;
 
@@ -822,7 +819,7 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
     });
 
     // Handle joins
-    joinRooms.forEach(function(joinObj) {
+    await Promise.mapSeries(joinRooms, async function(joinObj) {
         const room = joinObj.room;
         const stateEvents = self._mapSyncEventsFormat(joinObj.state, room);
         const timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room);
@@ -915,12 +912,16 @@ SyncApi.prototype._processSyncResponse = function(syncToken, data) {
             client.store.storeRoom(room);
             client.emit("Room", room);
         }
-        stateEvents.forEach(function(e) {
+
+        async function processRoomEvent(e) {
             client.emit("event", e);
-        });
-        timelineEvents.forEach(function(e) {
-            client.emit("event", e);
-        });
+            if (e.isState() && e.getType() == "m.room.encryption" && self.opts.crypto) {
+                await self.opts.crypto.onCryptoEvent(e);
+            }
+        }
+
+        await Promise.mapSeries(stateEvents, processRoomEvent);
+        await Promise.mapSeries(timelineEvents, processRoomEvent);
         ephemeralEvents.forEach(function(e) {
             client.emit("event", e);
         });


### PR DESCRIPTION
We're going to need to handle m.room.crypto events asynchronously, so restructure the way we do that.