### PR TITLE
Clean on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dist": "npm run build",
     "watch": "watchify -d browser-index.js -o 'exorcist dist/browser-matrix.js.map > dist/browser-matrix.js' -v",
     "lint": "eslint --max-warnings 109 src spec",
-    "prepublish": "npm run build && git rev-parse HEAD > git-revision.txt"
+    "prepublish": "npm run clean && npm run build && git rev-parse HEAD > git-revision.txt"
   },
   "repository": {
     "url": "https://github.com/matrix-org/matrix-js-sdk"


### PR DESCRIPTION
Otherwise you can make broken releases on case insensitive file
systems