### PR TITLE
add parameter to getIdentityServerUrl to strip the protocol for invites

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -89,9 +89,14 @@ MatrixBaseApis.prototype.getHomeserverUrl = function() {
 
 /**
  * Get the Identity Server URL of this client
+ * @param {boolean} stripProto whether or not to strip the protocol from the URL
  * @return {string} Identity Server URL of this client
  */
-MatrixBaseApis.prototype.getIdentityServerUrl = function() {
+MatrixBaseApis.prototype.getIdentityServerUrl = function(stripProto=false) {
+    if (stripProto && (this.idBaseUrl.startsWith("http://") ||
+            this.idBaseUrl.startsWith("https://"))) {
+        return this.idBaseUrl.split("://")[1];
+    }
     return this.idBaseUrl;
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -1547,17 +1547,12 @@ MatrixClient.prototype.inviteByThreePid = function(roomId, medium, address, call
         { $roomId: roomId },
     );
 
-    let identityServerUrl = this.getIdentityServerUrl();
+    const identityServerUrl = this.getIdentityServerUrl(true);
     if (!identityServerUrl) {
         return Promise.reject(new MatrixError({
             error: "No supplied identity server URL",
             errcode: "ORG.MATRIX.JSSDK_MISSING_PARAM",
         }));
-    }
-    if (identityServerUrl.indexOf("http://") === 0 ||
-            identityServerUrl.indexOf("https://") === 0) {
-        // this request must not have the protocol part because reasons
-        identityServerUrl = identityServerUrl.split("://")[1];
     }
 
     return this._http.authedRequest(callback, "POST", path, undefined, {


### PR DESCRIPTION
use new getIdentityServerUrl param in inviteByThreePid

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>