### PR TITLE
Don't do /keys/changes on incremental sync

### DIFF
--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -132,7 +132,7 @@ describe("MatrixClient", function() {
         ].reduce((r, k) => { r[k] = expect.createSpy(); return r; }, {});
         store = [
             "getRoom", "getRooms", "getUser", "getSyncToken", "scrollback",
-            "save", "setSyncToken", "storeEvents", "storeRoom", "storeUser",
+            "save", "wantsSave", "setSyncToken", "storeEvents", "storeRoom", "storeUser",
             "getFilterIdByName", "setFilterIdByName", "getFilter", "storeFilter",
             "getSyncAccumulator", "startup", "deleteAllData",
         ].reduce((r, k) => { r[k] = expect.createSpy(); return r; }, {});

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -146,18 +146,23 @@ export default class DeviceList {
      * The actual save will be delayed by a short amount of time to
      * aggregate multiple writes to the database.
      *
+     * @param {integer} delay Time in ms before which the save actually happens.
+     *     By default, the save is delayed for a short period in order to batch
+     *     multiple writes, but this behaviour can be disabled by passing 0.
+     *
      * @return {Promise<bool>} true if the data was saved, false if
      *     it was not (eg. because no changes were pending). The promise
      *     will only resolve once the data is saved, so may take some time
      *     to resolve.
      */
-    async saveIfDirty() {
+    async saveIfDirty(delay) {
         if (!this._dirty) return Promise.resolve(false);
+        if (delay === undefined) delay = 500;
 
         if (this._savePromise === null) {
             // Delay saves for a bit so we can aggregate multiple saves that happen
             // in quick succession (eg. when a whole room's devices are marked as known)
-            this._savePromise = Promise.delay(500).then(() => {
+            this._savePromise = Promise.delay(delay).then(() => {
                 console.log('Saving device tracking data at token ' + this._syncToken);
                 // null out savePromise now (after the delay but before the write),
                 // otherwise we could return the existing promise when the save has

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -163,6 +163,8 @@ export default class DeviceList {
      */
     async saveIfDirty(delay) {
         if (!this._dirty) return Promise.resolve(false);
+        // Delay saves for a bit so we can aggregate multiple saves that happen
+        // in quick succession (eg. when a whole room's devices are marked as known)
         if (delay === undefined) delay = 500;
 
         const targetTime = Date.now + delay;
@@ -185,8 +187,6 @@ export default class DeviceList {
         }
 
         if (this._saveTimer === null) {
-            // Delay saves for a bit so we can aggregate multiple saves that happen
-            // in quick succession (eg. when a whole room's devices are marked as known)
             const resolveSavePromise = this._resolveSavePromise;
             this._savePromiseTime = targetTime;
             this._saveTimer = setTimeout(() => {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -831,7 +831,7 @@ Crypto.prototype.handleDeviceListChanges = async function(syncData, syncDeviceLi
     if (!syncData.oldSyncToken) return;
 
     // Here, we're relying on the fact that we only ever save the sync data after
-    // sucessfully saving the device list data, so we're guarenteed that the device
+    // sucessfully saving the device list data, so we're guaranteed that the device
     // list store is at least as fresh as the sync token from the sync store, ie.
     // any device changes received in sync tokens prior to the 'next' token here
     // have been processed and are reflected in the current device list.

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -160,12 +160,26 @@ IndexedDBStore.prototype.deleteAllData = function() {
 };
 
 /**
+ * Whether this store would like to save its data
+ * Note that obviously whether the store wants to save or
+ * not could change between calling this function and calling
+ * save().
+ *
+ * @return {boolean} True if calling save() will actually save
+ *     (at the time this function is called).
+ */
+IndexedDBStore.prototype.wantsSave = function() {
+    const now = Date.now();
+    return now - this._syncTs > WRITE_DELAY_MS;
+};
+
+/**
  * Possibly write data to the database.
- * @return {Promise} Promise resolves after the write completes.
+ * @return {Promise} Promise resolves after the write completes
+ *     (or immediately if no write is performed)
  */
 IndexedDBStore.prototype.save = function() {
-    const now = Date.now();
-    if (now - this._syncTs > WRITE_DELAY_MS) {
+    if (this.wantsSave()) {
         return this._reallySave();
     }
     return Promise.resolve();

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -317,6 +317,8 @@ module.exports.MatrixInMemoryStore.prototype = {
 
     /**
      * We never want to save becase we have nothing to save to.
+     *
+     * @return {boolean} If the store wants to save
      */
     wantsSave: function() {
         return false;

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -316,6 +316,13 @@ module.exports.MatrixInMemoryStore.prototype = {
     },
 
     /**
+     * We never want to save becase we have nothing to save to.
+     */
+    wantsSave: function() {
+        return false;
+    },
+
+    /**
      * Save does nothing as there is no backing data store.
      */
     save: function() {},

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -217,6 +217,13 @@ StubStore.prototype = {
     },
 
     /**
+     * We never want to save becase we have nothing to save to.
+     */
+    wantsSave: function() {
+        return false;
+    },
+
+    /**
      * Save does nothing as there is no backing data store.
      */
     save: function() {},

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -218,6 +218,8 @@ StubStore.prototype = {
 
     /**
      * We never want to save becase we have nothing to save to.
+     *
+     * @return {boolean} If the store wants to save
      */
     wantsSave: function() {
         return false;


### PR DESCRIPTION
Remove the call to /keys/changes when we do an incremental syn
where the old sync token doesn't match the one in the device list
store. To allow us to do this, always save the device list store
before saving the sync data, so we can safely assume the device
list store is at least as fresh as the sync token in the sync store.

Thread save functions through to allow this, add a delay parameter
so the sync can save the device list immediately and skip the wait,
and add a wantsSave() method so the sync can skip saving the device
list if the sync store isn't going to save anyway.

Fixes https://github.com/vector-im/riot-web/issues/6068