### PR TITLE
Emit an event for crypto store migration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -391,6 +391,7 @@ MatrixClient.prototype.initCrypto = async function() {
     this.reEmitter.reEmit(crypto, [
         "crypto.roomKeyRequest",
         "crypto.roomKeyRequestCancellation",
+        "crypto.warning",
     ]);
 
     await crypto.init();

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -33,6 +33,7 @@ const DeviceVerification = DeviceInfo.DeviceVerification;
 const DeviceList = require('./DeviceList').default;
 
 import OutgoingRoomKeyRequestManager from './OutgoingRoomKeyRequestManager';
+import IndexedDBCryptoStore from './store/indexeddb-crypto-store';
 
 /**
  * Cryptography bits
@@ -108,6 +109,22 @@ utils.inherits(Crypto, EventEmitter);
  * Returns a promise which resolves once the crypto module is ready for use.
  */
 Crypto.prototype.init = async function() {
+    const sessionStoreHasAccount = Boolean(this._sessionStore.getEndToEndAccount());
+    let cryptoStoreHasAccount;
+    await this._cryptoStore.doTxn('readonly', [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
+        this._cryptoStore.getAccount(txn, (pickledAccount) => {
+            cryptoStoreHasAccount = Boolean(pickledAccount);
+        });
+    });
+    if (sessionStoreHasAccount && !cryptoStoreHasAccount) {
+        // we're about to migrate to the crypto store
+        this.emit("crypto.warning", 'CRYPTO_WARNING_ACCOUNT_MIGRATED');
+    } else if (sessionStoreHasAccount && cryptoStoreHasAccount) {
+        // There's an account in both stores: an old version of
+        // the code has been run against this store.
+        this.emit("crypto.warning", 'CRYPTO_WARNING_OLD_VERSION_DETECTED');
+    }
+
     await this._olmDevice.init();
 
     // build our device keys: these will later be uploaded
@@ -1330,6 +1347,25 @@ class IncomingRoomKeyRequestCancellation {
  *
  * @event module:client~MatrixClient#"crypto.roomKeyRequestCancellation"
  * @param {module:crypto~IncomingRoomKeyRequestCancellation} req
+ */
+
+/**
+ * Fires when the app may wish to warn the user about something related
+ * the end-to-end crypto.
+ *
+ * Comes with a type which is one of:
+ * * CRYPTO_WARNING_ACCOUNT_MIGRATED: Account data has been migrated from an older
+ *       version of the store in such a way that older clients will no longer be
+ *       able to read it. The app may wish to warn the user against going back to
+ *       an older version of the app.
+ * * CRYPTO_WARNING_OLD_VERSION_DETECTED: js-sdk has detected that an older version
+ *       of js-sdk has been run against the same store after a migration has been
+ *       performed. This is likely have caused unexpected behaviour in the old
+ *       version. For example, the old version and the new version may have two
+ *       different identity keys.
+ *
+ * @event module:client~MatrixClient#"crypto.warning"
+ * @param {string} type One of the strings listed above
  */
 
 /** */

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -111,11 +111,13 @@ utils.inherits(Crypto, EventEmitter);
 Crypto.prototype.init = async function() {
     const sessionStoreHasAccount = Boolean(this._sessionStore.getEndToEndAccount());
     let cryptoStoreHasAccount;
-    await this._cryptoStore.doTxn('readonly', [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
-        this._cryptoStore.getAccount(txn, (pickledAccount) => {
-            cryptoStoreHasAccount = Boolean(pickledAccount);
-        });
-    });
+    await this._cryptoStore.doTxn(
+        'readonly', [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
+            this._cryptoStore.getAccount(txn, (pickledAccount) => {
+                cryptoStoreHasAccount = Boolean(pickledAccount);
+            });
+        },
+    );
     if (sessionStoreHasAccount && !cryptoStoreHasAccount) {
         // we're about to migrate to the crypto store
         this.emit("crypto.warning", 'CRYPTO_WARNING_ACCOUNT_MIGRATED');


### PR DESCRIPTION
As we may want to warn the user to not go back to an older version.

Merge https://github.com/matrix-org/matrix-react-sdk/pull/1654 before this one otherwise nothing will be listening for the events (and they only happen once).