### PR TITLE
Create indexeddb worker when starting the store

### DIFF
--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -29,11 +29,11 @@ import Promise from 'bluebird';
  * @param {Object} WorkerApi The web worker compatible interface object
  */
 const RemoteIndexedDBStoreBackend = function RemoteIndexedDBStoreBackend(
-    workerScript, dbName, WorkerApi,
+    workerScript, dbName, workerApi,
 ) {
     this._workerScript = workerScript;
     this._dbName = dbName;
-    this._workerApi = WorkerApi;
+    this._workerApi = workerApi;
     this._worker = null;
     this._nextSeq = 0;
     // The currently in-flight requests to the actual backend

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -26,7 +26,7 @@ import Promise from 'bluebird';
  * @param {string} workerScript URL to the worker script
  * @param {string=} dbName Optional database name. The same name must be used
  * to open the same database.
- * @param {Object} WorkerApi The web worker compatible interface object
+ * @param {Object} workerApi The web worker compatible interface object
  */
 const RemoteIndexedDBStoreBackend = function RemoteIndexedDBStoreBackend(
     workerScript, dbName, workerApi,

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -40,6 +40,8 @@ const RemoteIndexedDBStoreBackend = function RemoteIndexedDBStoreBackend(
     this._inFlight = {
         // seq: promise,
     };
+    // Once we start connecting, we keep the promise and re-use it
+    // if we try to connect again
     this._startPromise = null;
 };
 


### PR DESCRIPTION
Rather than when creating it, otherwise we could potentially end
up starting workers unnecessarily.