### PR TITLE
fix typo where `headers` was not being used and thus sent wrong content-type

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -724,7 +724,7 @@ module.exports.MatrixHttpApi.prototype = {
                     body: data,
                     json: false,
                     timeout: localTimeoutMs,
-                    headers: opts.headers || {},
+                    headers: headers || {},
                     _matrix_opts: this.opts,
                 },
                 function(err, response, body) {


### PR DESCRIPTION
higher up this method copies `opts.headers` into `headers` and if `json && data` then sets the content-type to `application/json`
Whilst writing matrix-search I was left with js-sdk reaching out to the express server with some json payload but plain text content type

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>