### PR TITLE
Install babel-runtime, as it is required for operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   ],
   "dependencies": {
     "another-json": "^0.2.0",
+    "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.0",
     "browser-request": "^0.3.3",
     "content-type": "^1.0.2",


### PR DESCRIPTION
This is a missing dependency. Everything that uses the js-sdk appears to break at runtime due to the lack of dependency. 

Riot appears to be okay because it installs the dependency on its own.