### PR TITLE
Set sync token before incrementally syncing

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -471,9 +471,9 @@ SyncApi.prototype.sync = function() {
                 self.client.store.setSyncToken(savedSync.nextBatch);
 
                 // Sync from cache (asynchronously)
-                self._syncFromCache(savedSync);
+                return self._syncFromCache(savedSync);
             }
-
+        }).then(() => {
             // Get push rules and start syncing after getting the saved sync
             // to handle the case where we needed the `nextBatch` token to
             // start syncing from.

--- a/src/sync.js
+++ b/src/sync.js
@@ -466,11 +466,6 @@ SyncApi.prototype.sync = function() {
         // for persisted /sync data and use that if present.
         client.store.getSavedSync().then((savedSync) => {
             if (savedSync) {
-                // Do this before incrementally syncing otherwise we risk doing
-                // full sync
-                self.client.store.setSyncToken(savedSync.nextBatch);
-
-                // Sync from cache (asynchronously)
                 return self._syncFromCache(savedSync);
             }
         }).then(() => {
@@ -522,6 +517,9 @@ SyncApi.prototype._syncFromCache = async function(savedSync) {
     debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
 
     const nextSyncToken = savedSync.nextBatch;
+
+    // Set sync token for future incremental syncing
+    self.client.store.setSyncToken(nextSyncToken);
 
     // No previous sync, set old token to null
     const syncEventData = {


### PR DESCRIPTION
otherwise we risk doing a full sync by using the null token.

This must be done synchronously before we `getPushRules` and start
incrementally syncing.