### PR TITLE
[BREAKING] Change the behaviour of the unverfied devices blacklist flag

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -543,11 +543,10 @@ async function _setDeviceVerification(
 
 /**
  * Set the global override for whether the client should ever send encrypted
- * messages to unverified devices.  If false, it can still be overridden
- * per-room.  If true, it overrides the per-room settings.
+ * messages to unverified devices.  This provides the default for rooms which
+ * do not specify a value.
  *
- * @param {boolean} value whether to unilaterally blacklist all
- * unverified devices
+ * @param {boolean} value whether to blacklist all unverified devices by default
  */
 MatrixClient.prototype.setGlobalBlacklistUnverifiedDevices = function(value) {
     if (this._crypto === null) {
@@ -557,8 +556,7 @@ MatrixClient.prototype.setGlobalBlacklistUnverifiedDevices = function(value) {
 };
 
 /**
- * @return {boolean} whether to unilaterally blacklist all
- * unverified devices
+ * @return {boolean} whether to blacklist all unverified devices by default
  */
 MatrixClient.prototype.getGlobalBlacklistUnverifiedDevices = function() {
     if (this._crypto === null) {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -541,6 +541,12 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
         return u.userId;
     });
 
+    // The global value is treated as a default for when rooms don't specify a value.
+    let isBlacklisting = this._crypto.getBlacklistUnverifiedDevices();
+    if (room.getBlacklistUnverifiedDevices() !== null) {
+        isBlacklisting = room.getBlacklistUnverifiedDevices();
+    }
+
     // We are happy to use a cached version here: we assume that if we already
     // have a list of the user's devices, then we already share an e2e room
     // with them, which means that they will have announced any new devices via
@@ -564,9 +570,7 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
                 }
 
                 if (userDevices[deviceId].isBlocked() ||
-                    (userDevices[deviceId].isUnverified() &&
-                     (room.getBlacklistUnverifiedDevices() ||
-                      this._crypto.getGlobalBlacklistUnverifiedDevices()))
+                    (userDevices[deviceId].isUnverified() && isBlacklisting)
                    ) {
                     delete userDevices[deviceId];
                 }

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -542,7 +542,7 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
     });
 
     // The global value is treated as a default for when rooms don't specify a value.
-    let isBlacklisting = this._crypto.getBlacklistUnverifiedDevices();
+    let isBlacklisting = this._crypto.getGlobalBlacklistUnverifiedDevices();
     if (room.getBlacklistUnverifiedDevices() !== null) {
         isBlacklisting = room.getBlacklistUnverifiedDevices();
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -192,18 +192,17 @@ Crypto.prototype.getDeviceEd25519Key = function() {
 
 /**
  * Set the global override for whether the client should ever send encrypted
- * messages to unverified devices.  If false, it can still be overridden
- * per-room.  If true, it overrides the per-room settings.
+ * messages to unverified devices.  This provides the default for rooms which
+ * do not specify a value.
  *
- * @param {boolean} value whether to unilaterally blacklist all
- * unverified devices
+ * @param {boolean} value whether to blacklist all unverified devices by default
  */
 Crypto.prototype.setGlobalBlacklistUnverifiedDevices = function(value) {
     this._globalBlacklistUnverifiedDevices = value;
 };
 
 /**
- * @return {boolean} whether to unilaterally blacklist all unverified devices
+ * @return {boolean} whether to blacklist all unverified devices by default
  */
 Crypto.prototype.getGlobalBlacklistUnverifiedDevices = function() {
     return this._globalBlacklistUnverifiedDevices;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -169,7 +169,8 @@ function Room(roomId, opts) {
         this._pendingEventList = [];
     }
 
-    this._blacklistUnverifiedDevices = false; // read by megolm
+    // read by megolm; boolean value - null indicates "use global value"
+    this._blacklistUnverifiedDevices = null;
 }
 utils.inherits(Room, EventEmitter);
 
@@ -307,8 +308,8 @@ Room.prototype.setUnreadNotificationCount = function(type, count) {
 
 /**
  * Whether to send encrypted messages to devices within this room.
- * Will be ignored if MatrixClient's blacklistUnverifiedDevices setting is true.
- * @param {boolean} value if true, blacklist unverified devices.
+ * @param {Boolean} value true to blacklist unverified devices, null
+ * to use the global value for this room.
  */
 Room.prototype.setBlacklistUnverifiedDevices = function(value) {
     this._blacklistUnverifiedDevices = value;
@@ -316,8 +317,8 @@ Room.prototype.setBlacklistUnverifiedDevices = function(value) {
 
 /**
  * Whether to send encrypted messages to devices within this room.
- * Will be ignored if MatrixClient's blacklistUnverifiedDevices setting is true.
- * @return {boolean} true if blacklisting unverified devices.
+ * @return {Boolean} true if blacklisting unverified devices, null
+ * if the global value should be used for this room.
  */
 Room.prototype.getBlacklistUnverifiedDevices = function() {
     return this._blacklistUnverifiedDevices;


### PR DESCRIPTION
Previously the global flag was used as a way to completely ignore the per-room option. This commit makes the per-room and global settings be more flexible to allow users to, for example, blacklist unverified devices in all room with the exception of one or two. This is done by making the global setting a device-level default and the per-room option allowing for 3 states: true, false, and unset (use device default).

Signed-off-by: Travis Ralston <travpc@gmail.com>