### PR TITLE
Fix bug where global "Never send to unverified..." is ignored

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -411,8 +411,6 @@ MatrixClient.prototype.initCrypto = async function() {
     // handlers.
     crypto.registerEventHandlers(this);
     this._crypto = crypto;
-
-    this.emit("crypto.initComplete");
 };
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -411,6 +411,8 @@ MatrixClient.prototype.initCrypto = async function() {
     // handlers.
     crypto.registerEventHandlers(this);
     this._crypto = crypto;
+
+    this.emit("crypto.initComplete");
 };
 
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -543,7 +543,7 @@ MegolmEncryption.prototype._getDevicesInRoom = function(room) {
 
     // The global value is treated as a default for when rooms don't specify a value.
     let isBlacklisting = this._crypto.getGlobalBlacklistUnverifiedDevices();
-    if (room.getBlacklistUnverifiedDevices() !== null) {
+    if (typeof room.getBlacklistUnverifiedDevices() === 'boolean') {
         isBlacklisting = room.getBlacklistUnverifiedDevices();
     }
 


### PR DESCRIPTION
 - Emit `crypto.initComplete` for apps that need to execute code that requires crypto to have initialised
 - Fix overriding `undefined` per-room unverified devices setting

Codep https://github.com/matrix-org/matrix-react-sdk/pull/1772