### PR TITLE
Ignore inserts of dup inbound group sessions, pt 2

### DIFF
--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -394,12 +394,12 @@ export class Backend {
         const addReq = objectStore.add({
             senderCurve25519Key, sessionId, session: sessionData,
         });
-        addReq.onerror = (e) => {
+        addReq.onerror = (ev) => {
             if (addReq.error.name === 'ConstraintError') {
                 // This stops the error from triggering the txn's onerror
-                e.stopPropagation();
+                ev.stopPropagation();
                 // ...and this stops it from aborting the transaction
-                e.preventDefault();
+                ev.preventDefault();
                 console.log(
                     "Ignoring duplicate inbound group session: " +
                     senderCurve25519Key + " / " + sessionId,

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -394,8 +394,12 @@ export class Backend {
         const addReq = objectStore.add({
             senderCurve25519Key, sessionId, session: sessionData,
         });
-        addReq.onerror = () => {
+        addReq.onerror = (e) => {
             if (addReq.error.name === 'ConstraintError') {
+                // This stops the error from triggering the txn's onerror
+                e.stopPropagation();
+                // ...and this stops it from aborting the transaction
+                e.preventDefault();
                 console.log(
                     "Ignoring duplicate inbound group session: " +
                     senderCurve25519Key + " / " + sessionId,


### PR DESCRIPTION
Stop the error from propagating to the txn error handler and
aborting the rest of the transaction.