### PR TITLE
Lazy loading: store lazily loaded members in indexeddb

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -747,7 +747,7 @@ MatrixClient.prototype._loadMembers = async function(room) {
     // were the members loaded from the server?
     let fromServer = false;
     let rawMembersEvents = await this.store.getOutOfBandMembers(roomId);
-    if (rawMembersEvents.length == 0) {
+    if (rawMembersEvents === null) {
         fromServer = true;
         const lastEventId = room.getLastEventId();
         const response = await this.members(roomId, "join", "leave", lastEventId);
@@ -787,18 +787,8 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
         const rawMembersEvents = room.currentState.getMembers()
             .filter((m) => m.isOutOfBand())
             .map((m) => m.events.member.event);
-        // TODO: probably need a way to mark a room as lazy loaded
-        // even though we didn't store any members, as we'll just
-        // lazy loaded the room in every session. This is a likely
-        // scenario for DM's where all the members would likely
-        // be known without lazy loading.
-        if (rawMembersEvents.length) {
-            console.log(`LL: telling backend to store ${rawMembersEvents.length} members`);
-            await this.store.setOutOfBandMembers(roomId, rawMembersEvents);
-        }
-        else {
-            console.log(`LL: no members needed to be stored`);
-        }
+        console.log(`LL: telling backend to store ${rawMembersEvents.length} members`);
+        await this.store.setOutOfBandMembers(roomId, rawMembersEvents);
     }
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -766,6 +766,10 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     if (!room || !room.needsOutOfBandMembers()) {
         return;
     }
+    // Note that we don't await _loadMembers here first.
+    // setLazyLoadedMembers sets a flag before it awaits the promise passed in
+    // to avoid a race when calling membersNeedLoading/loadOutOfBandMembers
+    // in fast succession, before the first promise resolves.
     const membersPromise = this._loadMembers(room);
     await room.loadOutOfBandMembers(membersPromise);
 };

--- a/src/client.js
+++ b/src/client.js
@@ -768,17 +768,17 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
     if (!room || !room.needsOutOfBandMembers()) {
         return;
     }
+    // intercept whether we need to store oob members afterwards
+    let membersNeedStoring = false;
     // Note that we don't await _loadMembers here first.
     // setLazyLoadedMembers sets a flag before it awaits the promise passed in
     // to avoid a race when calling membersNeedLoading/loadOutOfBandMembers
     // in fast succession, before the first promise resolves.
-    let membersPromise = this._loadMembers(room);
-    // intercept whether we need to store oob members afterwards
-    let membersNeedStoring = false;
-    membersPromise = membersPromise.then(({memberEvents, fromServer}) => {
-        membersNeedStoring = fromServer;
-        return memberEvents;
-    });
+    const membersPromise = this._loadMembers(room)
+        .then(({memberEvents, fromServer}) => {
+            membersNeedStoring = fromServer;
+            return memberEvents;
+        });
     await room.loadOutOfBandMembers(membersPromise);
     // if loadOutOfBandMembers throws, this wont be called
     // but that's fine as we don't want to store members

--- a/src/client.js
+++ b/src/client.js
@@ -752,8 +752,6 @@ MatrixClient.prototype._loadMembers = async function(room) {
         const lastEventId = room.getLastEventId();
         const response = await this.members(roomId, "join", "leave", lastEventId);
         rawMembersEvents = response.chunk;
-        // TODO don't block on writing
-        await this.store.setOutOfBandMembers(roomId, rawMembersEvents);
     }
     const memberEvents = rawMembersEvents.map(this.getEventMapper());
     return {memberEvents, fromServer};

--- a/src/client.js
+++ b/src/client.js
@@ -752,6 +752,7 @@ MatrixClient.prototype._loadMembers = async function(room) {
         const lastEventId = room.getLastEventId();
         const response = await this.members(roomId, "join", "leave", lastEventId);
         rawMembersEvents = response.chunk;
+        console.log(`LL: got ${rawMembersEvents.length} members from server`);
     }
     const memberEvents = rawMembersEvents.map(this.getEventMapper());
     return {memberEvents, fromServer};
@@ -792,7 +793,11 @@ MatrixClient.prototype.loadRoomMembersIfNeeded = async function(roomId) {
         // scenario for DM's where all the members would likely
         // be known without lazy loading.
         if (rawMembersEvents.length) {
+            console.log(`LL: telling backend to store ${rawMembersEvents.length} members`);
             await this.store.setOutOfBandMembers(roomId, rawMembersEvents);
+        }
+        else {
+            console.log(`LL: no members needed to be stored`);
         }
     }
 };

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -432,9 +432,11 @@ RoomState.prototype.markOutOfBandMembersFailed = function() {
  * @param {MatrixEvent[]} stateEvents array of membership state events
  */
 RoomState.prototype.setOutOfBandMembers = function(stateEvents) {
+    console.log(`LL: RoomState about to set ${stateEvents.length} OOB members ...`);
     if (this._oobMemberFlags.status !== OOB_STATUS_INPROGRESS) {
         return;
     }
+    console.log(`LL: RoomState put in OOB_STATUS_FINISHED state ...`);
     this._oobMemberFlags.status = OOB_STATUS_FINISHED;
     stateEvents.forEach((e) => this._setOutOfBandMember(e));
 };

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -216,10 +216,14 @@ LocalIndexedDBStoreBackend.prototype = {
             request.onerror = (err) => {
                 reject(err);
             };
+        }).then((membershipEvents) => {
+            console.log(`LL: got ${membershipEvents.length} membershipEvents from storage for room ${roomId} ...`);
+            return membershipEvents;
         });
     },
 
     setOutOfBandMembers: function(roomId, membershipEvents) {
+        console.log(`LL: backend about to store ${membershipEvents.length} members for ${roomId}`);
         function ignoreResult() {};
         // run everything in a promise so anything that throws will reject
         return new Promise((resolve) =>{
@@ -230,6 +234,8 @@ LocalIndexedDBStoreBackend.prototype = {
                 return putPromise.then(ignoreResult);
             });
             resolve(Promise.all(puts).then(ignoreResult));
+        }).then(() => {
+            console.log(`LL: backend done storing for ${roomId}!`);
         });
     },
 

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -202,7 +202,7 @@ LocalIndexedDBStoreBackend.prototype = {
      * Returns the out-of-band membership events for this room that
      * were previously loaded.
      * @param {string} roomId
-     * @returns {event[]} the events, potentially an empty array if OOB loading didn't yield any new members
+     * @returns {Promise<event[]>} the events, potentially an empty array if OOB loading didn't yield any new members
      * @returns {null} in case the members for this room haven't been stored yet
      */
     getOutOfBandMembers: function(roomId) {

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -266,6 +266,9 @@ LocalIndexedDBStoreBackend.prototype = {
             const store = tx.objectStore("oob_membership_events");
             const eventPuts = membershipEvents.map((e) => {
                 const putPromise = promiseifyRequest(store.put(e));
+                // ignoring the result makes sure we discard the IDB success event
+                // ASAP, and not create a potentially big array containing them
+                // unneccesarily later on by calling Promise.all.
                 return putPromise.then(ignoreResult);
             });
             // aside from all the events, we also write a marker object to the store
@@ -280,6 +283,9 @@ LocalIndexedDBStoreBackend.prototype = {
             };
             const markerPut = promiseifyRequest(store.put(markerObject));
             const allPuts = eventPuts.concat(markerPut);
+            // ignore the empty array Promise.all creates
+            // as this method should just resolve
+            // to undefined on success
             resolve(Promise.all(allPuts).then(ignoreResult));
         }).then(() => {
             console.log(`LL: backend done storing for ${roomId}!`);

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -87,12 +87,27 @@ RemoteIndexedDBStoreBackend.prototype = {
         return this._doCmd('syncToDatabase', [users]);
     },
 
+    /**
+     * Returns the out-of-band membership events for this room that
+     * were previously loaded.
+     * @param {string} roomId
+     * @returns {event[]} the events, potentially an empty array if OOB loading didn't yield any new members
+     * @returns {null} in case the members for this room haven't been stored yet
+     */
     getOutOfBandMembers: function(roomId) {
         return this._doCmd('getOutOfBandMembers', [roomId]);
     },
 
-    setOutOfBandMembers: function(roomId, members) {
-        return this._doCmd('setOutOfBandMembers', [roomId, members]);
+    /**
+     * Stores the out-of-band membership events for this room. Note that
+     * it still makes sense to store an empty array as the OOB status for the room is
+     * marked as fetched, and getOutOfBandMembers will return an empty array instead of null
+     * @param {string} roomId
+     * @param {event[]} membershipEvents the membership events to store
+     * @returns {Promise} when all members have been stored
+     */
+    setOutOfBandMembers: function(roomId, membershipEvents) {
+        return this._doCmd('setOutOfBandMembers', [roomId, membershipEvents]);
     },
 
     /**

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -87,6 +87,13 @@ RemoteIndexedDBStoreBackend.prototype = {
         return this._doCmd('syncToDatabase', [users]);
     },
 
+    getOutOfBandMembers: function(roomId) {
+        return this._doCmd('getOutOfBandMembers', [roomId]);
+    },
+
+    setOutOfBandMembers: function(roomId, members) {
+        return this._doCmd('setOutOfBandMembers', [roomId, members]);
+    },
 
     /**
      * Load all user presence events from the database. This is not cached.

--- a/src/store/indexeddb-store-worker.js
+++ b/src/store/indexeddb-store-worker.js
@@ -92,6 +92,12 @@ class IndexedDBStoreWorker {
             case 'getNextBatchToken':
                 prom = this.backend.getNextBatchToken();
                 break;
+            case 'getOutOfBandMembers':
+                prom = this.backend.getOutOfBandMembers(msg.args[0]);
+                break;
+            case 'setOutOfBandMembers':
+                prom = this.backend.setOutOfBandMembers(msg.args[0], msg.args[1]);
+                break;
         }
 
         if (prom === undefined) {

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -219,4 +219,12 @@ IndexedDBStore.prototype.setSyncData = function(syncData) {
     return this.backend.setSyncData(syncData);
 };
 
+IndexedDBStore.prototype.getOutOfBandMembers = function(roomId) {
+    return this.backend.getOutOfBandMembers(roomId);
+};
+
+IndexedDBStore.prototype.setOutOfBandMembers = function(roomId, members) {
+    return this.backend.setOutOfBandMembers(roomId, members);
+};
+
 module.exports.IndexedDBStore = IndexedDBStore;

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -219,12 +219,27 @@ IndexedDBStore.prototype.setSyncData = function(syncData) {
     return this.backend.setSyncData(syncData);
 };
 
+/**
+ * Returns the out-of-band membership events for this room that
+ * were previously loaded.
+ * @param {string} roomId
+ * @returns {event[]} the events, potentially an empty array if OOB loading didn't yield any new members
+ * @returns {null} in case the members for this room haven't been stored yet
+ */
 IndexedDBStore.prototype.getOutOfBandMembers = function(roomId) {
     return this.backend.getOutOfBandMembers(roomId);
 };
 
-IndexedDBStore.prototype.setOutOfBandMembers = function(roomId, members) {
-    return this.backend.setOutOfBandMembers(roomId, members);
+/**
+ * Stores the out-of-band membership events for this room. Note that
+ * it still makes sense to store an empty array as the OOB status for the room is
+ * marked as fetched, and getOutOfBandMembers will return an empty array instead of null
+ * @param {string} roomId
+ * @param {event[]} membershipEvents the membership events to store
+ * @returns {Promise} when all members have been stored
+ */
+IndexedDBStore.prototype.setOutOfBandMembers = function(roomId, membershipEvents) {
+    return this.backend.setOutOfBandMembers(roomId, membershipEvents);
 };
 
 module.exports.IndexedDBStore = IndexedDBStore;

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -52,6 +52,9 @@ module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
         // type : content
     };
     this.localStorage = opts.localStorage;
+    this._oobMembers = {
+        // roomId: [member events]
+    };
 };
 
 module.exports.MatrixInMemoryStore.prototype = {
@@ -375,6 +378,28 @@ module.exports.MatrixInMemoryStore.prototype = {
         this.accountData = {
             // type : content
         };
+        return Promise.resolve();
+    },
+    /**
+     * Returns the out-of-band membership events for this room that
+     * were previously loaded.
+     * @param {string} roomId
+     * @returns {event[]} the events, potentially an empty array if OOB loading didn't yield any new members
+     * @returns {null} in case the members for this room haven't been stored yet
+     */
+    getOutOfBandMembers: function(roomId) {
+        return Promise.resolve(this._oobMembers[roomId] || null);
+    },
+    /**
+     * Stores the out-of-band membership events for this room. Note that
+     * it still makes sense to store an empty array as the OOB status for the room is
+     * marked as fetched, and getOutOfBandMembers will return an empty array instead of null
+     * @param {string} roomId
+     * @param {event[]} membershipEvents the membership events to store
+     * @returns {Promise} when all members have been stored
+     */
+    setOutOfBandMembers: function(roomId, membershipEvents) {
+        this._oobMembers[roomId] = membershipEvents;
         return Promise.resolve();
     },
 };

--- a/src/store/stub.js
+++ b/src/store/stub.js
@@ -264,6 +264,14 @@ StubStore.prototype = {
     deleteAllData: function() {
         return Promise.resolve();
     },
+
+    getOutOfBandMembers: function() {
+        return Promise.resolve(null);
+    },
+
+    setOutOfBandMembers: function() {
+        return Promise.resolve();
+    },
 };
 
 /** Stub Store class. */


### PR DESCRIPTION
This PR adds storing the lazy loaded members in indexeddb, so we don't have to call /members in every browser session (per browser session the members are already kept in memory once you've looked at the room).

It also stores a marker object in the same IDB store to know whether lazy loading was already done for a room even though it didn't yield any members to store (like in a DM where both members where active in the last 10 messages).