### PR TITLE
Restart broken Olm sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-    - node # Latest stable version of nodejs.
+    - "10.11.0"
 script:
     - ./travis.sh

--- a/spec/unit/crypto.spec.js
+++ b/spec/unit/crypto.spec.js
@@ -1,8 +1,12 @@
-
-"use strict";
 import 'source-map-support/register';
 import Crypto from '../../lib/crypto';
 import expect from 'expect';
+
+import WebStorageSessionStore from '../../lib/store/session/webstorage';
+import MemoryCryptoStore from '../../lib/crypto/store/memory-crypto-store.js';
+import MockStorageApi from '../MockStorageApi';
+
+const EventEmitter = require("events").EventEmitter;
 
 const sdk = require("../..");
 
@@ -19,5 +23,97 @@ describe("Crypto", function() {
 
     it("Crypto exposes the correct olm library version", function() {
         expect(Crypto.getOlmVersion()[0]).toEqual(3);
+    });
+
+
+    describe('Session management', function() {
+        const otkResponse = {
+            one_time_keys: {
+                '@alice:home.server': {
+                    aliceDevice: {
+                        'signed_curve25519:FLIBBLE': {
+                            key: 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI',
+                            signatures: {
+                                '@alice:home.server': {
+                                    'ed25519:aliceDevice': 'totally a valid signature',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        let crypto;
+        let mockBaseApis;
+        let mockRoomList;
+
+        let fakeEmitter;
+
+        beforeEach(async function() {
+            const mockStorage = new MockStorageApi();
+            const sessionStore = new WebStorageSessionStore(mockStorage);
+            const cryptoStore = new MemoryCryptoStore(mockStorage);
+
+            cryptoStore.storeEndToEndDeviceData({
+                devices: {
+                    '@bob:home.server': {
+                        'BOBDEVICE': {
+                            keys: {
+                                'curve25519:BOBDEVICE': 'this is a key',
+                            },
+                        },
+                    },
+                },
+                trackingStatus: {},
+            });
+
+            mockBaseApis = {
+                sendToDevice: expect.createSpy(),
+            };
+            mockRoomList = {};
+
+            fakeEmitter = new EventEmitter();
+
+            crypto = new Crypto(
+                mockBaseApis,
+                sessionStore,
+                "@alice:home.server",
+                "FLIBBLE",
+                sessionStore,
+                cryptoStore,
+                mockRoomList,
+            );
+            crypto.registerEventHandlers(fakeEmitter);
+            await crypto.init();
+        });
+
+        afterEach(async function() {
+            await crypto.stop();
+        });
+
+        it("restarts wedged Olm sessions", async function() {
+            const prom = new Promise((resolve) => {
+                mockBaseApis.claimOneTimeKeys = function() {
+                    resolve();
+                    return otkResponse;
+                };
+            });
+
+            fakeEmitter.emit('toDeviceEvent', {
+                getType: expect.createSpy().andReturn('m.room.message'),
+                getContent: expect.createSpy().andReturn({
+                    msgtype: 'm.bad.encrypted',
+                }),
+                getWireContent: expect.createSpy().andReturn({
+                    algorithm: 'm.olm.v1.curve25519-aes-sha2',
+                    sender_key: 'this is a key',
+                }),
+                getSender: expect.createSpy().andReturn('@bob:home.server'),
+            });
+
+            console.log("waiting");
+            await prom;
+            console.log("done");
+        });
     });
 });

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -509,6 +509,8 @@ OlmDevice.prototype.createInboundSession = async function(
                     this._storeAccount(txn, account);
 
                     const payloadString = session.decrypt(messageType, ciphertext);
+                    // this counts as an received message
+                    session.set_last_received_message_ts(Date.now());
 
                     this._saveSession(theirDeviceIdentityKey, session, txn);
 

--- a/src/crypto/OutgoingRoomKeyRequestManager.js
+++ b/src/crypto/OutgoingRoomKeyRequestManager.js
@@ -244,6 +244,21 @@ export default class OutgoingRoomKeyRequestManager {
         });
     }
 
+    /**
+     * Look for room key requests by target device and state
+     *
+     * @param {string} userId Target user ID
+     * @param {string} deviceId Target device ID
+     *
+     * @return {Promise} resolves to a list of all the
+     *    {@link module:crypto/store/base~OutgoingRoomKeyRequest}
+     */
+    getOutgoingSentRoomKeyRequest(userId, deviceId) {
+        return this._cryptoStore.getOutgoingRoomKeyRequestsByTarget(
+            userId, deviceId, [ROOM_KEY_REQUEST_STATES.SENT],
+        );
+    }
+
     // start the background timer to send queued requests, if the timer isn't
     // already running
     _startTimer() {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -499,7 +499,7 @@ MegolmEncryption.prototype.reshareKeyWithDevice = async function(
         },
     });
     logger.debug(
-        `Re-shared key for session ${sessionId}  with {userId}:{device.deviceId}`,
+        `Re-shared key for session ${sessionId}  with ${userId}:${device.deviceId}`,
     );
 };
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -439,7 +439,10 @@ MegolmEncryption.prototype.reshareKeyWithDevice = async function(
     }
     const sentChainIndex = obSessionInfo.sharedWithDevices[userId][device.deviceId];
     if (sentChainIndex === undefined) {
-        logger.debug("Session ID " + sessionId + " never shared with device " + userId + ":" + device.deviceId);
+        logger.debug(
+            "Session ID " + sessionId + " never shared with device " +
+            userId + ":" + device.deviceId,
+        );
         return;
     }
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -433,7 +433,15 @@ MegolmEncryption.prototype.reshareKeyWithDevice = async function(
     }
 
     // The chain index of the key we previously sent this device
+    if (obSessionInfo.sharedWithDevices[userId] === undefined) {
+        logger.debug("Session ID " + sessionId + " never shared with user " + userId);
+        return;
+    }
     const sentChainIndex = obSessionInfo.sharedWithDevices[userId][device.deviceId];
+    if (sentChainIndex === undefined) {
+        logger.debug("Session ID " + sessionId + " never shared with device " + userId + ":" + device.deviceId);
+        return;
+    }
 
     // get the key from the inbound session: the outbound one will already
     // have been ratcheted to the next chain index.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1196,7 +1196,7 @@ Crypto.prototype._onToDeviceBadEncrypted = async function(event) {
     // We send this first such that, as long as the toDevice messages arrive in the
     // same order we sent them, the other end will get this first, set up the new session,
     // then get the keyshare request and send the key over this new session (because it
-    // it the session it has most recently received a message on).
+    // is the session it has most recently received a message on).
     const encryptedContent = {
         algorithm: olmlib.OLM_ALGORITHM,
         sender_key: this._olmDevice.deviceCurve25519Key,

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1133,6 +1133,8 @@ Crypto.prototype._onToDeviceEvent = function(event) {
             this._onRoomKeyEvent(event);
         } else if (event.getType() == "m.room_key_request") {
             this._onRoomKeyRequestEvent(event);
+        } else if (event.getContent().msgtype === "m.bad.encrypted") {
+            this._onToDeviceBadEncrypted(event);
         } else if (event.isBeingDecrypted()) {
             // once the event has been decrypted, try again
             event.once('Event.decrypted', (ev) => {
@@ -1160,6 +1162,74 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
 
     const alg = this._getRoomDecryptor(content.room_id, content.algorithm);
     alg.onRoomKeyEvent(event);
+};
+
+/**
+ * Handle a toDevice event that couldn't be decrypted
+ *
+ * @private
+ * @param {module:models/event.MatrixEvent} event undecryptable event
+ */
+Crypto.prototype._onToDeviceBadEncrypted = async function(event) {
+    const content = event.getWireContent();
+    const sender = event.getSender();
+    const algorithm = content.algorithm;
+    const deviceKey = content.sender_key;
+
+    if (sender === undefined || deviceKey === undefined || deviceKey === undefined) {
+        return;
+    }
+
+    // establish a new olm session with this device since we're failing to decrypt messages
+    // on a current session.
+    // Note that an undecryptable message from another device could easily be spoofed -
+    // is there anything we can do to mitigate this?
+    const device = this._deviceList.getDeviceByIdentityKey(sender, algorithm, deviceKey);
+    const devicesByUser = {};
+    devicesByUser[sender] = [device];
+    await olmlib.ensureOlmSessionsForDevices(
+        this._olmDevice, this._baseApis, devicesByUser, true,
+    );
+
+    // Now send a blank message on that session so the other side knows about it.
+    // (The keyshare request is sent in the clear so that won't do)
+    // We send this first such that, as long as the toDevice messages arrive in the
+    // same order we sent them, the other end will get this first, set up the new session,
+    // then get the keyshare request and send the key over this new session (because it
+    // it the session it has most recently received a message on).
+    const encryptedContent = {
+        algorithm: olmlib.OLM_ALGORITHM,
+        sender_key: this._olmDevice.deviceCurve25519Key,
+        ciphertext: {},
+    };
+    await olmlib.encryptMessageForDevice(
+        encryptedContent.ciphertext,
+        this._userId,
+        this._deviceId,
+        this._olmDevice,
+        sender,
+        device,
+        {type: "m.dummy"},
+    );
+
+    await this._baseApis.sendToDevice("m.room.encrypted", {
+        [sender]: {
+            [device.deviceId]: encryptedContent,
+        },
+    });
+
+
+    // Most of the time this probably won't be necessary since we'll have queued up a key request when
+    // we failed to decrypt the message and will be waiting a bit for the key to arrive before sending
+    // it. This won't always be the case though so we need to re-send any that have already been sent
+    // to avoid races.
+    const requestsToResend =
+        await this._outgoingRoomKeyRequestManager.getOutgoingSentRoomKeyRequest(
+            sender, device.deviceId,
+        );
+    for (const keyReq of requestsToResend) {
+        this.cancelRoomKeyRequest(keyReq.requestBody, true);
+    }
 };
 
 /**
@@ -1287,9 +1357,27 @@ Crypto.prototype._processReceivedRoomKeyRequest = async function(req) {
                 ` for ${roomId} / ${body.session_id} (id ${req.requestId})`);
 
     if (userId !== this._userId) {
-        // TODO: determine if we sent this device the keys already: in
-        // which case we can do so again.
-        logger.log("Ignoring room key request from other user for now");
+        if (!this._roomEncryptors[roomId]) {
+            logger.debug(`room key request for unencrypted room ${roomId}`);
+            return;
+        }
+        const encryptor = this._roomEncryptors[roomId];
+        const device = this._deviceList.getStoredDevice(userId, deviceId);
+        if (!device) {
+            logger.debug(`Ignoring keyshare for unknown device ${userId}:${deviceId}`);
+            return;
+        }
+
+        try {
+            await encryptor.reshareKeyWithDevice(
+                body.sender_key, body.session_id, userId, device,
+            );
+        } catch (e) {
+            logger.warn(
+                "Failed to re-share keys for session " + body.session_id +
+                " with device " + userId + ":" + device.deviceId, e,
+            );
+        }
         return;
     }
 

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -116,14 +116,17 @@ module.exports.encryptMessageForDevice = async function(
  * @param {module:base-apis~MatrixBaseApis} baseApis
  *
  * @param {object<string, module:crypto/deviceinfo[]>} devicesByUser
- *    map from userid to list of devices
+ *    map from userid to list of devices to ensure sessions for
+ *
+ * @param {bolean} force If true, establish a new session even if one already exists.
+ *     Optional.
  *
  * @return {module:client.Promise} resolves once the sessions are complete, to
  *    an Object mapping from userId to deviceId to
  *    {@link module:crypto~OlmSessionResult}
  */
 module.exports.ensureOlmSessionsForDevices = async function(
-    olmDevice, baseApis, devicesByUser,
+    olmDevice, baseApis, devicesByUser, force,
 ) {
     const devicesWithoutSession = [
         // [userId, deviceId], ...
@@ -141,7 +144,7 @@ module.exports.ensureOlmSessionsForDevices = async function(
             const deviceId = deviceInfo.deviceId;
             const key = deviceInfo.getIdentityKey();
             const sessionId = await olmDevice.getSessionIdForDevice(key);
-            if (sessionId === null) {
+            if (sessionId === null || force) {
                 devicesWithoutSession.push([userId, deviceId]);
             }
             result[userId][deviceId] = {
@@ -177,7 +180,7 @@ module.exports.ensureOlmSessionsForDevices = async function(
         for (let j = 0; j < devices.length; j++) {
             const deviceInfo = devices[j];
             const deviceId = deviceInfo.deviceId;
-            if (result[userId][deviceId].sessionId) {
+            if (result[userId][deviceId].sessionId && !force) {
                 // we already have a result for this device
                 continue;
             }

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -350,7 +350,10 @@ export class Backend {
         getReq.onsuccess = function() {
             const cursor = getReq.result;
             if (cursor) {
-                results[cursor.value.sessionId] = cursor.value.session;
+                results[cursor.value.sessionId] = {
+                    session: cursor.value.session,
+                    lastReceivedMessagets: cursor.value.lastReceivedMessageTs,
+                };
                 cursor.continue();
             } else {
                 try {
@@ -368,7 +371,10 @@ export class Backend {
         getReq.onsuccess = function() {
             try {
                 if (getReq.result) {
-                    func(getReq.result.session);
+                    func({
+                        session: getReq.result.session,
+                        lastReceivedMessagets: getReq.result.lastReceivedMessageTs,
+                    });
                 } else {
                     func(null);
                 }
@@ -378,9 +384,14 @@ export class Backend {
         };
     }
 
-    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+    storeEndToEndSession(deviceKey, sessionId, sessionInfo, txn) {
         const objectStore = txn.objectStore("sessions");
-        objectStore.put({deviceKey, sessionId, session});
+        objectStore.put({
+            deviceKey,
+            sessionId,
+            session: sessionInfo.session,
+            lastReceivedMessageTs: sessionInfo.lastReceivedMessageTs,
+        });
     }
 
     // Inbound group sessions

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -208,6 +208,24 @@ export default class IndexedDBCryptoStore {
     }
 
     /**
+     * Look for room key requests by target device and state
+     *
+     * @param {string} userId Target user ID
+     * @param {string} deviceId Target device ID
+     * @param {Array<Number>} wantedStates list of acceptable states
+     *
+     * @return {Promise} resolves to a list of all the
+     *    {@link module:crypto/store/base~OutgoingRoomKeyRequest}
+     */
+    getOutgoingRoomKeyRequestsByTarget(userId, deviceId, wantedStates) {
+        return this._connect().then((backend) => {
+            return backend.getOutgoingRoomKeyRequestsByTarget(
+                userId, deviceId, wantedStates,
+            );
+        });
+    }
+
+    /**
      * Look for an existing room key request by id and state, and update it if
      * found
      *

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -302,7 +302,10 @@ export default class IndexedDBCryptoStore {
      * @param {string} sessionId The ID of the session to retrieve
      * @param {*} txn An active transaction. See doTxn().
      * @param {function(object)} func Called with A map from sessionId
-     *     to Base64 end-to-end session.
+     *     to session information object with 'session' key being the
+     *     Base64 end-to-end session and lastReceivedMessageTs being the
+     *     timestamp in milliseconds at which the session last received
+     *     a message.
      */
     getEndToEndSession(deviceKey, sessionId, txn, func) {
         this._backendPromise.value().getEndToEndSession(deviceKey, sessionId, txn, func);
@@ -314,7 +317,10 @@ export default class IndexedDBCryptoStore {
      * @param {string} deviceKey The public key of the other device.
      * @param {*} txn An active transaction. See doTxn().
      * @param {function(object)} func Called with A map from sessionId
-     *     to Base64 end-to-end session.
+     *     to session information object with 'session' key being the
+     *     Base64 end-to-end session and lastReceivedMessageTs being the
+     *     timestamp in milliseconds at which the session last received
+     *     a message.
      */
     getEndToEndSessions(deviceKey, txn, func) {
         this._backendPromise.value().getEndToEndSessions(deviceKey, txn, func);
@@ -324,12 +330,12 @@ export default class IndexedDBCryptoStore {
      * Store a session between the logged-in user and another device
      * @param {string} deviceKey The public key of the other device.
      * @param {string} sessionId The ID for this end-to-end session.
-     * @param {string} session Base64 encoded end-to-end session.
+     * @param {string} sessionInfo Session information object
      * @param {*} txn An active transaction. See doTxn().
      */
-    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+    storeEndToEndSession(deviceKey, sessionId, sessionInfo, txn) {
         this._backendPromise.value().storeEndToEndSession(
-            deviceKey, sessionId, session, txn,
+            deviceKey, sessionId, sessionInfo, txn,
         );
     }
 

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -145,6 +145,19 @@ export default class MemoryCryptoStore {
         return Promise.resolve(null);
     }
 
+    getOutgoingRoomKeyRequestsByTarget(userId, deviceId, wantedStates) {
+        const results = [];
+
+        for (const req of this._outgoingRoomKeyRequests) {
+            for (const state of wantedStates) {
+                if (req.state === state && req.recipients.includes({userId, deviceId})) {
+                    results.push(req);
+                }
+            }
+        }
+        return Promise.resolve(results);
+    }
+
     /**
      * Look for an existing room key request by id and state, and update it if
      * found

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -247,13 +247,13 @@ export default class MemoryCryptoStore {
         func(this._sessions[deviceKey] || {});
     }
 
-    storeEndToEndSession(deviceKey, sessionId, session, txn) {
+    storeEndToEndSession(deviceKey, sessionId, sessionInfo, txn) {
         let deviceSessions = this._sessions[deviceKey];
         if (deviceSessions === undefined) {
             deviceSessions = {};
             this._sessions[deviceKey] = deviceSessions;
         }
-        deviceSessions[sessionId] = session;
+        deviceSessions[sessionId] = sessionInfo;
     }
 
     // Inbound Group Sessions


### PR DESCRIPTION
![unwedge](https://user-images.githubusercontent.com/986903/48221633-83248200-e38a-11e8-8799-3a2b81c74141.gif)

* Start a new Olm sessions with a device when we get an undecryptable
   message on it.
 * Send a dummy message on that sessions such that the other end knows
   about it.
 * Re-send any outstanding keyshare requests for that device.

Also includes a unit test for megolm that isn't very related but came
out as a result anyway.

Includes #776
Fixes vector-im/riot-web#3822