### PR TITLE
Don't fail to start up if lazy load check fails

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -2,7 +2,7 @@
 // because of http://babeljs.io/docs/usage/caveats/#classes
 function InvalidStoreError(reason, value) {
     const message = `Store is invalid because ${reason}, ` +
-        `please delete all data and retry`;
+        `please stopthe client, delete all data and start the client again`;
     const instance = Reflect.construct(Error, [message]);
     Reflect.setPrototypeOf(instance, Reflect.getPrototypeOf(this));
     instance.reason = reason;

--- a/src/filter.js
+++ b/src/filter.js
@@ -51,6 +51,17 @@ function Filter(userId, filterId) {
     this.definition = {};
 }
 
+Filter.LAZY_LOADING_MESSAGES_FILTER = {
+    lazy_load_members: true,
+};
+
+Filter.LAZY_LOADING_SYNC_FILTER = {
+    room: {
+        state: Filter.LAZY_LOADING_MESSAGES_FILTER,
+    },
+};
+
+
 /**
  * Get the ID of this filter on your homeserver (if known)
  * @return {?Number} The filter ID


### PR DESCRIPTION
Do the lazy loading check in the batch of things we do before
starting a sync rather than at client start time, so we don't fail
to start the client if we can't hit the HS to determine LL support.

Fixes https://github.com/vector-im/riot-web/issues/7455