### PR TITLE
Make e2e work on Edge

### DIFF
--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -96,11 +96,13 @@ export default class IndexedDBCryptoStore {
             // Edge has IndexedDB but doesn't support compund keys which we use fairly extensively.
             // Try a dummy query which will fail if the browser doesn't support compund keys, so
             // we can fall back to a different backend.
-            return backend.doTxn('readonly', [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS], (txn) => {
-                backend.getEndToEndInboundGroupSession('', '', txn, () => {});
-            }).then(() => {
-                return backend;
-            });
+            return backend.doTxn(
+                'readonly', [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS], (txn) => {
+                    backend.getEndToEndInboundGroupSession('', '', txn, () => {});
+                }).then(() => {
+                    return backend;
+                },
+            );
         }).catch((e) => {
             console.warn(
                 `unable to connect to indexeddb ${this._dbName}` +

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -92,6 +92,15 @@ export default class IndexedDBCryptoStore {
                 console.log(`connected to indexeddb ${this._dbName}`);
                 resolve(new IndexedDBCryptoStoreBackend.Backend(db));
             };
+        }).then((backend) => {
+            // Edge has IndexedDB but doesn't support compund keys which we use fairly extensively.
+            // Try a dummy query which will fail if the browser doesn't support compund keys, so
+            // we can fall back to a different backend.
+            return backend.doTxn('readonly', [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS], (txn) => {
+                backend.getEndToEndInboundGroupSession('', '', txn, () => {});
+            }).then(() => {
+                return backend;
+            });
         }).catch((e) => {
             console.warn(
                 `unable to connect to indexeddb ${this._dbName}` +

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -97,7 +97,9 @@ export default class IndexedDBCryptoStore {
             // Try a dummy query which will fail if the browser doesn't support compund keys, so
             // we can fall back to a different backend.
             return backend.doTxn(
-                'readonly', [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS], (txn) => {
+                'readonly',
+                [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS],
+                (txn) => {
                     backend.getEndToEndInboundGroupSession('', '', txn, () => {});
                 }).then(() => {
                     return backend;


### PR DESCRIPTION
We were sucessfully opening indexeddb but any queries using compound
indicies were failing because Edge doesn't support them, so messages
were failing to decrypt with 'DataError'.

Try a dummy query at startup, so if it fails we fall back to a
different store (ie. end up using localstorage on Edge).