### PR TITLE
Reduce amount of promises created when inserting members

### DIFF
--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -265,7 +265,6 @@ LocalIndexedDBStoreBackend.prototype = {
      * marked as fetched, and getOutOfBandMembers will return an empty array instead of null
      * @param {string} roomId
      * @param {event[]} membershipEvents the membership events to store
-     * @returns {Promise} when all members have been stored
      */
     setOutOfBandMembers: async function(roomId, membershipEvents) {
         console.log(`LL: backend about to store ${membershipEvents.length}` +

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -269,7 +269,6 @@ LocalIndexedDBStoreBackend.prototype = {
     setOutOfBandMembers: async function(roomId, membershipEvents) {
         console.log(`LL: backend about to store ${membershipEvents.length}` +
             ` members for ${roomId}`);
-        // run everything in a promise so anything that throws will reject
         const tx = this.db.transaction(["oob_membership_events"], "readwrite");
         const store = tx.objectStore("oob_membership_events");
         membershipEvents.forEach((e) => {
@@ -286,9 +285,6 @@ LocalIndexedDBStoreBackend.prototype = {
             state_key: 0,
         };
         store.put(markerObject);
-        // ignore the empty array Promise.all creates
-        // as this method should just resolve
-        // to undefined on success
         await txnAsPromise(tx);
         console.log(`LL: backend done storing for ${roomId}!`);
     },

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -267,40 +267,31 @@ LocalIndexedDBStoreBackend.prototype = {
      * @param {event[]} membershipEvents the membership events to store
      * @returns {Promise} when all members have been stored
      */
-    setOutOfBandMembers: function(roomId, membershipEvents) {
+    setOutOfBandMembers: async function(roomId, membershipEvents) {
         console.log(`LL: backend about to store ${membershipEvents.length}` +
             ` members for ${roomId}`);
-        function ignoreResult() {}
         // run everything in a promise so anything that throws will reject
-        return new Promise((resolve) =>{
-            const tx = this.db.transaction(["oob_membership_events"], "readwrite");
-            const store = tx.objectStore("oob_membership_events");
-            const eventPuts = membershipEvents.map((e) => {
-                const putPromise = reqAsEventPromise(store.put(e));
-                // ignoring the result makes sure we discard the IDB success event
-                // ASAP, and not create a potentially big array containing them
-                // unneccesarily later on by calling Promise.all.
-                return putPromise.then(ignoreResult);
-            });
-            // aside from all the events, we also write a marker object to the store
-            // to mark the fact that OOB members have been written for this room.
-            // It's possible that 0 members need to be written as all where previously know
-            // but we still need to know whether to return null or [] from getOutOfBandMembers
-            // where null means out of band members haven't been stored yet for this room
-            const markerObject = {
-                room_id: roomId,
-                oob_written: true,
-                state_key: 0,
-            };
-            const markerPut = reqAsEventPromise(store.put(markerObject));
-            const allPuts = eventPuts.concat(markerPut);
-            // ignore the empty array Promise.all creates
-            // as this method should just resolve
-            // to undefined on success
-            resolve(Promise.all(allPuts).then(ignoreResult));
-        }).then(() => {
-            console.log(`LL: backend done storing for ${roomId}!`);
+        const tx = this.db.transaction(["oob_membership_events"], "readwrite");
+        const store = tx.objectStore("oob_membership_events");
+        membershipEvents.forEach((e) => {
+            store.put(e);
         });
+        // aside from all the events, we also write a marker object to the store
+        // to mark the fact that OOB members have been written for this room.
+        // It's possible that 0 members need to be written as all where previously know
+        // but we still need to know whether to return null or [] from getOutOfBandMembers
+        // where null means out of band members haven't been stored yet for this room
+        const markerObject = {
+            room_id: roomId,
+            oob_written: true,
+            state_key: 0,
+        };
+        store.put(markerObject);
+        // ignore the empty array Promise.all creates
+        // as this method should just resolve
+        // to undefined on success
+        await txnAsPromise(tx);
+        console.log(`LL: backend done storing for ${roomId}!`);
     },
 
     clearOutOfBandMembers: async function(roomId) {


### PR DESCRIPTION
Instead of creating a promise for every member inserted, just create on for the transaction. This saves about 100ms for ~7500 members.