### PR TITLE
Revert "Lazy loading: don't block on setting up room crypto"

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1318,9 +1318,6 @@ describe("Room", function() {
                     // events should already be MatrixEvents
                     return function(event) {return event;};
                 },
-                isRoomEncrypted: function() {
-                    return false;
-                },
                 _http: {
                     serverResponse,
                     authedRequest: function() {

--- a/src/crypto/RoomList.js
+++ b/src/crypto/RoomList.js
@@ -71,9 +71,6 @@ export default class RoomList {
     }
 
     async setRoomEncryption(roomId, roomInfo) {
-        // important that this happens before calling into the store
-        // as it prevents the Crypto::setRoomEncryption for calling
-        // this twice for consecutive m.room.encryption events
         this._roomEncryption[roomId] = roomInfo;
         await this._cryptoStore.doTxn(
             'readwrite', [IndexedDBCryptoStore.STORE_ROOMS], (txn) => {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -368,11 +368,6 @@ Room.prototype.loadMembersIfNeeded = function() {
     });
 
     this._membersPromise = promise;
-    // now the members are loaded, start to track the e2e devices if needed
-    if (this._client.isRoomEncrypted(this.roomId)) {
-        this._client._crypto.trackRoomDevices(this.roomId);
-    }
-
     return this._membersPromise;
 };
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -1085,16 +1085,15 @@ SyncApi.prototype._processSyncResponse = async function(
 
         self._processEventsForNotifs(room, timelineEvents);
 
-        function processRoomEvent(e) {
+        async function processRoomEvent(e) {
             client.emit("event", e);
             if (e.isState() && e.getType() == "m.room.encryption" && self.opts.crypto) {
-                self.opts.crypto.onCryptoEvent(e);
+                await self.opts.crypto.onCryptoEvent(e);
             }
         }
 
-        stateEvents.forEach(processRoomEvent);
-        timelineEvents.forEach(processRoomEvent);
-
+        await Promise.mapSeries(stateEvents, processRoomEvent);
+        await Promise.mapSeries(timelineEvents, processRoomEvent);
         ephemeralEvents.forEach(function(e) {
             client.emit("event", e);
         });


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#696
This isn't ready for prime-time yet, DeviceList tests are still failing and need to make sure all devices are always fetched before sending. Sorry for not making this clearer on the PR.