### PR TITLE
Improve setRoomEncryption guard against multiple m.room.encryption st…

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -648,7 +648,7 @@ Crypto.prototype.setRoomEncryption = async function(roomId, config, inhibitDevic
     // to avoid races when calling this method multiple times. Hence keep a hold of the promise.
     let storeConfigPromise = null;
     if(!existingConfig) {
-        const storeConfigPromise = this._roomList.setRoomEncryption(roomId, config);
+        storeConfigPromise = this._roomList.setRoomEncryption(roomId, config);
     }
 
     const AlgClass = algorithms.ENCRYPTION_CLASSES[config.algorithm];

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -627,7 +627,7 @@ Crypto.prototype.setRoomEncryption = async function(roomId, config, inhibitDevic
     // because it first stores in memory. We should await the promise only
     // after all the in-memory state (_roomEncryptors and _roomList) has been updated
     // to avoid races when calling this method multiple times. Hence keep a hold of the promise.
-    let storeConfigPromise;
+    let storeConfigPromise = null;
     // if state is being replayed from storage, we might already have a configuration
     // for this room. We just need to make sure the algorithm in
     // _roomEncryptors and config in _roomList are in sync


### PR DESCRIPTION
…ate events

we were only bailing out when receiving a non JSON-identical m.room.encryption event.
When receiving an identical event, the algorithm in _roomEncryptors would be reset,
generating a new megolm session every time this happens (there is a LL synapse bug
where this happens on every sync).

As the _roomList is backed by indexeddb you might already have a config without the algorithm being present though,
so we first check for the room encryptor algorithm being present. If so, always bail out as setRoomEncryption was
already called for the given room.

If no algorithm is present, still check if the config is not being changed.
Also setup the roomlist and room encryption synchronously before awaiting
the indexeddb operation to store the room encryption config in roomlist.

Fixes https://github.com/vector-im/riot-web/issues/7223 / https://github.com/vector-im/riot-web/issues/7222