### PR TITLE
Replies

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -40,6 +40,7 @@ const Filter = require("./filter");
 const SyncApi = require("./sync");
 const MatrixBaseApis = require("./base-apis");
 const MatrixError = httpApi.MatrixError;
+const ContentHelpers = require("./content-helpers");
 
 import ReEmitter from './ReEmitter';
 
@@ -1261,10 +1262,7 @@ MatrixClient.prototype.sendMessage = function(roomId, content, txnId, callback) 
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendTextMessage = function(roomId, body, txnId, callback) {
-    const content = {
-         msgtype: "m.text",
-         body: body,
-    };
+    const content = ContentHelpers.makeTextMessage(body);
     return this.sendMessage(roomId, content, txnId, callback);
 };
 
@@ -1277,10 +1275,7 @@ MatrixClient.prototype.sendTextMessage = function(roomId, body, txnId, callback)
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendNotice = function(roomId, body, txnId, callback) {
-    const content = {
-         msgtype: "m.notice",
-         body: body,
-    };
+    const content = ContentHelpers.makeNotice(body);
     return this.sendMessage(roomId, content, txnId, callback);
 };
 
@@ -1293,10 +1288,7 @@ MatrixClient.prototype.sendNotice = function(roomId, body, txnId, callback) {
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendEmoteMessage = function(roomId, body, txnId, callback) {
-    const content = {
-         msgtype: "m.emote",
-         body: body,
-    };
+    const content = ContentHelpers.makeEmoteMessage(body);
     return this.sendMessage(roomId, content, txnId, callback);
 };
 
@@ -1360,12 +1352,7 @@ MatrixClient.prototype.sendStickerMessage = function(roomId, url, info, text, ca
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendHtmlMessage = function(roomId, body, htmlBody, callback) {
-    const content = {
-        msgtype: "m.text",
-        format: "org.matrix.custom.html",
-        body: body,
-        formatted_body: htmlBody,
-    };
+    const content = ContentHelpers.makeHtmlMessage(body, htmlBody);
     return this.sendMessage(roomId, content, callback);
 };
 
@@ -1378,12 +1365,7 @@ MatrixClient.prototype.sendHtmlMessage = function(roomId, body, htmlBody, callba
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendHtmlNotice = function(roomId, body, htmlBody, callback) {
-    const content = {
-        msgtype: "m.notice",
-        format: "org.matrix.custom.html",
-        body: body,
-        formatted_body: htmlBody,
-    };
+    const content = ContentHelpers.makeHtmlNotice(body, htmlBody);
     return this.sendMessage(roomId, content, callback);
 };
 
@@ -1396,12 +1378,7 @@ MatrixClient.prototype.sendHtmlNotice = function(roomId, body, htmlBody, callbac
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixClient.prototype.sendHtmlEmote = function(roomId, body, htmlBody, callback) {
-    const content = {
-        msgtype: "m.emote",
-        format: "org.matrix.custom.html",
-        body: body,
-        formatted_body: htmlBody,
-    };
+    const content = ContentHelpers.makeHtmlEmote(body, htmlBody);
     return this.sendMessage(roomId, content, callback);
 };
 

--- a/src/content-helpers.js
+++ b/src/content-helpers.js
@@ -1,0 +1,100 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+"use strict";
+
+/** @module ContentHelpers */
+module.exports = {
+    /**
+     * Generates the content for a HTML Message event
+     * @param {string} body the plaintext body of the message
+     * @param {string} htmlBody the HTML representation of the message
+     * @returns {{msgtype: string, format: string, body: string, formatted_body: string}}
+     */
+    makeHtmlMessage: function(body, htmlBody) {
+        return {
+            msgtype: "m.text",
+            format: "org.matrix.custom.html",
+            body: body,
+            formatted_body: htmlBody,
+        };
+    },
+
+    /**
+     * Generates the content for a HTML Notice event
+     * @param {string} body the plaintext body of the notice
+     * @param {string} htmlBody the HTML representation of the notice
+     * @returns {{msgtype: string, format: string, body: string, formatted_body: string}}
+     */
+    makeHtmlNotice: function(body, htmlBody) {
+        return {
+            msgtype: "m.notice",
+            format: "org.matrix.custom.html",
+            body: body,
+            formatted_body: htmlBody,
+        };
+    },
+
+    /**
+     * Generates the content for a HTML Emote event
+     * @param {string} body the plaintext body of the emote
+     * @param {string} htmlBody the HTML representation of the emote
+     * @returns {{msgtype: string, format: string, body: string, formatted_body: string}}
+     */
+    makeHtmlEmote: function(body, htmlBody) {
+        return {
+            msgtype: "m.emote",
+            format: "org.matrix.custom.html",
+            body: body,
+            formatted_body: htmlBody,
+        };
+    },
+
+    /**
+     * Generates the content for a Plaintext Message event
+     * @param {string} body the plaintext body of the emote
+     * @returns {{msgtype: string, body: string}}
+     */
+    makeTextMessage: function(body) {
+        return {
+            msgtype: "m.text",
+            body: body,
+        };
+    },
+
+    /**
+     * Generates the content for a Plaintext Notice event
+     * @param {string} body the plaintext body of the notice
+     * @returns {{msgtype: string, body: string}}
+     */
+    makeNotice: function(body) {
+        return {
+            msgtype: "m.notice",
+            body: body,
+        };
+    },
+
+    /**
+     * Generates the content for a Plaintext Emote event
+     * @param {string} body the plaintext body of the emote
+     * @returns {{msgtype: string, body: string}}
+     */
+    makeEmoteMessage: function(body) {
+        return {
+            msgtype: "m.emote",
+            body: body,
+        };
+    },
+};

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -769,9 +769,21 @@ Crypto.prototype.encryptEvent = function(event, room) {
         );
     }
 
+    const content = event.getContent();
+    // If event has an m.relates_to then we need
+    // to put this on the wrapping event instead
+    const mRelatesTo = content['m.relates_to'];
+    if (mRelatesTo) {
+        delete content['m.relates_to'];
+    }
+
     return alg.encryptMessage(
-        room, event.getType(), event.getContent(),
+        room, event.getType(), content,
     ).then((encryptedContent) => {
+        if (mRelatesTo) {
+            encryptedContent['m.relates_to'] = mRelatesTo;
+        }
+
         event.makeEncrypted(
             "m.room.encrypted",
             encryptedContent,

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -769,11 +769,13 @@ Crypto.prototype.encryptEvent = function(event, room) {
         );
     }
 
-    const content = event.getContent();
+    let content = event.getContent();
     // If event has an m.relates_to then we need
     // to put this on the wrapping event instead
     const mRelatesTo = content['m.relates_to'];
     if (mRelatesTo) {
+        // Clone content here so we don't remove `m.relates_to` from the local-echo
+        content = Object.assign({}, content);
         delete content['m.relates_to'];
     }
 

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -16,6 +16,8 @@ limitations under the License.
 */
 "use strict";
 
+/** The {@link module:ContentHelpers} object */
+module.exports.ContentHelpers = require("./content-helpers");
 /** The {@link module:models/event.MatrixEvent|MatrixEvent} class. */
 module.exports.MatrixEvent = require("./models/event").MatrixEvent;
 /** The {@link module:models/event.EventStatus|EventStatus} enum. */


### PR DESCRIPTION
+ Hoist `m.relates_to` from the encrypted payload event.
+ Split send event helpers into their underlying content generation so that additional content fields can be added before sending

# For https://github.com/matrix-org/matrix-react-sdk/pull/1741

## Let me know where better to move/how better to structure this