### PR TITLE
Fix power level of sentinel members

### DIFF
--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -104,17 +104,20 @@ RoomMember.prototype.setPowerLevelEvent = function(powerLevelEvent) {
     if (powerLevelEvent.getType() !== "m.room.power_levels") {
         return;
     }
-    let maxLevel = powerLevelEvent.getContent().users_default || 0;
-    utils.forEach(utils.values(powerLevelEvent.getContent().users), function(lvl) {
+
+    const evContent = powerLevelEvent.getDirectionalContent();
+
+    let maxLevel = evContent.users_default || 0;
+    utils.forEach(utils.values(evContent.users), function(lvl) {
         maxLevel = Math.max(maxLevel, lvl);
     });
     const oldPowerLevel = this.powerLevel;
     const oldPowerLevelNorm = this.powerLevelNorm;
 
-    if (powerLevelEvent.getContent().users[this.userId] !== undefined) {
-        this.powerLevel = powerLevelEvent.getContent().users[this.userId];
-    } else if (powerLevelEvent.getContent().users_default !== undefined) {
-        this.powerLevel = powerLevelEvent.getContent().users_default;
+    if (evContent.users && evContent.users[this.userId] !== undefined) {
+        this.powerLevel = evContent.users[this.userId];
+    } else if (evContent.users_default !== undefined) {
+        this.powerLevel = evContent.users_default;
     } else {
         this.powerLevel = 0;
     }

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -205,12 +205,7 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
                 const newSentinel = new RoomMember(event.getRoomId(), userId);
                 newSentinel.setMembershipEvent(oldSentinel.events.member, self);
                 newSentinel.setPowerLevelEvent(event);
-                if (
-                    newSentinel.powerLevel != oldSentinel.powerLevel ||
-                    newSentinel.powerLevelNorm != oldSentinel.powerLevelNorm
-                ) {
-                    self._sentinels[userId] = newSentinel;
-                }
+                self._sentinels[userId] = newSentinel;
             }
         }
     });

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -197,6 +197,21 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
                 member.setPowerLevelEvent(event);
                 self.emit("RoomState.members", event, self, member);
             });
+
+            // Go through the sentinel members and see if any of them would be
+            // affected by the new power levels. If so, replace the sentinel.
+            for (const userId of Object.keys(self._sentinels)) {
+                const oldSentinel = self._sentinels[userId];
+                const newSentinel = new RoomMember(event.getRoomId(), userId);
+                newSentinel.setMembershipEvent(oldSentinel.events.member, self);
+                newSentinel.setPowerLevelEvent(event);
+                if (
+                    newSentinel.powerLevel != oldSentinel.powerLevel ||
+                    newSentinel.powerLevelNorm != oldSentinel.powerLevelNorm
+                ) {
+                    self._sentinels[userId] = newSentinel;
+                }
+            }
         }
     });
 };


### PR DESCRIPTION
When a ppower_levels event arrived, the current member objects were
being updated but the sentinel members were not, meaning that the
power levels of RoomMember objects associated with events had stale
power levels. This was causing power level based push rules to
be wrong.