### PR TITLE
Fix error handling in interactive-auth

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -293,7 +293,9 @@ InteractiveAuth.prototype = {
             },
         );
         if (!background) {
-            prom = prom.catch(this._completionDeferred.reject);
+            prom = prom.catch((e) => {
+                this._completionDeferred.reject(e);
+            });
         } else {
             // We ignore all failures here (even non-UI auth related ones)
             // since we don't want to suddenly fail if the internet connection


### PR DESCRIPTION
Now that we are using bluebird, `defer.reject` is not implicitly bound, so we
need to call it properly rather than just passing it into the catch handler.

This fixes an error:

   promise.js:711 Uncaught TypeError: Cannot read property 'promise' of undefined