### PR TITLE
Lazy load room members - Part I

### DIFF
--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -204,7 +204,7 @@ describe("RoomMember", function() {
         it("should allow precedence of state events",
         function() {
             const member = new RoomMember(roomId, lazyUserId);
-            member.setAsLazyLoadedMember(memberInfo);
+            member.setAsLazyLoadedMember(memberInfo.displayName, memberInfo.avatarUrl, memberInfo.membership);
             let url = member.getAvatarUrl(hsUrl);
             expect(url.indexOf("lazy/loaded")).toNotEqual(-1);
             expect(member.name).toEqual(displayName);

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -192,6 +192,50 @@ describe("RoomMember", function() {
         });
     });
 
+    describe("setAsLazyLoadedMember", function() {
+        const hsUrl = "https://my.home.server";
+        const lazyUserId = "@lazy:bar";
+        const displayName = "Mr. Lazy";
+        const memberInfo = {
+            avatarUrl: "mxc://lazy/loaded",
+            displayName: displayName ,
+            membership: "join"
+        };
+        it("should allow precedence of state events",
+        function() {
+            const member = new RoomMember(roomId, lazyUserId);
+            member.setAsLazyLoadedMember(memberInfo);
+            let url = member.getAvatarUrl(hsUrl);
+            expect(url.indexOf("lazy/loaded")).toNotEqual(-1);
+            expect(member.name).toEqual(displayName);
+            expect(member.isLazyLoaded()).toEqual(true);
+
+            member.setMembershipEvent(utils.mkEvent({
+                event: true,
+                type: "m.room.member",
+                skey: lazyUserId,
+                room: roomId,
+                user: lazyUserId,
+                content: {
+                    displayname: "Mr. State",
+                    membership: "join",
+                    avatar_url: "mxc://flibble/wibble",
+                },
+            }));
+
+            url = member.getAvatarUrl(hsUrl);
+            
+            // check that the member can't be set as lazy loaded anymore
+            // once it has a member event
+            for(let i = 0; i <= 2; ++i) {
+                expect(url.indexOf("flibble/wibble")).toNotEqual(-1);
+                expect(member.name).toEqual("Mr. State");
+                expect(member.isLazyLoaded()).toEqual(false);
+                member.setAsLazyLoadedMember(memberInfo);
+            }        
+        });
+    });
+
     describe("setMembershipEvent", function() {
         const joinEvent = utils.mkMembership({
             event: true,

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -192,51 +192,28 @@ describe("RoomMember", function() {
         });
     });
 
-    describe("setAsLazyLoadedMember", function() {
-        const hsUrl = "https://my.home.server";
-        const lazyUserId = "@lazy:bar";
-        const displayName = "Mr. Lazy";
-        const memberInfo = {
-            avatarUrl: "mxc://lazy/loaded",
-            displayName: displayName,
-            membership: "join",
-        };
-        it("should allow precedence of state events",
-        function() {
-            const member = new RoomMember(roomId, lazyUserId);
-            member.setAsLazyLoadedMember(
-                memberInfo.displayName,
-                memberInfo.avatarUrl,
-                memberInfo.membership);
+    describe("isOutOfBand", function() {
+        it("should be set by markOutOfBand", function() {
+            const member = new RoomMember();
+            expect(member.isOutOfBand()).toEqual(false);
+            member.markOutOfBand();
+            expect(member.isOutOfBand()).toEqual(true);
+        });
+    });
 
-            let url = member.getAvatarUrl(hsUrl);
-            expect(url.indexOf("lazy/loaded")).toNotEqual(-1);
-            expect(member.name).toEqual(displayName);
-            expect(member.isLazyLoaded()).toEqual(true);
-
-            member.setMembershipEvent(utils.mkEvent({
-                event: true,
-                type: "m.room.member",
-                skey: lazyUserId,
-                room: roomId,
-                user: lazyUserId,
-                content: {
-                    displayname: "Mr. State",
-                    membership: "join",
-                    avatar_url: "mxc://flibble/wibble",
-                },
-            }));
-
-            url = member.getAvatarUrl(hsUrl);
-
-            // check that the member can't be set as lazy loaded anymore
-            // once it has a member event
-            for(let i = 0; i < 2; ++i) {
-                expect(url.indexOf("flibble/wibble")).toNotEqual(-1);
-                expect(member.name).toEqual("Mr. State");
-                expect(member.isLazyLoaded()).toEqual(false);
-                member.setAsLazyLoadedMember(memberInfo);
-            }
+    describe("supersedesOutOfBand", function() {
+        it("should be set by markSupersedesOutOfBand", function() {
+            const member = new RoomMember();
+            expect(member.supersedesOutOfBand()).toEqual(false);
+            member.markSupersedesOutOfBand();
+            expect(member.supersedesOutOfBand()).toEqual(true);
+        });
+        it("should be cleared by clearSupersedesOutOfBand", function() {
+            const member = new RoomMember();
+            member.markSupersedesOutOfBand();
+            expect(member.supersedesOutOfBand()).toEqual(true);
+            member.clearSupersedesOutOfBand();
+            expect(member.supersedesOutOfBand()).toEqual(false);
         });
     });
 

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -198,13 +198,17 @@ describe("RoomMember", function() {
         const displayName = "Mr. Lazy";
         const memberInfo = {
             avatarUrl: "mxc://lazy/loaded",
-            displayName: displayName ,
-            membership: "join"
+            displayName: displayName,
+            membership: "join",
         };
         it("should allow precedence of state events",
         function() {
             const member = new RoomMember(roomId, lazyUserId);
-            member.setAsLazyLoadedMember(memberInfo.displayName, memberInfo.avatarUrl, memberInfo.membership);
+            member.setAsLazyLoadedMember(
+                memberInfo.displayName,
+                memberInfo.avatarUrl,
+                memberInfo.membership);
+
             let url = member.getAvatarUrl(hsUrl);
             expect(url.indexOf("lazy/loaded")).toNotEqual(-1);
             expect(member.name).toEqual(displayName);
@@ -224,7 +228,7 @@ describe("RoomMember", function() {
             }));
 
             url = member.getAvatarUrl(hsUrl);
-            
+
             // check that the member can't be set as lazy loaded anymore
             // once it has a member event
             for(let i = 0; i < 2; ++i) {
@@ -232,7 +236,7 @@ describe("RoomMember", function() {
                 expect(member.name).toEqual("Mr. State");
                 expect(member.isLazyLoaded()).toEqual(false);
                 member.setAsLazyLoadedMember(memberInfo);
-            }        
+            }
         });
     });
 

--- a/spec/unit/room-member.spec.js
+++ b/spec/unit/room-member.spec.js
@@ -227,7 +227,7 @@ describe("RoomMember", function() {
             
             // check that the member can't be set as lazy loaded anymore
             // once it has a member event
-            for(let i = 0; i <= 2; ++i) {
+            for(let i = 0; i < 2; ++i) {
                 expect(url.indexOf("flibble/wibble")).toNotEqual(-1);
                 expect(member.name).toEqual("Mr. State");
                 expect(member.isLazyLoaded()).toEqual(false);

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -11,6 +11,7 @@ describe("RoomState", function() {
     const roomId = "!foo:bar";
     const userA = "@alice:bar";
     const userB = "@bob:bar";
+    const userLazy = "@lazy:bar";
     let state;
 
     beforeEach(function() {
@@ -259,6 +260,91 @@ describe("RoomState", function() {
             expect(state.members[userB].setMembershipEvent).toHaveBeenCalledWith(
                 memberEvent, state,
             );
+        });
+    });
+
+    describe("setLazyLoadedMembers", function() {
+        const mrLazy = "Mr. Lazy";
+
+        it("should add a unknown member", function() {
+            expect(state.getMember(userLazy)).toBeFalsy();
+            state.setLazyLoadedMembers([{userId: userLazy}]);
+            const member = state.getMember(userLazy);
+            expect(member.userId).toEqual(userLazy);
+            expect(member.isLazyLoaded()).toEqual(true);
+        });
+
+        it("should emit newMember when adding a member", function() {
+            expect(state.getMember(userLazy)).toBeFalsy();
+            let eventReceived = false;
+            state.once('RoomState.newMember', (_, __, member) => {
+                expect(member.userId).toEqual(userLazy);
+                eventReceived = true;
+            });
+            state.setLazyLoadedMembers([{userId: userLazy}]);
+            expect(eventReceived).toEqual(true);
+        });
+
+        it("should not overwrite an existing member", function() {
+            state.setLazyLoadedMembers([{userId: userA, displayName: mrLazy}]);
+            const memberA = state.getMember(userA);
+            expect(memberA.name).toNotEqual(mrLazy);
+            expect(memberA.isLazyLoaded()).toEqual(false);
+        });
+
+        it("should update lazily loaded members if already present", function() {
+            state.setLazyLoadedMembers([{userId: userLazy}]);
+            state.setLazyLoadedMembers([{userId: userLazy, displayName: mrLazy}]);
+            expect(state.getMember(userLazy).name).toEqual(mrLazy);
+        });
+
+        it("should emit members when updating a member", function() {
+            state.setLazyLoadedMembers([{userId: userLazy}]);
+            let eventReceived = false;
+            state.once('RoomState.members', (_, __, member) => {
+                expect(member.userId).toEqual(userLazy);
+                eventReceived = true;
+            });
+            state.setLazyLoadedMembers([{userId: userLazy, displayName: mrLazy}]);
+            expect(eventReceived).toEqual(true);
+        });
+        
+
+        it("should disambiguate name taking state event members into account", function() {
+            state.setLazyLoadedMembers([{userId: userLazy, displayName: userA}]);
+            const member = state.getMember(userLazy);
+            expect(member.name).toNotEqual(userA);  //contain userA but not be equal
+            expect(member.name.indexOf(userA)).toNotEqual(-1);
+        });
+
+    });
+
+    describe("clone", function() {
+        it("should contain same information as original", function() {
+            // include LL members in copy
+            state.setLazyLoadedMembers([{userId: userLazy}]);
+            const copy = state.clone();
+            const memberA = state.getMember(userA),
+                  memberACopy = copy.getMember(userA),
+                  memberB = state.getMember(userB),
+                  memberBCopy = copy.getMember(userB),
+                  memberLazy = state.getMember(userLazy),
+                  memberLazyCopy = copy.getMember(userLazy);
+            // check individual members
+            expect(memberA.name).toEqual(memberACopy.name);
+            expect(memberA.isLazyLoaded()).toEqual(memberACopy.isLazyLoaded());
+            expect(memberB.name).toEqual(memberBCopy.name);
+            expect(memberB.isLazyLoaded()).toEqual(memberBCopy.isLazyLoaded());
+            expect(memberLazy.name).toEqual(memberLazyCopy.name);
+            expect(memberLazy.isLazyLoaded()).toEqual(memberLazyCopy.isLazyLoaded());
+            // check member keys
+            expect(Object.keys(state.members)).toEqual(Object.keys(copy.members));
+            // check join count
+            expect(state.getJoinedMemberCount()).toEqual(copy.getJoinedMemberCount());
+        });
+
+        it("should return copy independent of original", function() {
+
         });
     });
 

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -12,6 +12,8 @@ describe("RoomState", function() {
     const userA = "@alice:bar";
     const userB = "@bob:bar";
     const userLazy = "@lazy:bar";
+    const mrLazy = "Mr. Lazy";
+
     let state;
 
     beforeEach(function() {
@@ -264,8 +266,6 @@ describe("RoomState", function() {
     });
 
     describe("setLazyLoadedMembers", function() {
-        const mrLazy = "Mr. Lazy";
-
         it("should add a unknown member", function() {
             expect(state.getMember(userLazy)).toBeFalsy();
             state.setLazyLoadedMembers([{userId: userLazy}]);
@@ -344,7 +344,22 @@ describe("RoomState", function() {
         });
 
         it("should return copy independent of original", function() {
+            // include LL members in copy
+            state.setLazyLoadedMembers([{userId: userLazy, membership: "join"}]);
+            const copy = state.clone();
+            const memberLazyCopy = copy.getMember(userLazy);
+            memberLazyCopy.setAsLazyLoadedMember(mrLazy, null, "join");
+            expect(state.getMember(userLazy).name).toEqual(userLazy);
+            expect(memberLazyCopy.name).toEqual(mrLazy);
 
+            expect(state.getJoinedMemberCount()).toEqual(3);
+
+            copy.setStateEvents([utils.mkMembership({  // userA leaves
+                event: true, mship: "leave", user: userA, room: roomId,
+            })]);
+
+            expect(state.getJoinedMemberCount()).toEqual(3);
+            expect(copy.getJoinedMemberCount()).toEqual(2);
         });
     });
 

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -78,8 +78,8 @@ describe("RoomState", function() {
     });
 
     describe("getSentinelMember", function() {
-        it("should return null if there is no member", function() {
-            expect(state.getSentinelMember("@no-one:here")).toEqual(null);
+        it("should return a member with the user id as name", function() {
+            expect(state.getSentinelMember("@no-one:here").name).toEqual("@no-one:here");
         });
 
         it("should return a member which doesn't change when the state is updated",

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -308,15 +308,14 @@ describe("RoomState", function() {
             state.setLazyLoadedMembers([{userId: userLazy, displayName: mrLazy}]);
             expect(eventReceived).toEqual(true);
         });
-        
 
-        it("should disambiguate name taking state event members into account", function() {
+        it("should disambiguate name taking state event members into account",
+        function() {
             state.setLazyLoadedMembers([{userId: userLazy, displayName: userA}]);
             const member = state.getMember(userLazy);
             expect(member.name).toNotEqual(userA);  //contain userA but not be equal
             expect(member.name.indexOf(userA)).toNotEqual(-1);
         });
-
     });
 
     describe("clone", function() {
@@ -324,12 +323,12 @@ describe("RoomState", function() {
             // include LL members in copy
             state.setLazyLoadedMembers([{userId: userLazy}]);
             const copy = state.clone();
-            const memberA = state.getMember(userA),
-                  memberACopy = copy.getMember(userA),
-                  memberB = state.getMember(userB),
-                  memberBCopy = copy.getMember(userB),
-                  memberLazy = state.getMember(userLazy),
-                  memberLazyCopy = copy.getMember(userLazy);
+            const memberA = state.getMember(userA);
+            const memberACopy = copy.getMember(userA);
+            const memberB = state.getMember(userB);
+            const memberBCopy = copy.getMember(userB);
+            const memberLazy = state.getMember(userLazy);
+            const memberLazyCopy = copy.getMember(userLazy);
             // check individual members
             expect(memberA.name).toEqual(memberACopy.name);
             expect(memberA.isLazyLoaded()).toEqual(memberACopy.isLazyLoaded());

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1293,7 +1293,7 @@ describe("Room", function() {
             });
             const room = new Room(roomId);
 
-            const promise2 = Promise.resolve([memberEvent2])
+            const promise2 = Promise.resolve([memberEvent2]);
             const promise1 = promise2.then(() => [memberEvent]);
 
             await room.loadOutOfBandMembers(promise1);

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1272,4 +1272,64 @@ describe("Room", function() {
             expect(callCount).toEqual(1);
         });
     });
+
+    describe("setLazyLoadedMembers", function() {
+        it("should apply member info in promise", async function() {
+            const room = new Room(roomId);
+            expect(room.membersNeedLoading()).toEqual(true);
+            const infoA = {userId: userA, membership: "invite"};
+            const infoB = {userId: userB, membership: "join"};
+            const promise = room.setLazyLoadedMembers(Promise.resolve([infoA, infoB]));
+            await promise;
+            expect(room.membersNeedLoading()).toEqual(false);
+            const memberA = room.getMember(userA);
+            const memberB = room.getMember(userB);
+            expect(memberA.membership).toEqual("invite");
+            expect(memberA.isLazyLoaded()).toEqual(true);
+            expect(memberB.membership).toEqual("join");
+            expect(memberB.isLazyLoaded()).toEqual(true);
+        });
+
+        it("should revert needs loading on error", async function() {
+            const room = new Room(roomId);
+            let hasThrown = false;
+            try {
+                await room.setLazyLoadedMembers(Promise.reject(new Error("bugger")));
+            }
+            catch(err) {
+                hasThrown = true;
+            }
+            expect(hasThrown).toEqual(true);
+            expect(room.membersNeedLoading()).toEqual(true);
+        });
+
+        it("should revert needs loading on error", async function() {
+            const room = new Room(roomId);
+            let hasThrown = false;
+            try {
+                await room.setLazyLoadedMembers(Promise.reject(new Error("bugger")));
+            }
+            catch(err) {
+                hasThrown = true;
+            }
+            expect(hasThrown).toEqual(true);
+            expect(room.membersNeedLoading()).toEqual(true);
+        });
+
+        it("second call (also in immediate succession) should be ignored", async function() {
+            const room = new Room(roomId);
+            const promise1 = room.setLazyLoadedMembers(Promise.resolve([
+                {userId: userA, membership: "join"},
+                {userId: userB, membership: "join"}
+            ]));
+            const promise2 = room.setLazyLoadedMembers(Promise.resolve([
+                {userId: userC, membership: "join"}
+            ]));
+            await Promise.all([promise1, promise2]);
+            expect(room.getMember(userA)).toBeTruthy();
+            expect(room.getMember(userB)).toBeTruthy();
+            expect(room.getMember(userC)).toBeFalsy();
+        });
+        
+    });
 });

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1273,49 +1273,17 @@ describe("Room", function() {
         });
     });
 
-    describe("setLazyLoadedMembers", function() {
-        it("should apply member info in promise", async function() {
-            const room = new Room(roomId);
-            expect(room.membersNeedLoading()).toEqual(true);
-            const infoA = {userId: userA, membership: "invite"};
-            const infoB = {userId: userB, membership: "join"};
-            const promise = room.setLazyLoadedMembers(Promise.resolve([infoA, infoB]));
-            await promise;
-            expect(room.membersNeedLoading()).toEqual(false);
-            const memberA = room.getMember(userA);
-            const memberB = room.getMember(userB);
-            expect(memberA.membership).toEqual("invite");
-            expect(memberA.isLazyLoaded()).toEqual(true);
-            expect(memberB.membership).toEqual("join");
-            expect(memberB.isLazyLoaded()).toEqual(true);
-        });
-
+    describe("loadOutOfBandMembers", function() {
         it("should revert needs loading on error", async function() {
             const room = new Room(roomId);
             let hasThrown = false;
             try {
-                await room.setLazyLoadedMembers(Promise.reject(new Error("bugger")));
+                await room.loadOutOfBandMembers(Promise.reject(new Error("bugger")));
             } catch(err) {
                 hasThrown = true;
             }
             expect(hasThrown).toEqual(true);
-            expect(room.membersNeedLoading()).toEqual(true);
-        });
-
-        it("second call (also in immediate succession) should be ignored",
-        async function() {
-            const room = new Room(roomId);
-            const promise1 = room.setLazyLoadedMembers(Promise.resolve([
-                {userId: userA, membership: "join"},
-                {userId: userB, membership: "join"},
-            ]));
-            const promise2 = room.setLazyLoadedMembers(Promise.resolve([
-                {userId: userC, membership: "join"},
-            ]));
-            await Promise.all([promise1, promise2]);
-            expect(room.getMember(userA)).toBeTruthy();
-            expect(room.getMember(userB)).toBeTruthy();
-            expect(room.getMember(userC)).toBeFalsy();
+            expect(room.needsOutOfBandMembers()).toEqual(true);
         });
     });
 });

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1274,6 +1274,35 @@ describe("Room", function() {
     });
 
     describe("loadOutOfBandMembers", function() {
+        const memberEvent = utils.mkMembership({
+            user: "@user_a:bar", mship: "join",
+            room: roomId, event: true, name: "User A",
+        });
+
+        it("should apply member events", async function() {
+            const room = new Room(roomId);
+            await room.loadOutOfBandMembers(Promise.resolve([memberEvent]));
+            const memberA = room.getMember("@user_a:bar");
+            expect(memberA.name).toEqual("User A");
+        });
+
+        it("should apply first call, not first resolved promise", async function() {
+            const memberEvent2 = utils.mkMembership({
+                user: "@user_a:bar", mship: "join",
+                room: roomId, event: true, name: "Ms A",
+            });
+            const room = new Room(roomId);
+
+            const promise2 = Promise.resolve([memberEvent2])
+            const promise1 = promise2.then(() => [memberEvent]);
+
+            await room.loadOutOfBandMembers(promise1);
+            await room.loadOutOfBandMembers(promise2);
+
+            const memberA = room.getMember("@user_a:bar");
+            expect(memberA.name).toEqual("User A");
+        });
+
         it("should revert needs loading on error", async function() {
             const room = new Room(roomId);
             let hasThrown = false;

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1295,41 +1295,27 @@ describe("Room", function() {
             let hasThrown = false;
             try {
                 await room.setLazyLoadedMembers(Promise.reject(new Error("bugger")));
-            }
-            catch(err) {
+            } catch(err) {
                 hasThrown = true;
             }
             expect(hasThrown).toEqual(true);
             expect(room.membersNeedLoading()).toEqual(true);
         });
 
-        it("should revert needs loading on error", async function() {
-            const room = new Room(roomId);
-            let hasThrown = false;
-            try {
-                await room.setLazyLoadedMembers(Promise.reject(new Error("bugger")));
-            }
-            catch(err) {
-                hasThrown = true;
-            }
-            expect(hasThrown).toEqual(true);
-            expect(room.membersNeedLoading()).toEqual(true);
-        });
-
-        it("second call (also in immediate succession) should be ignored", async function() {
+        it("second call (also in immediate succession) should be ignored",
+        async function() {
             const room = new Room(roomId);
             const promise1 = room.setLazyLoadedMembers(Promise.resolve([
                 {userId: userA, membership: "join"},
-                {userId: userB, membership: "join"}
+                {userId: userB, membership: "join"},
             ]));
             const promise2 = room.setLazyLoadedMembers(Promise.resolve([
-                {userId: userC, membership: "join"}
+                {userId: userC, membership: "join"},
             ]));
             await Promise.all([promise1, promise2]);
             expect(room.getMember(userA)).toBeTruthy();
             expect(room.getMember(userB)).toBeTruthy();
             expect(room.getMember(userC)).toBeFalsy();
         });
-        
     });
 });

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -419,12 +419,30 @@ MatrixBaseApis.prototype.roomState = function(roomId, callback) {
 
 /**
  * @param {string} roomId
+ * @param {string} includeMembership the membership type to include in the response
+ * @param {string} excludeMembership the membership type to exclude from the response
+ * @param {string} atEventId the id of the event for which moment in the timeline the members should be returned for
  * @param {module:client.callback} callback Optional.
  * @return {module:client.Promise} Resolves: dictionary of userid to profile information
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixBaseApis.prototype.joinedMembers = function(roomId, callback) {
-    const path = utils.encodeUri("/rooms/$roomId/joined_members", {$roomId: roomId});
+MatrixBaseApis.prototype.members =
+function(roomId, includeMembership, excludeMembership, atEventId, callback) {
+    const queryParams = {};
+    if (includeMembership) {
+        queryParams.membership = includeMembership;
+    }
+    if (excludeMembership) {
+        queryParams.not_membership = excludeMembership;
+    }
+    if (atEventId) {
+        queryParams.at = atEventId;
+    }
+
+    const queryString = utils.encodeParams(queryParams);
+
+    const path = utils.encodeUri("/rooms/$roomId/members?" + queryString,
+        {$roomId: roomId});
     return this._http.authedRequest(callback, "GET", path);
 };
 

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -420,7 +420,7 @@ MatrixBaseApis.prototype.roomState = function(roomId, callback) {
 /**
  * @param {string} roomId
  * @param {module:client.callback} callback Optional.
- * @return {module:client.Promise} Resolves: TODO
+ * @return {module:client.Promise} Resolves: dictionary of userid to profile information
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixBaseApis.prototype.joinedMembers = function(roomId, callback) {

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -418,6 +418,18 @@ MatrixBaseApis.prototype.roomState = function(roomId, callback) {
 };
 
 /**
+ * @param {string} roomId
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.joinedMembers = function(roomId, callback) {
+    const path = utils.encodeUri("/rooms/$roomId/joined_members", {$roomId: roomId});
+    return this._http.authedRequest(callback, "GET", path);
+};
+
+
+/**
  * @param {string} groupId
  * @return {module:client.Promise} Resolves: Group summary object
  * @return {module:http-api.MatrixError} Rejects: with an error response.

--- a/src/client.js
+++ b/src/client.js
@@ -754,7 +754,7 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = function(roomId) {
     }
     const membersPromise = this.joinedMembers(roomId);
     room.setLazilyLoadedMembers(membersPromise);
-}
+};
 
 /**
  * Retrieve all known rooms.

--- a/src/client.js
+++ b/src/client.js
@@ -752,7 +752,18 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     if (!room || !room.membersNeedLoading()) {
         return;
     }
-    const membersPromise = this.joinedMembers(roomId);
+    const joinedMembersPromise = this.joinedMembers(roomId);
+    const membersPromise = joinedMembersPromise.then((profiles) => {
+        return Object.entries(profiles).map(([userId, profile]) => {
+            return {
+                userId: userId,
+                avatarUrl: profile.avatar_url,
+                displayName: profile.display_name,
+                membership: "join",  // as we need to support invitees as well
+                                    // in the future, already include but hardcode it
+            };
+        });
+    });
     await room.setLazilyLoadedMembers(membersPromise);
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -764,7 +764,7 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
             };
         });
     });
-    await room.setLazilyLoadedMembers(membersPromise);
+    await room.setLazyLoadedMembers(membersPromise);
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -756,10 +756,16 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     // room state at a given point in time. The plan is to do this by
     // passing the current next_batch sync token to the endpoint we use
     // to fetch the members. For now, this is a prototype that uses
-    // the /joined_members api, which does not support this synchronization,
-    // so there is a race condition here between the current /sync call
+    // the /joined_members api, which only tells us about the joined members
+    // (not invites for example) and does not support this synchronization.
+    // So there is a race condition here between the current /sync call
     // and the /joined_members call: if the have conflicting information, which one
     // represents the most recent state?
+    //
+    // Addressing this race condition and the fact that this only tells us about
+    // joined members is a prerequisite for taking this out of the prototype stage and
+    // enabling the feature flag (feature_lazyloading) that
+    // the call to this method is behind.
     const joinedMembersPromise = this.joinedMembers(roomId);
     const membersPromise = joinedMembersPromise.then((profiles) => {
         return Object.entries(profiles.joined).map(([userId, profile]) => {

--- a/src/client.js
+++ b/src/client.js
@@ -747,13 +747,13 @@ MatrixClient.prototype.getRoom = function(roomId) {
  * in case lazy loading of memberships is in use.
  * @param {string} roomId The room ID
  */
-MatrixClient.prototype.loadRoomMembersIfNeeded = function(roomId) {
+MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     const room = this.getRoom(roomId);
     if (!room || !room.membersNeedLoading()) {
         return;
     }
     const membersPromise = this.joinedMembers(roomId);
-    room.setLazilyLoadedMembers(membersPromise);
+    await room.setLazilyLoadedMembers(membersPromise);
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -756,7 +756,7 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     const lastEventId = room.getLastEventId();
     const responsePromise = this.members(roomId, "join", "leave", lastEventId);
     const eventsPromise = responsePromise.then((response) => {
-        return response.chunk.map(this.getEventMapper())
+        return response.chunk.map(this.getEventMapper());
     });
     await room.loadOutOfBandMembers(eventsPromise);
 };

--- a/src/client.js
+++ b/src/client.js
@@ -754,7 +754,7 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     }
     const joinedMembersPromise = this.joinedMembers(roomId);
     const membersPromise = joinedMembersPromise.then((profiles) => {
-        return Object.entries(profiles).map(([userId, profile]) => {
+        return Object.entries(profiles.joined).map(([userId, profile]) => {
             return {
                 userId: userId,
                 avatarUrl: profile.avatar_url,

--- a/src/client.js
+++ b/src/client.js
@@ -752,7 +752,6 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     if (!room || !room.membersNeedLoading()) {
         return;
     }
-    const joinedMembersPromise = this.joinedMembers(roomId);
     // XXX: we should make sure that the members we get back represent the
     // room state at a given point in time. The plan is to do this by
     // passing the current next_batch sync token to the endpoint we use
@@ -761,6 +760,7 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     // so there is a race condition here between the current /sync call
     // and the /joined_members call: if the have conflicting information, which one
     // represents the most recent state?
+    const joinedMembersPromise = this.joinedMembers(roomId);
     const membersPromise = joinedMembersPromise.then((profiles) => {
         return Object.entries(profiles.joined).map(([userId, profile]) => {
             return {

--- a/src/client.js
+++ b/src/client.js
@@ -743,6 +743,20 @@ MatrixClient.prototype.getRoom = function(roomId) {
 };
 
 /**
+ * Preloads the member list for the given room id,
+ * in case lazy loading of memberships is in use.
+ * @param {string} roomId The room ID
+ */
+MatrixClient.prototype.loadRoomMembersIfNeeded = function(roomId) {
+    const room = this.getRoom(roomId);
+    if (!room || !room.membersNeedLoading()) {
+        return;
+    }
+    const membersPromise = this.joinedMembers(roomId);
+    room.setLazilyLoadedMembers(membersPromise);
+}
+
+/**
  * Retrieve all known rooms.
  * @return {Room[]} A list of rooms, or an empty list if there is no data store.
  */

--- a/src/client.js
+++ b/src/client.js
@@ -755,7 +755,9 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
 
     const lastEventId = room.getLastEventId();
     const responsePromise = this.members(roomId, "join", "leave", lastEventId);
-    const eventsPromise = responsePromise.then((response) => response.chunk);
+    const eventsPromise = responsePromise.then((response) => {
+        return response.chunk.map(this.getEventMapper())
+    });
     await room.loadOutOfBandMembers(eventsPromise);
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -753,6 +753,14 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
         return;
     }
     const joinedMembersPromise = this.joinedMembers(roomId);
+    // XXX: we should make sure that the members we get back represent the
+    // room state at a given point in time. The plan is to do this by
+    // passing the current next_batch sync token to the endpoint we use
+    // to fetch the members. For now, this is a prototype that uses
+    // the /joined_members api, which does not support this synchronization,
+    // so there is a race condition here between the current /sync call
+    // and the /joined_members call: if the have conflicting information, which one
+    // represents the most recent state?
     const membersPromise = joinedMembersPromise.then((profiles) => {
         return Object.entries(profiles.joined).map(([userId, profile]) => {
             return {

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -74,11 +74,11 @@ function EventTimelineSet(room, opts) {
 utils.inherits(EventTimelineSet, EventEmitter);
 
 /**
- * Sets the lazily loaded members. For now only joined members.
- * @param {Profile[]} joinedMembers array with {avatar_url, display_name } tuples
+ * Sets the lazily loaded members.
+ * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
-EventTimelineSet.prototype.setJoinedMembers = function(joinedMembers) {
-    this._timelines.forEach((tl) => tl.setJoinedMembers(joinedMembers));
+EventTimelineSet.prototype.setLazilyLoadedMembers = function(members) {
+    this._timelines.forEach((tl) => tl.setLazilyLoadedMembers(members));
 };
 
 /**

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -176,49 +176,19 @@ EventTimelineSet.prototype.resetLiveTimeline = function(
     // if timeline support is disabled, forget about the old timelines
     const resetAllTimelines = !this._timelineSupport || !forwardPaginationToken;
 
-    let newTimeline;
+    const oldTimeline = this._liveTimeline;
+    const newTimeline = resetAllTimelines ?
+        oldTimeline.forkLive(EventTimeline.FORWARDS) :
+        oldTimeline.fork(EventTimeline.FORWARDS);
+
     if (resetAllTimelines) {
-        newTimeline = new EventTimeline(this);
         this._timelines = [newTimeline];
         this._eventIdToTimeline = {};
     } else {
-        newTimeline = this.addTimeline();
+        this._timelines.push(newTimeline);
     }
 
-    const oldTimeline = this._liveTimeline;
-
-    // Collect the state events from the old timeline
-    const evMap = oldTimeline.getState(EventTimeline.FORWARDS).events;
-    const events = [];
-    for (const evtype in evMap) {
-        if (!evMap.hasOwnProperty(evtype)) {
-            continue;
-        }
-        for (const stateKey in evMap[evtype]) {
-            if (!evMap[evtype].hasOwnProperty(stateKey)) {
-                continue;
-            }
-            events.push(evMap[evtype][stateKey]);
-        }
-    }
-
-    // Use those events to initialise the state of the new live timeline
-    newTimeline.initialiseState(events);
-
-    const freshEndState = newTimeline._endState;
-    // Now clobber the end state of the new live timeline with that from the
-    // previous live timeline. It will be identical except that we'll keep
-    // using the same RoomMember objects for the 'live' set of members with any
-    // listeners still attached
-    newTimeline._endState = oldTimeline._endState;
-
-    // If we're not resetting all timelines, we need to fix up the old live timeline
-    if (!resetAllTimelines) {
-        // Firstly, we just stole the old timeline's end state, so it needs a new one.
-        // Just swap them around and give it the one we just generated for the
-        // new live timeline.
-        oldTimeline._endState = freshEndState;
-
+    if (forwardPaginationToken) {
         // Now set the forward pagination token on the old live timeline
         // so it can be forward-paginated.
         oldTimeline.setPaginationToken(

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -75,11 +75,11 @@ utils.inherits(EventTimelineSet, EventEmitter);
 
 /**
  * Sets the lazily loaded members. For now only joined members.
- * @param {Profile[]} array with {avatar_url, display_name } tuples
+ * @param {Profile[]} joinedMembers array with {avatar_url, display_name } tuples
  */
 EventTimelineSet.prototype.setJoinedMembers = function(joinedMembers) {
-    this._timelines.forEach(tl => tl.setJoinedMembers(joinedMembers));
-}
+    this._timelines.forEach((tl) => tl.setJoinedMembers(joinedMembers));
+};
 
 /**
  * Get the filter object this timeline set is filtered on, if any

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -77,8 +77,8 @@ utils.inherits(EventTimelineSet, EventEmitter);
  * Sets the lazily loaded members.
  * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
-EventTimelineSet.prototype.setLazilyLoadedMembers = function(members) {
-    this._timelines.forEach((tl) => tl.setLazilyLoadedMembers(members));
+EventTimelineSet.prototype.setLazyLoadedMembers = function(members) {
+    this._timelines.forEach((tl) => tl.setLazyLoadedMembers(members));
 };
 
 /**

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -74,6 +74,14 @@ function EventTimelineSet(room, opts) {
 utils.inherits(EventTimelineSet, EventEmitter);
 
 /**
+ * Sets the lazily loaded members. For now only joined members.
+ * @param {Profile[]} array with {avatar_url, display_name } tuples
+ */
+EventTimelineSet.prototype.setJoinedMembers = function(joinedMembers) {
+    this._timelines.forEach(tl => tl.setJoinedMembers(joinedMembers));
+}
+
+/**
  * Get the filter object this timeline set is filtered on, if any
  * @return {?Filter} the optional filter for this timelineSet
  */

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -74,14 +74,6 @@ function EventTimelineSet(room, opts) {
 utils.inherits(EventTimelineSet, EventEmitter);
 
 /**
- * Sets the lazily loaded members.
- * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
- */
-EventTimelineSet.prototype.setLazyLoadedMembers = function(members) {
-    this._timelines.forEach((tl) => tl.setLazyLoadedMembers(members));
-};
-
-/**
  * Get the filter object this timeline set is filtered on, if any
  * @return {?Filter} the optional filter for this timelineSet
  */

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -159,15 +159,6 @@ EventTimeline.prototype.getRoomId = function() {
 };
 
 /**
- * Sets the lazily loaded members.
- * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
- */
-EventTimeline.prototype.setLazyLoadedMembers = function(members) {
-    this._startState.setLazyLoadedMembers(members);
-    this._endState.setLazyLoadedMembers(members);
-};
-
-/**
  * Get the filter for this timeline's timelineSet (if any)
  * @return {Filter} filter
  */

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -115,6 +115,15 @@ EventTimeline.prototype.getRoomId = function() {
 };
 
 /**
+ * Sets the lazily loaded members. For now only joined members.
+ * @param {Profile[]} array with {avatar_url, display_name } tuples
+ */
+EventTimeline.prototype.setJoinedMembers = function(joinedMembers) {
+    this._startState.setJoinedMembers(joinedMembers);
+    this._endState.setJoinedMembers(joinedMembers);
+}
+
+/**
  * Get the filter for this timeline's timelineSet (if any)
  * @return {Filter} filter
  */

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -107,6 +107,38 @@ EventTimeline.prototype.initialiseState = function(stateEvents) {
 };
 
 /**
+ * Forks the (live) timeline, taking ownership of the existing directional state of this timeline.
+ * All attached listeners will keep receiving state updates from the new live timeline state.
+ * The end state of this timeline gets replaced with an independent copy of the current RoomState,
+ * and will need a new pagination token if it ever needs to paginate forwards.
+ */
+EventTimeline.prototype.forkLive = function(direction) {
+    const forkState = this.getState(direction);
+    const timeline = new EventTimeline(this._eventTimelineSet);    
+    timeline._startState = forkState.clone();
+    // Now clobber the end state of the new live timeline with that from the
+    // previous live timeline. It will be identical except that we'll keep
+    // using the same RoomMember objects for the 'live' set of members with any
+    // listeners still attached
+    timeline._endState = forkState;
+    // Firstly, we just stole the current timeline's end state, so it needs a new one.
+    // Make an immutable copy of the state so back pagination will get the correct sentinels.
+    this._endState = forkState.clone();
+    return timeline;
+};
+
+/**
+ * Creates an independent timeline, inheriting the directional state from this timeline.
+ */
+EventTimeline.prototype.fork = function(direction) {
+    const forkState = this.getState(direction);
+    const timeline = new EventTimeline(this._eventTimelineSet);
+    timeline._startState = forkState.clone();
+    timeline._endState = forkState.clone();
+    return timeline;
+};
+
+/**
  * Get the ID of the room for this timeline
  * @return {string} room ID
  */

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -111,10 +111,16 @@ EventTimeline.prototype.initialiseState = function(stateEvents) {
  * All attached listeners will keep receiving state updates from the new live timeline state.
  * The end state of this timeline gets replaced with an independent copy of the current RoomState,
  * and will need a new pagination token if it ever needs to paginate forwards.
+
+ * @param {string} direction   EventTimeline.BACKWARDS to get the state at the
+ *   start of the timeline; EventTimeline.FORWARDS to get the state at the end
+ *   of the timeline.
+ *
+ * @return {EventTimeline} the new timeline
  */
 EventTimeline.prototype.forkLive = function(direction) {
     const forkState = this.getState(direction);
-    const timeline = new EventTimeline(this._eventTimelineSet);    
+    const timeline = new EventTimeline(this._eventTimelineSet);
     timeline._startState = forkState.clone();
     // Now clobber the end state of the new live timeline with that from the
     // previous live timeline. It will be identical except that we'll keep
@@ -129,6 +135,12 @@ EventTimeline.prototype.forkLive = function(direction) {
 
 /**
  * Creates an independent timeline, inheriting the directional state from this timeline.
+ *
+ * @param {string} direction   EventTimeline.BACKWARDS to get the state at the
+ *   start of the timeline; EventTimeline.FORWARDS to get the state at the end
+ *   of the timeline.
+ *
+ * @return {EventTimeline} the new timeline
  */
 EventTimeline.prototype.fork = function(direction) {
     const forkState = this.getState(direction);
@@ -148,12 +160,12 @@ EventTimeline.prototype.getRoomId = function() {
 
 /**
  * Sets the lazily loaded members. For now only joined members.
- * @param {Profile[]} array with {avatar_url, display_name } tuples
+ * @param {Profile[]} joinedMembers array with {avatar_url, display_name } tuples
  */
 EventTimeline.prototype.setJoinedMembers = function(joinedMembers) {
     this._startState.setJoinedMembers(joinedMembers);
     this._endState.setJoinedMembers(joinedMembers);
-}
+};
 
 /**
  * Get the filter for this timeline's timelineSet (if any)

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -162,9 +162,9 @@ EventTimeline.prototype.getRoomId = function() {
  * Sets the lazily loaded members.
  * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
-EventTimeline.prototype.setLazilyLoadedMembers = function(members) {
-    this._startState.setLazilyLoadedMembers(members);
-    this._endState.setLazilyLoadedMembers(members);
+EventTimeline.prototype.setLazyLoadedMembers = function(members) {
+    this._startState.setLazyLoadedMembers(members);
+    this._endState.setLazyLoadedMembers(members);
 };
 
 /**

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -159,12 +159,12 @@ EventTimeline.prototype.getRoomId = function() {
 };
 
 /**
- * Sets the lazily loaded members. For now only joined members.
- * @param {Profile[]} joinedMembers array with {avatar_url, display_name } tuples
+ * Sets the lazily loaded members.
+ * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
-EventTimeline.prototype.setJoinedMembers = function(joinedMembers) {
-    this._startState.setJoinedMembers(joinedMembers);
-    this._endState.setJoinedMembers(joinedMembers);
+EventTimeline.prototype.setLazilyLoadedMembers = function(members) {
+    this._startState.setLazilyLoadedMembers(members);
+    this._endState.setLazilyLoadedMembers(members);
 };
 
 /**

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -72,7 +72,7 @@ RoomMember.prototype.markOutOfBand = function() {
 };
 
 /**
- * @returns {bool} does the member come from a channel that is not sync?
+ * @return {bool} does the member come from a channel that is not sync?
  * This is used to store the member seperately
  * from the sync state so it available across browser sessions.
  */
@@ -83,9 +83,10 @@ RoomMember.prototype.isOutOfBand = function() {
 /**
  * Does the member supersede an incoming out-of-band
  * member? If so the out-of-band member should be ignored.
+ * @return {bool}
  */
 RoomMember.prototype.supersedesOutOfBand = function() {
-    this._supersedesOutOfBand;
+    return this._supersedesOutOfBand;
 };
 
 /**

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -105,15 +105,14 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
 
 /**
  * Update this room member from a lazily loaded member
- * @param {string} displayName
- * @param {string} avatarUrl
+ * @param {Member} memberInfo a {userId, avatarUrl, displayName, membership} tuple
  * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
-RoomMember.prototype.setAsJoinedMember = function(displayName, avatarUrl, roomState) {
-    this.membership = "join";
-    this.name = calculateDisplayName(this.userId, displayName, roomState);
-    this.rawDisplayName = displayName || this.userId;
-    this._lazyLoadAvatarUrl = avatarUrl;
+RoomMember.prototype.setAsLazilyLoadedMember = function(memberInfo, roomState) {
+    this.membership = memberInfo.membership;
+    this.name = calculateDisplayName(this.userId, memberInfo.displayName, roomState);
+    this.rawDisplayName = memberInfo.displayName || this.userId;
+    this._lazyLoadAvatarUrl = memberInfo.avatarUrl;
     this._isLazilyLoaded = true;
     //TODO: race condition between existing membership events since started syncing
 };

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -256,7 +256,7 @@ RoomMember.prototype.getAvatarUrl =
         allowDefault = true;
     }
 
-    const rawUrl = this._getRawAvatarMxcUrl();
+    const rawUrl = this.getMxcAvatarUrl();
 
     if (!rawUrl && !allowDefault) {
         return null;
@@ -277,11 +277,13 @@ RoomMember.prototype.getAvatarUrl =
  * get the mxc avatar url, either from a state event, or from a lazily loaded member
  * @return {string} the mxc avatar url
  */
-RoomMember.prototype._getRawAvatarMxcUrl = function() {
+RoomMember.prototype.getMxcAvatarUrl = function() {
     if (this._lazyLoadAvatarUrl) {
         return this._lazyLoadAvatarUrl;
     } else if(this.events.member) {
         return this.events.member.getContent().avatar_url;
+    } else if(this.user) {
+        return this.user.avatarUrl;
     }
     return null;
 }

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -64,6 +64,10 @@ function RoomMember(roomId, userId) {
 }
 utils.inherits(RoomMember, EventEmitter);
 
+RoomMember.prototype.isLazyLoaded = function() {
+    return this._isLazilyLoaded;
+}
+
 /**
  * Update this room member's membership event. May fire "RoomMember.name" if
  * this event updates this member's name.

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -113,12 +113,14 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
  * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
 RoomMember.prototype.setAsLazyLoadedMember = function(memberInfo, roomState) {
+    if (this.events.member) {
+        return;
+    }
     this.membership = memberInfo.membership;
     this.name = calculateDisplayName(this.userId, memberInfo.displayName, roomState);
     this.rawDisplayName = memberInfo.displayName || this.userId;
     this._lazyLoadAvatarUrl = memberInfo.avatarUrl;
     this._isLazyLoaded = true;
-    //TODO: race condition between existing membership events since started syncing
 };
 
 /**

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -205,7 +205,7 @@ RoomMember.prototype.isKicked = function() {
  * the user that invited this member
  * @return {string} user id of the inviter
  */
-RoomMember.prototype.getDirectChatInviter = function() {
+RoomMember.prototype.getDMInviter = function() {
     // when not available because that room state hasn't been loaded in,
     // we don't really know, but more likely to not be a direct chat
     if (this.events.member) {

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -109,10 +109,13 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
 
 /**
  * Update this room member from a lazily loaded member
- * @param {Member} memberInfo a {userId, avatarUrl, displayName, membership} tuple
+ * @param {string} displayName display name for lazy loaded member
+ * @param {string} avatarUrl avatar url for lazy loaded member
+ * @param {string} membership membership (join|invite|...) state for lazy loaded member
  * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
-RoomMember.prototype.setAsLazyLoadedMember = function(displayName, avatarUrl, membership, roomState) {
+RoomMember.prototype.setAsLazyLoadedMember =
+function(displayName, avatarUrl, membership, roomState) {
     if (this.events.member) {
         return;
     }

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -112,14 +112,14 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
  * @param {Member} memberInfo a {userId, avatarUrl, displayName, membership} tuple
  * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
-RoomMember.prototype.setAsLazyLoadedMember = function(memberInfo, roomState) {
+RoomMember.prototype.setAsLazyLoadedMember = function(displayName, avatarUrl, membership, roomState) {
     if (this.events.member) {
         return;
     }
-    this.membership = memberInfo.membership;
-    this.name = calculateDisplayName(this.userId, memberInfo.displayName, roomState);
-    this.rawDisplayName = memberInfo.displayName || this.userId;
-    this._lazyLoadAvatarUrl = memberInfo.avatarUrl;
+    this.membership = membership;
+    this.name = calculateDisplayName(this.userId, displayName, roomState);
+    this.rawDisplayName = displayName || this.userId;
+    this._lazyLoadAvatarUrl = avatarUrl;
     this._isLazyLoaded = true;
 };
 

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -81,6 +81,10 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
     if (event.getType() !== "m.room.member") {
         return;
     }
+
+    this._lazyLoadAvatarUrl = null;
+    this._isLazyLoaded = false;
+
     this.events.member = event;
 
     const oldMembership = this.membership;

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -302,7 +302,7 @@ RoomMember.prototype.getMxcAvatarUrl = function() {
 };
 
 function calculateDisplayName(selfUserId, displayName, roomState) {
-    if (!displayName) {
+    if (!displayName || displayName === selfUserId) {
         return selfUserId;
     }
 

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -66,7 +66,7 @@ utils.inherits(RoomMember, EventEmitter);
 
 RoomMember.prototype.isLazyLoaded = function() {
     return this._isLazilyLoaded;
-}
+};
 
 /**
  * Update this room member's membership event. May fire "RoomMember.name" if
@@ -102,8 +102,12 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
         this.emit("RoomMember.name", event, this, oldName);
     }
 };
+
 /**
  * Update this room member from a lazily loaded member
+ * @param {string} displayName
+ * @param {string} avatarUrl
+ * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
 RoomMember.prototype.setAsJoinedMember = function(displayName, avatarUrl, roomState) {
     this.membership = "join";
@@ -112,7 +116,7 @@ RoomMember.prototype.setAsJoinedMember = function(displayName, avatarUrl, roomSt
     this._lazyLoadAvatarUrl = avatarUrl;
     this._isLazilyLoaded = true;
     //TODO: race condition between existing membership events since started syncing
-}
+};
 
 /**
  * Update this room member's power level event. May fire
@@ -233,7 +237,7 @@ RoomMember.prototype.getDMInviter = function() {
             return inviteSender;
         }
     }
-}
+};
 
 
 /**
@@ -290,7 +294,7 @@ RoomMember.prototype.getMxcAvatarUrl = function() {
         return this.user.avatarUrl;
     }
     return null;
-}
+};
 
 function calculateDisplayName(selfUserId, displayName, roomState) {
     if (!displayName) {

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -192,6 +192,37 @@ RoomMember.prototype.getLastModifiedTime = function() {
     return this._modified;
 };
 
+
+/**
+ * If this member was invited with the is_direct flag set, return
+ * the user that invited this member
+ * @return {string} user id of the inviter
+ */
+RoomMember.prototype.getDirectChatInviter = function() {
+    // when not available because that room state hasn't been loaded in,
+    // we don't really know, but more likely to not be a direct chat
+    if (this.events.member) {
+        // TODO: persist the is_direct flag on the member as more member events
+        //       come in caused by displayName changes.
+
+        // the is_direct flag is set on the invite member event.
+        // This is copied on the prev_content section of the join member event
+        // when the invite is accepted.
+
+        const memberEvent = this.events.member;
+        let memberContent = memberEvent.getContent();
+
+        if (memberContent.membership === "join") {
+            memberContent = memberEvent.getPrevContent();
+        }
+
+        if (memberContent.membership === "invite" && memberContent.is_direct) {
+            return memberEvent.getUnsigned().prev_sender;
+        }
+    }
+}
+
+
 /**
  * Get the avatar URL for a room member.
  * @param {string} baseUrl The base homeserver URL See

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -59,13 +59,13 @@ function RoomMember(roomId, userId) {
         member: null,
     };
     this._lazyLoadAvatarUrl = null;
-    this._isLazilyLoaded = false;
+    this._isLazyLoaded = false;
     this._updateModifiedTime();
 }
 utils.inherits(RoomMember, EventEmitter);
 
 RoomMember.prototype.isLazyLoaded = function() {
-    return this._isLazilyLoaded;
+    return this._isLazyLoaded;
 };
 
 /**
@@ -108,12 +108,12 @@ RoomMember.prototype.setMembershipEvent = function(event, roomState) {
  * @param {Member} memberInfo a {userId, avatarUrl, displayName, membership} tuple
  * @param {RoomState} roomState the room state this member is part of, needed to disambiguate the display name
  */
-RoomMember.prototype.setAsLazilyLoadedMember = function(memberInfo, roomState) {
+RoomMember.prototype.setAsLazyLoadedMember = function(memberInfo, roomState) {
     this.membership = memberInfo.membership;
     this.name = calculateDisplayName(this.userId, memberInfo.displayName, roomState);
     this.rawDisplayName = memberInfo.displayName || this.userId;
     this._lazyLoadAvatarUrl = memberInfo.avatarUrl;
-    this._isLazilyLoaded = true;
+    this._isLazyLoaded = true;
     //TODO: race condition between existing membership events since started syncing
 };
 

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -252,6 +252,10 @@ RoomState.prototype._updateMember = function(member) {
     this._joinedMemberCount = null;
 }
 
+/**
+ * Sets the lazily loaded members. For now only joined members.
+ * @param {Profile[]} array with {avatar_url, display_name } tuples
+ */
 RoomState.prototype.setJoinedMembers = function(joinedMembers) {
     const joinedRoomMembers = Object.entries(joinedMembers).map(([userId, details]) => {
         const displayName = details.display_name;

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -323,7 +323,7 @@ RoomState.prototype.getLastModifiedTime = function() {
 /**
  * Get user IDs with the specified display name.
  * @param {string} displayName The display name to get user IDs from.
- * @return {string[]} An array of user IDs or an empty array. 
+ * @return {string[]} An array of user IDs or an empty array.
  */
 RoomState.prototype.getUserIdsWithDisplayName = function(displayName) {
     return this._displayNameToUserIds[displayName] || [];

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -118,14 +118,12 @@ RoomState.prototype.getSentinelMember = function(userId) {
     let sentinel = this._sentinels[userId];
 
     if (sentinel === undefined) {
-        sentinel = new RoomMember(this.roomId, userId);
-        const membershipEvent = this.getStateEvents("m.room.member", userId);
-        if (!membershipEvent) return null;
-        sentinel.setMembershipEvent(membershipEvent, this);
-        const pwrLvlEvent = this.getStateEvents("m.room.power_levels", "");
-        if (pwrLvlEvent) {
-            sentinel.setPowerLevelEvent(pwrLvlEvent);
+        const member = this.members[userId];
+        if (!member) {
+            return null;
         }
+        sentinel = new RoomMember();
+        Object.assign(sentinel, member);
         this._sentinels[userId] = sentinel;
     }
     return sentinel;

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -118,12 +118,11 @@ RoomState.prototype.getSentinelMember = function(userId) {
     let sentinel = this._sentinels[userId];
 
     if (sentinel === undefined) {
+        sentinel = new RoomMember(this.roomId, userId);
         const member = this.members[userId];
-        if (!member) {
-            return null;
+        if (member) {
+            Object.assign(sentinel, member);
         }
-        sentinel = new RoomMember();
-        Object.assign(sentinel, member);
         this._sentinels[userId] = sentinel;
     }
     return sentinel;

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -258,13 +258,19 @@ RoomState.prototype.setJoinedMembers = function(joinedMembers) {
         const avatarUrl = details.avatar_url;
         const member = new RoomMember(this.roomId, userId);
         member.setAsJoinedMember(displayName, avatarUrl, this);
-        return member;
+        const isNewMember = !this.members[userId];
+        return {member, isNewMember};
     });
-    joinedRoomMembers.forEach(member => {
+    joinedRoomMembers.forEach(({member, isNewMember}) => {
         _updateDisplayNameCache(this, member.userId, member.name);
         this._updateMember(member);
+        if (isNewMember) {
+            this.emit('RoomState.newMember', {}, self, member);
+        }
+        else {
+            this.emit('RoomState.members', {}, self, member);
+        }
     });
-    this.emit("Room");
 }
 
 /**

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -297,8 +297,7 @@ RoomState.prototype._setJoinedMember = function(userId, displayName, avatarUrl) 
     this._updateMember(member);
     if (isNewMember) {
         this.emit('RoomState.newMember', {}, self, member);
-    }
-    else {
+    } else {
         this.emit('RoomState.members', {}, self, member);
     }
 };

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -155,7 +155,6 @@ RoomState.prototype.getStateEvents = function(eventType, stateKey) {
  */
 RoomState.prototype.clone = function() {
     const copy = new RoomState(this.roomId);
-    //freeze and pass all state events to copy
     Object.values(this.events).forEach((eventsByStateKey) => {
         const eventsForType = Object.values(eventsByStateKey);
         copy.setStateEvents(eventsForType);
@@ -164,7 +163,7 @@ RoomState.prototype.clone = function() {
     const lazyLoadedMembers = Object.values(this.members)
         .filter((member) => member.isLazyLoaded());
     lazyLoadedMembers.forEach((m) => {
-        copy._setJoinedMember(m.userId, m.rawDisplayName, m.getMxcAvatarUrl());
+        copy._setLazyLoadedMember(m.userId, m.rawDisplayName, m.getMxcAvatarUrl(), m.membership);
     });
     return copy;
 };
@@ -274,17 +273,40 @@ RoomState.prototype._updateMember = function(member) {
  * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
 RoomState.prototype.setLazyLoadedMembers = function(members) {
-    let newMembers = members.filter((m) => !this.members.hasOwnProperty(m.userId));
-    newMembers.forEach((memberInfo) => {
-        const member = new RoomMember(this.roomId, memberInfo.userId);
-        // override the displayName and avatarUrl from the lazily loaded members
-        // as this is guaranteed to be the current state
-        member.setAsLazyLoadedMember(memberInfo, this);
-        _updateDisplayNameCache(this, member.userId, member.name);
-        this._updateMember(member);
-        this.emit('RoomState.newMember', {}, self, member);
+    members.forEach((m) => {
+        this._setLazyLoadedMember(
+            m.userId,
+            m.displayName,
+            m.avatarUrl,
+            m.membership
+        );
     });
 };
+
+/**
+ * Sets a single lazily loaded member, used by both setLazyLoadedMembers and clone
+ * @param {Member} members array of {userId, avatarUrl, displayName, membership} tuples
+ */
+RoomState.prototype._setLazyLoadedMember = function(userId, displayName, avatarUrl, membership) {
+    const preExistingMember = this.getMember(userId);
+    // don't overwrite existing state event members
+    if (preExistingMember && !preExistingMember.isLazyLoaded()) {
+        return;
+    }
+    const member = new RoomMember(this.roomId, userId);
+    member.setAsLazyLoadedMember(displayName, avatarUrl, membership, this);
+    _updateDisplayNameCache(this, member.userId, member.name);
+    this._updateMember(member);
+
+    if (preExistingMember) {
+        this.emit("RoomState.members", {}, this, member);
+    }
+    else {
+        this.emit('RoomState.newMember', {}, this, member);
+    }
+};
+
+
 
 /**
  * Set the current typing event for this room.

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -273,14 +273,14 @@ RoomState.prototype._updateMember = function(member) {
  * Sets the lazily loaded members.
  * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
  */
-RoomState.prototype.setLazilyLoadedMembers = function(members) {
-    members.forEach((member) => this._setLazilyLoadedMember(member));
+RoomState.prototype.setLazyLoadedMembers = function(members) {
+    members.forEach((member) => this._setLazyLoadedMember(member));
 };
 /**
  * Add/updates a lazily loaded member.
  * @param {Member} memberInfo a {userId, avatarUrl, displayName, membership} tuple
  */
-RoomState.prototype._setLazilyLoadedMember = function(memberInfo) {
+RoomState.prototype._setLazyLoadedMember = function(memberInfo) {
     const member = new RoomMember(this.roomId, memberInfo.userId);
     // try to find the member event for the user and set it first on the member
     // so inspection of the event is possible later on if we have it
@@ -290,7 +290,7 @@ RoomState.prototype._setLazilyLoadedMember = function(memberInfo) {
     }
     // override the displayName and avatarUrl from the lazily loaded members
     // as this is guaranteed to be the current state
-    member.setAsLazilyLoadedMember(memberInfo, this);
+    member.setAsLazyLoadedMember(memberInfo, this);
 
     const isNewMember = !this.members[member.userId];
 

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -257,6 +257,15 @@ RoomState.prototype.setJoinedMembers = function(joinedMembers) {
         const displayName = details.display_name;
         const avatarUrl = details.avatar_url;
         const member = new RoomMember(this.roomId, userId);
+        // try to find the member event for the user and set it first on the member
+        // so inspection of the event is possible later on if we have it
+        const membershipEvents = this.events["m.room.member"];
+        const userMemberEvent = membershipEvents && membershipEvents[userId];
+        if (userMemberEvent) {
+            member.setMembershipEvent(userMemberEvent, this);
+        }
+        // override the displayName and avatarUrl from the lazily loaded members
+        // as this is guaranteed to be the current state
         member.setAsJoinedMember(displayName, avatarUrl, this);
         const isNewMember = !this.members[userId];
         return {member, isNewMember};

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -163,7 +163,11 @@ RoomState.prototype.clone = function() {
     const lazyLoadedMembers = Object.values(this.members)
         .filter((member) => member.isLazyLoaded());
     lazyLoadedMembers.forEach((m) => {
-        copy._setLazyLoadedMember(m.userId, m.rawDisplayName, m.getMxcAvatarUrl(), m.membership);
+        copy._setLazyLoadedMember(
+            m.userId,
+            m.rawDisplayName,
+            m.getMxcAvatarUrl(),
+            m.membership);
     });
     return copy;
 };
@@ -278,16 +282,19 @@ RoomState.prototype.setLazyLoadedMembers = function(members) {
             m.userId,
             m.displayName,
             m.avatarUrl,
-            m.membership
-        );
+            m.membership);
     });
 };
 
 /**
  * Sets a single lazily loaded member, used by both setLazyLoadedMembers and clone
- * @param {Member} members array of {userId, avatarUrl, displayName, membership} tuples
+ * @param {string} userId user id for lazy loaded member
+ * @param {string} displayName display name for lazy loaded member
+ * @param {string} avatarUrl avatar url for lazy loaded member
+ * @param {string} membership membership (join|invite|...) state for lazy loaded member
  */
-RoomState.prototype._setLazyLoadedMember = function(userId, displayName, avatarUrl, membership) {
+RoomState.prototype._setLazyLoadedMember =
+function(userId, displayName, avatarUrl, membership) {
     const preExistingMember = this.getMember(userId);
     // don't overwrite existing state event members
     if (preExistingMember && !preExistingMember.isLazyLoaded()) {
@@ -300,13 +307,10 @@ RoomState.prototype._setLazyLoadedMember = function(userId, displayName, avatarU
 
     if (preExistingMember) {
         this.emit("RoomState.members", {}, this, member);
-    }
-    else {
+    } else {
         this.emit('RoomState.newMember', {}, this, member);
     }
 };
-
-
 
 /**
  * Set the current typing event for this room.

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -283,8 +283,7 @@ RoomState.prototype._setJoinedMember = function(userId, displayName, avatarUrl) 
     const member = new RoomMember(this.roomId, userId);
     // try to find the member event for the user and set it first on the member
     // so inspection of the event is possible later on if we have it
-    const membershipEvents = this.events["m.room.member"];
-    const userMemberEvent = membershipEvents && membershipEvents[userId];
+    const userMemberEvent = this.getStateEvents("m.room.member", userId);
     if (userMemberEvent) {
         member.setMembershipEvent(userMemberEvent, this);
     }

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -22,6 +22,11 @@ const EventEmitter = require("events").EventEmitter;
 const utils = require("../utils");
 const RoomMember = require("./room-member");
 
+// possible statuses for out-of-band member loading
+const OOB_STATUS_NOTSTARTED = 1;
+const OOB_STATUS_INPROGRESS = 2;
+const OOB_STATUS_FINISHED = 3;
+
 /**
  * Construct room state.
  *
@@ -46,13 +51,17 @@ const RoomMember = require("./room-member");
  * @constructor
  * @param {?string} roomId Optional. The ID of the room which has this state.
  * If none is specified it just tracks paginationTokens, useful for notifTimelineSet
+ * @param {?object} oobMemberFlags Optional. The state of loading out of bound members.
+ * As the timeline might get reset while they are loading, this state needs to be inherited
+ * and shared when the room state is cloned for the new timeline.
+ * This should only be passed from clone.
  * @prop {Object.<string, RoomMember>} members The room member dictionary, keyed
  * on the user's ID.
  * @prop {Object.<string, Object.<string, MatrixEvent>>} events The state
  * events dictionary, keyed on the event type and then the state_key value.
  * @prop {string} paginationToken The pagination token for this state.
  */
-function RoomState(roomId) {
+function RoomState(roomId, oobMemberFlags = undefined) {
     this.roomId = roomId;
     this.members = {
         // userId: RoomMember
@@ -70,6 +79,12 @@ function RoomState(roomId) {
     this._userIdsToDisplayNames = {};
     this._tokenToInvite = {}; // 3pid invite state_key to m.room.member invite
     this._joinedMemberCount = null; // cache of the number of joined members
+    if (!oobMemberFlags) {
+        oobMemberFlags = {
+            status: OOB_STATUS_NOTSTARTED,
+        };
+    }
+    this._oobMemberFlags = oobMemberFlags;
 }
 utils.inherits(RoomState, EventEmitter);
 
@@ -154,21 +169,45 @@ RoomState.prototype.getStateEvents = function(eventType, stateKey) {
  * @return {RoomState} the copy of the room state
  */
 RoomState.prototype.clone = function() {
-    const copy = new RoomState(this.roomId);
+    const copy = new RoomState(this.roomId, this._oobMemberFlags);
+
+    // Ugly hack: because setStateEvents will mark
+    // members as susperseding future out of bound members
+    // if loading is in progress (through _oobMemberFlags)
+    // since these are not new members, we're merely copying them
+    // set the status to not started
+    // after copying, we set back the status and
+    // copy the superseding flag from the current state
+    const status = this._oobMemberFlags.status;
+    this._oobMemberFlags.status = OOB_STATUS_NOTSTARTED;
+
     Object.values(this.events).forEach((eventsByStateKey) => {
         const eventsForType = Object.values(eventsByStateKey);
         copy.setStateEvents(eventsForType);
     });
-    // clone lazily loaded members
-    const lazyLoadedMembers = Object.values(this.members)
-        .filter((member) => member.isLazyLoaded());
-    lazyLoadedMembers.forEach((m) => {
-        copy._setLazyLoadedMember(
-            m.userId,
-            m.rawDisplayName,
-            m.getMxcAvatarUrl(),
-            m.membership);
-    });
+
+    // Ugly hack: see above
+    this._oobMemberFlags.status = status;
+
+    // copy out of band flags if needed
+    if (this._oobMemberFlags.status == OOB_STATUS_FINISHED) {
+        // copy markOutOfBand flags
+        this.getMembers().forEach((member) => {
+            if (member.isOutOfBand()) {
+                const copyMember = copy.getMember(member.userId);
+                copyMember.markOutOfBand();
+            }
+        });
+    } else if (this._oobMemberFlags.status == OOB_STATUS_INPROGRESS) {
+        // copy markSupersedesOutOfBand flags
+        this.getMembers().forEach((member) => {
+            if (member.supersedesOutOfBand()) {
+                const copyMember = copy.getMember(member.userId);
+                copyMember.markSupersedesOutOfBand();
+            }
+        });
+    }
+
     return copy;
 };
 
@@ -195,10 +234,7 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             return;
         }
 
-        if (self.events[event.getType()] === undefined) {
-            self.events[event.getType()] = {};
-        }
-        self.events[event.getType()][event.getStateKey()] = event;
+        self._setStateEvent(event);
         if (event.getType() === "m.room.member") {
             _updateDisplayNameCache(
                 self, event.getStateKey(), event.getContent().displayname,
@@ -243,6 +279,13 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             }
 
             member.setMembershipEvent(event, self);
+
+            // if out of band members are loading,
+            // mark the member as more recent
+            if (self._oobMemberFlags.status == OOB_STATUS_INPROGRESS) {
+                member.markSupersedesOutOfBand();
+            }
+
             self._updateMember(member);
             self.emit("RoomState.members", event, self, member);
         } else if (event.getType() === "m.room.power_levels") {
@@ -256,6 +299,13 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             self._sentinels = {};
         }
     });
+};
+
+RoomState.prototype._setStateEvent = function(event) {
+    if (this.events[event.getType()] === undefined) {
+        this.events[event.getType()] = {};
+    }
+    this.events[event.getType()][event.getStateKey()] = event;
 };
 
 RoomState.prototype._updateMember = function(member) {
@@ -273,39 +323,95 @@ RoomState.prototype._updateMember = function(member) {
 };
 
 /**
- * Sets the lazily loaded members.
- * @param {Member[]} members array of {userId, avatarUrl, displayName, membership} tuples
+ * Get the out-of-band members loading state, whether loading is needed or not.
+ * Note that loading might be in progress and hence isn't needed.
+ * @return {bool} whether or not the members of this room need to be loaded
  */
-RoomState.prototype.setLazyLoadedMembers = function(members) {
-    members.forEach((m) => {
-        this._setLazyLoadedMember(
-            m.userId,
-            m.displayName,
-            m.avatarUrl,
-            m.membership);
-    });
+RoomState.prototype.needsOutOfBandMembers = function() {
+    return this._oobMemberFlags.status === OOB_STATUS_NOTSTARTED;
 };
 
 /**
- * Sets a single lazily loaded member, used by both setLazyLoadedMembers and clone
- * @param {string} userId user id for lazy loaded member
- * @param {string} displayName display name for lazy loaded member
- * @param {string} avatarUrl avatar url for lazy loaded member
- * @param {string} membership membership (join|invite|...) state for lazy loaded member
+ * Mark this room state as waiting for out-of-band members,
+ * ensuring it doesn't ask for them to be requested again
+ * through needsOutOfBandMembers
  */
-RoomState.prototype._setLazyLoadedMember =
-function(userId, displayName, avatarUrl, membership) {
-    const preExistingMember = this.getMember(userId);
-    // don't overwrite existing state event members
-    if (preExistingMember && !preExistingMember.isLazyLoaded()) {
+RoomState.prototype.markOutOfBandMembersStarted = function() {
+    if (this._oobMemberFlags.status !== OOB_STATUS_NOTSTARTED) {
         return;
     }
-    const member = new RoomMember(this.roomId, userId);
-    member.setAsLazyLoadedMember(displayName, avatarUrl, membership, this);
+    this._oobMemberFlags.status = OOB_STATUS_INPROGRESS;
+};
+
+/**
+ * Mark this room state as having failed to fetch out-of-band members
+ */
+RoomState.prototype.markOutOfBandMembersFailed = function() {
+    if (this._oobMemberFlags.status !== OOB_STATUS_INPROGRESS) {
+        return;
+    }
+    // the request failed, there is nothing to supersede
+    // in case of a retry, these event would not supersede the
+    // retry anymore.
+    this.getMembers().forEach((m) => {
+        m.clearSupersedesOutOfBand();
+    });
+    this._oobMemberFlags.status = OOB_STATUS_NOTSTARTED;
+};
+
+/**
+ * Sets the loaded out-of-band members.
+ * @param {MatrixEvent[]} stateEvents array of membership state events
+ */
+RoomState.prototype.setOutOfBandMembers = function(stateEvents) {
+    if (this._oobMemberFlags.status !== OOB_STATUS_INPROGRESS) {
+        return;
+    }
+    this._oobMemberFlags.status = OOB_STATUS_FINISHED;
+    stateEvents.forEach((e) => this._setOutOfBandMember(e));
+};
+
+/**
+ * Sets a single out of band member, used by both setOutOfBandMembers and clone
+ * @param {MatrixEvent} stateEvent membership state event
+ */
+RoomState.prototype._setOutOfBandMember = function(stateEvent) {
+    if (stateEvent.getType() !== 'm.room.member') {
+        return;
+    }
+    const userId = stateEvent.getStateKey();
+    const existingMember = this.getMember(userId);
+    if (existingMember) {
+        const existingMemberEvent = existingMember.events.member;
+        // ignore out of band members with events we are
+        // already aware of.
+        if (existingMemberEvent.getId() === stateEvent.getId()) {
+            return;
+        }
+        // this member was updated since we started
+        // loading the out of band members.
+        // Ignore the out of band member and clear
+        // the "supersedes" flag as the out of members are now loaded
+        if (existingMember.supersedesOutOfBand()) {
+            existingMember.clearSupersedesOutOfBand();
+            return;
+        }
+    }
+
+    const member =
+        existingMember ? existingMember : new RoomMember(this.roomId, userId);
+    member.setMembershipEvent(stateEvent);
+    // needed to know which members need to be stored seperately
+    // as the are not part of the sync accumulator
+    // this is cleared by setMembershipEvent so when it's updated through /sync
+    member.markOutOfBand();
+
     _updateDisplayNameCache(this, member.userId, member.name);
+
+    this._setStateEvent(stateEvent);
     this._updateMember(member);
 
-    if (preExistingMember) {
+    if (existingMember) {
         this.emit("RoomState.members", {}, this, member);
     } else {
         this.emit('RoomState.newMember', {}, this, member);

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -149,19 +149,21 @@ RoomState.prototype.getStateEvents = function(eventType, stateKey) {
     return event ? event : null;
 };
 
-/** 
+/**
  * Creates a copy of this room state so that mutations to either won't affect the other.
+ * @return {RoomState} the copy of the room state
  */
 RoomState.prototype.clone = function() {
     const copy = new RoomState(this.roomId);
     //freeze and pass all state events to copy
-    Object.values(this.events).forEach(eventsByStateKey => {
+    Object.values(this.events).forEach((eventsByStateKey) => {
         const eventsForType = Object.values(eventsByStateKey);
         copy.setStateEvents(eventsForType);
     });
     // clone lazily loaded members
-    const lazyLoadedMembers = Object.values(this.members).filter(member => member.isLazyLoaded());
-    lazyLoadedMembers.forEach(m => {
+    const lazyLoadedMembers = Object.values(this.members)
+        .filter((member) => member.isLazyLoaded());
+    lazyLoadedMembers.forEach((m) => {
         copy._setJoinedMember(m.userId, m.rawDisplayName, m.getMxcAvatarUrl());
     });
     return copy;
@@ -265,17 +267,17 @@ RoomState.prototype._updateMember = function(member) {
 
     this.members[member.userId] = member;
     this._joinedMemberCount = null;
-}
+};
 
 /**
  * Sets the lazily loaded members. For now only joined members.
- * @param {Profile[]} array with {avatar_url, display_name } tuples
+ * @param {Profile[]} joinedMembers array with {avatar_url, display_name } tuples
  */
 RoomState.prototype.setJoinedMembers = function(joinedMembers) {
     Object.entries(joinedMembers).forEach(([userId, details]) => {
         this._setJoinedMember(userId, details.display_name, details.avatar_url);
     });
-}
+};
 
 RoomState.prototype._setJoinedMember = function(userId, displayName, avatarUrl) {
     const member = new RoomMember(this.roomId, userId);
@@ -290,7 +292,7 @@ RoomState.prototype._setJoinedMember = function(userId, displayName, avatarUrl) 
     // as this is guaranteed to be the current state
     member.setAsJoinedMember(displayName, avatarUrl, this);
     const isNewMember = !this.members[userId];
-    
+
     _updateDisplayNameCache(this, member.userId, member.name);
     this._updateMember(member);
     if (isNewMember) {
@@ -299,7 +301,7 @@ RoomState.prototype._setJoinedMember = function(userId, displayName, avatarUrl) 
     else {
         this.emit('RoomState.members', {}, self, member);
     }
-}
+};
 
 /**
  * Set the current typing event for this room.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -220,21 +220,20 @@ Room.prototype.needsOutOfBandMembers = function() {
 
 /**
  * Loads the out-of-band members from the promise passed in
- * @param {Promise} eventsPromise promise with array with state events
+ * @param {Promise<[MatrixEvent]>} eventsPromise state events for members
  */
 Room.prototype.loadOutOfBandMembers = async function(eventsPromise) {
-    if (!this.membersNeedLoading()) {
+    if (!this.needsOutOfBandMembers()) {
         return;
     }
     this.currentState.markOutOfBandMembersStarted();
-    let eventPojos = null;
+    let events = null;
     try {
-        eventPojos = await eventsPromise;
+        events = await eventsPromise;
     } catch (err) {
         this.currentState.markOutOfBandMembersFailed();
         throw err;  //rethrow so calling code is aware operation failed
     }
-    const events = eventPojos.map(this.client.getEventMapper());
     this.currentState.setOutOfBandMembers(events);
 };
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -225,7 +225,7 @@ Room.prototype.setLazyLoadedMembers = async function(membersPromise) {
         this._membersNeedLoading = true;
         throw err;  //rethrow so calling code is aware operation failed
     }
-    this._timelineSets.forEach((tlSet) => tlSet.setLazyLoadedMembers(members));
+    this.currentState.setLazyLoadedMembers(members);
     this.emit('Room', this);
 };
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -216,7 +216,7 @@ Room.prototype.membersNeedLoading = function() {
  * Sets the lazily loaded members from the result of calling /joined_members
  * @param {Promise} membersPromise promise with array of {userId, avatarUrl, displayName, membership} tuples
  */
-Room.prototype.setLazilyLoadedMembers = async function(membersPromise) {
+Room.prototype.setLazyLoadedMembers = async function(membersPromise) {
     this._membersNeedLoading = false;
     let members = null;
     try {
@@ -225,7 +225,7 @@ Room.prototype.setLazilyLoadedMembers = async function(membersPromise) {
         this._membersNeedLoading = true;
         throw err;  //rethrow so calling code is aware operation failed
     }
-    this._timelineSets.forEach((tlSet) => tlSet.setLazilyLoadedMembers(members));
+    this._timelineSets.forEach((tlSet) => tlSet.setLazyLoadedMembers(members));
     this.emit('Room', this);
 };
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -171,7 +171,10 @@ function Room(roomId, opts) {
 
     // read by megolm; boolean value - null indicates "use global value"
     this._blacklistUnverifiedDevices = null;
+    // in case of lazy loading, to keep track of loading state
+    this._membersNeedLoading = true;
 }
+
 utils.inherits(Room, EventEmitter);
 
 /**
@@ -200,7 +203,22 @@ Room.prototype.getPendingEvents = function() {
 Room.prototype.getLiveTimeline = function() {
     return this.getUnfilteredTimelineSet().getLiveTimeline();
 };
+/**
+ * Get the lazy loading state, whether loading is needed or not.
+ */
+Room.prototype.membersNeedLoading = function() {
+    return this._membersNeedLoading;
+}
 
+/**
+ * 
+ */
+Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
+    this._membersNeedLoading = false;
+    const members = await joinedMembersPromise;
+    this.currentState.setJoinedMembers(members.joined);    
+    //for all timelines > room state, call setJoinedMembers?
+}
 
 /**
  * Reset the live timeline of all timelineSets, and start new ones.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -222,12 +222,8 @@ Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     try {
         members = await joinedMembersPromise;
     } catch (err) {
-        const errorMessage = `Fetching room members for ${this.roomId} failed.` +
-            " Room members will appear incomplete.";
-        console.error(errorMessage);
-        console.error(err);
         this._membersNeedLoading = true;
-        return;
+        throw err;  //rethrow so calling code is aware operation failed
     }
     this._timelineSets.forEach((tlSet) => tlSet.setJoinedMembers(members.joined));
     this.emit('Room', this);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -171,6 +171,7 @@ function Room(roomId, opts) {
 
     // read by megolm; boolean value - null indicates "use global value"
     this._blacklistUnverifiedDevices = null;
+    this._syncedMembership = null;
 }
 
 utils.inherits(Room, EventEmitter);
@@ -202,9 +203,28 @@ Room.prototype.getLiveTimeline = function() {
     return this.getUnfilteredTimelineSet().getLiveTimeline();
 };
 
+/**
+ * @return {string} the id of the last event in the live timeline
+ */
 Room.prototype.getLastEventId = function() {
     const liveEvents = this.getLiveTimeline().getEvents();
     return liveEvents.length ? liveEvents[liveEvents.length - 1].getId() : undefined;
+};
+
+/**
+ * @return {string} the membership type (join | leave | invite) this room was received as during sync
+ */
+Room.prototype.getSyncedMembership = function() {
+    return this._syncedMembership;
+};
+
+
+/**
+ * Sets the membership this room was received as during sync
+ * @param {string} membership join | leave | invite
+ */
+Room.prototype.setSyncedMembership = function(membership) {
+    this._syncedMembership = membership;
 };
 
 /**

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -212,12 +212,18 @@ Room.prototype.getLastEventId = function() {
 };
 
 /**
- * @return {string} the membership type (join | leave | invite) this room was received as during sync
+ * @param {string} myUserId the user id for the logged in member
+ * @return {string} the membership type (join | leave | invite) for the logged in user
  */
-Room.prototype.getSyncedMembership = function() {
+Room.prototype.getMyMembership = function(myUserId) {
+    if (myUserId) {
+        const me = this.getMember(myUserId);
+        if (me) {
+            return me.membership;
+        }
+    }
     return this._syncedMembership;
 };
-
 
 /**
  * Sets the membership this room was received as during sync

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -217,6 +217,9 @@ Room.prototype.membersNeedLoading = function() {
  * @param {Promise} membersPromise promise with array of {userId, avatarUrl, displayName, membership} tuples
  */
 Room.prototype.setLazyLoadedMembers = async function(membersPromise) {
+    if (!this._membersNeedLoading) {
+        return;
+    }
     this._membersNeedLoading = false;
     let members = null;
     try {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -221,9 +221,10 @@ Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     let members = null;
     try {
         members = await joinedMembersPromise;
-    }
-    catch (err) {
-        console.error(`Fetching room members for ${this.roomId} failed. Room members will appear incomplete.`);
+    } catch (err) {
+        const errorMessage = `Fetching room members for ${this.roomId} failed.` +
+            " Room members will appear incomplete.";
+        console.error(errorMessage);
         console.error(err);
         this._membersNeedLoading = true;
         return;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -214,18 +214,18 @@ Room.prototype.membersNeedLoading = function() {
 
 /**
  * Sets the lazily loaded members from the result of calling /joined_members
- * @param {Promise} joinedMembersPromise promise with result of /joined_members endpoint
+ * @param {Promise} membersPromise promise with array of {userId, avatarUrl, displayName, membership} tuples
  */
-Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
+Room.prototype.setLazilyLoadedMembers = async function(membersPromise) {
     this._membersNeedLoading = false;
     let members = null;
     try {
-        members = await joinedMembersPromise;
+        members = await membersPromise;
     } catch (err) {
         this._membersNeedLoading = true;
         throw err;  //rethrow so calling code is aware operation failed
     }
-    this._timelineSets.forEach((tlSet) => tlSet.setJoinedMembers(members.joined));
+    this._timelineSets.forEach((tlSet) => tlSet.setLazilyLoadedMembers(members));
     this.emit('Room', this);
 };
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -244,7 +244,7 @@ Room.prototype.needsOutOfBandMembers = function() {
 
 /**
  * Loads the out-of-band members from the promise passed in
- * @param {Promise<[MatrixEvent]>} eventsPromise state events for members
+ * @param {Promise} eventsPromise promise that resolves to an array with membership MatrixEvents for the members
  */
 Room.prototype.loadOutOfBandMembers = async function(eventsPromise) {
     if (!this.needsOutOfBandMembers()) {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -203,22 +203,28 @@ Room.prototype.getPendingEvents = function() {
 Room.prototype.getLiveTimeline = function() {
     return this.getUnfilteredTimelineSet().getLiveTimeline();
 };
+
 /**
  * Get the lazy loading state, whether loading is needed or not.
+ * @return {bool} whether or not the members of this room need to be loaded
  */
 Room.prototype.membersNeedLoading = function() {
     return this._membersNeedLoading;
-}
+};
 
 /**
  * Sets the lazily loaded members from the result of calling /joined_members
- * @param {Promise} promise with result of /joined_members endpoint
+ * @param {Promise} joinedMembersPromise promise with result of /joined_members endpoint
  */
 Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     this._membersNeedLoading = false;
     const members = await joinedMembersPromise;
-    this._timelineSets.forEach(tlSet => tlSet.setJoinedMembers(members.joined));
-}
+    //wait 10 seconds
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    console.log('set lazily loaded members!');
+    this._timelineSets.forEach((tlSet) => tlSet.setJoinedMembers(members.joined));
+    this.emit('Room', this);
+};
 
 /**
  * Reset the live timeline of all timelineSets, and start new ones.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -219,9 +219,6 @@ Room.prototype.membersNeedLoading = function() {
 Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     this._membersNeedLoading = false;
     const members = await joinedMembersPromise;
-    //wait 10 seconds
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-    console.log('set lazily loaded members!');
     this._timelineSets.forEach((tlSet) => tlSet.setJoinedMembers(members.joined));
     this.emit('Room', this);
 };

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -211,13 +211,13 @@ Room.prototype.membersNeedLoading = function() {
 }
 
 /**
- * 
+ * Sets the lazily loaded members from the result of calling /joined_members
+ * @param {Promise} promise with result of /joined_members endpoint
  */
 Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     this._membersNeedLoading = false;
     const members = await joinedMembersPromise;
-    this.currentState.setJoinedMembers(members.joined);    
-    //for all timelines > room state, call setJoinedMembers?
+    this._timelineSets.forEach(tlSet => tlSet.setJoinedMembers(members.joined));
 }
 
 /**

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -171,8 +171,6 @@ function Room(roomId, opts) {
 
     // read by megolm; boolean value - null indicates "use global value"
     this._blacklistUnverifiedDevices = null;
-    // in case of lazy loading, to keep track of loading state
-    this._membersNeedLoading = true;
 }
 
 utils.inherits(Room, EventEmitter);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -218,7 +218,16 @@ Room.prototype.membersNeedLoading = function() {
  */
 Room.prototype.setLazilyLoadedMembers = async function(joinedMembersPromise) {
     this._membersNeedLoading = false;
-    const members = await joinedMembersPromise;
+    let members = null;
+    try {
+        members = await joinedMembersPromise;
+    }
+    catch (err) {
+        console.error(`Fetching room members for ${this.roomId} failed. Room members will appear incomplete.`);
+        console.error(err);
+        this._membersNeedLoading = true;
+        return;
+    }
     this._timelineSets.forEach((tlSet) => tlSet.setJoinedMembers(members.joined));
     this.emit('Room', this);
 };

--- a/src/sync.js
+++ b/src/sync.js
@@ -945,6 +945,7 @@ SyncApi.prototype._processSyncResponse = async function(
     // Handle invites
     inviteRooms.forEach(function(inviteObj) {
         const room = inviteObj.room;
+        room.setSyncedMembership("invite");
         const stateEvents =
             self._mapSyncEventsFormat(inviteObj.invite_state, room);
         self._processRoomEvents(room, stateEvents);
@@ -961,6 +962,7 @@ SyncApi.prototype._processSyncResponse = async function(
     // Handle joins
     await Promise.mapSeries(joinRooms, async function(joinObj) {
         const room = joinObj.room;
+        room.setSyncedMembership("join");
         const stateEvents = self._mapSyncEventsFormat(joinObj.state, room);
         const timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room);
         const ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
@@ -1076,6 +1078,8 @@ SyncApi.prototype._processSyncResponse = async function(
     // Handle leaves (e.g. kicked rooms)
     leaveRooms.forEach(function(leaveObj) {
         const room = leaveObj.room;
+        room.setSyncedMembership("leave");
+
         const stateEvents =
             self._mapSyncEventsFormat(leaveObj.state, room);
         const timelineEvents =


### PR DESCRIPTION
Lazy loading of members, for now using the /joined_members endpoint until we have something better.
 - [x] prototype lazily loaded members with /joined_members
- [x] pull code that assumes `RoomMember.events...` into RoomMember so it can transparently take lazily loaded members into account. 
 - [x] return fake sentinels with just user id when users haven't been loaded yet, better than breaking message continuation.
 - [x] timeline reset should take into account lazily loaded members of previous timeline
 - [x] use `/members` endpoint
 - [x] fix rooms not visible on initial sync where user wasn't active recently 
- [x] write/fix unit tests

Parent issue: https://github.com/vector-im/riot-web/issues/6611