### PR TITLE
fix filtering

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2209,7 +2209,8 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
         if (filter) {
             // XXX: it's horrific that /messages' filter parameter doesn't match
             // /sync's one - see https://matrix.org/jira/browse/SPEC-451
-            params.filter = JSON.stringify(filter.getRoomTimelineFilterComponent());
+            const component = filter.getRoomTimelineFilterComponent();
+            params.filter = JSON.stringify(component ? component.filter_json : undefined);
         }
 
         promise =

--- a/src/filter-component.js
+++ b/src/filter-component.js
@@ -70,7 +70,7 @@ FilterComponent.prototype.check = function(event) {
         event.getRoomId(),
         event.getSender(),
         event.getType(),
-        event.getContent() ? event.getContent().url !== undefined : false,
+        event.getContent() ? typeof event.getContent().url === 'string' : false,
     );
 };
 


### PR DESCRIPTION
### Fixes rest of https://github.com/vector-im/riot-web/issues/6250

`/messages` has a weird filter format, currently js-sdk sent the derived fields at the root and the original filter defn in `filter_json` which is unread and unspecced.
![image](https://user-images.githubusercontent.com/2403652/41507685-ae1d72cc-722f-11e8-9468-0f810f813d10.png)

We want to pass the raw defn to Synapse so that any filtering it does is identical to if this filter was used by ID via the sync API.

Also check if event.content.url is a string to decide whether it `contains_url`