### PR TITLE
Introduce Room.myMembership event

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1405,6 +1405,23 @@ describe("Room", function() {
             room.updateMyMembership("invite");
             expect(room.getMyMembership()).toEqual("invite");
         });
+        it("should emit a Room.myMembership event on a change",
+        function() {
+            const room = new Room(roomId, null, userA);
+            const events = [];
+            room.on("Room.myMembership", (_room, membership, oldMembership) => {
+                events.push({membership, oldMembership});
+            });
+            room.updateMyMembership("invite");
+            expect(room.getMyMembership()).toEqual("invite");
+            expect(events[0]).toEqual({membership: "invite", oldMembership: null});
+            events.splice(0);   //clear
+            room.updateMyMembership("invite");
+            expect(events.length).toEqual(0);
+            room.updateMyMembership("join");
+            expect(room.getMyMembership()).toEqual("join");
+            expect(events[0]).toEqual({membership: "join", oldMembership: "invite"});
+        });
     });
 
     describe("guessDMUserId", function() {

--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1402,13 +1402,8 @@ describe("Room", function() {
         it("should return synced membership if membership isn't available yet",
         function() {
             const room = new Room(roomId, null, userA);
-            room.setSyncedMembership("invite");
+            room.updateMyMembership("invite");
             expect(room.getMyMembership()).toEqual("invite");
-            room.addLiveEvents([utils.mkMembership({
-                user: userA, mship: "join",
-                room: roomId, event: true,
-            })]);
-            expect(room.getMyMembership()).toEqual("join");
         });
     });
 
@@ -1439,11 +1434,11 @@ describe("Room", function() {
         it("should return false if synced membership not join",
         function() {
             const room = new Room(roomId, null, userA);
-            room.setSyncedMembership("invite");
+            room.updateMyMembership("invite");
             expect(room.maySendMessage()).toEqual(false);
-            room.setSyncedMembership("leave");
+            room.updateMyMembership("leave");
             expect(room.maySendMessage()).toEqual(false);
-            room.setSyncedMembership("join");
+            room.updateMyMembership("join");
             expect(room.maySendMessage()).toEqual(true);
         });
     });

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -257,12 +257,6 @@ Room.prototype.getLiveTimeline = function() {
  * @return {string} the membership type (join | leave | invite) for the logged in user
  */
 Room.prototype.getMyMembership = function() {
-    if (this.myUserId) {
-        const me = this.getMember(this.myUserId);
-        if (me) {
-            return me.membership;
-        }
-    }
     return this._selfMembership;
 };
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -178,7 +178,7 @@ function Room(roomId, client, myUserId, opts) {
 
     // read by megolm; boolean value - null indicates "use global value"
     this._blacklistUnverifiedDevices = null;
-    this._syncedMembership = null;
+    this._selfMembership = null;
     this._summaryHeroes = null;
     // awaited by getEncryptionTargetMembers while room members are loading
 
@@ -263,7 +263,7 @@ Room.prototype.getMyMembership = function() {
             return me.membership;
         }
     }
-    return this._syncedMembership;
+    return this._selfMembership;
 };
 
 /**
@@ -278,7 +278,7 @@ Room.prototype.getDMInviter = function() {
             return me.getDMInviter();
         }
     }
-    if (this._syncedMembership === "invite") {
+    if (this._selfMembership === "invite") {
         // fall back to summary information
         const memberCount = this.getInvitedAndJoinedMemberCount();
         if (memberCount == 2 && this._summaryHeroes.length) {
@@ -362,8 +362,15 @@ Room.prototype.getAvatarFallbackMember = function() {
  * Sets the membership this room was received as during sync
  * @param {string} membership join | leave | invite
  */
-Room.prototype.setSyncedMembership = function(membership) {
-    this._syncedMembership = membership;
+Room.prototype.updateMyMembership = function(membership) {
+    const prevMembership = this._selfMembership;
+    this._selfMembership = membership;
+    if (prevMembership !== membership) {
+        if (membership === "leave") {
+            this._cleanupAfterLeaving();
+        }
+        this.emit("Room.myMembership", this, membership, prevMembership);
+    }
 };
 
 Room.prototype._loadMembersFromServer = async function() {
@@ -470,7 +477,7 @@ Room.prototype.clearLoadedMembersIfNeeded = async function() {
  * called when sync receives this room in the leave section
  * to do cleanup after leaving a room. Possibly called multiple times.
  */
-Room.prototype.onLeft = function() {
+Room.prototype._cleanupAfterLeaving = function() {
     this.clearLoadedMembersIfNeeded().catch((err) => {
         console.error(`error after clearing loaded members from ` +
             `room ${this.roomId} after leaving`);


### PR DESCRIPTION
As you don't always have your own member with lazy loading
of members enabled, looking at the sync response section
where a room appears is the most reliable way of determining
the syncing user's membership in a room.

Before we already used this to read the
current room membership with `room.getMyMembership()`,
but we were still using the `RoomMember.membership` event
to detect when the syncing user's membership changed.

This event will help make those checks work well with LL enabled.