### PR TITLE
Handle 'left' users in the deviceList mananagement

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -33,12 +33,20 @@ import Promise from 'bluebird';
  * @param {string} userId
  * @param {string} deviceId
  * @param {string} accessToken
+ *
+ * @param {WebStorage=} sessionStoreBackend a web storage object to use for the
+ *     session store. If undefined, we will create a MockStorageApi.
  */
-export default function TestClient(userId, deviceId, accessToken) {
+export default function TestClient(
+    userId, deviceId, accessToken, sessionStoreBackend,
+) {
     this.userId = userId;
     this.deviceId = deviceId;
 
-    this.storage = new sdk.WebStorageSessionStore(new testUtils.MockStorageApi());
+    if (sessionStoreBackend === undefined) {
+        sessionStoreBackend = new testUtils.MockStorageApi();
+    }
+    this.storage = new sdk.WebStorageSessionStore(sessionStoreBackend);
     this.httpBackend = new MockHttpBackend();
     this.client = sdk.createClient({
         baseUrl: "http://" + userId + ".test.server",

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -69,7 +69,6 @@ function Crypto(baseApis, sessionStore, userId, deviceId,
 
     this._olmDevice = new OlmDevice(sessionStore);
     this._deviceList = new DeviceList(baseApis, sessionStore, this._olmDevice);
-    this._initialDeviceListInvalidationPending = false;
 
     // the last time we did a check for the number of one-time-keys on the
     // server.
@@ -150,15 +149,6 @@ Crypto.prototype.init = async function() {
  */
 Crypto.prototype.registerEventHandlers = function(eventEmitter) {
     const crypto = this;
-    eventEmitter.on("sync", function(syncState, oldState, data) {
-        try {
-            if (syncState === "SYNCING") {
-                crypto._onSyncCompleted(data);
-            }
-        } catch (e) {
-            console.error("Error handling sync", e);
-        }
-    });
 
     eventEmitter.on("RoomMember.membership", function(event, member, oldMembership) {
         try {
@@ -248,7 +238,7 @@ Crypto.prototype.uploadDeviceKeys = function() {
 
 /**
  * Stores the current one_time_key count which will be handled later (in a call of
- * _onSyncCompleted). The count is e.g. coming from a /sync response.
+ * onSyncCompleted). The count is e.g. coming from a /sync response.
  *
  * @param {Number} currentCount The current count of one_time_keys to be stored
  */
@@ -837,7 +827,7 @@ Crypto.prototype.onCryptoEvent = async function(event) {
 
     try {
         // inhibit the device list refresh for now - it will happen once we've
-        // finished processing the sync, in _onSyncCompleted.
+        // finished processing the sync, in onSyncCompleted.
         await this.setRoomEncryption(roomId, content, true);
     } catch (e) {
         console.error("Error configuring encryption in room " + roomId +
@@ -853,7 +843,7 @@ Crypto.prototype.onCryptoEvent = async function(event) {
  *
  * @param {Object} syncData  the data from the 'MatrixClient.sync' event
  */
-Crypto.prototype._onSyncCompleted = function(syncData) {
+Crypto.prototype.onSyncCompleted = async function(syncData) {
     const nextSyncToken = syncData.nextSyncToken;
 
     if (!syncData.oldSyncToken) {
@@ -863,18 +853,15 @@ Crypto.prototype._onSyncCompleted = function(syncData) {
         // invalidate devices which have changed since then.
         const oldSyncToken = this._sessionStore.getEndToEndDeviceSyncToken();
         if (oldSyncToken !== null) {
-            this._initialDeviceListInvalidationPending = true;
-            this._invalidateDeviceListsSince(
-                oldSyncToken, nextSyncToken,
-            ).catch((e) => {
+            try {
+                await this._invalidateDeviceListsSince(
+                    oldSyncToken, nextSyncToken,
+                );
+            } catch (e) {
                 // if that failed, we fall back to invalidating everyone.
                 console.warn("Error fetching changed device list", e);
                 this._deviceList.invalidateAllDeviceLists();
-            }).done(() => {
-                this._initialDeviceListInvalidationPending = false;
-                this._deviceList.lastKnownSyncToken = nextSyncToken;
-                this._deviceList.refreshOutdatedDeviceLists();
-            });
+            }
         } else {
             // otherwise, we have to invalidate all devices for all users we
             // are tracking.
@@ -884,14 +871,12 @@ Crypto.prototype._onSyncCompleted = function(syncData) {
         }
     }
 
-    if (!this._initialDeviceListInvalidationPending) {
-        // we can now store our sync token so that we can get an update on
-        // restart rather than having to invalidate everyone.
-        //
-        // (we don't really need to do this on every sync - we could just
-        // do it periodically)
-        this._sessionStore.storeEndToEndDeviceSyncToken(nextSyncToken);
-    }
+    // we can now store our sync token so that we can get an update on
+    // restart rather than having to invalidate everyone.
+    //
+    // (we don't really need to do this on every sync - we could just
+    // do it periodically)
+    this._sessionStore.storeEndToEndDeviceSyncToken(nextSyncToken);
 
     // catch up on any new devices we got told about during the sync.
     this._deviceList.lastKnownSyncToken = nextSyncToken;
@@ -925,13 +910,11 @@ Crypto.prototype._invalidateDeviceListsSince = function(
     ).then((r) => {
         console.log("got key changes since", oldSyncToken, ":", r.changed);
 
-        if (!r.changed || !Array.isArray(r.changed)) {
-            return;
+        if (r.changed && Array.isArray(r.changed)) {
+            r.changed.forEach((u) => {
+                this._deviceList.invalidateUserDeviceList(u);
+            });
         }
-
-        r.changed.forEach((u) => {
-            this._deviceList.invalidateUserDeviceList(u);
-        });
     });
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -1024,10 +1024,14 @@ SyncApi.prototype._processSyncResponse = async function(syncToken, data) {
     }
 
     // Handle device list updates
-    if (this.opts.crypto && data.device_lists && data.device_lists.changed) {
-        data.device_lists.changed.forEach((u) => {
-            this.opts.crypto.userDeviceListChanged(u);
-        });
+    if (data.device_lists) {
+        if (this.opts.crypto) {
+            await this.opts.crypto.handleDeviceListChanges(data.device_lists);
+        } else {
+            // FIXME if we *don't* have a crypto module, we still need to
+            // invalidate the device lists. But that would require a
+            // substantial bit of rework :/.
+        }
     }
 
     // Handle one_time_keys_count

--- a/src/sync.js
+++ b/src/sync.js
@@ -634,8 +634,14 @@ SyncApi.prototype._sync = async function(syncOptions) {
         syncOptions.hasSyncedBefore = true;
     }
 
-    // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
     if (!isCachedResponse) {
+        // tell the crypto module to do its processing. It may block (to do a
+        // /keys/changes request).
+        if (this.opts.crypto) {
+            await this.opts.crypto.onSyncCompleted(syncEventData);
+        }
+
+        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
         this._updateSyncState("SYNCING", syncEventData);
 
         // tell databases that everything is now in a consistent state and can be


### PR DESCRIPTION
When we no longer share any rooms with a given user, the server will stop sending us updates on their device list, and will (once synapse is updated) send us a notification of that fact via the 'left' field in the device_lists field in /sync, or the response from /keys/changes.

Fixes https://github.com/vector-im/riot-web/issues/4983