### PR TITLE
Honour cached push rules

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -813,6 +813,10 @@ SyncApi.prototype._processSyncResponse = async function(
         client.store.storeAccountDataEvents(events);
         events.forEach(
             function(accountDataEvent) {
+                // Honour push rules that come down the sync stream but also
+                // honour push rules that were previously cached. Base rules
+                // will be updated when we recieve push rules via getPushRules
+                // (see SyncApi.prototype.sync) before syncing over the network.
                 if (accountDataEvent.getType() == 'm.push_rules') {
                     client.pushRules = accountDataEvent.getContent();
                 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -538,7 +538,7 @@ SyncApi.prototype._syncFromCache = async function(savedSync) {
     };
 
     try {
-        await this._processSyncResponse(syncEventData, data, true);
+        await this._processSyncResponse(syncEventData, data);
     } catch(e) {
         console.error("Error processing cached sync", e.stack || e);
     }
@@ -656,7 +656,7 @@ SyncApi.prototype._sync = async function(syncOptions) {
     }
 
     try {
-        await this._processSyncResponse(syncEventData, data, false);
+        await this._processSyncResponse(syncEventData, data);
     } catch(e) {
         // log the exception with stack if we have it, else fall back
         // to the plain description
@@ -731,10 +731,9 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
  *
  * @param {Object} syncEventData Object containing sync tokens associated with this sync
  * @param {Object} data The response from /sync
- * @param {bool} isCachedResponse True if this response is from our local cache
  */
 SyncApi.prototype._processSyncResponse = async function(
-    syncEventData, data, isCachedResponse,
+    syncEventData, data,
 ) {
     const client = this.client;
     const self = this;
@@ -814,13 +813,7 @@ SyncApi.prototype._processSyncResponse = async function(
         client.store.storeAccountDataEvents(events);
         events.forEach(
             function(accountDataEvent) {
-                // XXX: This is awful: ignore push rules from our cached sync. We fetch the
-                // push rules before syncing so we actually have up-to-date ones. We do want
-                // to honour new push rules that come down the sync but synapse doesn't
-                // put new push rules in the sync stream when the base rules change, so
-                // if the base rules change, we do need to refresh. We therefore ignore
-                // the push rules in our cached sync response.
-                if (accountDataEvent.getType() == 'm.push_rules' && !isCachedResponse) {
+                if (accountDataEvent.getType() == 'm.push_rules') {
                     client.pushRules = accountDataEvent.getContent();
                 }
                 client.emit("accountData", accountDataEvent);


### PR DESCRIPTION
so that we have push rules loaded into the client after doing
a cached sync (so that the client can assume that we do have
push rules, even if it was loaded from a cached sync).

These rules will be updated once `getPushRules` is completed
prior to the first networked sync.