### PR TITLE
Only emit CATCHUP if recovering from conn error

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1245,7 +1245,7 @@ SyncApi.prototype._pokeKeepAlive = function(connDidFail) {
     ).done(function() {
         success();
     }, function(err) {
-        if (err.httpStatus == 400) {
+        if (err.httpStatus == 400 || err.httpStatus == 404) {
             // treat this as a success because the server probably just doesn't
             // support /versions: point is, we're getting a response.
             // We wait a short time though, just in case somehow the server


### PR DESCRIPTION
Have the keepalive promise return a boolean indicating whether it
detected a connectivity failure or not. Use this to only emit
CATCHUP if there was a connectivity error, to try & suppress
the state flip-flopping back & forth between CATCHUP and ERROR
in the case where we have connectivity but the sync is returning
and error for whatever reason.