### PR TITLE
Fix: show spinner again while recovering from connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ BREAKING CHANGE
 ---------------
 
  * `MatrixClient::startClient` now returns a Promise. No method should be called on the client before that promise resolves. Before this method didn't return anything.
+ * A new `CATCHUP` sync state, emitted by `MatrixClient#"sync"` and returned by `MatrixClient::getSyncState()`, when doing initial sync after the `ERROR` state. See `MatrixClient` documentation for details.
 
 Changes in [0.11.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.11.0) (TDB)
 ==================================================================================================

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -380,7 +380,7 @@ describe("MatrixClient", function() {
             client.startClient();
         });
 
-        it("should transition ERROR -> PREPARED after /sync if prev failed",
+        it("should transition ERROR -> CATCHUP after /sync if prev failed",
         function(done) {
             const expectedStates = [];
             acceptKeepalives = false;
@@ -403,7 +403,7 @@ describe("MatrixClient", function() {
 
             expectedStates.push(["RECONNECTING", null]);
             expectedStates.push(["ERROR", "RECONNECTING"]);
-            expectedStates.push(["PREPARED", "ERROR"]);
+            expectedStates.push(["CATCHUP", "ERROR"]);
             client.on("sync", syncChecker(expectedStates, done));
             client.startClient();
         });

--- a/src/client.js
+++ b/src/client.js
@@ -3504,6 +3504,12 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * a state of SYNCING. <i>This is the equivalent of "syncComplete" in the
  * previous API.</i></li>
  *
+ * <li>CATCHUP: The client has detected the connection to the server might be
+ * available again and will now try to do a sync again. As this sync might take
+ * a long time (depending how long ago was last synced, and general server
+ * performance) the client is put in this mode so the UI can reflect trying
+ * to catch up with the server after losing connection.</li>
+ *
  * <li>SYNCING : The client is currently polling for new events from the server.
  * This will be called <i>after</i> processing latest events from a sync.</li>
  *
@@ -3527,11 +3533,11 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  *                                          +---->STOPPED
  *                                          |
  *              +----->PREPARED -------> SYNCING <--+
- *              |        ^                |  ^      |
- *              |        |                |  |      |
- *              |        |                V  |      |
- *   null ------+        |  +--------RECONNECTING   |
- *              |        |  V                       |
+ *              |                        ^  |  ^    |
+ *              |      CATCHUP ----------+  |  |    |
+ *              |        ^                  V  |    |
+ *   null ------+        |  +------- RECONNECTING   |
+ *              |        V  V                       |
  *              +------->ERROR ---------------------+
  *
  * NB: 'null' will never be emitted by this event.

--- a/src/sync.js
+++ b/src/sync.js
@@ -780,7 +780,7 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
     // instead, so that clients can observe this state
     // if they wish.
     this._startKeepAlives().then(() => {
-        if (this.getSyncState() == 'ERROR') {
+        if (this.getSyncState() === 'ERROR') {
             this._updateSyncState("PREPARED", {
                 oldSyncToken: null,
                 nextSyncToken: null,

--- a/src/sync.js
+++ b/src/sync.js
@@ -780,6 +780,13 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
     // instead, so that clients can observe this state
     // if they wish.
     this._startKeepAlives().then(() => {
+        if (this.getSyncState() == 'ERROR') {
+            this._updateSyncState("PREPARED", {
+                oldSyncToken: null,
+                nextSyncToken: null,
+                catchingUp: true,
+            });
+        }
         this._sync(syncOptions);
     });
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -781,7 +781,7 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
     // if they wish.
     this._startKeepAlives().then(() => {
         if (this.getSyncState() === 'ERROR') {
-            this._updateSyncState("PREPARED", {
+            this._updateSyncState("CATCHUP", {
                 oldSyncToken: null,
                 nextSyncToken: null,
                 catchingUp: true,


### PR DESCRIPTION
Pass through PREPARED state after error, when keepalive returns succes.
This is according to the state diagram in client.js.
This will show a spinner at the bottom of a room again
while the catchup sync is in progress,
which seems to have broken at some point.

Addresses item 6 (We no longer show a spinner when recovering after losing connectivity) of https://github.com/vector-im/riot-web/issues/7182