### PR TITLE
throw error with same name and message over idb worker boundary

### DIFF
--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -184,7 +184,9 @@ RemoteIndexedDBStoreBackend.prototype = {
             if (msg.command == 'cmd_success') {
                 def.resolve(msg.result);
             } else {
-                def.reject(msg.error);
+                const error = new Error(msg.error.message);
+                error.name = msg.error.name;
+                def.reject(error);
             }
         } else {
             console.warn("Unrecognised message from worker: " + msg);

--- a/src/store/indexeddb-store-worker.js
+++ b/src/store/indexeddb-store-worker.js
@@ -135,7 +135,10 @@ class IndexedDBStoreWorker {
                 command: 'cmd_fail',
                 seq: msg.seq,
                 // Just send a string because Error objects aren't cloneable
-                error: "Error running command",
+                error: {
+                    message: err.message,
+                    name: err.name,
+                },
             });
         });
     }


### PR DESCRIPTION
Gives more information in the logs, and will make it easier to handle idb errors on the main thread in the future.