### PR TITLE
Fix infinite spinner upon joining a room

### DIFF
--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -162,6 +162,7 @@ describe("RoomState", function() {
             ];
             let emitCount = 0;
             state.on("RoomState.newMember", function(ev, st, mem) {
+                expect(state.getMember(mem.userId)).toEqual(mem);
                 expect(mem.userId).toEqual(memberEvents[emitCount].getSender());
                 expect(mem.membership).toBeFalsy();  // not defined yet
                 emitCount += 1;

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -217,8 +217,13 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             }
 
             let member = self.members[userId];
+            self._joinedMemberCount = null;
+
             if (!member) {
                 member = new RoomMember(event.getRoomId(), userId);
+                // add member to members before emitting any events,
+                // as event handlers often lookup the member
+                self.members[userId] = member;
                 self.emit("RoomState.newMember", event, self, member);
             }
 
@@ -232,8 +237,6 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
             // blow away the sentinel which is now outdated
             delete self._sentinels[userId];
 
-            self.members[userId] = member;
-            self._joinedMemberCount = null;
             self.emit("RoomState.members", event, self, member);
         } else if (event.getType() === "m.room.power_levels") {
             const members = utils.values(self.members);

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -546,7 +546,8 @@ function _updateDisplayNameCache(roomState, userId, displayName) {
 
  /**
  * Fires whenever a member is added to the members dictionary. The RoomMember
- * will not be fully populated yet (e.g. no membership state).
+ * will not be fully populated yet (e.g. no membership state) but will already
+ * be available in the members dictionary.
  * @event module:client~MatrixClient#"RoomState.newMember"
  * @param {MatrixEvent} event The matrix event which caused this event to fire.
  * @param {RoomState} state The room state whose RoomState.members dictionary


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/6679

The way the spinner is supposed to disappear when clicking join in the room preview bar is a bit convoluted, but as far as I could figure out it works like this:
1. `RoomView` listens for `"RoomMember.membership`
1. when this fires, it checks if its for the logged in user, if so, forces a rerender
1.  in render, we will lookup and check the membership of the logged in user, to determine if the aux panel with the spinner (if !join) and the composer should be shown (if join). Even if `state.joining` remains `true`, which it is in this case.

What went wrong is that the lookup in `render` failed because the event was emitted before the new member was added to `RoomState::members`, and not seeing the membership is now `join`. This PR addresses that.

This also explains why this problem does not occur when you were invited into a room. Your member and membership would already be added to the state.

Also, I don't think `RoomViewStore/RoomView::joining` ever gets cleared apart from viewing the room again, which doesn't help to understand all of this. But just the changes here already fixed the problem for me.