### PR TITLE
Manually construct query strings for browser-request instances

### DIFF
--- a/browser-index.js
+++ b/browser-index.js
@@ -2,7 +2,7 @@ var matrixcs = require("./lib/matrix");
 const request = require('browser-request');
 const queryString = require('query-string');
 
-matrixcs.request((opts, fn) => {
+matrixcs.request(function(opts, fn) {
     // We manually fix the query string for browser-request because
     // it doesn't correctly handle cases like ?via=one&via=two. Instead
     // we mimic `request`'s query string interface to make it all work

--- a/browser-index.js
+++ b/browser-index.js
@@ -1,6 +1,6 @@
 var matrixcs = require("./lib/matrix");
 const request = require('browser-request');
-const queryString = require('query-string');
+const queryString = require('qs');
 
 matrixcs.request(function(opts, fn) {
     // We manually fix the query string for browser-request because

--- a/browser-index.js
+++ b/browser-index.js
@@ -1,5 +1,7 @@
 var matrixcs = require("./lib/matrix");
-matrixcs.request(require("request"));
+var request = require("browser-request");
+request.enableConstructionOfQueryString = true; // note: this is long so we hopefully don't collide
+matrixcs.request(request);
 
 // just *accessing* indexedDB throws an exception in firefox with
 // indexeddb disabled.

--- a/browser-index.js
+++ b/browser-index.js
@@ -1,6 +1,6 @@
 var matrixcs = require("./lib/matrix");
 var request = require("browser-request");
-request.enableConstructionOfQueryString = true; // note: this is long so we hopefully don't collide
+global.enableConstructionOfQueryString = true; // note: this is long so we hopefully don't collide
 matrixcs.request(request);
 
 // just *accessing* indexedDB throws an exception in firefox with

--- a/browser-index.js
+++ b/browser-index.js
@@ -1,7 +1,17 @@
 var matrixcs = require("./lib/matrix");
-var request = require("browser-request");
-global.enableConstructionOfQueryString = true; // note: this is long so we hopefully don't collide
-matrixcs.request(request);
+const request = require('browser-request');
+const queryString = require('query-string');
+
+matrixcs.request((opts, fn) => {
+    // We manually fix the query string for browser-request because
+    // it doesn't correctly handle cases like ?via=one&via=two. Instead
+    // we mimic `request`'s query string interface to make it all work
+    // as expected.
+    // browser-request will happily take the constructed string as the
+    // query string without trying to modify it further.
+    opts.qs = queryString.stringify(opts.qs || {}, opts.qsStringifyOptions);
+    return request(opts, fn);
+});
 
 // just *accessing* indexedDB throws an exception in firefox with
 // indexeddb disabled.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "content-type": "^1.0.2",
     "loglevel": "1.6.1",
     "memfs": "^2.10.1",
+    "query-string": "^6.2.0",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "content-type": "^1.0.2",
     "loglevel": "1.6.1",
     "memfs": "^2.10.1",
-    "query-string": "^6.2.0",
+    "qs": "^6.5.2",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -19,6 +19,7 @@ limitations under the License.
  * @module http-api
  */
 import Promise from 'bluebird';
+const queryString = require('query-string');
 const parseContentType = require('content-type').parse;
 
 const utils = require("./utils");
@@ -746,6 +747,9 @@ module.exports.MatrixHttpApi.prototype = {
         const reqPromise = defer.promise;
 
         try {
+            if (this.opts.request.enableConstructionOfQueryString) {
+                queryParams = queryString.stringify(queryParams, opts.qsStringifyOptions);
+            }
             req = this.opts.request(
                 {
                     uri: uri,

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -19,7 +19,6 @@ limitations under the License.
  * @module http-api
  */
 import Promise from 'bluebird';
-const queryString = require('query-string');
 const parseContentType = require('content-type').parse;
 
 const utils = require("./utils");
@@ -747,9 +746,6 @@ module.exports.MatrixHttpApi.prototype = {
         const reqPromise = defer.promise;
 
         try {
-            if (global && global.enableConstructionOfQueryString) {
-                queryParams = queryString.stringify(queryParams, opts.qsStringifyOptions);
-            }
             req = this.opts.request(
                 {
                     uri: uri,

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -747,7 +747,7 @@ module.exports.MatrixHttpApi.prototype = {
         const reqPromise = defer.promise;
 
         try {
-            if (this.opts.request.enableConstructionOfQueryString) {
+            if (global && global.enableConstructionOfQueryString) {
                 queryParams = queryString.stringify(queryParams, opts.qsStringifyOptions);
             }
             req = this.opts.request(


### PR DESCRIPTION
Because `request` just doesn't work for us in the browser, but `browser-request` is fine despite us having to do our own query strings.

Fixes https://github.com/vector-im/riot-web/issues/7620