### PR TITLE
Default to a room version of 1 when there is no room create event

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -198,7 +198,10 @@ utils.inherits(Room, EventEmitter);
  */
 Room.prototype.getVersion = function() {
     const createEvent = this.currentState.getStateEvents("m.room.create", "");
-    if (!createEvent) return null;
+    if (!createEvent) {
+        console.warn("Room " + this.room_id + " does not have an m.room.create event");
+        return '1';
+    }
     const ver = createEvent.getContent()['room_version'];
     if (ver === undefined) return '1';
     return ver;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/7331

There is something to be worried about when there is no room create event, however. This should always be available, although due to cache problems or servers that don't provide the event we can't be sure of this.