### PR TITLE
Make unknown pushrule conditions not match

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -126,7 +127,10 @@ function PushProcessor(client) {
         if (condition_functions[cond.kind]) {
             return condition_functions[cond.kind](cond, ev);
         }
-        return true;
+        // unknown conditions: we previously matched all unknown conditions,
+        // but given that rules can be added to the base rules on a server,
+        // it's probably better to not match unknown conditions.
+        return false;
     };
 
     const eventFulfillsRoomMemberCountCondition = function(cond, ev) {


### PR DESCRIPTION
Unknown conditions previously were assumed to match, but given rules
can be added on the server as base rules, it's probably better to not
match unknown conditions.