### PR TITLE
Fix: Lazy loading: missed call site while renaming prependStateEvents

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2242,7 +2242,7 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
             if (res.state) {
                 const roomState = eventTimeline.getState(dir);
                 const stateEvents = utils.map(res.state, self.getEventMapper());
-                roomState.prependStateEvents(stateEvents);
+                roomState.setUnknownStateEvents(stateEvents);
             }
             const token = res.end;
             const matrixEvents = utils.map(res.chunk, self.getEventMapper());


### PR DESCRIPTION
Fixup for https://github.com/matrix-org/matrix-js-sdk/commit/fe772ed84d46c91cdfa22ded8faa5fbf54cd7ec4