### PR TITLE
Switch event type to m.sticker.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1365,7 +1365,7 @@ MatrixClient.prototype.sendStickerMessage = function(roomId, url, info, text, ca
          body: text,
     };
     return this.sendEvent(
-        roomId, "m.room.sticker", content, callback, undefined,
+        roomId, "m.sticker", content, callback, undefined,
     );
 };
 


### PR DESCRIPTION
@ara4n - Can you just confirm that you're happy with switching the m.room.sticker type to plain m.sticker (as discussed).