### PR TITLE
Fix for "otherMember.getAvatarUrl is not a function"

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -22,6 +22,7 @@ const EventEmitter = require("events").EventEmitter;
 
 const EventStatus = require("./event").EventStatus;
 const RoomSummary = require("./room-summary");
+const RoomMember = require("./room-member");
 const MatrixEvent = require("./event").MatrixEvent;
 const utils = require("../utils");
 const ContentRepo = require("../content-repo");
@@ -350,6 +351,19 @@ Room.prototype.getAvatarFallbackMember = function() {
         });
         if (availableMember) {
             return availableMember;
+        }
+    }
+    // if all else fails, try falling back to a user,
+    // and create a one-off member for it
+    if (hasHeroes) {
+        const availableUser = this._summaryHeroes.map((userId) => {
+            return this._client.getUser(userId);
+        }).find((user) => !!user);
+        if (availableUser) {
+            const member = new RoomMember(
+                this.roomId, availableUser.userId);
+            member.user = availableUser;
+            return member;
         }
     }
 };

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -328,17 +328,28 @@ Room.prototype.guessDMUserId = function() {
 
 Room.prototype.getAvatarFallbackMember = function() {
     const memberCount = this.getInvitedAndJoinedMemberCount();
-    if (memberCount <= 2) {
-        if (this._summaryHeroes && this._summaryHeroes.length) {
-            return this._summaryHeroes[0];
+    if (memberCount > 2) {
+        return;
+    }
+    const hasHeroes = Array.isArray(this._summaryHeroes) &&
+        this._summaryHeroes.length;
+    if (hasHeroes) {
+        const availableMember = this._summaryHeroes.map((userId) => {
+            return this.getMember(userId);
+        }).find((member) => !!member);
+        if (availableMember) {
+            return availableMember;
         }
-        const members = this.currentState.getMembers();
-        // could be different than memberCount
-        // as this includes left members
-        if (members.length <= 2) {
-            return members.find((m) => {
-                return m.userId !== this.myUserId;
-            });
+    }
+    const members = this.currentState.getMembers();
+    // could be different than memberCount
+    // as this includes left members
+    if (members.length <= 2) {
+        const availableMember = members.find((m) => {
+            return m.userId !== this.myUserId;
+        });
+        if (availableMember) {
+            return availableMember;
         }
     }
 };


### PR DESCRIPTION
https://github.com/matrix-org/riot-web-rageshakes/issues/962
was hitting `Unhandled rejection TypeError: otherMember.getAvatarUrl is not a function` because in case of summary heroes it is returning a userid and not a member.

Also adds another fallback route for getting the avatar by looking up the user.