### PR TITLE
Create sentinel members on-demand

### DIFF
--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -80,6 +80,7 @@ RoomState.prototype.getMember = function(userId) {
  * @return {RoomMember} The member or null if they do not exist.
  */
 RoomState.prototype.getSentinelMember = function(userId) {
+    if (!userId) return null;
     let sentinel = this._sentinels[userId];
 
     if (sentinel === undefined) {

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -187,14 +187,12 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
                 self.emit("RoomState.newMember", event, self, member);
             }
 
-            utils.forEach([member], function(roomMember) {
-                roomMember.setMembershipEvent(event, self);
-                // this member may have a power level already, so set it.
-                const pwrLvlEvent = self.getStateEvents("m.room.power_levels", "");
-                if (pwrLvlEvent) {
-                    roomMember.setPowerLevelEvent(pwrLvlEvent);
-                }
-            });
+            member.setMembershipEvent(event, self);
+            // this member may have a power level already, so set it.
+            const pwrLvlEvent = self.getStateEvents("m.room.power_levels", "");
+            if (pwrLvlEvent) {
+                member.setPowerLevelEvent(pwrLvlEvent);
+            }
 
             // blow away the sentinel which is now outdated
             delete self._sentinels[userId];


### PR DESCRIPTION
We only need sentinel members for things like the 'sender' field
of events, so we previously created sentinels for everyone in the
room, but a large number of them were never used.

Instead, create them on-demand and cache them.