### PR TITLE
Transform `async` functions to bluebird promises

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
         // this transforms async functions into generator functions, which
         // are then made to use the regenerator module by babel's
         // transform-regnerator plugin (which is enabled by es2015).
-        "transform-async-to-generator",
+        "transform-async-to-bluebird",
 
         // This makes sure that the regenerator runtime is available to
         // the transpiled code.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^7.1.1",
-    "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-async-to-bluebird": "^1.1.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "browserify": "^14.0.0",


### PR DESCRIPTION
Now that we use transform-runtime instead of regenerator-runtime, we need to
use the async-to-bluebird transform to make sure that `async` functions get
transformed into bluebird promises.