### PR TITLE
Supporting fixes For making UnknownDeviceDialog not pop up automatically

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1127,6 +1127,9 @@ function _sendEvent(client, room, event, callback) {
         try {
             _updatePendingEventStatus(room, event, EventStatus.NOT_SENT);
             event.error = err;
+            // also put the event object on the error: the caller will need this
+            // to resend or cancel the event
+            err.event = event;
 
             if (callback) {
                 callback(err);

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -26,6 +26,22 @@ const DEBUG = true;  // set true to enable console logging.
 // events: hangup, error(err), replaced(call), state(state, oldState)
 
 /**
+ * Fires whenever an error occurs when call.js encounters an issue with setting up the call.
+ * <p>
+ * The error given will have a code equal to either `MatrixCall.ERR_LOCAL_OFFER_FAILED` or
+ * `MatrixCall.ERR_NO_USER_MEDIA`. `ERR_LOCAL_OFFER_FAILED` is emitted when the local client
+ * fails to create an offer. `ERR_NO_USER_MEDIA` is emitted when the user has denied access
+ * to their audio/video hardware.
+ *
+ * @event module:webrtc/call~MatrixCall#"error"
+ * @param {Error} err The error raised by MatrixCall.
+ * @example
+ * matrixCall.on("error", function(err){
+ *   console.error(err.code, err);
+ * });
+ */
+
+/**
  * Construct a new Matrix Call.
  * @constructor
  * @param {Object} opts Config options.

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -767,6 +767,7 @@ MatrixCall.prototype._getLocalOfferFailed = function(error) {
  * @param {Object} error
  */
 MatrixCall.prototype._getUserMediaFailed = function(error) {
+    terminate(this, "local", 'user_media_failed', false);
     this.emit(
         "error",
         callError(
@@ -775,7 +776,6 @@ MatrixCall.prototype._getUserMediaFailed = function(error) {
             "does this app have permission?",
         ),
     );
-    this.hangup("user_media_failed");
 };
 
 /**

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -25,47 +25,6 @@ const DEBUG = true;  // set true to enable console logging.
 // events: hangup, error(err), replaced(call), state(state, oldState)
 
 /**
- * Fires when the MatrixCall encounters an error when sending a Matrix event.
- * <p>
- * This is required to allow errors, which occur during sending of events, to bubble up.
- * (This is because call.js does a hangup when it encounters a normal `error`, which in
- * turn could lead to an UnknownDeviceError.)
- * <p>
- * To deal with an UnknownDeviceError when trying to send events, the application should let
- * users know that there are new devices in the encrypted room (into which the event was
- * sent) and give the user the options to resend unsent events or cancel them. Resending
- * is done using {@link module:client~MatrixClient#resendEvent} and cancelling can be done by using
- * {@link module:client~MatrixClient#cancelPendingEvent}.
- * <p>
- * MatrixCall will not do anything in response to an error that causes `send_event_error`
- * to be emitted with the exception of sending `m.call.candidates`, which is retried upon
- * failure when ICE candidates are being sent. This happens during call setup.
- *
- * @event module:webrtc/call~MatrixCall#"send_event_error"
- * @param {Error} err The error caught from calling client.sendEvent in call.js.
- * @example
- * matrixCall.on("send_event_error", function(err){
- *   console.error(err);
- * });
- */
-
-/**
- * Fires whenever an error occurs when call.js encounters an issue with setting up the call.
- * <p>
- * The error given will have a code equal to either `MatrixCall.ERR_LOCAL_OFFER_FAILED` or
- * `MatrixCall.ERR_NO_USER_MEDIA`. `ERR_LOCAL_OFFER_FAILED` is emitted when the local client
- * fails to create an offer. `ERR_NO_USER_MEDIA` is emitted when the user has denied access
- * to their audio/video hardware.
- *
- * @event module:webrtc/call~MatrixCall#"error"
- * @param {Error} err The error raised by MatrixCall.
- * @example
- * matrixCall.on("error", function(err){
- *   console.error(err.code, err);
- * });
- */
-
-/**
  * Construct a new Matrix Call.
  * @constructor
  * @param {Object} opts Config options.
@@ -972,11 +931,7 @@ const setState = function(self, state) {
  * @return {Promise}
  */
 const sendEvent = function(self, eventType, content) {
-    return self.client.sendEvent(self.roomId, eventType, content).catch(
-        (err) => {
-            self.emit('send_event_error', err);
-        },
-    );
+    return self.client.sendEvent(self.roomId, eventType, content);
 };
 
 const sendCandidate = function(self, content) {


### PR DESCRIPTION
This is mostly a lot of VoIP fixes to make the flow of trying to place or answer a call when there are unknown devices in the room. We don't want to stack up VoIP events in the pending events and then fire them all out later: we should just abort the call and place a new one once the user has reviewed the new devices.

Reviewing this commit-by-commit may make more sense: the commits are fairly well contained, functionality-wise, but all in the same commit because they'd otherwise leave things a bit broken.