### PR TITLE
Stop devicelist when client is stopped

### DIFF
--- a/spec/unit/crypto/DeviceList.spec.js
+++ b/spec/unit/crypto/DeviceList.spec.js
@@ -59,14 +59,23 @@ describe('DeviceList', function() {
     let downloadSpy;
     let sessionStore;
     let cryptoStore;
+    let deviceLists = [];
 
     beforeEach(function() {
         testUtils.beforeEach(this); // eslint-disable-line no-invalid-this
+
+        deviceLists = [];
 
         downloadSpy = expect.createSpy();
         const mockStorage = new MockStorageApi();
         sessionStore = new WebStorageSessionStore(mockStorage);
         cryptoStore = new MemoryCryptoStore();
+    });
+
+    afterEach(function() {
+        for (const dl of deviceLists) {
+            dl.stop();
+        }
     });
 
     function createTestDeviceList() {
@@ -76,7 +85,9 @@ describe('DeviceList', function() {
         const mockOlm = {
             verifySignature: function(key, message, signature) {},
         };
-        return new DeviceList(baseApis, cryptoStore, sessionStore, mockOlm);
+        const dl = new DeviceList(baseApis, cryptoStore, sessionStore, mockOlm);
+        deviceLists.push(dl);
+        return dl;
     }
 
     it("should successfully download and store device keys", function() {

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -146,6 +146,12 @@ export default class DeviceList {
         }
     }
 
+    stop() {
+        if (this._saveTimer !== null) {
+            clearTimeout(this._saveTimer);
+        }
+    }
+
     /**
      * Save the device tracking state to storage, if any changes are
      * pending other than updating the sync token

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -221,6 +221,7 @@ Crypto.prototype.start = function() {
 /** Stop background processes related to crypto */
 Crypto.prototype.stop = function() {
     this._outgoingRoomKeyRequestManager.stop();
+    this._deviceList.stop();
 };
 
 /**


### PR DESCRIPTION
To avoid the devicelist trying to save after the client has been
stopped

Hopefully will fix random test failures on node 11.