### PR TITLE
Fix logging of DecryptionErrors to be more useful

### DIFF
--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -179,30 +179,25 @@ class DecryptionError extends Error {
     constructor(msg, details) {
         super(msg);
         this.name = 'DecryptionError';
-        this.details = details;
-    }
-
-    /**
-     * override the string used when logging
-     *
-     * @returns {String}
-     */
-    toString() {
-        let result = this.name + '[msg: ' + this.message;
-
-        if (this.details) {
-            result += ', ' +
-                Object.keys(this.details).map(
-                    (k) => k + ': ' + this.details[k],
-                ).join(', ');
-        }
-
-        result += ']';
-
-        return result;
+        this.detailedString = _detailedStringForDecryptionError(this, details);
     }
 }
 export {DecryptionError}; // https://github.com/jsdoc3/jsdoc/issues/1272
+
+function _detailedStringForDecryptionError(err, details) {
+    let result = err.name + '[msg: ' + err.message;
+
+    if (details) {
+        result += ', ' +
+            Object.keys(details).map(
+                (k) => k + ': ' + details[k],
+            ).join(', ');
+    }
+
+    result += ']';
+
+    return result;
+}
 
 /**
  * Exception thrown specifically when we want to warn the user to consider

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -424,7 +424,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
                     // decryption error, but we have a retry queued.
                     console.log(
                         `Got error decrypting event (id=${this.getId()}: ` +
-                        `${e.message}), but retrying`,
+                        `${e}), but retrying`,
                     );
                     continue;
                 }
@@ -432,7 +432,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
                 // decryption error, no retries queued. Warn about the error and
                 // set it to m.bad.encrypted.
                 console.warn(
-                    `Error decrypting event (id=${this.getId()}): ${e}`,
+                    `Error decrypting event (id=${this.getId()}): ${e.detailedString}`,
                 );
 
                 res = this._badEncryptedMessage(e.message);


### PR DESCRIPTION
We were relying on being able to override toString in DecryptionError, which
(a) doesn't work thanks to https://github.com/babel/babel/issues/3083, and (b)
was a bit naughty anyway. Instead, just add a detailedString property and use
that.