### PR TITLE
Stop cloning events when adding to state

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -383,22 +383,25 @@ describe("Room", function() {
     });
 
     const resetTimelineTests = function(timelineSupport) {
-        const events = [
-            utils.mkMessage({
-                room: roomId, user: userA, msg: "A message", event: true,
-            }),
-            utils.mkEvent({
-                type: "m.room.name", room: roomId, user: userA, event: true,
-                content: { name: "New Room Name" },
-            }),
-            utils.mkEvent({
-                type: "m.room.name", room: roomId, user: userA, event: true,
-                content: { name: "Another New Name" },
-            }),
-        ];
+        let events = null;
 
         beforeEach(function() {
             room = new Room(roomId, {timelineSupport: timelineSupport});
+            // set events each time to avoid resusing Event objects (which
+            // doesn't work because they get frozen)
+            events = [
+                utils.mkMessage({
+                    room: roomId, user: userA, msg: "A message", event: true,
+                }),
+                utils.mkEvent({
+                    type: "m.room.name", room: roomId, user: userA, event: true,
+                    content: { name: "New Room Name" },
+                }),
+                utils.mkEvent({
+                    type: "m.room.name", room: roomId, user: userA, event: true,
+                    content: { name: "Another New Name" },
+                }),
+            ];
         });
 
         it("should copy state from previous timeline", function() {

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -94,6 +94,10 @@ EventTimeline.prototype.initialiseState = function(stateEvents) {
     // not change. Duplicating the events uses a lot of extra memory,
     // so we now no longer do it. To assert that they really do never change,
     // freeze them! Note that we can't do this for events in general:
+    // although it looks like the only things preventing us are the
+    // 'status' flag, forwardLooking (which is only set once when adding to the
+    // timeline) and possibly the sender (which seems like it should never be
+    // reset but in practice causes a lot of the tests to break).
     for (const e of stateEvents) {
         Object.freeze(e);
     }

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -20,8 +20,6 @@ limitations under the License.
  */
 
 const RoomState = require("./room-state");
-const utils = require("../utils");
-const MatrixEvent = require("./event").MatrixEvent;
 
 /**
  * Construct a new EventTimeline

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -88,19 +88,19 @@ EventTimeline.prototype.initialiseState = function(stateEvents) {
         throw new Error("Cannot initialise state after events are added");
     }
 
-    // we deep-copy the events here, in case they get changed later - we don't
-    // want changes to the start state leaking through to the end state.
-    const oldStateEvents = utils.map(
-        utils.deepCopy(
-            stateEvents.map(function(mxEvent) {
-                return mxEvent.event;
-            }),
-        ),
-    function(ev) {
-        return new MatrixEvent(ev);
-    });
+    // We previously deep copied events here and used different copies in
+    // the oldState and state events: this decision seems to date back
+    // quite a way and was apparently made to fix a bug where modifications
+    // made to the start state leaked through to the end state.
+    // This really shouldn't be possible though: the events themselves should
+    // not change. Duplicating the events uses a lot of extra memory,
+    // so we now no longer do it. To assert that they really do never change,
+    // freeze them! Note that we can't do this for events in general:
+    for (const e of stateEvents) {
+        Object.freeze(e);
+    }
 
-    this._startState.setStateEvents(oldStateEvents);
+    this._startState.setStateEvents(stateEvents);
     this._endState.setStateEvents(stateEvents);
 };
 


### PR DESCRIPTION
As comment hopefully explains.

On my test account:
Before: 394657 MatrixEvents, 53MB shallow size
After: 198863 MatrixEvents, 27MB shallow size