### PR TITLE
Fix notifEvent computation

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1303,7 +1303,7 @@ SyncApi.prototype._processEventForNotifs = function(room, timelineEventList) {
     // gather our notifications into this._notifEvents
     if (this.client.getNotifTimelineSet()) {
         for (let i = 0; i < timelineEventList.length; i++) {
-            const pushActions = client.getPushActionsForEvent(timelineEventList[i]);
+            const pushActions = this.client.getPushActionsForEvent(timelineEventList[i]);
             if (pushActions && pushActions.notify &&
                 pushActions.tweaks && pushActions.tweaks.highlight) {
                 this._notifEvents.push(timelineEventList[i]);

--- a/src/sync.js
+++ b/src/sync.js
@@ -232,7 +232,7 @@ SyncApi.prototype.syncLeftRooms = function() {
             client.store.storeRoom(room);
             client.emit("Room", room);
 
-            self._processEventForNotifs(room, timelineEvents);
+            self._processEventsForNotifs(room, timelineEvents);
         });
         return rooms;
     });
@@ -963,7 +963,7 @@ SyncApi.prototype._processSyncResponse = async function(syncToken, data) {
             client.emit("Room", room);
         }
 
-        self._processEventForNotifs(room, timelineEvents);
+        self._processEventsForNotifs(room, timelineEvents);
 
         async function processRoomEvent(e) {
             client.emit("event", e);
@@ -1001,7 +1001,7 @@ SyncApi.prototype._processSyncResponse = async function(syncToken, data) {
             client.emit("Room", room);
         }
 
-        self._processEventForNotifs(room, timelineEvents);
+        self._processEventsForNotifs(room, timelineEvents);
 
         stateEvents.forEach(function(e) {
             client.emit("event", e);
@@ -1299,7 +1299,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
  * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
  * is earlier in time. Higher index is later.
  */
-SyncApi.prototype._processEventForNotifs = function(room, timelineEventList) {
+SyncApi.prototype._processEventsForNotifs = function(room, timelineEventList) {
     // gather our notifications into this._notifEvents
     if (this.client.getNotifTimelineSet()) {
         for (let i = 0; i < timelineEventList.length; i++) {


### PR DESCRIPTION
We were previously computing notifEvents at the point where we
processed them but before the room they belong to was stored.
This was problematic because some push conditions try to get the
room and therefore failed. Since the push actions are cached, this
spurious calculation also got cached.

This moves the calculation out to a separate function that gets
called only after the room has been stored.