### PR TITLE
Set access_token and user_id after login in with username and password.

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -277,7 +277,21 @@ MatrixBaseApis.prototype.loginWithPassword = function(user, password, callback) 
     return this.login("m.login.password", {
         user: user,
         password: password,
-    }, callback);
+    }, (error, response) => {
+        if (response && response.access_token) {
+            this._http.opts.accessToken = response.access_token;
+        }
+
+        if (response && response.user_id) {
+            this.credentials = {
+                userId: response.user_id,
+            };
+        }
+
+        if(callback) {
+            callback(error, response);
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
Set access token and user ID after successfully logging in with username and password.

This fixes - https://github.com/matrix-org/matrix-js-sdk/issues/130.