### PR TITLE
keep track of event ID and timestamp of decrypted messages

### DIFF
--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -628,6 +628,7 @@ MegolmDecryption.prototype.decryptEvent = async function(event) {
     try {
         res = await this._olmDevice.decryptGroupMessage(
             event.getRoomId(), content.sender_key, content.session_id, content.ciphertext,
+            event.getId(), event.getTs(),
         );
     } catch (e) {
         if (e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {


### PR DESCRIPTION
This is to avoid false positives when detecting replay attacks.

fixes: vector-im/riot-web#3712

Signed-off-by: Hubert Chathi <hubert@uhoreg.ca>

@richvdh PTAL