### PR TITLE
Fix: also load invited members when lazy loading members

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -354,7 +354,6 @@ Room.prototype.setSyncedMembership = function(membership) {
 Room.prototype._loadMembersFromServer = async function() {
     const lastSyncToken = this._client.store.getSyncToken();
     const queryString = utils.encodeParams({
-        membership: "join",
         not_membership: "leave",
         at: lastSyncToken,
     });


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7243