### PR TITLE
Set `rawDisplayName` to `userId` if membership has `displayname=null`

### DIFF
--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -82,7 +82,7 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
 
     const oldName = this.name;
     this.name = calculateDisplayName(this, event, roomState);
-    this.rawDisplayName = event.getDirectionalContent().displayname;
+    this.rawDisplayName = event.getDirectionalContent().displayname || this.userId;
     if (oldMembership !== this.membership) {
         this._updateModifiedTime();
         this.emit("RoomMember.membership", event, this, oldMembership);


### PR DESCRIPTION
This mirrors the behaviour of `name` such that the default is always `userId` but if the membership event has a `displayname`, we use that.

(As reported and theorised by @krombel, thanks!)