### PR TITLE
Consider cases where the sender may not redact their own event

### DIFF
--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -258,7 +258,11 @@ RoomState.prototype.maySendRedactionForEvent = function(mxEvent, userId) {
     if (!member || member.membership === 'leave') return false;
 
     if (mxEvent.status || mxEvent.isRedacted()) return false;
-    if (mxEvent.getSender() === userId) return true;
+
+    // The user may have been the sender, but they can't redact their own message
+    // if redactions are blocked.
+    const canRedact = this.maySendEvent("m.room.redaction", userId);
+    if (mxEvent.getSender() === userId) return canRedact;
 
     return this._hasSufficientPowerLevelFor('redact', member.powerLevel);
 };


### PR DESCRIPTION
Just because they sent the event does not mean they'll be able to actually redact it.