### PR TITLE
Remove the request-only stuff we don't need anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "browser-request": "^0.3.3",
     "content-type": "^1.0.2",
     "loglevel": "1.6.1",
-    "memfs": "^2.10.1",
     "qs": "^6.5.2",
     "request": "^2.88.0"
   },


### PR DESCRIPTION
Paired with (**please review all 3**):
* https://github.com/vector-im/riot-web/pull/7637
* https://github.com/matrix-org/matrix-react-sdk/pull/2263

----

This was introduced in https://github.com/matrix-org/matrix-react-sdk/pull/2250 but can be pulled out due to https://github.com/matrix-org/matrix-js-sdk/pull/770. See https://github.com/vector-im/riot-web/issues/7634 for more information about the future.