### PR TITLE
take into account homoglyphs when calculating similar display names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6735,6 +6735,11 @@
         }
       }
     },
+    "unhomoglyph": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unhomoglyph/-/unhomoglyph-1.0.2.tgz",
+      "integrity": "sha1-1p5fWmocayEZQaCIm4HrqGWVwlM="
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "bluebird": "^3.5.0",
     "browser-request": "^0.3.3",
     "content-type": "^1.0.2",
-    "request": "^2.53.0"
+    "request": "^2.53.0",
+    "unhomoglyph": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,8 @@ limitations under the License.
  * @module utils
  */
 
+const unhomoglyph = require('unhomoglyph');
+
 /**
  * Encode a dictionary of query parameters.
  * @param {Object} params A dict of key/values to encode e.g.
@@ -665,10 +667,11 @@ module.exports.isNumber = function(value) {
 
 /**
  * Removes zero width chars, diacritics and whitespace from the string
+ * Also applies an unhomoglyph on the string, to prevent similar looking chars
  * @param {string} str the string to remove hidden characters from
  * @return {string} a string with the hidden characters removed
  */
 module.exports.removeHiddenChars = function(str) {
-    return str.normalize('NFD').replace(removeHiddenCharsRegex, '');
+    return unhomoglyph(str.normalize('NFD').replace(removeHiddenCharsRegex, ''));
 };
 const removeHiddenCharsRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;


### PR DESCRIPTION
to prevent homoglyph attacks

for riot-web requires https://github.com/vector-im/riot-web/pull/7093
Fixes https://github.com/vector-im/riot-web/issues/5826

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>