### PR TITLE
Precompute push actions for state events

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1299,6 +1299,16 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     const liveTimeline = room.getLiveTimeline();
     const timelineWasEmpty = liveTimeline.getEvents().length == 0;
     if (timelineWasEmpty) {
+        // Passing these events into initialiseState will freeze them, so we need
+        // to compute and cache the push actions for them now.
+        // XXX: This is pretty horrible and is assuming all sorts of behaviour from
+        // these functions that it shouldn't be. We should probably either store the
+        // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise
+        // find some solution where MatrixEvents are immutable but allow for a cache
+        // field.
+        for (const ev of stateEventList) {
+            this.client.getPushActionsForEvent(ev);
+        }
         liveTimeline.initialiseState(stateEventList);
     }
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -1300,7 +1300,8 @@ SyncApi.prototype._processRoomEvents = function(room, stateEventList,
     const timelineWasEmpty = liveTimeline.getEvents().length == 0;
     if (timelineWasEmpty) {
         // Passing these events into initialiseState will freeze them, so we need
-        // to compute and cache the push actions for them now.
+        // to compute and cache the push actions for them now, otherwise sync dies
+        // with an attempt to assign to read only property.
         // XXX: This is pretty horrible and is assuming all sorts of behaviour from
         // these functions that it shouldn't be. We should probably either store the
         // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise


### PR DESCRIPTION
State events get froze now, so we can't write to the push actions
cache after having done so: precompute the push actions to work
around this.