### PR TITLE
Broken example in docs. Fixes #421

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -260,9 +260,10 @@ if [ -z "$skip_jsdoc" ]; then
     echo "generating jsdocs"
     npm run gendoc
 
-    echo "copying jsdocs to gh-pages branch"
+    echo "copying jsdocs and examples to gh-pages branch"
     git checkout gh-pages
     git pull
+    cp -ar "examples/" .
     cp -a ".jsdoc/matrix-js-sdk/$release" .
     perl -i -pe 'BEGIN {$rel=shift} $_ =~ /^<\/ul>/ && print
         "<li><a href=\"${rel}/index.html\">Version ${rel}</a></li>\n"' \


### PR DESCRIPTION
This is what I think is needed to repair the link to the broken working examples.

Why?

Right now, we use `npm run gendoc` in three places. Only one deals with gh-pages, so I left `travis.sh` and `jenkins.sh` untouched.

In `release.sh` we do the following: https://github.com/matrix-org/matrix-js-sdk/blob/v0.12.1/release.sh#L266

```sh
if [ -z "$skip_jsdoc" ]; then
    echo "generating jsdocs"
    npm run gendoc

    echo "copying jsdocs to gh-pages branch"
    git checkout gh-pages
    git pull
    cp -a ".jsdoc/matrix-js-sdk/$release" .
    perl -i -pe 'BEGIN {$rel=shift} $_ =~ /^<\/ul>/ && print
        "<li><a href=\"${rel}/index.html\">Version ${rel}</a></li>\n"' \
        $release index.html
    git add "$release"
    git commit --no-verify -m "Add jsdoc for $release" index.html "$release"
fi
```

So here we only copy the jsdocs folder to gh-pages. jsdocs gets generated from `src` only:
https://github.com/matrix-org/matrix-js-sdk/blob/v0.12.1/package.json#L12

So that's why I included the `examples` directory also.

However, two things I want to highlight:
1. `examples/browser/lib/matrix.js` and `examples/voip/lib/matrix.js` are symlinks on my Linux box.
2. `README.md` of all three examples are pushed to GH-Pages with this patch as well. Shall I strip them out?