### PR TITLE
Set event error before emitting

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2017 Vector Creations Ltd
+Copyright 2017, 2018 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2017, 2018 Vector Creations Ltd
+Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client.js
+++ b/src/client.js
@@ -1136,8 +1136,11 @@ function _sendEvent(client, room, event, callback) {
         console.error("Error sending event", err.stack || err);
 
         try {
-            _updatePendingEventStatus(room, event, EventStatus.NOT_SENT);
+            // set the error on the event before we update the status:
+            // updating the status emits the event, so the state should be
+            // consistent at that point.
             event.error = err;
+            _updatePendingEventStatus(room, event, EventStatus.NOT_SENT);
             // also put the event object on the error: the caller will need this
             // to resend or cancel the event
             err.event = event;


### PR DESCRIPTION
So the event object properties are in a consistent state when we
the event is emitted.

Fixes first part of https://github.com/vector-im/riot-web/issues/5936