### PR TITLE
Support room notifs

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -123,6 +123,7 @@ function PushProcessor(client) {
             "device": eventFulfillsDeviceCondition,
             "contains_display_name": eventFulfillsDisplayNameCondition,
             "room_member_count": eventFulfillsRoomMemberCountCondition,
+            "sender_notification_permission": eventFulfillsSenderNotificationPermCondition,
         };
         if (condition_functions[cond.kind]) {
             return condition_functions[cond.kind](cond, ev);
@@ -132,6 +133,33 @@ function PushProcessor(client) {
         // it's probably better to not match unknown conditions.
         return false;
     };
+
+    const eventFulfillsSenderNotificationPermCondition = function(cond, ev) {
+        const notifLevelKey = cond['key'];
+        if (!notifLevelKey) {
+            return false;
+        }
+
+        const room = client.getRoom(ev.getRoomId());
+        if (!room || !room.currentState) {
+            return false;
+        }
+
+        const powerLevels = room.currentState.getStateEvents('m.room.power_levels', '');
+        if (!powerLevels || !powerLevels.getContent()) {
+            return false;
+        }
+
+        let notifLevel = 50;
+        if (
+            powerLevels.getContent().notifications &&
+            powerLevels.getContent().notifications[notifLevelKey]
+        ) {
+            notifLevel = powerLevels.getContent().notifications[notifLevelKey];
+        }
+
+        return ev.sender.powerLevel >= notifLevel;
+    }
 
     const eventFulfillsRoomMemberCountCondition = function(cond, ev) {
         if (!cond.is) {

--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -123,7 +123,7 @@ function PushProcessor(client) {
             "device": eventFulfillsDeviceCondition,
             "contains_display_name": eventFulfillsDisplayNameCondition,
             "room_member_count": eventFulfillsRoomMemberCountCondition,
-            "sender_notification_permission": eventFulfillsSenderNotificationPermCondition,
+            "sender_notification_permission": eventFulfillsSenderNotifPermCondition,
         };
         if (condition_functions[cond.kind]) {
             return condition_functions[cond.kind](cond, ev);
@@ -134,7 +134,7 @@ function PushProcessor(client) {
         return false;
     };
 
-    const eventFulfillsSenderNotificationPermCondition = function(cond, ev) {
+    const eventFulfillsSenderNotifPermCondition = function(cond, ev) {
         const notifLevelKey = cond['key'];
         if (!notifLevelKey) {
             return false;
@@ -159,7 +159,7 @@ function PushProcessor(client) {
         }
 
         return ev.sender.powerLevel >= notifLevel;
-    }
+    };
 
     const eventFulfillsRoomMemberCountCondition = function(cond, ev) {
         if (!cond.is) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -1277,6 +1277,12 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // may make notifications appear which should have the right name.
     room.recalculate(this.client.credentials.userId);
 
+    // execute the timeline events, this will begin to diverge the current state
+    // if the timeline has any state events in it.
+    // This also needs to be done before running push rules on the events as they need
+    // to be decorated with sender etc.
+    room.addLiveEvents(timelineEventList);
+
     // gather our notifications into this._notifEvents
     if (client.getNotifTimelineSet()) {
         for (let i = 0; i < timelineEventList.length; i++) {
@@ -1287,10 +1293,6 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
             }
         }
     }
-
-    // execute the timeline events, this will begin to diverge the current state
-    // if the timeline has any state events in it.
-    room.addLiveEvents(timelineEventList);
 };
 
 /**


### PR DESCRIPTION
Specifically, add support for the sender_notification_permission
push rule condition. Also delays calculating notification events
until after they're added to the timeline, as per comment.

NB. there is a bug that causes this to be wrong in some circumstances because the power level for the sentinel member is incorrect, but this is just a general bug in the js-sdk and doesn't need to be part of this PR.