### PR TITLE
Move glob regex utilities out of the pushprocessor and into a more generic place

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -14,6 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+import {escapeRegExp, globToRegexp} from "./utils";
+
 /**
  * @module pushprocessor
  */
@@ -26,10 +29,6 @@ const RULEKINDS_IN_ORDER = ['override', 'content', 'room', 'sender', 'underride'
  * @param {Object} client The Matrix client object to use
  */
 function PushProcessor(client) {
-    const escapeRegExp = function(string) {
-        return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    };
-
     const cachedGlobToRegex = {
         // $glob: RegExp,
     };
@@ -242,22 +241,6 @@ function PushProcessor(client) {
             'i', // Case insensitive
         );
         return cachedGlobToRegex[glob];
-    };
-
-    const globToRegexp = function(glob) {
-        // From
-        // https://github.com/matrix-org/synapse/blob/abbee6b29be80a77e05730707602f3bbfc3f38cb/synapse/push/__init__.py#L132
-        // Because micromatch is about 130KB with dependencies,
-        // and minimatch is not much better.
-        let pat = escapeRegExp(glob);
-        pat = pat.replace(/\\\*/g, '.*');
-        pat = pat.replace(/\?/g, '.');
-        pat = pat.replace(/\\\[(!|)(.*)\\]/g, function(match, p1, p2, offset, string) {
-            const first = p1 && '^' || '';
-            const second = p2.replace(/\\\-/, '-');
-            return '[' + first + second + ']';
-        });
-        return pat;
     };
 
     const valueForDottedKey = function(key, ev) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -672,3 +672,27 @@ module.exports.removeHiddenChars = function(str) {
     return str.normalize('NFD').replace(removeHiddenCharsRegex, '');
 };
 const removeHiddenCharsRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;
+
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+module.exports.escapeRegExp = escapeRegExp;
+
+module.exports.globToRegexp = function(glob, extended) {
+    extended = typeof(extended) === 'boolean' ? extended : true;
+    // From
+    // https://github.com/matrix-org/synapse/blob/abbee6b29be80a77e05730707602f3bbfc3f38cb/synapse/push/__init__.py#L132
+    // Because micromatch is about 130KB with dependencies,
+    // and minimatch is not much better.
+    let pat = escapeRegExp(glob);
+    pat = pat.replace(/\\\*/g, '.*');
+    pat = pat.replace(/\?/g, '.');
+    if (extended) {
+        pat = pat.replace(/\\\[(!|)(.*)\\]/g, function (match, p1, p2, offset, string) {
+            const first = p1 && '^' || '';
+            const second = p2.replace(/\\\-/, '-');
+            return '[' + first + second + ']';
+        });
+    }
+    return pat;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -688,7 +688,7 @@ module.exports.globToRegexp = function(glob, extended) {
     pat = pat.replace(/\\\*/g, '.*');
     pat = pat.replace(/\?/g, '.');
     if (extended) {
-        pat = pat.replace(/\\\[(!|)(.*)\\]/g, function (match, p1, p2, offset, string) {
+        pat = pat.replace(/\\\[(!|)(.*)\\]/g, function(match, p1, p2, offset, string) {
             const first = p1 && '^' || '';
             const second = p2.replace(/\\\-/, '-');
             return '[' + first + second + ']';


### PR DESCRIPTION
So they can be used by other things.