### PR TITLE
[FIX #3015] Add drag drop urls room view, add resolve_url api

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1010,6 +1010,40 @@ MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
 // ================
 
 /**
+ * Resolve a url to the media repository on the home server.
+ *
+ * @param {string=} url The url to resolve
+ *
+ * @param {object} opts  options object
+ *
+ * @param {string=} opts.name   Name to give the file on the server. Defaults
+ *   to 'default'.
+ *
+ * @param {string=} opts.type   Content-type for the upload. Defaults to
+ *   <tt>applicaton/octet-stream</tt>.
+ *
+ * @param {boolean=} opts.rawResponse Return the raw body, rather than
+ *   parsing the JSON. Defaults to false (except on node.js, where it
+ *   defaults to true for backwards compatibility).
+ *
+ * @param {boolean=} opts.onlyContentUri Just return the content URI,
+ *   rather than the whole body. Defaults to false (except on browsers,
+ *   where it defaults to true for backwards compatibility). Ignored if
+ *   opts.rawResponse is true.
+ *
+ * @param {Function=} opts.callback Deprecated. Optional. The callback to
+ *    invoke on success/failure. See the promise return values for more
+ *    information.
+ *
+ * @return {module:client.Promise} Resolves to response object, as
+ *    determined by this.opts.onlyData, opts.rawResponse, and
+ *    opts.onlyContentUri.  Rejects with an error (usually a MatrixError).
+ */
+MatrixBaseApis.prototype.resolveUrl = function(url, opts) {
+    return this._http.resolveUrl(url, opts);
+};
+
+/**
  * Upload a file to the media repository on the home server.
  *
  * @param {object} file The object to upload. On a browser, something that

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1066,9 +1066,6 @@ MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
  *
  * @param {object} opts  options object
  *
- * @param {string=} opts.name   Name to give the file on the server. Defaults
- *   to 'default'.
- *
  * @param {boolean=} opts.rawResponse Return the raw body, rather than
  *   parsing the JSON. Defaults to false (except on node.js, where it
  *   defaults to true for backwards compatibility).

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1069,21 +1069,9 @@ MatrixBaseApis.prototype.searchUserDirectory = function(opts) {
  * @param {string=} opts.name   Name to give the file on the server. Defaults
  *   to 'default'.
  *
- * @param {string=} opts.type   Content-type for the upload. Defaults to
- *   <tt>applicaton/octet-stream</tt>.
- *
  * @param {boolean=} opts.rawResponse Return the raw body, rather than
  *   parsing the JSON. Defaults to false (except on node.js, where it
  *   defaults to true for backwards compatibility).
- *
- * @param {boolean=} opts.onlyContentUri Just return the content URI,
- *   rather than the whole body. Defaults to false (except on browsers,
- *   where it defaults to true for backwards compatibility). Ignored if
- *   opts.rawResponse is true.
- *
- * @param {Function=} opts.callback Deprecated. Optional. The callback to
- *    invoke on success/failure. See the promise return values for more
- *    information.
  *
  * @return {module:client.Promise} Resolves to response object, as
  *    determined by this.opts.onlyData, opts.rawResponse, and


### PR DESCRIPTION
Hi everyone!

As part of this issue(vector-im/riot-web#3015) I were working on resolve api(matrix-org/synapse#2751) in synapse project and now it would require to integrate together.

By using resolve api as part of media api of synapse project it will solve CORS requests issue.

pull requests:

- https://github.com/matrix-org/synapse/pull/3308
- https://github.com/matrix-org/matrix-react-sdk/pull/1689

Signed-off-by: Alexandr Korsak alex.korsak@gmail.com