### PR TITLE
Move Device Tracking Data to Crypto Store

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -25,6 +25,7 @@ import testUtils from './test-utils';
 import MockHttpBackend from 'matrix-mock-request';
 import expect from 'expect';
 import Promise from 'bluebird';
+import LocalStorageCryptoStore from '../lib/crypto/store/localStorage-crypto-store';
 
 /**
  * Wrapper for a MockStorageApi, MockHttpBackend and MatrixClient
@@ -47,6 +48,9 @@ export default function TestClient(
         sessionStoreBackend = new testUtils.MockStorageApi();
     }
     this.storage = new sdk.WebStorageSessionStore(sessionStoreBackend);
+
+    const cryptoStore = new LocalStorageCryptoStore(sessionStoreBackend);
+
     this.httpBackend = new MockHttpBackend();
     this.client = sdk.createClient({
         baseUrl: "http://" + userId + ".test.server",
@@ -54,6 +58,7 @@ export default function TestClient(
         accessToken: accessToken,
         deviceId: deviceId,
         sessionStore: this.storage,
+        cryptoStore: cryptoStore,
         request: this.httpBackend.requestFn,
     });
 

--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -47,9 +47,10 @@ export default function TestClient(
     if (sessionStoreBackend === undefined) {
         sessionStoreBackend = new testUtils.MockStorageApi();
     }
-    this.storage = new sdk.WebStorageSessionStore(sessionStoreBackend);
+    const sessionStore = new sdk.WebStorageSessionStore(sessionStoreBackend);
 
-    const cryptoStore = new LocalStorageCryptoStore(sessionStoreBackend);
+    // expose this so the tests can get to it
+    this.cryptoStore = new LocalStorageCryptoStore(sessionStoreBackend);
 
     this.httpBackend = new MockHttpBackend();
     this.client = sdk.createClient({
@@ -57,8 +58,8 @@ export default function TestClient(
         userId: userId,
         accessToken: accessToken,
         deviceId: deviceId,
-        sessionStore: this.storage,
-        cryptoStore: cryptoStore,
+        sessionStore: sessionStore,
+        cryptoStore: this.cryptoStore,
         request: this.httpBackend.requestFn,
     });
 

--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -281,7 +281,6 @@ describe("DeviceList management:", function() {
                     0, "Alice should be tracking bob's device list",
                 );
             });
-
         });
 
         it("when Bob leaves", async function() {

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -366,9 +366,9 @@ describe("DeviceList management:", function() {
                 anotherTestClient.httpBackend.when('GET', '/sync').respond(
                     200, getSyncResponse([]));
                 await anotherTestClient.flushSync();
-                await aliceTestClient.client._crypto._deviceList.saveIfDirty();
+                await anotherTestClient.client._crypto._deviceList.saveIfDirty();
 
-                aliceTestClient.cryptoStore.getEndToEndDeviceData(null, (data) => {
+                anotherTestClient.cryptoStore.getEndToEndDeviceData(null, (data) => {
                     const bobStat = data.trackingStatus['@bob:xyz'];
 
                     expect(bobStat).toEqual(

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -1,3 +1,20 @@
+/*
+Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import expect from 'expect';
 import Promise from 'bluebird';
 

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -198,8 +198,9 @@ describe("DeviceList management:", function() {
                    }
                    const chrisStat = data.trackingStatus['@chris:abc'];
                    if (chrisStat != 1 && chrisStat != 2) {
-                       throw new Error('Unexpected status for chris: wanted 1 or 2, got ' +
-                                       chrisStat);
+                       throw new Error(
+                           'Unexpected status for chris: wanted 1 or 2, got ' + chrisStat,
+                       );
                    }
                });
 
@@ -227,8 +228,9 @@ describe("DeviceList management:", function() {
                    expect(bobStat).toEqual(3);
                    const chrisStat = data.trackingStatus['@chris:abc'];
                    if (chrisStat != 1 && chrisStat != 2) {
-                       throw new Error('Unexpected status for chris: wanted 1 or 2, got ' +
-                                       bobStat);
+                       throw new Error(
+                           'Unexpected status for chris: wanted 1 or 2, got ' + bobStat,
+                       );
                    }
                });
 

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -154,11 +154,15 @@ function aliDownloadsKeys() {
 
     // check that the localStorage is updated as we expect (not sure this is
     // an integration test, but meh)
-    return Promise.all([p1, p2]).then(function() {
-        const devices = aliTestClient.storage.getEndToEndDevicesForUser(bobUserId);
-        expect(devices[bobDeviceId].keys).toEqual(bobTestClient.deviceKeys.keys);
-        expect(devices[bobDeviceId].verified).
-            toBe(0); // DeviceVerification.UNVERIFIED
+    return Promise.all([p1, p2]).then(() => {
+        return aliTestClient.client._crypto._deviceList.saveIfDirty();
+    }).then(() => {
+        aliTestClient.cryptoStore.getEndToEndDeviceData(null, (data) => {
+            const devices = data.devices[bobUserId];
+            expect(devices[bobDeviceId].keys).toEqual(bobTestClient.deviceKeys.keys);
+            expect(devices[bobDeviceId].verified).
+                toBe(0); // DeviceVerification.UNVERIFIED
+        });
     });
 }
 

--- a/spec/unit/crypto/DeviceList.spec.js
+++ b/spec/unit/crypto/DeviceList.spec.js
@@ -49,7 +49,7 @@ describe('DeviceList', function() {
         downloadSpy = expect.createSpy();
         const mockStorage = new MockStorageApi();
         sessionStore = new WebStorageSessionStore(mockStorage);
-        cryptoStore = new MemoryCryptoStore(mockStorage);
+        cryptoStore = new MemoryCryptoStore();
     });
 
     function createTestDeviceList() {

--- a/spec/unit/crypto/DeviceList.spec.js
+++ b/spec/unit/crypto/DeviceList.spec.js
@@ -1,3 +1,20 @@
+/*
+Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import DeviceList from '../../../lib/crypto/DeviceList';
 import MockStorageApi from '../../MockStorageApi';
 import WebStorageSessionStore from '../../../lib/store/session/webstorage';

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -150,6 +150,8 @@ export default class DeviceList {
         if (!this._dirty) return Promise.resolve(false);
 
         if (this._savePromise === null) {
+            // Delay saves for a bit so we can aggregate multiple saves that happen
+            // in quick succession (eg. when a whole room's devices are marked as known)
             this._savePromise = Promise.delay(500).then(() => {
                 console.log('Saving device tracking data at token ' + this._syncToken);
                 return this._cryptoStore.doTxn(
@@ -172,7 +174,7 @@ export default class DeviceList {
     }
 
     /**
-     * Gets the current sync token
+     * Gets the sync token last set with setSyncToken
      *
      * @return {string} The sync token
      */
@@ -181,7 +183,8 @@ export default class DeviceList {
     }
 
     /**
-     * Sets the current sync token
+     * Sets the sync token that the app will pass as the 'since' to the /sync
+     * endpoint next time it syncs.
      * The sync token must always be set after any changes made as a result of
      * data in that sync since setting the sync token to a newer one will mean
      * those changed will not be synced from the server if a new client starts

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -144,11 +144,11 @@ export default class DeviceList {
      * Save the device tracking state to storage, if any changes are
      * pending other than updating the sync token
      *
-     * @return {Promise<bool>} True is the data was saved, false if
+     * @return {Promise<bool>} true is the data was saved, false if
      *     it was not (eg. because no changes were pending)
      */
     async saveIfDirty() {
-        if (!this._dirty) return Promise.resolve(False);
+        if (!this._dirty) return Promise.resolve(false);
 
         if (this._saveTimer === null) {
             this._saveTimer = setTimeout(() => {
@@ -164,7 +164,7 @@ export default class DeviceList {
                     },
                 ).then(() => {
                     this._dirty = false;
-                    return True;
+                    return true;
                 });
             }, 500);
         } else {

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -100,7 +100,8 @@ export default class DeviceList {
             'readonly', [IndexedDBCryptoStore.STORE_DEVICE_DATA], (txn) => {
                 this._cryptoStore.getEndToEndDeviceData(txn, (deviceData) => {
                     this._devices = deviceData ? deviceData.devices : {},
-                    this._deviceTrackingStatus = deviceData ? deviceData.trackingStatus : {};
+                    this._deviceTrackingStatus = deviceData ?
+                        deviceData.trackingStatus : {};
                     this._syncToken = deviceData ? deviceData.syncToken : null;
                 });
             },
@@ -327,6 +328,9 @@ export default class DeviceList {
 
     /**
      * Replaces the list of devices for a user with the given device list
+     *
+     * @param {string} u The user ID
+     * @param {Object} devs New device info for user
      */
     storeDevicesForUser(u, devs) {
         this._devices[u] = devs;

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -417,6 +417,19 @@ export default class DeviceList {
         this._dirty = true;
     }
 
+    /**
+     * Set all users we're currently tracking to untracked
+     *
+     * This will flag each user whose devices we are tracking as in need of an
+     * update.
+     */
+    stopTrackingAllDeviceLists() {
+        for (const userId of Object.keys(this._deviceTrackingStatus)) {
+            this._deviceTrackingStatus[userId] = TRACKING_STATUS_NOT_TRACKED;
+        }
+        console.log("stopped tracking all: "+JSON.stringify(this._deviceTrackingStatus));
+        this._dirty = true;
+    }
 
     /**
      * Mark the cached device list for the given user outdated.
@@ -438,18 +451,6 @@ export default class DeviceList {
         // of calls; we save all data together once the sync is done
 
         this._dirty = true;
-    }
-
-    /**
-     * Mark all tracked device lists as outdated.
-     *
-     * This will flag each user whose devices we are tracking as in need of an
-     * update.
-     */
-    invalidateAllDeviceLists() {
-        for (const userId of Object.keys(this._deviceTrackingStatus)) {
-            this.invalidateUserDeviceList(userId);
-        }
     }
 
     /**

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -68,11 +68,11 @@ export default class DeviceList {
         //         [device info]
         //     }
         // }
-        this._devices = null;
+        this._devices = {};
 
         // which users we are tracking device status for.
         // userId -> TRACKING_STATUS_*
-        this._deviceTrackingStatus = null; // loaded from storage in load()
+        this._deviceTrackingStatus = {}; // loaded from storage in load()
 
         // The 'next_batch' sync token at the point the data was writen,
         // ie. a token represtenting the point immediately after the
@@ -104,8 +104,10 @@ export default class DeviceList {
                 this._cryptoStore.getEndToEndDeviceData(txn, (deviceData) => {
                     if (deviceData === null) {
                         console.log("Migrating e2e device data...");
-                        this._devices = this._sessionStore.getAllEndToEndDevices();
-                        this._deviceTrackingStatus = this._sessionStore.getEndToEndDeviceTrackingStatus();
+                        this._devices = this._sessionStore.getAllEndToEndDevices() || {};
+                        this._deviceTrackingStatus = (
+                            this._sessionStore.getEndToEndDeviceTrackingStatus() || {}
+                        );
                         this._syncToken = this._sessionStore.getEndToEndDeviceSyncToken();
                         this._cryptoStore.storeEndToEndDeviceData({
                             devices: this._devices,

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -161,7 +161,7 @@ export default class DeviceList {
                 console.log('Saving device tracking data at token ' + this._syncToken);
                 // null out savePromise now (after the delay but before the write),
                 // otherwise we could return the existing promise when the save has
-                // actually already happened. Likewsie for the dirty flag.
+                // actually already happened. Likewise for the dirty flag.
                 this._savePromise = null;
                 this._dirty = false;
                 return this._cryptoStore.doTxn(

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -605,7 +605,7 @@ class DeviceListUpdateSerialiser {
      *
      * @return {module:client.Promise} resolves when all the users listed have
      *     been updated. rejects if there was a problem updating any of the
-     *     users. Returns a fresh device list object for the users queried.
+     *     users.
      */
     updateDevicesForUsers(users, syncToken) {
         users.forEach((u) => {

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -193,8 +193,9 @@ export default class DeviceList {
     }
 
     /**
-     * Download the keys for a list of users and stores the keys in the session
-     * store.
+     * Ensures up to date keys for a list of users are stored in the session store,
+     * downloading and storing them if they're not (or if forceDownload is
+     * true).
      * @param {Array} userIds The users to fetch.
      * @param {bool} forceDownload Always download the keys even if cached.
      *
@@ -427,7 +428,6 @@ export default class DeviceList {
         for (const userId of Object.keys(this._deviceTrackingStatus)) {
             this._deviceTrackingStatus[userId] = TRACKING_STATUS_NOT_TRACKED;
         }
-        console.log("stopped tracking all: "+JSON.stringify(this._deviceTrackingStatus));
         this._dirty = true;
     }
 
@@ -513,6 +513,9 @@ export default class DeviceList {
 
         const finished = (newDevices) => {
             users.forEach((u) => {
+                this._devices[u] = newDevices[u];
+                this._dirty = true;
+
                 // we may have queued up another download request for this user
                 // since we started this request. If that happens, we should
                 // ignore the completion of the first one.
@@ -528,8 +531,6 @@ export default class DeviceList {
                         // we didn't get any new invalidations since this download started:
                         // this user's device list is now up to date.
                         this._deviceTrackingStatus[u] = TRACKING_STATUS_UP_TO_DATE;
-                        this._devices[u] = newDevices[u];
-                        this._dirty = true;
                         console.log("Device list for", u, "now up to date");
                     } else {
                         this._deviceTrackingStatus[u] = TRACKING_STATUS_PENDING_DOWNLOAD;

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -69,7 +69,7 @@ function Crypto(baseApis, sessionStore, userId, deviceId,
     this._cryptoStore = cryptoStore;
 
     this._olmDevice = new OlmDevice(sessionStore, cryptoStore);
-    this._deviceList = new DeviceList(baseApis, cryptoStore, this._olmDevice);
+    this._deviceList = new DeviceList(baseApis, cryptoStore, sessionStore, this._olmDevice);
 
     // the last time we did a check for the number of one-time-keys on the
     // server.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -812,7 +812,8 @@ Crypto.prototype.decryptEvent = function(event) {
  * Handle the notification from /sync or /keys/changes that device lists have
  * been changed.
  *
- * @param {Object} deviceLists device_lists field from /sync, or response from
+ * @param {Object} syncData Object containing sync tokens associated with this sync
+ * @param {Object} syncDeviceLists device_lists field from /sync, or response from
  * /keys/changes
  */
 Crypto.prototype.handleDeviceListChanges = async function(syncData, syncDeviceLists) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -69,7 +69,9 @@ function Crypto(baseApis, sessionStore, userId, deviceId,
     this._cryptoStore = cryptoStore;
 
     this._olmDevice = new OlmDevice(sessionStore, cryptoStore);
-    this._deviceList = new DeviceList(baseApis, cryptoStore, sessionStore, this._olmDevice);
+    this._deviceList = new DeviceList(
+        baseApis, cryptoStore, sessionStore, this._olmDevice,
+    );
 
     // the last time we did a check for the number of one-time-keys on the
     // server.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -820,10 +820,8 @@ Crypto.prototype.decryptEvent = function(event) {
  * /keys/changes
  */
 Crypto.prototype.handleDeviceListChanges = async function(syncData, syncDeviceLists) {
-    // No point processing device list changes for initial syncs: they'd be meaningless
-    // since the server doesn't know what point we were were at previously. We'll either
-    // get the complete list of changes for the interval or invalidate everything in
-    // onSyncComplete
+    // Initial syncs don't have device change lists. We'll either get the complete list
+    // of changes for the interval or invalidate everything in onSyncComplete
     if (!syncData.oldSyncToken) return;
 
     if (syncData.oldSyncToken === this._deviceList.getSyncToken()) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -954,6 +954,9 @@ Crypto.prototype._evalDeviceListChanges = async function(deviceLists) {
     }
 
     if (deviceLists.left && Array.isArray(deviceLists.left)) {
+        // Check we really don't share any rooms with these users
+        // any more: the server isn't required to give us the
+        // exact correct set.
         const e2eUserIds = new Set(this._getE2eUsers());
 
         deviceLists.left.forEach((u) => {

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -1,3 +1,20 @@
+/*
+Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Promise from 'bluebird';
 import utils from '../../utils';
 

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -96,7 +96,7 @@ export default class IndexedDBCryptoStore {
                 `unable to connect to indexeddb ${this._dbName}` +
                     `: falling back to localStorage store: ${e}`,
             );
-            return new LocalStorageCryptoStore();
+            return new LocalStorageCryptoStore(global.localStorage);
         }).catch((e) => {
             console.warn(
                 `unable to open localStorage: falling back to in-memory store: ${e}`,

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -368,6 +368,7 @@ export default class IndexedDBCryptoStore {
      * is always consistent, so they are stored in one object.
      *
      * @param {Object} deviceData
+     * @param {*} txn An active transaction. See doTxn().
      */
     storeEndToEndDeviceData(deviceData, txn) {
         this._backendPromise.value().storeEndToEndDeviceData(deviceData, txn);
@@ -377,9 +378,11 @@ export default class IndexedDBCryptoStore {
      * Get the state of all tracked devices
      *
      * @param {*} txn An active transaction. See doTxn().
+     * @param {function(Object)} func Function called with the
+     *     device data
      */
     getEndToEndDeviceData(txn, func) {
-        return this._backendPromise.value().getEndToEndDeviceData(txn, func);
+        this._backendPromise.value().getEndToEndDeviceData(txn, func);
     }
 
     /**

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -358,6 +358,30 @@ export default class IndexedDBCryptoStore {
         );
     }
 
+    // End-to-end device tracking
+
+    /**
+     * Store the state of all tracked devices
+     * This contains devices for each user, a tracking state for each user
+     * and a sync token matching the point in time the snapshot represents.
+     * These all need to be written out in full each time such that the snapshot
+     * is always consistent, so they are stored in one object.
+     *
+     * @param {Object} deviceData
+     */
+    storeEndToEndDeviceData(deviceData, txn) {
+        this._backendPromise.value().storeEndToEndDeviceData(deviceData, txn);
+    }
+
+    /**
+     * Get the state of all tracked devices
+     *
+     * @param {*} txn An active transaction. See doTxn().
+     */
+    getEndToEndDeviceData(txn, func) {
+        return this._backendPromise.value().getEndToEndDeviceData(txn, func);
+    }
+
     /**
      * Perform a transaction on the crypto store. Any store methods
      * that require a transaction (txn) object to be passed in may
@@ -389,3 +413,4 @@ export default class IndexedDBCryptoStore {
 IndexedDBCryptoStore.STORE_ACCOUNT = 'account';
 IndexedDBCryptoStore.STORE_SESSIONS = 'sessions';
 IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS = 'inbound_group_sessions';
+IndexedDBCryptoStore.STORE_DEVICE_DATA = 'device_data';

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -135,7 +135,9 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
     }
 
     storeEndToEndDeviceData(deviceData, txn) {
-        this.store.setItem(KEY_DEVICE_DATA, deviceData);
+        setJsonItem(
+            this.store, KEY_DEVICE_DATA, deviceData,
+        );
     }
 
     /**
@@ -151,12 +153,14 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
     // Olm account
 
     getAccount(txn, func) {
-        const account = this.store.getItem(KEY_END_TO_END_ACCOUNT);
+        const account = getJsonItem(this.store, KEY_END_TO_END_ACCOUNT);
         func(account);
     }
 
     storeAccount(txn, newData) {
-        this.store.setItem(KEY_END_TO_END_ACCOUNT, newData);
+        setJsonItem(
+            this.store, KEY_END_TO_END_ACCOUNT, newData,
+        );
     }
 
     doTxn(mode, stores, func) {

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 New Vector Ltd
+Copyright 2017, 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -29,6 +29,7 @@ import MemoryCryptoStore from './memory-crypto-store.js';
 
 const E2E_PREFIX = "crypto.";
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
+const KEY_DEVICE_DATA = E2E_PREFIX + "device_data";
 const KEY_INBOUND_SESSION_PREFIX = E2E_PREFIX + "inboundgroupsessions/";
 
 function keyEndToEndSessions(deviceKey) {
@@ -125,6 +126,16 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
             keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId),
             sessionData,
         );
+    }
+
+    getEndToEndDeviceData(txn, func) {
+        func(getJsonItem(
+            this.store, KEY_DEVICE_DATA,
+        ));
+    }
+
+    storeEndToEndDeviceData(deviceData, txn) {
+        this.store.setItem(KEY_DEVICE_DATA, deviceData);
     }
 
     /**

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -44,9 +44,9 @@ function keyEndToEndInboundGroupSession(senderKey, sessionId) {
  * @implements {module:crypto/store/base~CryptoStore}
  */
 export default class LocalStorageCryptoStore extends MemoryCryptoStore {
-    constructor() {
+    constructor(webStore) {
         super();
-        this.store = global.localStorage;
+        this.store = webStore;
     }
 
     // Olm Sessions

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -36,6 +36,8 @@ export default class MemoryCryptoStore {
         this._sessions = {};
         // Map of {senderCurve25519Key+'/'+sessionId -> session data object}
         this._inboundGroupSessions = {};
+        // Opaque device data object
+        this._deviceData = {};
     }
 
     /**
@@ -268,6 +270,16 @@ export default class MemoryCryptoStore {
 
     storeEndToEndInboundGroupSession(senderCurve25519Key, sessionId, sessionData, txn) {
         this._inboundGroupSessions[senderCurve25519Key+'/'+sessionId] = sessionData;
+    }
+
+    // Device Data
+
+    getEndToEndDeviceData(txn, func) {
+        func(this._deviceData);
+    }
+
+    storeEndToEndDeviceData(deviceData, txn) {
+        this._deviceData = deviceData;
     }
 
 

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -37,7 +37,7 @@ export default class MemoryCryptoStore {
         // Map of {senderCurve25519Key+'/'+sessionId -> session data object}
         this._inboundGroupSessions = {};
         // Opaque device data object
-        this._deviceData = {};
+        this._deviceData = null;
     }
 
     /**

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -68,41 +68,22 @@ WebStorageSessionStore.prototype = {
     },
 
     /**
-     * Stores the known devices for a user.
-     * @param {string} userId The user's ID.
-     * @param {object} devices A map from device ID to keys for the device.
+     * Retrieves the known devices for all users.
+     * @return {object} A map from user ID to map of device ID to keys for the device.
      */
-    storeEndToEndDevicesForUser: function(userId, devices) {
-        setJsonItem(this.store, keyEndToEndDevicesForUser(userId), devices);
-    },
-
-    /**
-     * Retrieves the known devices for a user.
-     * @param {string} userId The user's ID.
-     * @return {object} A map from device ID to keys for the device.
-     */
-    getEndToEndDevicesForUser: function(userId) {
-        return getJsonItem(this.store, keyEndToEndDevicesForUser(userId));
-    },
-
-    storeEndToEndDeviceTrackingStatus: function(statusMap) {
-        setJsonItem(this.store, KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS, statusMap);
+    getAllEndToEndDevices: function() {
+        const prefix = keyEndToEndDevicesForUser('');
+        const devices = {};
+        for (let i = 0; i < store.length; ++i) {
+            const key = store.key(i);
+            const userId = key.substr(prefix.length);
+            if (key.startsWith(prefix)) devices[userId] = getJsonItem(this.store, key);
+        }
+        return devices;
     },
 
     getEndToEndDeviceTrackingStatus: function() {
         return getJsonItem(this.store, KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS);
-    },
-
-    /**
-     * Store the sync token corresponding to the device list.
-     *
-     * This is used when starting the client, to get a list of the users who
-     * have changed their device list since the list time we were running.
-     *
-     * @param {String?} token
-     */
-    storeEndToEndDeviceSyncToken: function(token) {
-        setJsonItem(this.store, KEY_END_TO_END_DEVICE_SYNC_TOKEN, token);
     },
 
     /**
@@ -112,6 +93,15 @@ WebStorageSessionStore.prototype = {
      */
     getEndToEndDeviceSyncToken: function() {
         return getJsonItem(this.store, KEY_END_TO_END_DEVICE_SYNC_TOKEN);
+    },
+
+    /**
+     * Removes all end to end device data from the store
+     */
+    removeEndToEndDeviceData: function() {
+        removeByPrefix(this.store, keyEndToEndDevicesForUser(''));
+        removeByPrefix(this.store, KEY_END_TO_END_DEVICE_LIST_TRACKING_STATUS);
+        removeByPrefix(this.store, KEY_END_TO_END_DEVICE_SYNC_TOKEN);
     },
 
     /**

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -74,8 +74,8 @@ WebStorageSessionStore.prototype = {
     getAllEndToEndDevices: function() {
         const prefix = keyEndToEndDevicesForUser('');
         const devices = {};
-        for (let i = 0; i < store.length; ++i) {
-            const key = store.key(i);
+        for (let i = 0; i < this.store.length; ++i) {
+            const key = this.store.key(i);
             const userId = key.substr(prefix.length);
             if (key.startsWith(prefix)) devices[userId] = getJsonItem(this.store, key);
         }

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 New Vector Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sync.js
+++ b/src/sync.js
@@ -641,6 +641,9 @@ SyncApi.prototype._sync = async function(syncOptions) {
         console.error("Caught /sync error", e.stack || e);
     }
 
+    // update this as it may have changed
+    syncEventData.catchingUp = this._catchingUp;
+
     // emit synced events
     if (!syncOptions.hasSyncedBefore) {
         this._updateSyncState("PREPARED", syncEventData);

--- a/src/sync.js
+++ b/src/sync.js
@@ -702,8 +702,7 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
  * Process data returned from a sync response and propagate it
  * into the model objects
  *
- * @param {string} syncToken the old next_batch token sent to this
- *    sync request.
+ * @param {Object} syncEventData Object containing sync tokens associated with this sync
  * @param {Object} data The response from /sync
  * @param {bool} isCachedResponse True if this response is from our local cache
  */
@@ -950,7 +949,8 @@ SyncApi.prototype._processSyncResponse = async function(
                 self._deregisterStateListeners(room);
                 room.resetLiveTimeline(
                     joinObj.timeline.prev_batch,
-                    self.opts.canResetEntireTimeline(room.roomId) ? null : syncEventData.oldSyncToken,
+                    self.opts.canResetEntireTimeline(room.roomId) ?
+                        null : syncEventData.oldSyncToken,
                 );
 
                 // We have to assume any gap in any timeline is
@@ -1046,7 +1046,9 @@ SyncApi.prototype._processSyncResponse = async function(
     // Handle device list updates
     if (data.device_lists) {
         if (this.opts.crypto) {
-            await this.opts.crypto.handleDeviceListChanges(syncEventData, data.device_lists);
+            await this.opts.crypto.handleDeviceListChanges(
+                syncEventData, data.device_lists,
+            );
         } else {
             // FIXME if we *don't* have a crypto module, we still need to
             // invalidate the device lists. But that would require a

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
+Copyright 2018 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sync.js
+++ b/src/sync.js
@@ -627,6 +627,12 @@ SyncApi.prototype._sync = async function(syncOptions) {
         catchingUp: this._catchingUp,
     };
 
+    if (this.opts.crypto && !isCachedResponse) {
+        // tell the crypto module we're about to process a sync
+        // response
+        await this.opts.crypto.onSyncWillProcess(syncEventData);
+    }
+
     try {
         await this._processSyncResponse(syncEventData, data, isCachedResponse);
     } catch(e) {


### PR DESCRIPTION
Moves the device tracking to the crypto store.

Most of the cross-tab safety here works by writing all the device data atomically, so it's all stored in one big object, much as it feels like an abuse of indexeddb.

This also changes the API a little (in particular there's an explicit save to avoid multiple writes when we mark a room full of devices as known)