### PR TITLE
WIP: online incremental megolm backups

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -393,6 +393,7 @@ MatrixClient.prototype.initCrypto = async function() {
         "crypto.roomKeyRequest",
         "crypto.roomKeyRequestCancellation",
         "crypto.warning",
+        "crypto.suggestKeyRestore",
     ]);
 
     await crypto.init();

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -91,6 +91,21 @@ function OlmDevice(sessionStore, cryptoStore) {
     this.deviceEd25519Key = null;
     this._maxOneTimeKeys = null;
 
+    // track whether this device's megolm keys are being backed up incrementally
+    // to the server or not.
+    // XXX: this should probably have a single source of truth from OlmAccount
+    this.backupKey = null;
+
+    // track which of our other devices (if any) have cross-signed this device
+    // XXX: this should probably have a single source of truth in the /devices
+    // API store or whatever we use to track our self-signed devices.
+    this.crossSelfSigs = [];
+
+    // track whether we have already suggested to the user that they should
+    // restore their keys from backup or by cross-signing the device.
+    // We use this to avoid repeatedly emitting the suggestion event.
+    this.suggestedKeyRestore = false;
+
     // we don't bother stashing outboundgroupsessions in the sessionstore -
     // instead we keep them here.
     this._outboundGroupSessionStore = {};
@@ -921,6 +936,11 @@ OlmDevice.prototype.addInboundGroupSession = async function(
                         this._cryptoStore.addEndToEndInboundGroupSession(
                             senderKey, sessionId, sessionData, txn,
                         );
+
+                        if (this.backupKey) {
+                            // get olm::Account::generate_backup_encryption_secret
+                            // save sessionData (pickled with this secret) to the server
+                        }
                     } finally {
                         session.free();
                     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1015,6 +1015,13 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
         return;
     }
 
+    if (!device.suggestedKeyRestore && 
+        !device.backupKey && !device.selfCrossSigs.length)
+    {
+        this.emit("crypto.suggestKeyRestore");
+        device.suggestKeyRestore = true;
+    }
+
     const alg = this._getRoomDecryptor(content.room_id, content.algorithm);
     alg.onRoomKeyEvent(event);
 };
@@ -1353,6 +1360,13 @@ class IncomingRoomKeyRequestCancellation {
  *
  * @event module:client~MatrixClient#"crypto.roomKeyRequestCancellation"
  * @param {module:crypto~IncomingRoomKeyRequestCancellation} req
+ */
+
+/**
+ * Fires when we want to suggest to the user that they restore their megolm keys
+ * from backup or by cross-signing the device.
+ *
+ * @event module:client~MatrixClient#"crypto.suggestKeyRestore"
  */
 
 /**


### PR DESCRIPTION
**This doesn't remotely work yet (not even tried to compile it yet) and isn't finished, but opening a PR to aid feedback/review**

Adds a new `crypto.suggestKeyRestore` event which the js-sdk fires when the user starts interacting with e2e (by receiving room_keys) for the first time on a given device.  The event should prompt the user to sync in keys.

Stuff left to do:
 * [ ] Actually wire up the backupKey field to `olm::Account`
 * [ ] In future, hook up the cross-signing field to /devices store
 * [ ] Persist suggestedKeyRestore somewhere in localStorage or equivalent