### PR TITLE
Move Olm account to IndexedDB

### DIFF
--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -198,7 +198,7 @@ OlmDevice.prototype._getAccount = async function(func) {
                 return save(pickledAccount);
             });
         } finally {
-            if (account !== null) account.free();
+            account.free();
         }
     });
     return result;

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -208,18 +208,6 @@ OlmDevice.prototype._getAccount = async function(func) {
 
 
 /**
- * store our OlmAccount in the session store
- *
- * @param {OlmAccount} account
- * @private
- */
-OlmDevice.prototype._saveAccount = async function(account) {
-    const pickledAccount = account.pickle(this._pickleKey);
-    await this._cryptoStore.storeEndToEndAccount(pickledAccount);
-};
-
-
-/**
  * extract an OlmSession from the session store and call the given function
  *
  * @param {string} deviceKey

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -173,7 +173,7 @@ OlmDevice.prototype._getAccount = async function(func) {
     let result;
 
     await this._cryptoStore.endToEndAccountTransaction((accountData, save) => {
-        // Olm has a limited stack size so we must tightly control the number of
+        // Olm has a limited heap size so we must tightly control the number of
         // Olm account objects in existence at any given time: once created, it
         // must be destroyed again before we await.
         const account = new Olm.Account();

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -177,8 +177,8 @@ OlmDevice.getOlmVersion = function() {
 /**
  * extract our OlmAccount from the crypto store and call the given function
  * with the account object and a 'save' function which returns a promise.
- * The function will not be awaited upon and the save function must be
- * called before the function returns, or not at all.
+ * The `account` will be freed as soon as `func` returns - even if func returns
+ * a promise
  *
  * @param {function} func
  * @return {object} result of func

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -74,7 +74,8 @@ function checkPayloadLength(payloadString) {
  * @alias module:crypto/OlmDevice
  *
  * @param {Object} sessionStore A store to be used for data in end-to-end
- *    crypto
+ *    crypto. This is deprecated and being replaced by cryptoStore.
+ * @param {Object} cryptoStore A store for crypto data
  *
  * @property {string} deviceCurve25519Key   Curve25519 key for the account
  * @property {string} deviceEd25519Key      Ed25519 key for the account
@@ -297,7 +298,6 @@ OlmDevice.prototype.maxNumberOfOneTimeKeys = function() {
  * Marks all of the one-time keys as published.
  */
 OlmDevice.prototype.markKeysAsPublished = async function() {
-    const self = this;
     await this._getAccount(function(account, save) {
         account.mark_keys_as_published();
         return save();
@@ -308,9 +308,9 @@ OlmDevice.prototype.markKeysAsPublished = async function() {
  * Generate some new one-time keys
  *
  * @param {number} numKeys number of keys to generate
+ * @return {Promise} Resolved once the account is saved back having generated the keys
  */
 OlmDevice.prototype.generateOneTimeKeys = async function(numKeys) {
-    const self = this;
     return this._getAccount(function(account, save) {
         account.generate_one_time_keys(numKeys);
         return save();

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -126,7 +126,9 @@ OlmDevice.prototype.init = async function() {
     let e2eKeys;
     const account = new Olm.Account();
     try {
-        await _initialise_account(this._sessionStore, this._cryptoStore, this._pickleKey, account);
+        await _initialise_account(
+            this._sessionStore, this._cryptoStore, this._pickleKey, account,
+        );
         e2eKeys = JSON.parse(account.identity_keys());
 
         this._maxOneTimeKeys = account.max_number_of_one_time_keys();

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -197,7 +197,7 @@ OlmDevice.prototype._getAccount = async function(func) {
 
             result = func(account, () => {
                 const pickledAccount = account.pickle(this._pickleKey);
-                return save(pickledAccount);
+                save(pickledAccount);
             });
         } finally {
             account.free();
@@ -315,7 +315,7 @@ OlmDevice.prototype.maxNumberOfOneTimeKeys = function() {
 OlmDevice.prototype.markKeysAsPublished = async function() {
     await this._getAccount(function(account, save) {
         account.mark_keys_as_published();
-        return save();
+        save();
     });
 };
 
@@ -328,7 +328,7 @@ OlmDevice.prototype.markKeysAsPublished = async function() {
 OlmDevice.prototype.generateOneTimeKeys = async function(numKeys) {
     return this._getAccount(function(account, save) {
         account.generate_one_time_keys(numKeys);
-        return save();
+        save();
     });
 };
 
@@ -345,12 +345,12 @@ OlmDevice.prototype.createOutboundSession = async function(
     theirIdentityKey, theirOneTimeKey,
 ) {
     const self = this;
-    return await this._getAccount(async function(account, save) {
+    return await this._getAccount(function(account, save) {
         const session = new Olm.Session();
         try {
             session.create_outbound(account, theirIdentityKey, theirOneTimeKey);
-            await save();
-            await self._saveSession(theirIdentityKey, session);
+            save();
+            self._saveSession(theirIdentityKey, session);
             return session.session_id();
         } finally {
             session.free();
@@ -380,12 +380,12 @@ OlmDevice.prototype.createInboundSession = async function(
     }
 
     const self = this;
-    return await this._getAccount(async function(account, save) {
+    return await this._getAccount(function(account, save) {
         const session = new Olm.Session();
         try {
             session.create_inbound_from(account, theirDeviceIdentityKey, ciphertext);
             account.remove_one_time_keys(session);
-            await save();
+            save();
 
             const payloadString = session.decrypt(message_type, ciphertext);
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -67,7 +67,7 @@ function Crypto(baseApis, sessionStore, userId, deviceId,
     this._clientStore = clientStore;
     this._cryptoStore = cryptoStore;
 
-    this._olmDevice = new OlmDevice(sessionStore);
+    this._olmDevice = new OlmDevice(sessionStore, cryptoStore);
     this._deviceList = new DeviceList(baseApis, sessionStore, this._olmDevice);
 
     // the last time we did a check for the number of one-time-keys on the

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -265,7 +265,7 @@ export class Backend {
      * back to the database. This allows the account to be read and writen
      * atomically.
      * @param {function(string, function())} func Function called with the
-     *     account data and a save function
+     *     picked account and a save function
      * @return {Promise} Resolves with the return value of `func` once
      *     the transaction is complete (ie. once data is written back if the
      *     save function is called.)

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -275,6 +275,10 @@ export class Backend {
 
         return new Promise((resolve, reject) => {
             const getReq = objectStore.get("-");
+            // We resolve on success here rather than on complete:
+            // the caller may wish to save the account back, which needs
+            // to be done while the transaction is still open (ie. before
+            // oncomplete)
             getReq.onsuccess = function() {
                 resolve({
                     account: getReq.result || null,

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -282,7 +282,6 @@ export class Backend {
                 getReq.result || null,
                 (newData) => {
                     objectStore.put(newData, "-");
-                    return txnPromise;
                 },
             );
         };

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -260,14 +260,15 @@ export class Backend {
 
     /**
      * Load the end to end account for the logged-in user. Once the account
-     * is retrieved, the given function is executed and passed the base64
-     * encoded account string and a method for saving the account string
+     * is retrieved, the given function is executed and passed the pickled
+     * account string and a method for saving the pickle
      * back to the database. This allows the account to be read and writen
      * atomically.
-     * @param {func} func Function called with the account data and a save function
-     * @return {Promise} Resolves with the return value of the function once
+     * @param {function(string, function())} func Function called with the
+     *     account data and a save function
+     * @return {Promise} Resolves with the return value of `func` once
      *     the transaction is complete (ie. once data is written back if the
-     *     save function is called.
+     *     save function is called.)
      */
     endToEndAccountTransaction(func) {
         const txn = this._db.transaction("account", "readwrite");

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -264,7 +264,8 @@ export class Backend {
      * encoded account string and a method for saving the account string
      * back to the database. This allows the account to be read and writen
      * atomically.
-     * @return {Promise} * Resolves with the return value of the function once
+     * @param {func} func Function called with the account data and a save function
+     * @return {Promise} Resolves with the return value of the function once
      *     the transaction is complete (ie. once data is written back if the
      *     save function is called.
      */
@@ -280,12 +281,14 @@ export class Backend {
             result = func(
                 getReq.result || null,
                 (newData) => {
-                    const saveReq = objectStore.put(newData, "-");
+                    objectStore.put(newData, "-");
                     return txnPromise;
                 },
             );
         };
-        return txnPromise;
+        return txnPromise.then(() => {
+            return result;
+        });
     }
 }
 

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -227,7 +227,8 @@ export default class IndexedDBCryptoStore {
      * encoded account string and a method for saving the account string
      * back to the database. This allows the account to be read and writen
      * atomically.
-     * @return {Promise} * Resolves with the return value of the function once
+     * @param {func} func Function called with the account data and a save function
+     * @return {Promise} Resolves with the return value of the function once
      *     the transaction is complete (ie. once data is written back if the
      *     save function is called.
      */

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -220,4 +220,20 @@ export default class IndexedDBCryptoStore {
             return backend.deleteOutgoingRoomKeyRequest(requestId, expectedState);
         });
     }
+
+    /**
+     * Load the end to end account for the logged-in user, giving an object
+     * that has the base64 encoded account string and a method for saving
+     * the account string back to the database. This allows the account
+     * to be read and writen atomically.
+     * @return {Promise<Object>} Object
+     * @return {Promise<Object>.account} Base64 encoded account.
+     * @return {Promise<Object>.save} Function to save account data back.
+     *     Takes base64 encoded account data, returns a promise.
+     */
+    endToEndAccountTransaction() {
+        return this._connect().then((backend) => {
+            return backend.endToEndAccountTransaction();
+        });
+    }
 }

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -229,14 +229,15 @@ export default class IndexedDBCryptoStore {
 
     /**
      * Load the end to end account for the logged-in user. Once the account
-     * is retrieved, the given function is executed and passed the base64
-     * encoded account string and a method for saving the account string
+     * is retrieved, the given function is executed and passed the pickled
+     * account string and a method for saving the pickle
      * back to the database. This allows the account to be read and writen
      * atomically.
-     * @param {func} func Function called with the account data and a save function
-     * @return {Promise} Resolves with the return value of the function once
+     * @param {function(string, function())} func Function called with the
+     *     account data and a save function
+     * @return {Promise} Resolves with the return value of `func` once
      *     the transaction is complete (ie. once data is written back if the
-     *     save function is called.
+     *     save function is called.)
      */
     endToEndAccountTransaction(func) {
         return this._connect().then((backend) => {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -222,18 +222,18 @@ export default class IndexedDBCryptoStore {
     }
 
     /**
-     * Load the end to end account for the logged-in user, giving an object
-     * that has the base64 encoded account string and a method for saving
-     * the account string back to the database. This allows the account
-     * to be read and writen atomically.
-     * @return {Promise<Object>} Object
-     * @return {Promise<Object>.account} Base64 encoded account.
-     * @return {Promise<Object>.save} Function to save account data back.
-     *     Takes base64 encoded account data, returns a promise.
+     * Load the end to end account for the logged-in user. Once the account
+     * is retrieved, the given function is executed and passed the base64
+     * encoded account string and a method for saving the account string
+     * back to the database. This allows the account to be read and writen
+     * atomically.
+     * @return {Promise} * Resolves with the return value of the function once
+     *     the transaction is complete (ie. once data is written back if the
+     *     save function is called.
      */
-    endToEndAccountTransaction() {
+    endToEndAccountTransaction(func) {
         return this._connect().then((backend) => {
-            return backend.endToEndAccountTransaction();
+            return backend.endToEndAccountTransaction(func);
         });
     }
 }

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 import Promise from 'bluebird';
 
+import LocalStorageCryptoStore from './localStorage-crypto-store';
 import MemoryCryptoStore from './memory-crypto-store';
 import * as IndexedDBCryptoStoreBackend from './indexeddb-crypto-store-backend';
 
@@ -93,7 +94,12 @@ export default class IndexedDBCryptoStore {
         }).catch((e) => {
             console.warn(
                 `unable to connect to indexeddb ${this._dbName}` +
-                    `: falling back to in-memory store: ${e}`,
+                    `: falling back to localStorage store: ${e}`,
+            );
+            return new LocalStorageCryptoStore();
+        }).catch((e) => {
+            console.warn(
+                `unable to open localStorage: falling back to in-memory store: ${e}`,
             );
             return new MemoryCryptoStore();
         });

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -23,7 +23,6 @@ import MemoryCryptoStore from './memory-crypto-store.js';
  * some things backed by localStorage. It exists because indexedDB
  * is broken in Firefox private mode or set to, "will not remember
  * history".
- * 
  *
  * @module
  */

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Promise from 'bluebird';
+import MemoryCryptoStore from './memory-crypto-store.js';
+
+/**
+ * Internal module. Partial localStorage backed storage for e2e.
+ * This is not a full crypto store, just the in-memory store with
+ * some things backed by localStorage. It exists because indexedDB
+ * is broken in Firefox private mode or set to, "will not remember
+ * history".
+ * 
+ *
+ * @module
+ */
+
+const E2E_PREFIX = "crypto.";
+const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
+
+/**
+ * @implements {module:crypto/store/base~CryptoStore}
+ */
+export default class LocalStorageCryptoStore extends MemoryCryptoStore {
+    constructor() {
+        super();
+        this.store = global.localStorage;
+    }
+
+    /**
+     * Delete all data from this store.
+     *
+     * @returns {Promise} Promise which resolves when the store has been cleared.
+     */
+    deleteAllData() {
+        this.store.removeItem(KEY_END_TO_END_ACCOUNT);
+        return Promise.resolve();
+    }
+
+    endToEndAccountTransaction(func) {
+        const account = this.store.getItem(KEY_END_TO_END_ACCOUNT);
+        return Promise.resolve(func(account, (newData) => {
+            this.store.setItem(KEY_END_TO_END_ACCOUNT, newData);
+        }));
+    }
+}

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -199,21 +199,18 @@ export default class MemoryCryptoStore {
     }
 
     /**
-     * Load the end to end account for the logged-in user, giving an object
-     * that has the base64 encoded account string and a method for saving
-     * the account string back to the database. This allows the account
-     * to be read and writen atomically.
-     * @return {Promise<Object>} Object
-     * @return {Promise<Object>.account} Base64 encoded account.
-     * @return {Promise<Object>.save} Function to save account data back.
-     *     Takes base64 encoded account data, returns a promise.
+     * Load the end to end account for the logged-in user. Once the account
+     * is retrieved, the given function is executed and passed the base64
+     * encoded account string and a method for saving the account string
+     * back to the database. This allows the account to be read and writen
+     * atomically.
+     * @return {Promise} * Resolves with the return value of the function once
+     *     the transaction is complete (ie. once data is written back if the
+     *     save function is called.
      */
-    endToEndAccountTransaction() {
-        return Promise.resolve({
-            account: this._account,
-            save: (newData) => {
-                this._account = newData;
-            },
-        });
+    endToEndAccountTransaction(func) {
+        return Promise.resolve(func(this._account, (newData) => {
+            this._account = newData;
+        }));
     }
 }

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -30,6 +30,7 @@ import utils from '../../utils';
 export default class MemoryCryptoStore {
     constructor() {
         this._outgoingRoomKeyRequests = [];
+        this._account = null;
     }
 
     /**
@@ -195,5 +196,24 @@ export default class MemoryCryptoStore {
         }
 
         return Promise.resolve(null);
+    }
+
+    /**
+     * Load the end to end account for the logged-in user, giving an object
+     * that has the base64 encoded account string and a method for saving
+     * the account string back to the database. This allows the account
+     * to be read and writen atomically.
+     * @return {Promise<Object>} Object
+     * @return {Promise<Object>.account} Base64 encoded account.
+     * @return {Promise<Object>.save} Function to save account data back.
+     *     Takes base64 encoded account data, returns a promise.
+     */
+    endToEndAccountTransaction() {
+        return Promise.resolve({
+            account: this._account,
+            save: (newData) => {
+                this._account = newData;
+            },
+        });
     }
 }

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -204,7 +204,8 @@ export default class MemoryCryptoStore {
      * encoded account string and a method for saving the account string
      * back to the database. This allows the account to be read and writen
      * atomically.
-     * @return {Promise} * Resolves with the return value of the function once
+     * @param {func} func Function called with the account data and a save function
+     * @return {Promise} Resolves with the return value of the function once
      *     the transaction is complete (ie. once data is written back if the
      *     save function is called.
      */

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -57,6 +57,9 @@ WebStorageSessionStore.prototype = {
 
     /**
      * Load the end to end account for the logged-in user.
+     * Note that the end-to-end account is now stored in the
+     * crypto store rather than here: this remains here so
+     * old sessions can be migrated out of the session store.
      * @return {?string} Base64 encoded account.
      */
     getEndToEndAccount: function() {

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -48,13 +48,11 @@ function WebStorageSessionStore(webStore) {
 }
 
 WebStorageSessionStore.prototype = {
-
     /**
-     * Store the end to end account for the logged-in user.
-     * @param {string} account Base64 encoded account.
+     * Remove the stored end to end account for the logged-in user.
      */
-    storeEndToEndAccount: function(account) {
-        this.store.setItem(KEY_END_TO_END_ACCOUNT, account);
+    removeEndToEndAccount: function() {
+        this.store.removeItem(KEY_END_TO_END_ACCOUNT);
     },
 
     /**


### PR DESCRIPTION
Migrates the Olm account storage from the session store to the crypto store, backed by indexedDB. This allows us to lock access to it in a transaction, so multiple tabs can't overwrite each other's data.

Also adds a localstorage-backed crypto store to prevent people using Firefox in ones of its modes where IndexedDB support is broken from losing all their e2e data. It still uses the in-memory store for key requests as before, but saves the Olm account to localstorage. We may want to kick the app to warn the user that they're running in a degraded mode?

Olm accounts in the old session store are migrated into the crypto store seamlessly.