### PR TITLE
Add getThirdpartyUser to base api

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1668,7 +1668,7 @@ MatrixBaseApis.prototype.getThirdpartyProtocols = function() {
  * Get information on how a specific place on a third party protocol
  * may be reached.
  * @param {string} protocol The protocol given in getThirdpartyProtocols()
- * @param {object} params Protocol-specific parameters, as given in th
+ * @param {object} params Protocol-specific parameters, as given in the
  *                        response to getThirdpartyProtocols()
  * @return {module:client.Promise} Resolves to the result object
  */

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1684,6 +1684,25 @@ MatrixBaseApis.prototype.getThirdpartyLocation = function(protocol, params) {
 };
 
 /**
+ * Get information on how a specific user on a third party protocol
+ * may be reached.
+ * @param {string} protocol The protocol given in getThirdpartyProtocols()
+ * @param {object} params Protocol-specific parameters, as given in the
+ *                        response to getThirdpartyProtocols()
+ * @return {module:client.Promise} Resolves to the result object
+ */
+MatrixBaseApis.prototype.getThirdpartyUser = function(protocol, params) {
+    const path = utils.encodeUri("/thirdparty/user/$protocol", {
+        $protocol: protocol,
+    });
+
+    return this._http.authedRequestWithPrefix(
+        undefined, "GET", path, params, undefined,
+        httpApi.PREFIX_UNSTABLE,
+    );
+};
+
+/**
  * MatrixBaseApis object
  */
 module.exports = MatrixBaseApis;


### PR DESCRIPTION
I investigated options to build a new bridge for XMPP and found that this API method would be very useful for it. My assumption is that it could be used to enhance the invite dialog in a way so that it also understands protocols and external IDs, similar to the way how the room directory currently works.

Signed-off-by: Johannes Bornhold <johannes@bornhold.name>
  