### PR TITLE
Add cancelAndRetry flag to decryptEvent

### DIFF
--- a/src/crypto/OutgoingRoomKeyRequestManager.js
+++ b/src/crypto/OutgoingRoomKeyRequestManager.js
@@ -135,7 +135,7 @@ export default class OutgoingRoomKeyRequestManager {
      * @param {module:crypto~RoomKeyRequestBody} requestBody
      *
      * @returns {Promise} resolves when the request has been updated in our
-     *    pending list.
+     *    pending list and we have sent the cancellation.
      */
     cancelRoomKeyRequest(requestBody) {
         return this._cryptoStore.getOutgoingRoomKeyRequest(
@@ -195,9 +195,10 @@ export default class OutgoingRoomKeyRequestManager {
                         // with the same transaction_id, so only one message will get
                         // sent).
                         //
-                        // (We also don't want to wait for the response from the server
-                        // here, as it will slow down processing of received keys if we
-                        // do.)
+                        // (We want to wait for the response from the server here, so that
+                        // we can be sure that the request has been cancelled before
+                        // resolving, despite the fact that it will slow down processing
+                        // of received keys)
                         return this._sendOutgoingRoomKeyRequestCancellation(
                             updatedReq,
                         ).catch((e) => {

--- a/src/crypto/OutgoingRoomKeyRequestManager.js
+++ b/src/crypto/OutgoingRoomKeyRequestManager.js
@@ -198,7 +198,7 @@ export default class OutgoingRoomKeyRequestManager {
                         // (We also don't want to wait for the response from the server
                         // here, as it will slow down processing of received keys if we
                         // do.)
-                        this._sendOutgoingRoomKeyRequestCancellation(
+                        return this._sendOutgoingRoomKeyRequestCancellation(
                             updatedReq,
                         ).catch((e) => {
                             console.error(
@@ -206,7 +206,7 @@ export default class OutgoingRoomKeyRequestManager {
                                 + " will retry later.", e,
                             );
                             this._startTimer();
-                        }).done();
+                        });
                     });
 
                 default:

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -856,7 +856,8 @@ Crypto.prototype.requestRoomKey = function(requestBody, recipients) {
  *
  * @param {module:crypto~RoomKeyRequestBody} requestBody
  *    parameters to match for cancellation
- * @returns {Promise}
+ * @returns {Promise} Promise which resolves when the room key request has been
+ *                    cancelled.
  */
 Crypto.prototype.cancelRoomKeyRequest = function(requestBody) {
     return this._outgoingRoomKeyRequestManager.cancelRoomKeyRequest(requestBody)

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -856,12 +856,13 @@ Crypto.prototype.requestRoomKey = function(requestBody, recipients) {
  *
  * @param {module:crypto~RoomKeyRequestBody} requestBody
  *    parameters to match for cancellation
+ * @returns {Promise}
  */
 Crypto.prototype.cancelRoomKeyRequest = function(requestBody) {
-    this._outgoingRoomKeyRequestManager.cancelRoomKeyRequest(requestBody)
+    return this._outgoingRoomKeyRequestManager.cancelRoomKeyRequest(requestBody)
     .catch((e) => {
         console.warn("Error clearing pending room key requests", e);
-    }).done();
+    });
 };
 
 /**

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -340,19 +340,34 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @internal
      *
      * @param {module:crypto} crypto crypto module
+     * @param {boolean} cancelAndRetry retry the attempt, even if we tried to decrypt
+     *                                 this event before. If there's an existing
+     *                                 pending key request for this event, cancel it
+     *                                 before retrying.
      *
      * @returns {Promise} promise which resolves (to undefined) when the decryption
      * attempt is completed.
      */
-    attemptDecryption: async function(crypto) {
+    attemptDecryption: async function(crypto, cancelAndRetry=false) {
         // start with a couple of sanity checks.
         if (!this.isEncrypted()) {
             throw new Error("Attempt to decrypt event which isn't encrypted");
         }
 
-        if (
-            this._clearEvent && this._clearEvent.content &&
+        if (cancelAndRetry) {
+            const wireContent = this.getWireContent();
+            await crypto.cancelRoomKeyRequest({
+                algorithm: wireContent.algorithm,
+                room_id: this.getRoomId(),
+                session_id: wireContent.session_id,
+                sender_key: wireContent.sender_key,
+            });
+        }
+
+        if (!cancelAndRetry && (
+                this._clearEvent && this._clearEvent.content &&
                 this._clearEvent.content.msgtype !== "m.bad.encrypted"
+            )
         ) {
             // we may want to just ignore this? let's start with rejecting it.
             throw new Error(

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -349,7 +349,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * attempt is completed.
      */
     attemptDecryption: async function(crypto, cancelAndRetry=false) {
-        // start with a couple of sanity checks.
+        // If this event isn't encrypted, decryption will fail so throw early
         if (!this.isEncrypted()) {
             throw new Error("Attempt to decrypt event which isn't encrypted");
         }
@@ -364,6 +364,10 @@ utils.extend(module.exports.MatrixEvent.prototype, {
             });
         }
 
+        // Don't attempt to decrypt an event which has already been encrypted,
+        // unless cancelAndRetry is true, in which case we allow a retry
+        // because we've just cancelled the room key request and can expect a
+        // new request to be started when we fail to decrypt again.
         if (!cancelAndRetry && (
                 this._clearEvent && this._clearEvent.content &&
                 this._clearEvent.content.msgtype !== "m.bad.encrypted"


### PR DESCRIPTION
that allows for cancellation of outgoing key requests before
attempting to decrypt, which itself may do an outgoing key
request upon failure.

This is useful for cases where other clients have ignored the
requests but the user would like to resend the key request
manually.