### PR TITLE
De-dup code: use the initialiseState function

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -437,6 +437,26 @@ describe("MatrixClient syncing", function() {
             });
         });
 
+        it("should correctly interpret state in incremental sync.", function() {
+            httpBackend.when("GET", "/sync").respond(200, syncData);
+            httpBackend.when("GET", "/sync").respond(200, nextSyncData);
+
+            client.startClient();
+            return Promise.all([
+                httpBackend.flushAllExpected(),
+                awaitSyncEvent(2),
+            ]).then(function() {
+                const room = client.getRoom(roomOne);
+                const stateAtStart = room.getLiveTimeline().getState(EventTimeline.BACKWARDS);
+                const startRoomNameEvent = stateAtStart.getStateEvents('m.room.name', '');
+                expect(startRoomNameEvent.getContent().name).toEqual('Old room name');
+
+                const stateAtEnd = room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+                const endRoomNameEvent = stateAtEnd.getStateEvents('m.room.name', '');
+                expect(endRoomNameEvent.getContent().name).toEqual('A new room name');
+            });
+        });
+
         xit("should update power levels for users in a room", function() {
 
         });

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -447,11 +447,15 @@ describe("MatrixClient syncing", function() {
                 awaitSyncEvent(2),
             ]).then(function() {
                 const room = client.getRoom(roomOne);
-                const stateAtStart = room.getLiveTimeline().getState(EventTimeline.BACKWARDS);
+                const stateAtStart = room.getLiveTimeline().getState(
+                    EventTimeline.BACKWARDS,
+                );
                 const startRoomNameEvent = stateAtStart.getStateEvents('m.room.name', '');
                 expect(startRoomNameEvent.getContent().name).toEqual('Old room name');
 
-                const stateAtEnd = room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+                const stateAtEnd = room.getLiveTimeline().getState(
+                    EventTimeline.FORWARDS,
+                );
                 const endRoomNameEvent = stateAtEnd.getStateEvents('m.room.name', '');
                 expect(endRoomNameEvent.getContent().name).toEqual('A new room name');
             });

--- a/src/sync.js
+++ b/src/sync.js
@@ -1294,6 +1294,9 @@ SyncApi.prototype._resolveInvites = function(room) {
  */
 SyncApi.prototype._processRoomEvents = function(room, stateEventList,
                                                 timelineEventList) {
+    // We'll only get state events in stateEventList if this is a limited
+    // sync, in which case this should be a fresh timeline, and this is us
+    // initialising it.
     if (stateEventList.length > 0) {
         room.getLiveTimeline().initialiseState(stateEventList);
     }

--- a/src/sync.js
+++ b/src/sync.js
@@ -1296,9 +1296,10 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
                                                 timelineEventList) {
     // If there are no events in the timeline yet, initialise it with
     // the given state events
-    const timelineWasEmpty = room.getLiveTimeline().getEvents().length == 0;
+    const liveTimeline = room.getLiveTimeline();
+    const timelineWasEmpty = liveTimeline.getEvents().length == 0;
     if (timelineWasEmpty) {
-        room.getLiveTimeline().initialiseState(stateEventList);
+        liveTimeline.initialiseState(stateEventList);
     }
 
     this._resolveInvites(room);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1297,7 +1297,12 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // We'll only get state events in stateEventList if this is a limited
     // sync, in which case this should be a fresh timeline, and this is us
     // initialising it.
-    if (stateEventList.length > 0) {
+
+
+    // If there are no events in the timeline yet, initialise it with
+    // the given state events
+    const timelinewasEmpty = room.getLiveTimeline().getEvents().length == 0;
+    if (timelinewasEmpty) {
         room.getLiveTimeline().initialiseState(stateEventList);
     }
 
@@ -1307,7 +1312,13 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // may make notifications appear which should have the right name.
     room.recalculate(this.client.credentials.userId);
 
-    // execute the timeline events, this will begin to diverge the current state
+    // If the timeline wasn't empty, we process the state events here: they're
+    // defined as updates to the state before the start of the timeline, so this
+    // starts to roll the state forward.
+    if (!timelinewasEmpty) {
+        room.addLiveEvents(stateEventList || []);
+    }
+    // execute the timeline events, this will continue to diverge the current state
     // if the timeline has any state events in it.
     // This also needs to be done before running push rules on the events as they need
     // to be decorated with sender etc.

--- a/src/sync.js
+++ b/src/sync.js
@@ -1306,6 +1306,13 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
 
     // recalculate the room name at this point as adding events to the timeline
     // may make notifications appear which should have the right name.
+    // XXX: This looks suspect: we'll end up recalculating the room once here
+    // and then again after adding events (_processSyncResponse calls it after
+    // calling us) even if no state events were added. It also means that if
+    // one of the room events in timelineEventList is something that needs
+    // a recalculation (like m.room.name) we won't recalculate until we've
+    // finished adding all the events, which will cause the notification to have
+    // the old room name rather than the new one.
     room.recalculate(this.client.credentials.userId);
 
     // If the timeline wasn't empty, we process the state events here: they're

--- a/src/sync.js
+++ b/src/sync.js
@@ -1294,29 +1294,9 @@ SyncApi.prototype._resolveInvites = function(room) {
  */
 SyncApi.prototype._processRoomEvents = function(room, stateEventList,
                                                 timelineEventList) {
-    timelineEventList = timelineEventList || [];
-    const client = this.client;
-    // "old" and "current" state are the same initially; they
-    // start diverging if the user paginates.
-    // We must deep copy otherwise membership changes in old state
-    // will leak through to current state!
-    const oldStateEvents = utils.map(
-        utils.deepCopy(
-            stateEventList.map(function(mxEvent) {
-                return mxEvent.event;
-            }),
-        ), client.getEventMapper(),
-    );
-    const stateEvents = stateEventList;
-
-    // set the state of the room to as it was before the timeline executes
-    //
-    // XXX: what if we've already seen (some of) the events in the timeline,
-    // and they modify some of the state set in stateEvents? In that case we'll
-    // end up with the state from stateEvents, instead of the more recent state
-    // from the timeline.
-    room.oldState.setStateEvents(oldStateEvents);
-    room.currentState.setStateEvents(stateEvents);
+    if (stateEventList.length > 0) {
+        room.getLiveTimeline().initialiseState(stateEventList);
+    }
 
     this._resolveInvites(room);
 
@@ -1328,7 +1308,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // if the timeline has any state events in it.
     // This also needs to be done before running push rules on the events as they need
     // to be decorated with sender etc.
-    room.addLiveEvents(timelineEventList);
+    room.addLiveEvents(timelineEventList || []);
 };
 
 /**

--- a/src/sync.js
+++ b/src/sync.js
@@ -1294,11 +1294,6 @@ SyncApi.prototype._resolveInvites = function(room) {
  */
 SyncApi.prototype._processRoomEvents = function(room, stateEventList,
                                                 timelineEventList) {
-    // We'll only get state events in stateEventList if this is a limited
-    // sync, in which case this should be a fresh timeline, and this is us
-    // initialising it.
-
-
     // If there are no events in the timeline yet, initialise it with
     // the given state events
     const timelinewasEmpty = room.getLiveTimeline().getEvents().length == 0;
@@ -1318,7 +1313,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     if (!timelinewasEmpty) {
         room.addLiveEvents(stateEventList || []);
     }
-    // execute the timeline events, this will continue to diverge the current state
+    // execute the timeline events. This will continue to diverge the current state
     // if the timeline has any state events in it.
     // This also needs to be done before running push rules on the events as they need
     // to be decorated with sender etc.

--- a/src/sync.js
+++ b/src/sync.js
@@ -1296,8 +1296,8 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
                                                 timelineEventList) {
     // If there are no events in the timeline yet, initialise it with
     // the given state events
-    const timelinewasEmpty = room.getLiveTimeline().getEvents().length == 0;
-    if (timelinewasEmpty) {
+    const timelineWasEmpty = room.getLiveTimeline().getEvents().length == 0;
+    if (timelineWasEmpty) {
         room.getLiveTimeline().initialiseState(stateEventList);
     }
 
@@ -1310,7 +1310,7 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     // If the timeline wasn't empty, we process the state events here: they're
     // defined as updates to the state before the start of the timeline, so this
     // starts to roll the state forward.
-    if (!timelinewasEmpty) {
+    if (!timelineWasEmpty) {
         room.addLiveEvents(stateEventList || []);
     }
     // execute the timeline events. This will continue to diverge the current state


### PR DESCRIPTION
This should behave identically, but the code here appeared to be
identical to the code in initialiseState, so let's use it (it also
has an extra sanity check in there that we only init empty timelines).

Edit: I take back what I said about this being functionally identical: it isn't. It appears that previously we were applying any events in the `state` field of the join room to both the old state and the new state, which is surely wrong. Although these are normally only ever sent in a limited or initial sync (so it wouldn't matter) they are well-defined in other syncs as events that precede the timeline events, so we should process them as we would timeline events, before we process the timeline events. The tests send sync responses with state changes in `state` rather than `timeline`.