### PR TITLE
Use `olm-loader` in all crypto tests

### DIFF
--- a/spec/unit/crypto.spec.js
+++ b/spec/unit/crypto.spec.js
@@ -1,4 +1,7 @@
 import 'source-map-support/register';
+
+import '../olm-loader';
+
 import Crypto from '../../lib/crypto';
 import expect from 'expect';
 

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -1,8 +1,4 @@
-try {
-    global.Olm = require('olm');
-} catch (e) {
-    console.warn("unable to run megolm tests: libolm not available");
-}
+import '../../../olm-loader';
 
 import expect from 'expect';
 import Promise from 'bluebird';

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -14,11 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-try {
-    global.Olm = require('olm');
-} catch (e) {
-    console.warn("unable to run megolm tests: libolm not available");
-}
+import '../../../olm-loader';
 
 import expect from 'expect';
 import WebStorageSessionStore from '../../../../lib/store/session/webstorage';

--- a/spec/unit/crypto/backup.spec.js
+++ b/spec/unit/crypto/backup.spec.js
@@ -13,11 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-try {
-    global.Olm = require('olm');
-} catch (e) {
-    console.warn("unable to run megolm backup tests: libolm not available");
-}
+
+import '../../olm-loader';
 
 import expect from 'expect';
 import Promise from 'bluebird';


### PR DESCRIPTION
Standardize on importing `olm-loader` rather than pasting the same boilerplate
in different tests.  Importantly, `spec/unit/crypto.spec.js` did not include any
loading approach, so it would only find Olm if some other test loaded it first.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>