### PR TITLE
Groups: Sync Stream, Accept Invite & Leave

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -467,6 +467,32 @@ MatrixBaseApis.prototype.removeUserFromGroup = function(groupId, userId) {
 };
 
 /**
+ * @param {string} groupId
+ * @return {module:client.Promise} Resolves: Empty object
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.acceptGroupInvite = function(groupId) {
+    const path = utils.encodeUri(
+        "/groups/$groupId/self/accept_invite",
+        {$groupId: groupId},
+    );
+    return this._http.authedRequest(undefined, "PUT", path, undefined, {});
+};
+
+/**
+ * @param {string} groupId
+ * @return {module:client.Promise} Resolves: Empty object
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.leaveGroup = function(groupId) {
+    const path = utils.encodeUri(
+        "/groups/$groupId/self/leave",
+        {$groupId: groupId},
+    );
+    return this._http.authedRequest(undefined, "PUT", path, undefined, {});
+};
+
+/**
  * @return {module:client.Promise} Resolves: The groups to which the user is joined
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */

--- a/src/client.js
+++ b/src/client.js
@@ -659,6 +659,30 @@ MatrixClient.prototype.importRoomKeys = function(keys) {
     return this._crypto.importRoomKeys(keys);
 };
 
+// Group ops
+// =========
+// Operations on groups that come down the sync stream (ie. ones the
+// user is a member of or invited to)
+
+/**
+ * Get the group for the given group ID.
+ * This function will return a valid group for any group for which a Group event
+ * has been emitted.
+ * @param {string} groupId The group ID
+ * @return {Group} The Group or null if the group is not known or there is no data store.
+ */
+MatrixClient.prototype.getGroup = function(groupId) {
+    return this.store.getGroup(groupId);
+};
+
+/**
+ * Retrieve all known groups.
+ * @return {Groups[]} A list of groups, or an empty list if there is no data store.
+ */
+MatrixClient.prototype.getGroups = function() {
+    return this.store.getGroups();
+};
+
 // Room ops
 // ========
 
@@ -3420,6 +3444,17 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  *       var rooms = matrixClient.getRooms();
  *       break;
  *   }
+ * });
+ */
+
+ /**
+ * Fires whenever the sdk learns about a new group. <strong>This event
+ * is experimental and may change.</strong>
+ * @event module:client~MatrixClient#"Group"
+ * @param {Group} group The newly created, fully populated group.
+ * @example
+ * matrixClient.on("Group", function(group){
+ *   var groupId = group.groupId;
  * });
  */
 

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @module models/group
+ */
+const EventEmitter = require("events").EventEmitter;
+
+const utils = require("../utils");
+
+/**
+ * Construct a new Group.
+ *
+ * @param {string} groupId The ID of this group.
+ *
+ * @prop {string} groupId The ID of this group.
+ * @prop {string} name The human-readable display name for this group.
+ * @prop {string} avatarUrl The mxc URL for this group's avatar.
+ * @prop {string} myMembership The logged in user's membership of this group
+ */
+function Group(groupId) {
+    this.groupId = groupId;
+    this.name = null;
+    this.avatarUrl = null;
+    this.myMembership = null;
+}
+utils.inherits(Group, EventEmitter);
+
+Group.prototype.setProfile = function(name, avatarUrl) {
+    if (this.name === name && this.avatarUrl === avatarUrl) return;
+
+    this.name = name || this.groupId;
+    this.avatarUrl = avatarUrl;
+
+    this.emit("Group.profile", this);
+};
+
+Group.prototype.setMyMembership = function(membership) {
+    if (this.myMembership === membership) return;
+
+    this.myMembership = membership;
+
+    this.emit("Group.myMembership", this);
+};
+
+module.exports = Group;
+
+/**
+ * Fires whenever a group's profile information is updated.
+ * This means the 'name' and 'avatarUrl' properties.
+ * @event module:client~MatrixClient#"Group.profile"
+ * @param {Group} group The group whose profile was updated.
+ * @example
+ * matrixClient.on("Group.profile", function(group){
+ *   var name = group.name;
+ * });
+ */
+
+/**
+ * Fires whenever the logged in user's membership status of
+ * the group is updated.
+ * @event module:client~MatrixClient#"Group.myMembership"
+ * @param {Group} group The group in which the user's membership changed
+ * @example
+ * matrixClient.on("Group.myMembership", function(group){
+ *   var myMembership = group.myMembership;
+ * });
+ */

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -30,12 +30,16 @@ const utils = require("../utils");
  * @prop {string} name The human-readable display name for this group.
  * @prop {string} avatarUrl The mxc URL for this group's avatar.
  * @prop {string} myMembership The logged in user's membership of this group
+ * @prop {Object} inviter Infomation about the user who invited the logged in user
+ *       to the group, if myMembership is 'invite'.
+ * @prop {string} inviter.userId The user ID of the inviter
  */
 function Group(groupId) {
     this.groupId = groupId;
     this.name = null;
     this.avatarUrl = null;
     this.myMembership = null;
+    this.inviter = null;
 }
 utils.inherits(Group, EventEmitter);
 
@@ -54,6 +58,16 @@ Group.prototype.setMyMembership = function(membership) {
     this.myMembership = membership;
 
     this.emit("Group.myMembership", this);
+};
+
+/**
+ * Sets the 'inviter' property. This does not emit an event (the inviter
+ * will only change when the user is revited / reinvited to a room),
+ * so set this before setting myMembership.
+ * @param {Object} inviter Infomation about who invited us to the room
+ */
+Group.prototype.setInviter = function(inviter) {
+    this.inviter = inviter;
 };
 
 module.exports = Group;

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -175,6 +175,7 @@ LocalIndexedDBStoreBackend.prototype = {
             this._syncAccumulator.accumulate({
                 next_batch: syncData.nextBatch,
                 rooms: syncData.roomsData,
+                groups: syncData.groupsData,
                 account_data: {
                     events: accountData,
                 },
@@ -251,7 +252,9 @@ LocalIndexedDBStoreBackend.prototype = {
         return Promise.all([
             this._persistUserPresenceEvents(userTuples),
             this._persistAccountData(syncData.accountData),
-            this._persistSyncData(syncData.nextBatch, syncData.roomsData),
+            this._persistSyncData(
+                syncData.nextBatch, syncData.roomsData, syncData.groupsData,
+            ),
         ]);
     },
 
@@ -259,9 +262,10 @@ LocalIndexedDBStoreBackend.prototype = {
      * Persist rooms /sync data along with the next batch token.
      * @param {string} nextBatch The next_batch /sync value.
      * @param {Object} roomsData The 'rooms' /sync data from a SyncAccumulator
+     * @param {Object} groupsData The 'groups' /sync data from a SyncAccumulator
      * @return {Promise} Resolves if the data was persisted.
      */
-    _persistSyncData: function(nextBatch, roomsData) {
+    _persistSyncData: function(nextBatch, roomsData, groupsData) {
         console.log("Persisting sync data up to ", nextBatch);
         return Promise.try(() => {
             const txn = this.db.transaction(["sync"], "readwrite");
@@ -270,6 +274,7 @@ LocalIndexedDBStoreBackend.prototype = {
                 clobber: "-", // constant key so will always clobber
                 nextBatch: nextBatch,
                 roomsData: roomsData,
+                groupsData: groupsData,
             }); // put == UPSERT
             return promiseifyTxn(txn);
         });

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -19,8 +19,8 @@ limitations under the License.
  * This is an internal module. See {@link MatrixInMemoryStore} for the public class.
  * @module store/memory
  */
- const utils = require("../utils");
- const User = require("../models/user");
+const utils = require("../utils");
+const User = require("../models/user");
 import Promise from 'bluebird';
 
 /**
@@ -34,6 +34,9 @@ module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
     opts = opts || {};
     this.rooms = {
         // roomId: Room
+    };
+    this.groups = {
+        // groupId: Group
     };
     this.users = {
         // userId: User
@@ -67,6 +70,31 @@ module.exports.MatrixInMemoryStore.prototype = {
      */
     setSyncToken: function(token) {
         this.syncToken = token;
+    },
+
+    /**
+     * Store the given room.
+     * @param {Group} group The group to be stored
+     */
+    storeGroup: function(group) {
+        this.groups[group.groupId] = group;
+    },
+
+    /**
+     * Retrieve a group by its group ID.
+     * @param {string} groupId The group ID.
+     * @return {Group} The group or null.
+     */
+    getGroup: function(groupId) {
+        return this.groups[groupId] || null;
+    },
+
+    /**
+     * Retrieve all known groups.
+     * @return {Group[]} A list of groups, which may be empty.
+     */
+    getGroups: function() {
+        return utils.values(this.groups);
     },
 
     /**

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -49,6 +49,30 @@ StubStore.prototype = {
 
     /**
      * No-op.
+     * @param {Group} group
+     */
+    storeGroup: function(group) {
+    },
+
+    /**
+     * No-op.
+     * @param {string} groupId
+     * @return {null}
+     */
+    getGroup: function(groupId) {
+        return null;
+    },
+
+    /**
+     * No-op.
+     * @return {Array} An empty array.
+     */
+    getGroups: function() {
+        return [];
+    },
+
+    /**
+     * No-op.
      * @param {Room} room
      */
     storeRoom: function(room) {

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -359,6 +359,20 @@ class SyncAccumulator {
                 );
             });
         }
+        if (syncResponse.groups.join) {
+            Object.keys(syncResponse.groups.join).forEach((groupId) => {
+                this._accumulateGroup(
+                    groupId, "join", syncResponse.groups.join[groupId],
+                );
+            });
+        }
+        if (syncResponse.groups.leave) {
+            Object.keys(syncResponse.groups.leave).forEach((groupId) => {
+                this._accumulateGroup(
+                    groupId, "leave", syncResponse.groups.leave[groupId],
+                );
+            });
+        }
     }
 
     _accumulateGroup(groupId, category, data) {

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -72,10 +72,18 @@ class SyncAccumulator {
         // coherent /sync response and know at what point they should be
         // streaming from without losing events.
         this.nextBatch = null;
+
+        // { ('invite'|'join'|'leave'): $groupId: { ... sync 'group' data } }
+        this.groups = {
+            invite: {},
+            join: {},
+            leave: {},
+        };
     }
 
     accumulate(syncResponse) {
         this._accumulateRooms(syncResponse);
+        this._accumulateGroups(syncResponse);
         this._accumulateAccountData(syncResponse);
         this.nextBatch = syncResponse.next_batch;
     }
@@ -337,6 +345,30 @@ class SyncAccumulator {
     }
 
     /**
+     * Accumulate incremental /sync group data.
+     * @param {Object} syncResponse the complete /sync JSON
+     */
+    _accumulateGroups(syncResponse) {
+        if (!syncResponse.groups) {
+            return;
+        }
+        if (syncResponse.groups.invite) {
+            Object.keys(syncResponse.groups.invite).forEach((groupId) => {
+                this._accumulateGroup(
+                    groupId, "invite", syncResponse.groups.invite[groupId],
+                );
+            });
+        }
+    }
+
+    _accumulateGroup(groupId, category, data) {
+        for (const cat of ['invite', 'join', 'leave']) {
+            delete this.groups[cat][groupId];
+        }
+        this.groups[category][groupId] = data;
+    }
+
+    /**
      * Return everything under the 'rooms' key from a /sync response which
      * represents all room data that should be stored. This should be paired
      * with the sync token which represents the most recent /sync response
@@ -470,6 +502,7 @@ class SyncAccumulator {
         return {
             nextBatch: this.nextBatch,
             roomsData: data,
+            groupsData: this.groups,
             accountData: accData,
         };
     }

--- a/src/sync.js
+++ b/src/sync.js
@@ -1111,7 +1111,7 @@ SyncApi.prototype._pokeKeepAlive = function() {
 };
 
 /**
- * @param {Object} obj Groups section object, eg. response.groups.invite
+ * @param {Object} groupsSection Groups section object, eg. response.groups.invite
  * @param {string} sectionName Which section this is ('invite', 'join' or 'leave')
  */
 SyncApi.prototype._processGroupSyncEntry = function(groupsSection, sectionName) {


### PR DESCRIPTION
 * API wrappers for accepting invites and leaving rooms (reject invite == leave)
 * Parse groups that come down in the sync stream and store them in the JS SDK
 * Make the sync accumulator support groups
 * Add new events for groups
 * Methods to get groups out of the js-sdk store