### PR TITLE
displayname disambiguation fixes

### DIFF
--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -231,7 +231,7 @@ function calculateDisplayName(member, event, roomState) {
 
     // First check if the displayname is something we consider truthy
     // after stripping it of zero width characters and padding spaces
-    const strippedDisplayName = utils.stripDisplayName(displayName);
+    const strippedDisplayName = utils.removeHiddenChars(displayName);
     if (!strippedDisplayName) {
         return selfUserId;
     }

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -229,18 +229,23 @@ function calculateDisplayName(member, event, roomState) {
         return displayName;
     }
 
+    // First check if the displayname is something we consider truthy
+    // after stripping it of zero width characters and padding spaces
+    const strippedDisplayName = utils.stripDisplayName(displayName);
+    if (!strippedDisplayName) {
+        return selfUserId;
+    }
 
-    // Check if the name contains something that look like a mxid
+    // Next check if the name contains something that look like a mxid
     // If it does, it may be someone trying to impersonate someone else
     // Show full mxid in this case
     // Also show mxid if there are other people with the same displayname
+    // ignoring any zero width chars (unicode 200B-200D)
+    // if their displayname is made up of just zero width chars, show full mxid
     let disambiguate = /@.+:.+/.test(displayName);
     if (!disambiguate) {
-        const userIds = roomState.getUserIdsWithDisplayName(displayName);
-        const otherUsers = userIds.filter(function(u) {
-            return u !== selfUserId;
-        });
-        disambiguate = otherUsers.length > 0;
+        const userIds = roomState.getUserIdsWithDisplayName(strippedDisplayName);
+        disambiguate = userIds.some((u) => u !== selfUserId);
     }
 
     if (disambiguate) {

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -494,7 +494,8 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
         // We clobber the user_id > name lookup but the name -> [user_id] lookup
         // means we need to remove that user ID from that array rather than nuking
         // the lot.
-        const strippedOldName = utils.stripDisplayName(oldName);
+        const strippedOldName = utils.removeHiddenChars(oldName);
+
         const existingUserIds = roomState._displayNameToUserIds[strippedOldName];
         if (existingUserIds) {
             for (let i = 0; i < existingUserIds.length; i++) {
@@ -510,7 +511,7 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
 
     roomState._userIdsToDisplayNames[userId] = displayName;
 
-    const strippedDisplayname = displayName && utils.stripDisplayName(displayName);
+    const strippedDisplayname = displayName && utils.removeHiddenChars(displayName);
     // an empty stripped displayname (undefined/'') will be set to MXID in room-member.js
     if (strippedDisplayname) {
         if (!roomState._displayNameToUserIds[strippedDisplayname]) {

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -494,22 +494,30 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
         // We clobber the user_id > name lookup but the name -> [user_id] lookup
         // means we need to remove that user ID from that array rather than nuking
         // the lot.
-        const existingUserIds = roomState._displayNameToUserIds[oldName] || [];
-        for (let i = 0; i < existingUserIds.length; i++) {
-            if (existingUserIds[i] === userId) {
-                // remove this user ID from this array
-                existingUserIds.splice(i, 1);
-                i--;
+        const strippedOldName = utils.stripDisplayName(oldName);
+        const existingUserIds = roomState._displayNameToUserIds[strippedOldName];
+        if (existingUserIds) {
+            for (let i = 0; i < existingUserIds.length; i++) {
+                if (existingUserIds[i] === userId) {
+                    // remove this user ID from this array
+                    existingUserIds.splice(i, 1);
+                    i--;
+                }
             }
+            roomState._displayNameToUserIds[strippedOldName] = existingUserIds;
         }
-        roomState._displayNameToUserIds[oldName] = existingUserIds;
     }
 
     roomState._userIdsToDisplayNames[userId] = displayName;
-    if (!roomState._displayNameToUserIds[displayName]) {
-        roomState._displayNameToUserIds[displayName] = [];
+
+    const strippedDisplayname = displayName && utils.stripDisplayName(displayName);
+    // an empty stripped displayname (undefined/'') will be set to MXID in room-member.js
+    if (strippedDisplayname) {
+        if (!roomState._displayNameToUserIds[strippedDisplayname]) {
+            roomState._displayNameToUserIds[strippedDisplayname] = [];
+        }
+        roomState._displayNameToUserIds[strippedDisplayname].push(userId);
     }
-    roomState._displayNameToUserIds[displayName].push(userId);
 }
 
 /**

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -498,14 +498,9 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
 
         const existingUserIds = roomState._displayNameToUserIds[strippedOldName];
         if (existingUserIds) {
-            for (let i = 0; i < existingUserIds.length; i++) {
-                if (existingUserIds[i] === userId) {
-                    // remove this user ID from this array
-                    existingUserIds.splice(i, 1);
-                    i--;
-                }
-            }
-            roomState._displayNameToUserIds[strippedOldName] = existingUserIds;
+            // remove this user ID from this array
+            const filteredUserIDs = existingUserIds.filter((id) => id !== userId);
+            roomState._displayNameToUserIds[strippedOldName] = filteredUserIDs;
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -664,11 +664,11 @@ module.exports.isNumber = function(value) {
 };
 
 /**
- * Strips zero width chars, diaritics and whitespace from the displayName
- * @param {string} displayName the displayname to strip
- * @return {string} the stripped displayname
+ * Removes zero width chars, diacritics and whitespace from the string
+ * @param {string} str the string to remove hidden characters from
+ * @return {string} a string with the hidden characters removed
  */
-module.exports.stripDisplayName = function(displayName) {
-    return displayName.normalize('NFD').replace(stripDisplayNameRegex, '');
+module.exports.removeHiddenChars = function(str) {
+    return str.normalize('NFD').replace(removeHiddenCharsRegex, '');
 };
-const stripDisplayNameRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;
+const removeHiddenCharsRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;

--- a/src/utils.js
+++ b/src/utils.js
@@ -664,10 +664,10 @@ module.exports.isNumber = function(value) {
 };
 
 /**
- * Strips zero width chars and padding spaces from the displayName
+ * Strips zero width chars, diaritics and whitespace from the displayName
  * @param {string} displayName the displayname to strip
  * @return {string} the stripped displayname
  */
 module.exports.stripDisplayName = function(displayName) {
-    return displayName.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+    return displayName.normalize('NFD').replace(/[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g, '');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -662,3 +662,12 @@ module.exports.inherits = function(ctor, superCtor) {
 module.exports.isNumber = function(value) {
     return typeof value === 'number' && isFinite(value);
 };
+
+/**
+ * Strips zero width chars and padding spaces from the displayName
+ * @param {string} displayName the displayname to strip
+ * @return {string} the stripped displayname
+ */
+module.exports.stripDisplayName = function(displayName) {
+    return displayName.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -669,5 +669,6 @@ module.exports.isNumber = function(value) {
  * @return {string} the stripped displayname
  */
 module.exports.stripDisplayName = function(displayName) {
-    return displayName.normalize('NFD').replace(/[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g, '');
+    return displayName.normalize('NFD').replace(stripDisplayNameRegex, '');
 };
+const stripDisplayNameRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;


### PR DESCRIPTION
+ fixes disambiguation occurring if someone's is set to `undefined` because javascript type coercion.
+ strips zero width chars and whitespace from displayName when doing disambiguation logic
+ if someone's displayname is just spaces/zero width chars show just their MXID instead.

### Fixes https://github.com/vector-im/riot-web/issues/6896 and https://github.com/vector-im/riot-web/issues/5827

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>