### PR TITLE
Refactor sync._sync as an async function

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -498,7 +498,7 @@ SyncApi.prototype.retryImmediately = function() {
  * @param {string} syncOptions.filterId
  * @param {boolean} syncOptions.hasSyncedBefore
  */
-SyncApi.prototype._sync = function(syncOptions) {
+SyncApi.prototype._sync = async function(syncOptions) {
     const client = this.client;
     const self = this;
 
@@ -562,124 +562,129 @@ SyncApi.prototype._sync = function(syncOptions) {
         qps.timeout = 0;
     }
 
-    let isCachedResponse = false;
-
-    let syncPromise;
+    let savedSync;
     if (!syncOptions.hasSyncedBefore) {
         // Don't do an HTTP hit to /sync. Instead, load up the persisted /sync data,
         // if there is data there.
-        syncPromise = client.store.getSavedSync();
-    } else {
-        syncPromise = Promise.resolve(null);
+        savedSync = await client.store.getSavedSync();
     }
 
-    syncPromise.then((savedSync) => {
-        if (savedSync) {
-            debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
-            isCachedResponse = true;
-            return {
-                next_batch: savedSync.nextBatch,
-                rooms: savedSync.roomsData,
-                groups: savedSync.groupsData,
-                account_data: {
-                    events: savedSync.accountData,
-                },
-            };
-        } else {
+    let isCachedResponse = false;
+    let data;
+
+    if (savedSync) {
+        debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
+        isCachedResponse = true;
+        data = {
+            next_batch: savedSync.nextBatch,
+            rooms: savedSync.roomsData,
+            groups: savedSync.groupsData,
+            account_data: {
+                events: savedSync.accountData,
+            },
+        };
+    } else {
+        try {
             //debuglog('Starting sync since=' + syncToken);
             this._currentSyncRequest = client._http.authedRequest(
                 undefined, "GET", "/sync", qps, undefined, clientSideTimeoutMs,
             );
-            return this._currentSyncRequest;
-        }
-    }).then(function(data) {
-        //debuglog('Completed sync, next_batch=' + data.next_batch);
-
-        // set the sync token NOW *before* processing the events. We do this so
-        // if something barfs on an event we can skip it rather than constantly
-        // polling with the same token.
-        client.store.setSyncToken(data.next_batch);
-
-        // Reset after a successful sync
-        self._failedSyncCount = 0;
-
-        // We need to wait until the sync data has been sent to the backend
-        // because it appears that the sync data gets modified somewhere in
-        // processing it in such a way as to make it no longer cloneable.
-        // XXX: Find out what is modifying it!
-        if (!isCachedResponse) {
-            // Don't give the store back its own cached data
-            return client.store.setSyncData(data).then(() => {
-                return data;
-            });
-        } else {
-            return Promise.resolve(data);
-        }
-    }).done((data) => {
-        self._processSyncResponse(syncToken, data).catch((e) => {
-            // log the exception with stack if we have it, else fall back
-            // to the plain description
-            console.error("Caught /sync error", e.stack || e);
-        }).then(() => {
-            // emit synced events
-            const syncEventData = {
-                oldSyncToken: syncToken,
-                nextSyncToken: data.next_batch,
-                catchingUp: self._catchingUp,
-            };
-
-            if (!syncOptions.hasSyncedBefore) {
-                self._updateSyncState("PREPARED", syncEventData);
-                syncOptions.hasSyncedBefore = true;
-            }
-
-            // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
-            if (!isCachedResponse) {
-                self._updateSyncState("SYNCING", syncEventData);
-
-                // tell databases that everything is now in a consistent state and can be
-                // saved (no point doing so if we only have the data we just got out of the
-                // store).
-                client.store.save();
-            }
-
-            // Begin next sync
-            self._sync(syncOptions);
-        });
-    }, function(err) {
-        if (!self._running) {
-            debuglog("Sync no longer running: exiting");
-            if (self._connectionReturnedDefer) {
-                self._connectionReturnedDefer.reject();
-                self._connectionReturnedDefer = null;
-            }
-            self._updateSyncState("STOPPED");
+            data = await this._currentSyncRequest;
+        } catch (e) {
+            this._onSyncError(e, syncOptions);
             return;
         }
-        console.error("/sync error %s", err);
-        console.error(err);
+    }
 
-        self._failedSyncCount++;
-        console.log('Number of consecutive failed sync requests:', self._failedSyncCount);
+    //debuglog('Completed sync, next_batch=' + data.next_batch);
 
-        debuglog("Starting keep-alive");
-        // Note that we do *not* mark the sync connection as
-        // lost yet: we only do this if a keepalive poke
-        // fails, since long lived HTTP connections will
-        // go away sometimes and we shouldn't treat this as
-        // erroneous. We set the state to 'reconnecting'
-        // instead, so that clients can onserve this state
-        // if they wish.
-        self._startKeepAlives().done(function() {
-            self._sync(syncOptions);
-        });
-        self._currentSyncRequest = null;
-        // Transition from RECONNECTING to ERROR after a given number of failed syncs
-        self._updateSyncState(
-            self._failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
-                "ERROR" : "RECONNECTING",
-        );
+    // set the sync token NOW *before* processing the events. We do this so
+    // if something barfs on an event we can skip it rather than constantly
+    // polling with the same token.
+    client.store.setSyncToken(data.next_batch);
+
+    // Reset after a successful sync
+    self._failedSyncCount = 0;
+
+    // We need to wait until the sync data has been sent to the backend
+    // because it appears that the sync data gets modified somewhere in
+    // processing it in such a way as to make it no longer cloneable.
+    // XXX: Find out what is modifying it!
+    if (!isCachedResponse) {
+        // Don't give the store back its own cached data
+        await client.store.setSyncData(data);
+    }
+
+    try {
+        await this._processSyncResponse(syncToken, data);
+    } catch(e) {
+        // log the exception with stack if we have it, else fall back
+        // to the plain description
+        console.error("Caught /sync error", e.stack || e);
+    }
+
+    // emit synced events
+    const syncEventData = {
+        oldSyncToken: syncToken,
+        nextSyncToken: data.next_batch,
+        catchingUp: self._catchingUp,
+    };
+
+    if (!syncOptions.hasSyncedBefore) {
+        self._updateSyncState("PREPARED", syncEventData);
+        syncOptions.hasSyncedBefore = true;
+    }
+
+    // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
+    if (!isCachedResponse) {
+        self._updateSyncState("SYNCING", syncEventData);
+
+        // tell databases that everything is now in a consistent state and can be
+        // saved (no point doing so if we only have the data we just got out of the
+        // store).
+        client.store.save();
+    }
+
+    // Begin next sync
+    self._sync(syncOptions);
+};
+
+SyncApi.prototype._onSyncError = function(err, syncOptions) {
+    const self = this;
+    if (!self._running) {
+        debuglog("Sync no longer running: exiting");
+        if (self._connectionReturnedDefer) {
+            self._connectionReturnedDefer.reject();
+            self._connectionReturnedDefer = null;
+        }
+        self._updateSyncState("STOPPED");
+        return;
+    }
+
+    console.error("/sync error %s", err);
+    console.error(err);
+
+    self._failedSyncCount++;
+    console.log('Number of consecutive failed sync requests:', self._failedSyncCount);
+
+    debuglog("Starting keep-alive");
+    // Note that we do *not* mark the sync connection as
+    // lost yet: we only do this if a keepalive poke
+    // fails, since long lived HTTP connections will
+    // go away sometimes and we shouldn't treat this as
+    // erroneous. We set the state to 'reconnecting'
+    // instead, so that clients can onserve this state
+    // if they wish.
+    self._startKeepAlives().done(function() {
+        self._sync(syncOptions);
     });
+
+    self._currentSyncRequest = null;
+    // Transition from RECONNECTING to ERROR after a given number of failed syncs
+    self._updateSyncState(
+        self._failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
+            "ERROR" : "RECONNECTING",
+    );
 };
 
 /**


### PR DESCRIPTION
This stuff is much more clearly expressed as an async function than as a
promise chain, and I'm about to add more stuff to the chain, so let's refactor
now.

~~There is plenty more that could be done here (self -> this, for instance), but
I've gone for keeping the diff minimal.~~

I've done the self->this refactor in a separate commit.