### PR TITLE
try a hunch to fix https://github.com/vector-im/riot-web/issues/6212

### DIFF
--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -361,7 +361,7 @@ LocalIndexedDBStoreBackend.prototype = {
      */
     _loadSyncData: function() {
         console.log(
-            `LocalIndexedDBStoreBackend: loaded sync data`,
+            `LocalIndexedDBStoreBackend: loading sync data`,
         );
         return Promise.try(() => {
             console.log(

--- a/src/sync.js
+++ b/src/sync.js
@@ -1019,6 +1019,13 @@ SyncApi.prototype._processSyncResponse = async function(
         accountDataEvents.forEach(function(e) {
             client.emit("event", e);
         });
+
+        // try to release the bits of the sync structure we just
+        // converted into events, so that they can be GC'd
+        // https://github.com/vector-im/riot-web/issues/6212
+        delete joinRooms(joinRooms.indexOf(joinObj));
+        delete data.rooms.join[room.roomId];
+        // hopefully there is nothing else dangling around...
     });
 
     // Handle leaves (e.g. kicked rooms)

--- a/src/sync.js
+++ b/src/sync.js
@@ -1023,7 +1023,7 @@ SyncApi.prototype._processSyncResponse = async function(
         // try to release the bits of the sync structure we just
         // converted into events, so that they can be GC'd
         // https://github.com/vector-im/riot-web/issues/6212
-        delete joinRooms(joinRooms.indexOf(joinObj));
+        delete joinRooms[joinRooms.indexOf(joinObj)];
         delete data.rooms.join[room.roomId];
         // hopefully there is nothing else dangling around...
     });


### PR DESCRIPTION
by deleting fields from /sync responses as you emit them into events,
to avoid wasting RAM when parsing the enormous accumulated sync response
from indexeddb on launch