### PR TITLE
Re-emit events from, er, Event objects

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3241,6 +3241,9 @@ function _resolve(callback, defer, res) {
 function _PojoToMatrixEventMapper(client) {
     function mapper(plainOldJsObject) {
         const event = new MatrixEvent(plainOldJsObject);
+        reEmit(client, event, [
+            "Event.decrypted",
+        ]);
         if (event.isEncrypted()) {
             event.attemptDecryption(client._crypto);
         }


### PR DESCRIPTION
We do create Events in more places, but this is probably the only
place that matters since the only event is 'decrypted' which won't
fire for, eg. events we send.