### PR TITLE
WIP: track gappy sync performance metrics

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -766,6 +766,10 @@ module.exports.MatrixHttpApi.prototype = {
                         }
                     }
 
+                    if (typeof opts.reportContentLength === "function") {
+                        opts.reportContentLength(body ? body.length : 0);
+                    }
+
                     const handlerFn = requestCallback(
                         defer, callback, self.opts.onlyData,
                         bodyParser,

--- a/src/sync.js
+++ b/src/sync.js
@@ -506,6 +506,7 @@ SyncApi.prototype.sync = function() {
             // Send this first sync request here so we can then wait for the saved
             // sync data to finish processing before we process the results of this one.
             console.log("Sending first sync request...");
+            self._stats.initialSync = true;
             self._currentSyncRequest = self._doSyncRequest({ filterId }, savedSyncToken);
         }
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -714,9 +714,12 @@ SyncApi.prototype._sync = async function(syncOptions) {
 
 SyncApi.prototype._doSyncRequest = function(syncOptions, syncToken) {
     const qps = this._getSyncParams(syncOptions, syncToken);
+    const requestOpts = {
+        localTimeoutMs: qps.timeout + BUFFER_PERIOD_MS,
+        reportContentLength: (len) => this._stats.responseSize = len,
+    };
     return this.client._http.authedRequest(
-        undefined, "GET", "/sync", qps, undefined,
-        qps.timeout + BUFFER_PERIOD_MS,
+        undefined, "GET", "/sync", qps, undefined, requestOpts,
     );
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,18 @@ limitations under the License.
  */
 
 /**
+ * Start measuring the duration of an operation.
+ * @return {Function} A function to call to end the measurement,
+ * returns elapsed milliseconds.
+ */
+module.exports.startDuration = function() {
+    const start = performance.now();
+    return function() {
+        const end = performance.now();
+        return end - start;
+    }
+};
+/**
  * Encode a dictionary of query parameters.
  * @param {Object} params A dict of key/values to encode e.g.
  * {"foo": "bar", "baz": "taz"}


### PR DESCRIPTION
this is quite hacky but couldn't find an immediate better way of going about it, and also wanted to validate the idea first with the team before putting more effort in. So any feedback welcome on better ways of doing this.
Related to https://github.com/vector-im/riot-web/issues/7327
See https://github.com/matrix-org/matrix-react-sdk/pull/2172 of how this could be sent to Analytics...