### PR TITLE
Support custom status messages

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2263,6 +2263,27 @@ MatrixClient.prototype.mxcUrlToHttp =
 };
 
 /**
+ * Sets a new status message for the user. The message may be null/falsey
+ * to clear the message.
+ * @param {string} newMessage The new message to set.
+ * @return {module:client.Promise} Resolves: to nothing
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.setStatusMessage = function(newMessage) {
+    return Promise.all(this.getRooms().map((room) => {
+        const isJoined = room.getMyMembership() === "join";
+        const looksLikeDm = room.getInvitedAndJoinedMemberCount() === 2;
+        if (isJoined && looksLikeDm) {
+            return this.sendStateEvent(room.roomId, "im.vector.user_status", {
+                status: newMessage,
+            }, this.getUserId());
+        } else {
+            return Promise.resolve();
+        }
+    }));
+};
+
+/**
  * @param {Object} opts Options to apply
  * @param {string} opts.presence One of "online", "offline" or "unavailable"
  * @param {string} opts.status_msg The status message to attach.

--- a/src/client.js
+++ b/src/client.js
@@ -2269,7 +2269,7 @@ MatrixClient.prototype.mxcUrlToHttp =
  * @return {module:client.Promise} Resolves: to nothing
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixClient.prototype.setStatusMessage = function(newMessage) {
+MatrixClient.prototype._unstable_setStatusMessage = function(newMessage) {
     return Promise.all(this.getRooms().map((room) => {
         const isJoined = room.getMyMembership() === "join";
         const looksLikeDm = room.getInvitedAndJoinedMemberCount() === 2;

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -155,6 +155,16 @@ RoomState.prototype.getMembers = function() {
 };
 
 /**
+ * Get all RoomMembers in this room, excluding the user IDs provided.
+ * @param {Array<string>} excludedIds The user IDs to exclude.
+ * @return {Array<RoomMember>} A list of RoomMembers.
+ */
+RoomState.prototype.getMembersExcept = function(excludedIds) {
+    return utils.values(this.members)
+        .filter((m) => !excludedIds.includes(m.userId));
+};
+
+/**
  * Get a room member by their user ID.
  * @param {string} userId The room member's user ID.
  * @return {RoomMember} The member or null if they do not exist.

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -39,6 +39,9 @@ limitations under the License.
  *                when a user was last active.
  * @prop {Boolean} currentlyActive Whether we should consider lastActiveAgo to be
  *               an approximation and that the user should be seen as active 'now'
+ * @prop {string} statusMessage The status message for the user, if known. This is
+ *                different from the presenceStatusMsg in that this is not tied to
+ *                the user's presence, and should be represented differently.
  * @prop {Object} events The events describing this user.
  * @prop {MatrixEvent} events.presence The m.presence event for this user.
  */
@@ -46,6 +49,7 @@ function User(userId) {
     this.userId = userId;
     this.presence = "offline";
     this.presenceStatusMsg = null;
+    this.statusMessage = "";
     this.displayName = userId;
     this.rawDisplayName = userId;
     this.avatarUrl = null;
@@ -177,6 +181,16 @@ User.prototype.getLastModifiedTime = function() {
  */
 User.prototype.getLastActiveTs = function() {
     return this.lastPresenceTs - this.lastActiveAgo;
+};
+
+/**
+ * Manually set the user's status message.
+ * @param {MatrixEvent} event The <code>im.vector.user_status</code> event.
+ */
+User.prototype.updateStatusMessage = function(event) {
+    if (!event.getContent()) this.statusMessage = "";
+    else this.statusMessage = event.getContent()["status"];
+    this._updateModifiedTime();
 };
 
 /**

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -49,7 +49,7 @@ function User(userId) {
     this.userId = userId;
     this.presence = "offline";
     this.presenceStatusMsg = null;
-    this.statusMessage = "";
+    this._unstable_statusMessage = "";
     this.displayName = userId;
     this.rawDisplayName = userId;
     this.avatarUrl = null;
@@ -187,9 +187,9 @@ User.prototype.getLastActiveTs = function() {
  * Manually set the user's status message.
  * @param {MatrixEvent} event The <code>im.vector.user_status</code> event.
  */
-User.prototype.updateStatusMessage = function(event) {
-    if (!event.getContent()) this.statusMessage = "";
-    else this.statusMessage = event.getContent()["status"];
+User.prototype._unstable_updateStatusMessage = function(event) {
+    if (!event.getContent()) this._unstable_statusMessage = "";
+    else this._unstable_statusMessage = event.getContent()["status"];
     this._updateModifiedTime();
 };
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -39,7 +39,7 @@ limitations under the License.
  *                when a user was last active.
  * @prop {Boolean} currentlyActive Whether we should consider lastActiveAgo to be
  *               an approximation and that the user should be seen as active 'now'
- * @prop {string} statusMessage The status message for the user, if known. This is
+ * @prop {string} _unstable_statusMessage The status message for the user, if known. This is
  *                different from the presenceStatusMsg in that this is not tied to
  *                the user's presence, and should be represented differently.
  * @prop {Object} events The events describing this user.

--- a/src/sync.js
+++ b/src/sync.js
@@ -1172,6 +1172,16 @@ SyncApi.prototype._processSyncResponse = async function(
             if (e.isState() && e.getType() == "m.room.encryption" && self.opts.crypto) {
                 await self.opts.crypto.onCryptoEvent(e);
             }
+            if (e.isState() && e.getType() === "im.vector.user_status") {
+                let user = client.store.getUser(e.getStateKey());
+                if (user) {
+                    user.updateStatusMessage(e);
+                } else {
+                    user = createNewUser(client, e.getStateKey());
+                    user.updateStatusMessage(e);
+                    client.store.storeUser(user);
+                }
+            }
         }
 
         await Promise.mapSeries(stateEvents, processRoomEvent);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1175,10 +1175,10 @@ SyncApi.prototype._processSyncResponse = async function(
             if (e.isState() && e.getType() === "im.vector.user_status") {
                 let user = client.store.getUser(e.getStateKey());
                 if (user) {
-                    user.updateStatusMessage(e);
+                    user._unstable_updateStatusMessage(e);
                 } else {
                     user = createNewUser(client, e.getStateKey());
-                    user.updateStatusMessage(e);
+                    user._unstable_updateStatusMessage(e);
                     client.store.storeUser(user);
                 }
             }


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/1528

Status messages are short strings of text that users can set to be visible to other users. The js-sdk bits here are for setting and reading the status message for a given user.

Status messages are completely unrelated to the presence status message in that they do not expire and have a different intent. Presence status messages are intended to be read as "Online reading documentation" whereas status messages would be just "Reading documentation" (no associative presence). 

This currently uses a state event in direct chats to represent the status. It is intended that in the future there will be extensible profiles which can better communicate this information. Because this is a feature we're trying out, the event type is `im.vector.user_status` instead of something in the Matrix namespace. The API here should be abstract enough that changing to extensible profiles in the future should be easy.

----

**`im.vector.user_status` spec**:

The user status event is a state event with a state key of the user ID the status is for with a single `status` field in the content. The `status` field is a string of preferably limited length (<60 characters, not enforced) where falsey values (empty, null, undefined, not set, etc) equate to "no status" whereas a string with content represents the user's status. 

It is not intended at this time to support per-room status messages, despite using a state event. This is why this js-sdk PR happily overwrites the user's status message when it sees an `im.vector.user_status` state event. Simply seeing the state event in any room will change that user's status message everywhere.