### PR TITLE
Fix the force TURN option

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -175,6 +175,8 @@ function MatrixClient(opts) {
     this._cryptoStore = opts.cryptoStore;
     this._sessionStore = opts.sessionStore;
 
+    this._forceTURN = opts.forceTURN || false;
+
     if (CRYPTO_ENABLED) {
         this.olmVersion = Crypto.getOlmVersion();
     }
@@ -250,6 +252,15 @@ MatrixClient.prototype.getDeviceId = function() {
  */
 MatrixClient.prototype.supportsVoip = function() {
     return this._supportsVoip;
+};
+
+/**
+ * Set whether VoIP calls are forced to use only TURN
+ * candidates. This is the same as the forceTURN option
+ * when creating the client.
+ */
+MatrixClient.prototype.setForceTURN = function(forceTURN) {
+    return this._forceTURN = forceTURN;
 };
 
 /**
@@ -3153,7 +3164,9 @@ function setupCallEventHandler(client) {
                 );
             }
 
-            call = webRtcCall.createNewMatrixCall(client, event.getRoomId());
+            call = webRtcCall.createNewMatrixCall(client, event.getRoomId(), {
+                forceTURN: client._forceTURN,
+            });
             if (!call) {
                 console.log(
                     "Incoming call ID " + content.call_id + " but this client " +

--- a/src/client.js
+++ b/src/client.js
@@ -258,9 +258,10 @@ MatrixClient.prototype.supportsVoip = function() {
  * Set whether VoIP calls are forced to use only TURN
  * candidates. This is the same as the forceTURN option
  * when creating the client.
+ * @param {bool} forceTURN True to force use of TURN servers
  */
 MatrixClient.prototype.setForceTURN = function(forceTURN) {
-    return this._forceTURN = forceTURN;
+    this._forceTURN = forceTURN;
 };
 
 /**

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -1300,7 +1300,7 @@ module.exports.setVideoInput = function(deviceId) { videoInput = deviceId; };
  * @param {boolean} options.forceTURN whether relay through TURN should be forced.
  * @return {MatrixCall} the call or null if the browser doesn't support calling.
  */
-module.exports.createNewMatrixCall = function(client, roomId, options) {
+module.exports.createNewMatrixCall = function(client, roomId) {
     const w = global.window;
     const doc = global.document;
     if (!w || !doc) {
@@ -1357,7 +1357,7 @@ module.exports.createNewMatrixCall = function(client, roomId, options) {
         roomId: roomId,
         turnServers: client.getTurnServers(),
         // call level options
-        forceTURN: options ? options.forceTURN : false,
+        forceTURN: client._forceTURN,
     };
     return new MatrixCall(opts);
 };

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -1296,11 +1296,11 @@ module.exports.setVideoInput = function(deviceId) { videoInput = deviceId; };
  * Create a new Matrix call for the browser.
  * @param {MatrixClient} client The client instance to use.
  * @param {string} roomId The room the call is in.
- * @param {Object?} options optional options map.
- * @param {boolean} options.forceTURN whether relay through TURN should be forced.
+ * @param {Object?} options DEPRECATED optional options map.
+ * @param {boolean} options.forceTURN DEPRECATED whether relay through TURN should be forced. This option is deprecated - use opts.forceTURN when creating the matrix client since it's only possible to set this option on outbound calls.
  * @return {MatrixCall} the call or null if the browser doesn't support calling.
  */
-module.exports.createNewMatrixCall = function(client, roomId) {
+module.exports.createNewMatrixCall = function(client, roomId, options) {
     const w = global.window;
     const doc = global.document;
     if (!w || !doc) {
@@ -1350,6 +1350,9 @@ module.exports.createNewMatrixCall = function(client, roomId) {
             !webRtc.RtcPeerConnection || !webRtc.getUserMedia) {
         return null; // WebRTC is not supported.
     }
+
+    const optionsForceTURN = options ? options.forceTURN : false;
+
     const opts = {
         webRtc: webRtc,
         client: client,
@@ -1357,7 +1360,7 @@ module.exports.createNewMatrixCall = function(client, roomId) {
         roomId: roomId,
         turnServers: client.getTurnServers(),
         // call level options
-        forceTURN: client._forceTURN,
+        forceTURN: client._forceTURN || optionsForceTURN,
     };
     return new MatrixCall(opts);
 };


### PR DESCRIPTION
Option needed to be passed in when creating a webrtc call, but for
incoming calls the js-sdk creates the call itself, so the app never
gets a chance to set the option.