### PR TITLE
RoomState.members emitted with wrong argument order for OOB members

### DIFF
--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -511,7 +511,7 @@ RoomState.prototype._setOutOfBandMember = function(stateEvent) {
 
     this._setStateEvent(stateEvent);
     this._updateMember(member);
-    this.emit("RoomState.members", {}, stateEvent, member);
+    this.emit("RoomState.members", stateEvent, this, member);
 };
 
 /**


### PR DESCRIPTION
Example of correct order: https://github.com/matrix-org/matrix-js-sdk/blob/9e02049b0551c1e9b068a03b1a91289285dc0e75/src/models/room-state.js#L356