### PR TITLE
Revert "room name should only take canonical alias into account"

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -863,24 +863,24 @@ describe("Room", function() {
                 expect(name.indexOf(userB)).toNotEqual(-1, name);
             });
 
-            it("should not show the room alias if one exists for private " +
+            it("should show the room alias if one exists for private " +
             "(invite join_rules) rooms if a room name doesn't exist.", function() {
                 const alias = "#room_alias:here";
                 setJoinRule("invite");
                 setAliases([alias, "#another:one"]);
                 room.recalculate();
                 const name = room.name;
-                expect(name).toEqual("Empty room");
+                expect(name).toEqual(alias);
             });
 
-            it("should not show the room alias if one exists for public " +
+            it("should show the room alias if one exists for public " +
             "(public join_rules) rooms if a room name doesn't exist.", function() {
                 const alias = "#room_alias:here";
                 setJoinRule("public");
                 setAliases([alias, "#another:one"]);
                 room.recalculate();
                 const name = room.name;
-                expect(name).toEqual("Empty room");
+                expect(name).toEqual(alias);
             });
 
             it("should show the room name if one exists for private " +

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1525,7 +1525,15 @@ function calculateRoomName(room, userId, ignoreRoomNameEvent) {
         }
     }
 
-    const alias = room.getCanonicalAlias();
+    let alias = room.getCanonicalAlias();
+
+    if (!alias) {
+        const aliases = room.getAliases();
+
+        if (aliases.length) {
+            alias = aliases[0];
+        }
+    }
     if (alias) {
         return alias;
     }


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#733

This leaves a lot of room with no name for lots of people, so we're going to give some time for https://github.com/matrix-org/matrix-react-sdk/pull/2171 to have an impact before doing this.