### PR TITLE
Allow a mode of operation without HS connection

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -510,6 +510,9 @@ SyncApi.prototype.retryImmediately = function() {
  * @param {Object} syncOptions
  * @param {string} syncOptions.filterId
  * @param {boolean} syncOptions.hasSyncedBefore
+ * @param {Object} syncOptions.savedSync a saved sync that was persisted by a
+ *                                       store. Should have been acquired via
+ *                                       client.store.getSavedSync().
  */
 SyncApi.prototype._sync = async function(syncOptions) {
     const client = this.client;

--- a/src/sync.js
+++ b/src/sync.js
@@ -462,8 +462,8 @@ SyncApi.prototype.sync = function() {
         // no push rules for guests, no access to POST filter for guests.
         self._sync({});
     } else {
-        // Don't do an HTTP hit to /sync. Instead, load up the persisted /sync data,
-        // if there is data there.
+        // Before fetching push rules, fetching the filter and syncing, check
+        // for persisted /sync data and use that if present.
         client.store.getSavedSync().then((savedSync) => {
             if (savedSync) {
                 self._syncFromCache(savedSync);
@@ -676,9 +676,7 @@ SyncApi.prototype._sync = async function(syncOptions) {
     // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
     this._updateSyncState("SYNCING", syncEventData);
 
-    // tell databases that everything is now in a consistent state and can be
-    // saved (no point doing so if we only have the data we just got out of the
-    // store).
+    // tell databases that everything is now in a consistent state and can be saved.
     client.store.save();
 
     // Begin next sync

--- a/src/sync.js
+++ b/src/sync.js
@@ -504,7 +504,11 @@ SyncApi.prototype.retryImmediately = function() {
     this._startKeepAlives(0);
     return true;
 };
-
+/**
+ * Process a single set of cached sync data.
+ * @param {Object} savedSync a saved sync that was persisted by a store. This
+ * should have been acquired via client.store.getSavedSync().
+ */
 SyncApi.prototype._syncFromCache = async function(savedSync) {
     debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
 
@@ -542,9 +546,6 @@ SyncApi.prototype._syncFromCache = async function(savedSync) {
  * @param {Object} syncOptions
  * @param {string} syncOptions.filterId
  * @param {boolean} syncOptions.hasSyncedBefore
- * @param {Object} syncOptions.savedSync a saved sync that was persisted by a
- *                                       store. Should have been acquired via
- *                                       client.store.getSavedSync().
  */
 SyncApi.prototype._sync = async function(syncOptions) {
     const client = this.client;

--- a/src/sync.js
+++ b/src/sync.js
@@ -512,7 +512,8 @@ SyncApi.prototype.retryImmediately = function() {
 SyncApi.prototype._syncFromCache = async function(savedSync) {
     debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
 
-    const oldSyncToken = this.client.store.getSyncToken();
+    // No previous sync, set old token to null
+    const oldSyncToken = null;
     const nextSyncToken = savedSync.nextBatch;
 
     this.client.store.setSyncToken(nextSyncToken);

--- a/src/sync.js
+++ b/src/sync.js
@@ -650,7 +650,7 @@ SyncApi.prototype._sync = async function(syncOptions) {
     }
 
     try {
-        await this._processSyncResponse(syncToken, data, false);
+        await this._processSyncResponse(syncEventData, data, false);
     } catch(e) {
         // log the exception with stack if we have it, else fall back
         // to the plain description

--- a/src/sync.js
+++ b/src/sync.js
@@ -464,12 +464,11 @@ SyncApi.prototype.sync = function() {
         // Don't do an HTTP hit to /sync. Instead, load up the persisted /sync data,
         // if there is data there.
         client.store.getSavedSync().then((savedSync) => {
-            getPushRules();
-
             if (savedSync) {
                 self._sync({ savedSync });
             }
         });
+        getPushRules();
     }
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -464,9 +464,6 @@ SyncApi.prototype.sync = function() {
         // Don't do an HTTP hit to /sync. Instead, load up the persisted /sync data,
         // if there is data there.
         client.store.getSavedSync().then((savedSync) => {
-            // Indicate whether we should sync after getting push rules,
-            // this should only be done if aren't about to start syncing
-            // with the savedSync as a first sync.
             getPushRules();
 
             if (savedSync) {


### PR DESCRIPTION
Instead of blocking the first sync on getting the push rules and
filter, load sync data from disc.

When the client comes online, the push rules will be acquired and
a sync cycle started. This could be immediate if the client is
already online.

This could be a breaking change for clients that get push rules
before a successful sync has been done.