### PR TITLE
Make Events create Dates on demand

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -108,8 +108,6 @@ module.exports.MatrixEvent = function MatrixEvent(
     this.error = null;
     this.forwardLooking = true;
     this._pushActions = null;
-    this._date = this.event.origin_server_ts ?
-        new Date(this.event.origin_server_ts) : null;
 
     this._clearEvent = {};
 
@@ -204,7 +202,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {Date} The event date, e.g. <code>new Date(1433502692297)</code>
      */
     getDate: function() {
-        return this._date;
+        return this.event.origin_server_ts ? new Date(this.event.origin_server_ts) : null;
     },
 
     /**
@@ -652,7 +650,6 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         this.event = event;
         // successfully sent.
         this.status = null;
-        this._date = new Date(this.event.origin_server_ts);
      },
 });
 


### PR DESCRIPTION
My test account had 37MB (shallow) of Date objects knocking around
in memory. This gets rid of them. I can't see any appreciable
difference in the time taken to switch rooms (where now we recreate
a bunch of Dates that previously would have been cached).