### PR TITLE
Revert "Don't rely on members to query if syncing user can post to room"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,3 @@
-Changes in [0.11.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.11.0) (TDB)
-==================================================================================================
-[Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.10.9...v0.11.0)
-
- * Support for lazy loading members. This should improve performance for
-   users who joined big rooms a lot. Pass to `lazyLoadMembers = true` option when calling `startClient`.
-
-BREAKING CHANGES
-----------------
-
- * `MatrixClient::startClient` now returns a Promise. No method should be called on the client before that promise resolves. Before this method didn't return anything.
- * A new `CATCHUP` sync state, emitted by `MatrixClient#"sync"` and returned by `MatrixClient::getSyncState()`, when doing initial sync after the `ERROR` state. See `MatrixClient` documentation for details.
- * `RoomState::maySendEvent('m.room.message', userId)` & `RoomState::maySendMessage(userId)` do not check the membership of the user anymore, only the power level. To check if the syncing user is allowed to write in a room, use `Room::maySendMessage()` as `RoomState` is not always aware of the syncing user's membership anymore, in case lazy loading of members is enabled.
-
 Changes in [0.10.9](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.10.9) (2018-09-03)
 ==================================================================================================
 [Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.10.9-rc.2...v0.10.9)
@@ -49,6 +35,19 @@ Changes in [0.10.9-rc.1](https://github.com/matrix-org/matrix-js-sdk/releases/ta
    [\#693](https://github.com/matrix-org/matrix-js-sdk/pull/693)
  * Lazy loading of room members
    [\#691](https://github.com/matrix-org/matrix-js-sdk/pull/691)
+
+BREAKING CHANGE
+---------------
+
+ * `MatrixClient::startClient` now returns a Promise. No method should be called on the client before that promise resolves. Before this method didn't return anything.
+ * A new `CATCHUP` sync state, emitted by `MatrixClient#"sync"` and returned by `MatrixClient::getSyncState()`, when doing initial sync after the `ERROR` state. See `MatrixClient` documentation for details.
+
+Changes in [0.11.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.11.0) (TDB)
+==================================================================================================
+[Full Changelog](https://github.com/matrix-org/matrix-js-sdk/compare/v0.10.6...v0.11.0)
+
+ * Support for lazy loading members. This should improve performance for
+   users who joined big rooms a lot. Pass to `lazyLoadMembers = true` option when calling `startClient`.
 
 Changes in [0.10.8](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v0.10.8) (2018-08-20)
 ==================================================================================================

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -447,6 +447,13 @@ describe("RoomState", function() {
     });
 
     describe("maySendStateEvent", function() {
+        it("should say non-joined members may not send state",
+        function() {
+            expect(state.maySendStateEvent(
+                'm.room.name', "@nobody:nowhere",
+            )).toEqual(false);
+        });
+
         it("should say any member may send state with no power level event",
         function() {
             expect(state.maySendStateEvent('m.room.name', userA)).toEqual(true);
@@ -633,6 +640,14 @@ describe("RoomState", function() {
     });
 
     describe("maySendEvent", function() {
+        it("should say non-joined members may not send events",
+        function() {
+            expect(state.maySendEvent(
+                'm.room.message', "@nobody:nowhere",
+            )).toEqual(false);
+            expect(state.maySendMessage("@nobody:nowhere")).toEqual(false);
+        });
+
         it("should say any member may send events with no power level event",
         function() {
             expect(state.maySendEvent('m.room.message', userA)).toEqual(true);

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1400,7 +1400,7 @@ describe("Room", function() {
 
     describe("getMyMembership", function() {
         it("should return synced membership if membership isn't available yet",
-        function() {
+        async function() {
             const room = new Room(roomId, null, userA);
             room.setSyncedMembership("invite");
             expect(room.getMyMembership()).toEqual("invite");
@@ -1432,19 +1432,6 @@ describe("Room", function() {
         function() {
             const room = new Room(roomId, null, userA);
             expect(room.guessDMUserId()).toEqual(userA);
-        });
-    });
-
-    describe("maySendMessage", function() {
-        it("should return false if synced membership not join",
-        function() {
-            const room = new Room(roomId, null, userA);
-            room.setSyncedMembership("invite");
-            expect(room.maySendMessage()).toEqual(false);
-            room.setSyncedMembership("leave");
-            expect(room.maySendMessage()).toEqual(false);
-            room.setSyncedMembership("join");
-            expect(room.maySendMessage()).toEqual(true);
         });
     });
 });

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1485,17 +1485,6 @@ Room.prototype.getAccountData = function(type) {
     return this.accountData[type];
 };
 
-
-/**
- * Returns wheter the syncing user has permission to send a message in the room
- * @return {boolean} true if the user should be permitted to send
- *                   message events into the room.
- */
-Room.prototype.maySendMessage = function() {
-    return this.getMyMembership() === 'join' &&
-        this.currentState.maySendEvent('m.room.message', this.myUserId);
-};
-
 /**
  * This is an internal method. Calculates the name of the room from the current
  * room state.


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#717

as it seems to be causing the tests to fail