### PR TITLE
make sure room.tags is always a valid object to avoid crashes

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1143,7 +1143,7 @@ Room.prototype.addTags = function(event) {
     // }
 
     // XXX: do we need to deep copy here?
-    this.tags = event.getContent().tags;
+    this.tags = event.getContent().tags || {};
 
     // XXX: we could do a deep-comparison to see if the tags have really
     // changed - but do we want to bother?


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/issues/7025