### PR TITLE
Only re-emit events from Event objects if needed

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3274,10 +3274,10 @@ function _resolve(callback, defer, res) {
 function _PojoToMatrixEventMapper(client) {
     function mapper(plainOldJsObject) {
         const event = new MatrixEvent(plainOldJsObject);
-        reEmit(client, event, [
-            "Event.decrypted",
-        ]);
         if (event.isEncrypted()) {
+            reEmit(client, event, [
+                "Event.decrypted",
+            ]);
             event.attemptDecryption(client._crypto);
         }
         return event;


### PR DESCRIPTION
The only event an Event emits is 'Event.decrypted', so don't
bother to add listeners if the event isn't encrypted.