### PR TITLE
consume trailing slash when creating Matrix Client in HS and IS urls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -113,6 +113,16 @@ try {
  *    crypto store implementation.
  */
 function MatrixClient(opts) {
+    // Allow trailing slash in HS url
+    if (opts.baseUrl && opts.baseUrl.endsWith("/")) {
+        opts.baseUrl = opts.baseUrl.substr(0, opts.baseUrl.length - 1);
+    }
+
+    // Allow trailing slash in IS url
+    if (opts.idBaseUrl && opts.idBaseUrl.endsWith("/")) {
+        opts.idBaseUrl = opts.idBaseUrl.substr(0, opts.idBaseUrl.length - 1);
+    }
+
     MatrixBaseApis.call(this, opts);
 
     this.store = opts.store || new StubStore();


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/334

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>