### PR TITLE
Lazy loading: don't block on setting up room crypto

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1318,6 +1318,9 @@ describe("Room", function() {
                     // events should already be MatrixEvents
                     return function(event) {return event;};
                 },
+                isRoomEncrypted: function() {
+                    return false;
+                },
                 _http: {
                     serverResponse,
                     authedRequest: function() {

--- a/src/crypto/RoomList.js
+++ b/src/crypto/RoomList.js
@@ -71,6 +71,9 @@ export default class RoomList {
     }
 
     async setRoomEncryption(roomId, roomInfo) {
+        // important that this happens before calling into the store
+        // as it prevents the Crypto::setRoomEncryption for calling
+        // this twice for consecutive m.room.encryption events
         this._roomEncryption[roomId] = roomInfo;
         await this._cryptoStore.doTxn(
             'readwrite', [IndexedDBCryptoStore.STORE_ROOMS], (txn) => {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -669,7 +669,7 @@ Crypto.prototype.trackRoomDevices = function(roomId) {
         members.forEach((m) => {
             this._deviceList.startTrackingDeviceList(m.userId);
         });
-        return refreshPromise = this._deviceList.refreshOutdatedDeviceLists();
+        return this._deviceList.refreshOutdatedDeviceLists();
     };
 
     let promise = this._roomDeviceTrackingState[roomId];

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -653,6 +653,7 @@ Crypto.prototype.setRoomEncryption = async function(roomId, config) {
  * Make sure we are tracking the device lists for all users in this room.
  *
  * @param {string} roomId The room ID to start tracking devices in.
+ * @returns {Promise} when all devices for the room have been fetched and marked to track
  */
 Crypto.prototype.trackRoomDevices = function(roomId) {
     const trackAndRefresh = async () => {
@@ -678,7 +679,7 @@ Crypto.prototype.trackRoomDevices = function(roomId) {
         this._roomDeviceTrackingState[roomId] = promise;
     }
     return promise;
-}
+};
 
 /**
  * @typedef {Object} module:crypto~OlmSessionResult
@@ -770,7 +771,7 @@ Crypto.prototype.importRoomKeys = function(keys) {
         },
     );
 };
-
+/* eslint-disable valid-jsdoc */    //https://github.com/eslint/eslint/issues/7307
 /**
  * Encrypt an event according to the configuration of the room.
  *
@@ -781,6 +782,7 @@ Crypto.prototype.importRoomKeys = function(keys) {
  * @return {module:client.Promise?} Promise which resolves when the event has been
  *     encrypted, or null if nothing was needed
  */
+/* eslint-enable valid-jsdoc */
 Crypto.prototype.encryptEvent = async function(event, room) {
     if (!room) {
         throw new Error("Cannot send encrypted messages in unknown rooms");
@@ -816,7 +818,7 @@ Crypto.prototype.encryptEvent = async function(event, room) {
     }
 
     const encryptedContent = await alg.encryptMessage(
-        room, event.getType(), content)
+        room, event.getType(), content);
 
     if (mRelatesTo) {
         encryptedContent['m.relates_to'] = mRelatesTo;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -368,6 +368,11 @@ Room.prototype.loadMembersIfNeeded = function() {
     });
 
     this._membersPromise = promise;
+    // now the members are loaded, start to track the e2e devices if needed
+    if (this._client.isRoomEncrypted(this.roomId)) {
+        this._client._crypto.trackRoomDevices(this.roomId);
+    }
+
     return this._membersPromise;
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -1085,15 +1085,16 @@ SyncApi.prototype._processSyncResponse = async function(
 
         self._processEventsForNotifs(room, timelineEvents);
 
-        async function processRoomEvent(e) {
+        function processRoomEvent(e) {
             client.emit("event", e);
             if (e.isState() && e.getType() == "m.room.encryption" && self.opts.crypto) {
-                await self.opts.crypto.onCryptoEvent(e);
+                self.opts.crypto.onCryptoEvent(e);
             }
         }
 
-        await Promise.mapSeries(stateEvents, processRoomEvent);
-        await Promise.mapSeries(timelineEvents, processRoomEvent);
+        stateEvents.forEach(processRoomEvent);
+        timelineEvents.forEach(processRoomEvent);
+
         ephemeralEvents.forEach(function(e) {
             client.emit("event", e);
         });


### PR DESCRIPTION
setting up room crypto will load members in case of LL and could take quite some time
The two async actions performed by onCryptoEvent is saving the crypto config
to the roomlist store and fetching the room members to track.
Both are guarded against double calls so not awaiting this should be fine.