### PR TITLE
disable lazy loading for guests as they cant create filters

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3117,6 +3117,9 @@ MatrixClient.prototype.startClient = async function(opts) {
     // shallow-copy the opts dict before modifying and storing it
     opts = Object.assign({}, opts);
 
+    if (opts.lazyLoadMembers && this.isGuest()) {
+        opts.lazyLoadMembers = false;
+    }
     if (opts.lazyLoadMembers) {
         const supported = await this.doesServerSupportLazyLoading();
         if (supported) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7405