### PR TITLE
Use new stop() method on matrix-mock-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "istanbul": "^0.4.5",
     "jsdoc": "^3.5.5",
     "lolex": "^1.5.2",
-    "matrix-mock-request": "^1.2.0",
+    "matrix-mock-request": "^1.2.2",
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.0",
     "rimraf": "^2.5.4",

--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -105,6 +105,7 @@ TestClient.prototype.start = function() {
  */
 TestClient.prototype.stop = function() {
     this.client.stopClient();
+    return this.httpBackend.stop();
 };
 
 /**

--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -102,6 +102,7 @@ TestClient.prototype.start = function() {
 
 /**
  * stop the client
+ * @return {Promise} Resolves once the mock http backend has finished all pending flushes
  */
 TestClient.prototype.stop = function() {
     this.client.stopClient();

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -97,7 +97,7 @@ describe("DeviceList management:", function() {
     });
 
     afterEach(function() {
-        aliceTestClient.stop();
+        return aliceTestClient.stop();
     });
 
     it("Alice shouldn't do a second /query for non-e2e-capable devices", function() {

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -410,10 +410,10 @@ describe("MatrixClient crypto", function() {
     });
 
     afterEach(function() {
-        aliTestClient.stop();
         aliTestClient.httpBackend.verifyNoOutstandingExpectation();
-        bobTestClient.stop();
         bobTestClient.httpBackend.verifyNoOutstandingExpectation();
+
+        return Promise.all([aliTestClient.stop(), bobTestClient.stop()]);
     });
 
     it("Bob uploads device keys", function() {

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -30,6 +30,7 @@ describe("MatrixClient events", function() {
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
         client.stopClient();
+        return httpBackend.stop();
     });
 
     describe("emissions", function() {

--- a/spec/integ/matrix-client-event-timeline.spec.js
+++ b/spec/integ/matrix-client-event-timeline.spec.js
@@ -111,6 +111,7 @@ describe("getEventTimeline support", function() {
         if (client) {
             client.stopClient();
         }
+        return httpBackend.stop();
     });
 
     it("timeline support must be enabled to work", function(done) {

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -41,6 +41,7 @@ describe("MatrixClient", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        return httpBackend.stop();
     });
 
     describe("uploadContent", function() {

--- a/spec/integ/matrix-client-opts.spec.js
+++ b/spec/integ/matrix-client-opts.spec.js
@@ -64,6 +64,7 @@ describe("MatrixClient opts", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        return httpBackend.stop();
     });
 
     describe("without opts.store", function() {

--- a/spec/integ/matrix-client-retrying.spec.js
+++ b/spec/integ/matrix-client-retrying.spec.js
@@ -36,6 +36,7 @@ describe("MatrixClient retrying", function() {
 
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
+        return httpBackend.stop();
     });
 
     xit("should retry according to MatrixScheduler.retryFn", function() {

--- a/spec/integ/matrix-client-room-timeline.spec.js
+++ b/spec/integ/matrix-client-room-timeline.spec.js
@@ -130,6 +130,7 @@ describe("MatrixClient room timelines", function() {
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
         client.stopClient();
+        return httpBackend.stop();
     });
 
     describe("local echo events", function() {

--- a/spec/integ/matrix-client-syncing.spec.js
+++ b/spec/integ/matrix-client-syncing.spec.js
@@ -38,6 +38,7 @@ describe("MatrixClient syncing", function() {
     afterEach(function() {
         httpBackend.verifyNoOutstandingExpectation();
         client.stopClient();
+        return httpBackend.stop();
     });
 
     describe("startClient", function() {

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -296,7 +296,7 @@ describe("megolm", function() {
     });
 
     afterEach(function() {
-        aliceTestClient.stop();
+        return aliceTestClient.stop();
     });
 
     it("Alice receives a megolm message", function() {


### PR DESCRIPTION
To finish all pending flushes between tests. This stops the unit
tests from hanging on node 11 when run in certain combinations.

Requires https://github.com/matrix-org/matrix-mock-request/pull/6
(so will need a release of matrix-mock-request before merging)

For the record, one such combination was:

```
npx mocha specbuild/integ/devicelist-integ-spec.js specbuild/integ/matrix-client-methods.spec.js specbuild/integ/matrix-client-room-timeline.spec.js
```

This would complete all the tests but hang spinning a CPU core instead of exiting. Adding `--exit` (so mocha called process.exit once the tests were all done) made it exit. Adding `specbuild/integ/megolm-integ.spec.js` would cause it to hang before completing the tests.