### PR TITLE
Guard against no pushRules in getPushRuleById

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -357,6 +357,7 @@ function PushProcessor(client) {
      * @return {object} The push rule, or null if no such rule was found
      */
     this.getPushRuleById = function(ruleId) {
+        if (!client.pushRules) return null;
         for (const scope of ['device', 'global']) {
             if (client.pushRules[scope] === undefined) continue;
 


### PR DESCRIPTION
so that clients that attempt to get push rules before they have
been fetched will receive `null` instead of an NPE.