### PR TITLE
Add wrapper around getJoinedMemberCount()

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -637,6 +637,14 @@ Room.prototype.getJoinedMemberCount = function() {
 };
 
 /**
+ * Returns the number of invited members in this room
+ * @return {integer} The number of members in this room whose membership is 'invite'
+ */
+Room.prototype.getInvitedMemberCount = function() {
+    return this.currentState.getInvitedMemberCount();
+};
+
+/**
  * Get a list of members with given membership state.
  * @param {string} membership The membership state.
  * @return {RoomMember[]} A list of members with the given membership state.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -626,6 +626,17 @@ Room.prototype.addEventsToTimeline = function(events, toStartOfTimeline,
  };
 
 /**
+ * Returns the number of joined members in this room
+ * This method caches the result.
+ * This is a wrapper around the method of the same name in roomState, returning
+ * its result for the room's current state.
+ * @return {integer} The number of members in this room whose membership is 'join'
+ */
+Room.prototype.getJoinedMemberCount = function() {
+    return this.currentState.getJoinedMemberCount();
+};
+
+/**
  * Get a list of members with given membership state.
  * @param {string} membership The membership state.
  * @return {RoomMember[]} A list of members with the given membership state.


### PR DESCRIPTION
On Room, because it's super confusing that Room has
getJoinedMembers() but not getJoinedMemberCount()

https://github.com/matrix-org/matrix-react-sdk/pull/2126 had assumed
that this method was on Room