### PR TITLE
Move sessions to the crypto store

### DIFF
--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -256,7 +256,7 @@ OlmDevice.prototype._storeAccount = function(txn, account) {
  *
  * @param {string} deviceKey
  * @param {string} sessionId
- * @param {*} txn
+ * @param {*} txn Opaque transaction object from cryptoStore.doTxn()
  * @param {function} func
  * @private
  */

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -616,15 +616,21 @@ OlmDevice.prototype.decryptMessage = async function(
     theirDeviceIdentityKey, sessionId, messageType, ciphertext,
 ) {
     let payloadString;
+    let exception;
     await this._cryptoStore.doTxn(
         'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
         (txn) => {
             this._getSession(theirDeviceIdentityKey, sessionId, txn, (session) => {
-                payloadString = session.decrypt(messageType, ciphertext);
+                try {
+                    payloadString = session.decrypt(messageType, ciphertext);
+                } catch (e) {
+                    exception = e;
+                }
                 this._saveSession(theirDeviceIdentityKey, session, txn);
             });
         },
     );
+    if (exception) throw exception;
     return payloadString;
 };
 

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -167,18 +167,20 @@ OlmDevice.getOlmVersion = function() {
 OlmDevice.prototype._migrateFromSessionStore = async function() {
     // account
     let migratedAccount = false;
-    await this._cryptoStore.doTxn('readwrite', [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
-        this._cryptoStore.getAccount(txn, (pickledAccount) => {
-            if (pickledAccount === null) {
-                // Migrate from sessionStore
-                pickledAccount = this._sessionStore.getEndToEndAccount();
-                if (pickledAccount !== null) {
-                    console.log("Migrating account from session store");
-                    migratedAccount = true;
-                    this._cryptoStore.storeAccount(txn, pickledAccount);
+    await this._cryptoStore.doTxn(
+        'readwrite', [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
+            this._cryptoStore.getAccount(txn, (pickledAccount) => {
+                if (pickledAccount === null) {
+                    // Migrate from sessionStore
+                    pickledAccount = this._sessionStore.getEndToEndAccount();
+                    if (pickledAccount !== null) {
+                        console.log("Migrating account from session store");
+                        migratedAccount = true;
+                        this._cryptoStore.storeAccount(txn, pickledAccount);
+                    }
                 }
-            }
-        });
+            },
+        );
     });
 
     // only remove this once it's safely saved to the crypto store
@@ -206,7 +208,7 @@ OlmDevice.prototype._migrateFromSessionStore = async function() {
 
         this._sessionStore.removeAllEndToEndSessions();
     }
-}
+};
 
 /**
  * extract our OlmAccount from the crypto store and call the given function

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -219,26 +219,46 @@ OlmDevice.prototype._storeAccount = function(txn, account) {
 
 /**
  * extract an OlmSession from the session store and call the given function
+ * The session is useable only within the callback passed to this
+ * function and will be freed as soon the callback returns. It is *not*
+ * useable for the rest of the lifetime of the transaction.
  *
  * @param {string} deviceKey
  * @param {string} sessionId
+ * @param {*} txn
  * @param {function} func
- * @return {object} result of func
  * @private
  */
-OlmDevice.prototype._getSession = function(deviceKey, sessionId, func) {
-    const sessions = this._sessionStore.getEndToEndSessions(deviceKey);
-    const pickledSession = sessions[sessionId];
+OlmDevice.prototype._getSession = function(deviceKey, sessionId, txn, func) {
+    const sessions = this._cryptoStore.getEndToEndSession(deviceKey, sessionId, txn, (pickledSession) => {
+        const session = new Olm.Session();
+        try {
+            session.unpickle(this._pickleKey, pickledSession);
+            func(session);
+        } finally {
+            session.free();
+        }
+    });
+};
 
+/**
+ * Creates a session object from a session pickle and executes the given
+ * function with it. The session object is destroyed once the function
+ * returns.
+ *
+ * @param {string} pickledSession
+ * @param {function} func
+ * @private
+ */
+OlmDevice.prototype._unpickleSession = function(pickledSession, func) {
     const session = new Olm.Session();
     try {
         session.unpickle(this._pickleKey, pickledSession);
-        return func(session);
+        func(session);
     } finally {
         session.free();
     }
 };
-
 
 /**
  * store our OlmSession in the session store
@@ -247,10 +267,10 @@ OlmDevice.prototype._getSession = function(deviceKey, sessionId, func) {
  * @param {OlmSession} session
  * @private
  */
-OlmDevice.prototype._saveSession = function(deviceKey, session) {
+OlmDevice.prototype._saveSession = function(deviceKey, session, txn) {
     const pickledSession = session.pickle(this._pickleKey);
-    this._sessionStore.storeEndToEndSession(
-        deviceKey, session.session_id(), pickledSession,
+    this._cryptoStore.storeEndToEndSession(
+        deviceKey, session.session_id(), pickledSession, txn,
     );
 };
 
@@ -369,7 +389,10 @@ OlmDevice.prototype.createOutboundSession = async function(
 ) {
     let newSessionId;
     await this._cryptoStore.doTxn(
-        'readwrite', [IndexedDBCryptoStore.STORE_ACCOUNT],
+        'readwrite', [
+            IndexedDBCryptoStore.STORE_ACCOUNT,
+            IndexedDBCryptoStore.STORE_SESSIONS,
+        ],
         (txn) => {
             this._getAccount(txn, (account) => {
                 const session = new Olm.Session();
@@ -377,8 +400,7 @@ OlmDevice.prototype.createOutboundSession = async function(
                     session.create_outbound(account, theirIdentityKey, theirOneTimeKey);
                     newSessionId = session.session_id();
                     this._storeAccount(txn, account);
-                    this._saveSession(theirIdentityKey, session);
-                    return session.session_id();
+                    this._saveSession(theirIdentityKey, session, txn);
                 } finally {
                     session.free();
                 }
@@ -411,7 +433,10 @@ OlmDevice.prototype.createInboundSession = async function(
 
     let result;
     await this._cryptoStore.doTxn(
-        'readwrite', [IndexedDBCryptoStore.STORE_ACCOUNT],
+        'readwrite', [
+            IndexedDBCryptoStore.STORE_ACCOUNT,
+            IndexedDBCryptoStore.STORE_SESSIONS,
+        ],
         (txn) => {
             this._getAccount(txn, (account) => {
                 const session = new Olm.Session();
@@ -424,7 +449,7 @@ OlmDevice.prototype.createInboundSession = async function(
 
                     const payloadString = session.decrypt(messageType, ciphertext);
 
-                    this._saveSession(theirDeviceIdentityKey, session);
+                    this._saveSession(theirDeviceIdentityKey, session, txn);
 
                     result = {
                         payload: payloadString,
@@ -449,10 +474,17 @@ OlmDevice.prototype.createInboundSession = async function(
  * @return {Promise<string[]>}  a list of known session ids for the device
  */
 OlmDevice.prototype.getSessionIdsForDevice = async function(theirDeviceIdentityKey) {
-    const sessions = this._sessionStore.getEndToEndSessions(
-        theirDeviceIdentityKey,
+    let sessionIds;
+    await this._cryptoStore.doTxn(
+        'readonly', [IndexedDBCryptoStore.STORE_SESSIONS],
+        (txn) => {
+            this._cryptoStore.getEndToEndSessions(theirDeviceIdentityKey, txn, (sessions) => {
+                sessionIds = Object.keys(sessions);
+            });
+        },
     );
-    return utils.keys(sessions);
+
+    return sessionIds;
 };
 
 /**
@@ -484,23 +516,26 @@ OlmDevice.prototype.getSessionIdForDevice = async function(theirDeviceIdentityKe
  * @return {Array.<{sessionId: string, hasReceivedMessage: Boolean}>}
  */
 OlmDevice.prototype.getSessionInfoForDevice = async function(deviceIdentityKey) {
-    const sessionIds = await this.getSessionIdsForDevice(deviceIdentityKey);
-    sessionIds.sort();
-
     const info = [];
 
-    function getSessionInfo(session) {
-        return {
-            hasReceivedMessage: session.has_received_message(),
-        };
-    }
+    await this._cryptoStore.doTxn(
+        'readonly', [IndexedDBCryptoStore.STORE_SESSIONS],
+        (txn) => {
+            this._cryptoStore.getEndToEndSessions(deviceIdentityKey, txn, (sessions) => {
+                const sessionIds = Object.keys(sessions).sort();
+                for (let i = 0; i < sessionIds.length; i++) {
+                    const sessionId = sessionIds[i];
+                    this._unpickleSession(sessions[sessionId], (session) => {
+                        info.push({
+                            hasReceivedMessage: session.has_received_message(),
+                            sessionId: sessionId,
+                        });
+                    });
+                }
+            });
+        },
+    );
 
-    for (let i = 0; i < sessionIds.length; i++) {
-        const sessionId = sessionIds[i];
-        const res = this._getSession(deviceIdentityKey, sessionId, getSessionInfo);
-        res.sessionId = sessionId;
-        info.push(res);
-    }
     return info;
 };
 
@@ -517,15 +552,19 @@ OlmDevice.prototype.getSessionInfoForDevice = async function(deviceIdentityKey) 
 OlmDevice.prototype.encryptMessage = async function(
     theirDeviceIdentityKey, sessionId, payloadString,
 ) {
-    const self = this;
-
     checkPayloadLength(payloadString);
 
-    return this._getSession(theirDeviceIdentityKey, sessionId, function(session) {
-        const res = session.encrypt(payloadString);
-        self._saveSession(theirDeviceIdentityKey, session);
-        return res;
-    });
+    let res;
+    await this._cryptoStore.doTxn(
+        'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
+        (txn) => {
+            this._getSession(theirDeviceIdentityKey, sessionId, txn, (session) => {
+                res = session.encrypt(payloadString);
+                this._saveSession(theirDeviceIdentityKey, session, txn);
+            });
+        },
+    );
+    return res;
 };
 
 /**
@@ -542,14 +581,17 @@ OlmDevice.prototype.encryptMessage = async function(
 OlmDevice.prototype.decryptMessage = async function(
     theirDeviceIdentityKey, sessionId, messageType, ciphertext,
 ) {
-    const self = this;
-
-    return this._getSession(theirDeviceIdentityKey, sessionId, function(session) {
-        const payloadString = session.decrypt(messageType, ciphertext);
-        self._saveSession(theirDeviceIdentityKey, session);
-
-        return payloadString;
-    });
+    let payloadString;
+    await this._cryptoStore.doTxn(
+        'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
+        (txn) => {
+            this._getSession(theirDeviceIdentityKey, sessionId, txn, (session) => {
+                payloadString = session.decrypt(messageType, ciphertext);
+                this._saveSession(theirDeviceIdentityKey, session, txn);
+            });
+        },
+    );
+    return payloadString;
 };
 
 /**
@@ -571,9 +613,16 @@ OlmDevice.prototype.matchesSession = async function(
         return false;
     }
 
-    return this._getSession(theirDeviceIdentityKey, sessionId, function(session) {
-        return session.matches_inbound(ciphertext);
-    });
+    let matches;
+    await this._cryptoStore.doTxn(
+        'readonly', [IndexedDBCryptoStore.STORE_SESSIONS],
+        (txn) => {
+            this._getSession(theirDeviceIdentityKey, sessionId, txn, (session) => {
+                matches = session.matches_inbound(ciphertext);
+            });
+        },
+    );
+    return matches;
 };
 
 

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -553,8 +553,7 @@ OlmDevice.prototype.getSessionInfoForDevice = async function(deviceIdentityKey) 
         (txn) => {
             this._cryptoStore.getEndToEndSessions(deviceIdentityKey, txn, (sessions) => {
                 const sessionIds = Object.keys(sessions).sort();
-                for (let i = 0; i < sessionIds.length; i++) {
-                    const sessionId = sessionIds[i];
+                for (const sessionId of sessionIds) {
                     this._unpickleSession(sessions[sessionId], (session) => {
                         info.push({
                             hasReceivedMessage: session.has_received_message(),

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -263,13 +263,7 @@ OlmDevice.prototype._storeAccount = function(txn, account) {
 OlmDevice.prototype._getSession = function(deviceKey, sessionId, txn, func) {
     this._cryptoStore.getEndToEndSession(
         deviceKey, sessionId, txn, (pickledSession) => {
-            const session = new Olm.Session();
-            try {
-                session.unpickle(this._pickleKey, pickledSession);
-                func(session);
-            } finally {
-                session.free();
-            }
+            this._unpickleSession(pickledSession, func);
         },
     );
 };

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -611,21 +611,15 @@ OlmDevice.prototype.decryptMessage = async function(
     theirDeviceIdentityKey, sessionId, messageType, ciphertext,
 ) {
     let payloadString;
-    let exception;
     await this._cryptoStore.doTxn(
         'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
         (txn) => {
             this._getSession(theirDeviceIdentityKey, sessionId, txn, (session) => {
-                try {
-                    payloadString = session.decrypt(messageType, ciphertext);
-                } catch (e) {
-                    exception = e;
-                }
+                payloadString = session.decrypt(messageType, ciphertext);
                 this._saveSession(theirDeviceIdentityKey, session, txn);
             });
         },
     );
-    if (exception) throw exception;
     return payloadString;
 };
 

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -406,7 +406,7 @@ OlmDevice.prototype.generateOneTimeKeys = function(numKeys) {
 /**
  * Generate a new outbound session
  *
- * The new session will be stored in the sessionStore.
+ * The new session will be stored in the cryptoStore.
  *
  * @param {string} theirIdentityKey remote user's Curve25519 identity key
  * @param {string} theirOneTimeKey  remote user's one-time Curve25519 key

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -359,7 +359,14 @@ function createDatabase(db) {
     outgoingRoomKeyRequestsStore.createIndex("state", "state");
 }
 
+/*
+ * Aborts a transaction with a given exception
+ * The transaction promise will be rejected with this exception.
+ */
 function abortWithException(txn, e) {
+    // We cheekily stick our exception onto the transaction object here
+    // We could alternatively make the thing we pass back to the app
+    // an object containing the transaction and exception.
     txn._mx_abortexception = e;
     txn.abort();
 }

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -302,7 +302,11 @@ export default class IndexedDBCryptoStore {
      *     transaction object: an opaque object that should be passed
      *     to store functions.
      * @return {Promise} Promise that resolves with the result of the `func`
-     *     when the transaction is complete
+     *     when the transaction is complete. If the backend is
+     *     async (ie. the indexeddb backend) any of the callback
+     *     functions throwing an exception will cause this promise to
+     *     reject with that exception. On synchronous backends, the
+     *     exception will propagate to the caller of the getFoo method.
      */
     doTxn(mode, stores, func) {
         return this._connect().then((backend) => {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -282,7 +282,9 @@ export default class IndexedDBCryptoStore {
      * @param {*} txn An active transaction. See doTxn().
      */
     storeEndToEndSession(deviceKey, sessionId, session, txn) {
-        this._backendPromise.value().storeEndToEndSession(deviceKey, sessionId, session, txn);
+        this._backendPromise.value().storeEndToEndSession(
+            deviceKey, sessionId, session, txn,
+        );
     }
 
     /**

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -250,6 +250,42 @@ export default class IndexedDBCryptoStore {
     }
 
     /**
+     * Retrieve a specific end-to-end session between the logged-in user
+     * and another device.
+     * @param {string} deviceKey The public key of the other device.
+     * @param {string} sessionId The ID of the session to retrieve
+     * @param {*} txn An active transaction. See doTxn().
+     * @param {function(object)} func Called with A map from sessionId
+     *     to Base64 end-to-end session.
+     */
+    getEndToEndSession(deviceKey, sessionId, txn, func) {
+        this._backendPromise.value().getEndToEndSession(deviceKey, sessionId, txn, func);
+    }
+
+    /**
+     * Retrieve the end-to-end sessions between the logged-in user and another
+     * device.
+     * @param {string} deviceKey The public key of the other device.
+     * @param {*} txn An active transaction. See doTxn().
+     * @param {function(object)} func Called with A map from sessionId
+     *     to Base64 end-to-end session.
+     */
+    getEndToEndSessions(deviceKey, txn, func) {
+        this._backendPromise.value().getEndToEndSessions(deviceKey, txn, func);
+    }
+
+    /**
+     * Store a session between the logged-in user and another device
+     * @param {string} deviceKey The public key of the other device.
+     * @param {string} sessionId The ID for this end-to-end session.
+     * @param {string} session Base64 encoded end-to-end session.
+     * @param {*} txn An active transaction. See doTxn().
+     */
+    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+        this._backendPromise.value().storeEndToEndSession(deviceKey, sessionId, session, txn);
+    }
+
+    /**
      * Perform a transaction on the crypto store. Any store methods
      * that require a transaction (txn) object to be passed in may
      * only be called within a callback of either this function or
@@ -274,3 +310,4 @@ export default class IndexedDBCryptoStore {
 }
 
 IndexedDBCryptoStore.STORE_ACCOUNT = 'account';
+IndexedDBCryptoStore.STORE_SESSIONS = 'sessions';

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -30,6 +30,10 @@ import MemoryCryptoStore from './memory-crypto-store.js';
 const E2E_PREFIX = "crypto.";
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 
+function keyEndToEndSessions(deviceKey) {
+    return E2E_PREFIX + "sessions/" + deviceKey;
+}
+
 /**
  * @implements {module:crypto/store/base~CryptoStore}
  */
@@ -37,6 +41,27 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
     constructor() {
         super();
         this.store = global.localStorage;
+    }
+
+    _getEndToEndSessions(deviceKey, txn, func) {
+        return getJsonItem(this.store, keyEndToEndSessions(deviceKey));
+    }
+
+    getEndToEndSession(deviceKey, sessionId, txn, func) {
+        const sessions = this._getEndToEndSessions(deviceKey);
+        func(sessions[sessionId] || {});
+    }
+
+    getEndToEndSessions(deviceKey, txn, func) {
+        func(this._getEndToEndSessions(deviceKey) || {});
+    }
+
+    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+        const sessions = this._getEndToEndSessions(deviceKey) || {};
+        sessions[sessionId] = session;
+        setJsonItem(
+            this.store, keyEndToEndSessions(deviceKey), sessions,
+        );
     }
 
     /**
@@ -61,4 +86,20 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
     doTxn(mode, stores, func) {
         return Promise.resolve(func(null));
     }
+}
+
+function getJsonItem(store, key) {
+    try {
+        // if the key is absent, store.getItem() returns null, and
+        // JSON.parse(null) === null, so this returns null.
+        return JSON.parse(store.getItem(key));
+    } catch (e) {
+        console.log("Failed to get key %s: %s", key, e);
+        console.log(e.stack);
+    }
+    return null;
+}
+
+function setJsonItem(store, key, val) {
+    store.setItem(key, JSON.stringify(val));
 }

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -94,7 +94,7 @@ function getJsonItem(store, key) {
         // JSON.parse(null) === null, so this returns null.
         return JSON.parse(store.getItem(key));
     } catch (e) {
-        console.log("Failed to get key %s: %s", key, e);
+        console.log("Error: Failed to get key %s: %s", key, e.stack || e);
         console.log(e.stack);
     }
     return null;

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -31,6 +31,8 @@ export default class MemoryCryptoStore {
     constructor() {
         this._outgoingRoomKeyRequests = [];
         this._account = null;
+
+        // Map of {devicekey -> {sessionId -> session pickle}}
         this._sessions = {};
     }
 

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -31,6 +31,7 @@ export default class MemoryCryptoStore {
     constructor() {
         this._outgoingRoomKeyRequests = [];
         this._account = null;
+        this._sessions = {};
     }
 
     /**
@@ -204,6 +205,24 @@ export default class MemoryCryptoStore {
 
     storeAccount(txn, newData) {
         this._account = newData;
+    }
+
+    getEndToEndSession(deviceKey, sessionId, txn, func) {
+        const deviceSessions = this._sessions[deviceKey] || {};
+        func(deviceSessions[sessionId] || null);
+    }
+
+    getEndToEndSessions(deviceKey, txn, func) {
+        func(this._sessions[deviceKey] || {});
+    }
+
+    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+        let deviceSessions = this._sessions[deviceKey];
+        if (deviceSessions === undefined) {
+            deviceSessions = {};
+            this._sessions[deviceKey] = deviceSessions;
+        }
+        deviceSessions[sessionId] = session;
     }
 
     doTxn(mode, stores, func) {

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -139,6 +139,10 @@ WebStorageSessionStore.prototype = {
         return results;
     },
 
+    /**
+     * Remove all end-to-end sessions from the store
+     * This is used after migrating sessions awat from the sessions store.
+     */
     removeAllEndToEndSessions: function() {
         removeByPrefix(this.store, keyEndToEndSessions(''));
     },

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -147,7 +147,8 @@ WebStorageSessionStore.prototype = {
         const deviceKeys = getKeysWithPrefix(this.store, keyEndToEndSessions(''));
         const results = {};
         for (const k of deviceKeys) {
-            results[k] = getJsonItem(this.store, k);
+            const unprefixedKey = k.substr(keyEndToEndSessions('').length);
+            results[unprefixedKey] = getJsonItem(this.store, k);
         }
         return results;
     },

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -139,6 +139,24 @@ WebStorageSessionStore.prototype = {
     },
 
     /**
+     * Retrieve all end-to-end sessions between the logged-in user and other
+     * devices.
+     * @return {object} A map of {deviceKey -> {sessionId -> session pickle}}
+     */
+    getAllEndToEndSessions: function() {
+        const deviceKeys = getKeysWithPrefix(this.store, keyEndToEndSessions(''));
+        const results = {};
+        for (const k of deviceKeys) {
+            results[k] = getJsonItem(this.store, k);
+        }
+        return results;
+    },
+
+    removeAllEndToEndSessions: function() {
+        removeByPrefix(this.store, keyEndToEndSessions(''));
+    },
+
+    /**
      * Retrieve a list of all known inbound group sessions
      *
      * @return {{senderKey: string, sessionId: string}}
@@ -227,6 +245,26 @@ function getJsonItem(store, key) {
 
 function setJsonItem(store, key, val) {
     store.setItem(key, JSON.stringify(val));
+}
+
+function getKeysWithPrefix(store, prefix) {
+    const results = [];
+    for (let i = 0; i < store.length; ++i) {
+        const key = store.key(i);
+        if (key.startsWith(prefix)) results.push(key);
+    }
+    return results;
+}
+
+function removeByPrefix(store, prefix) {
+    const toRemove = [];
+    for (let i = 0; i < store.length; ++i) {
+        const key = store.key(i);
+        if (key.startsWith(prefix)) toRemove.push(key);
+    }
+    for (const key of toRemove) {
+        store.removeItem(key);
+    }
 }
 
 function debuglog() {

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -115,20 +115,6 @@ WebStorageSessionStore.prototype = {
     },
 
     /**
-     * Store a session between the logged-in user and another device
-     * @param {string} deviceKey The public key of the other device.
-     * @param {string} sessionId The ID for this end-to-end session.
-     * @param {string} session Base64 encoded end-to-end session.
-     */
-    storeEndToEndSession: function(deviceKey, sessionId, session) {
-        const sessions = this.getEndToEndSessions(deviceKey) || {};
-        sessions[sessionId] = session;
-        setJsonItem(
-            this.store, keyEndToEndSessions(deviceKey), sessions,
-        );
-    },
-
-    /**
      * Retrieve the end-to-end sessions between the logged-in user and another
      * device.
      * @param {string} deviceKey The public key of the other device.


### PR DESCRIPTION
Migrates the olm sessions to the crypto store. On startup, looks for any sessions still in the session store and moves them over to the crypto store.

Also moves the account migration into the same function to keep all the migration code together.