### PR TITLE
Conform to base-x >= 3.0.5 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-js-sdk",
-  "version": "0.13.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1207,9 +1207,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }

--- a/src/crypto/recoverykey.js
+++ b/src/crypto/recoverykey.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { Buffer } from 'buffer';
 import bs58 from 'bs58';
 
 // picked arbitrarily but to try & avoid clashing with any bitcoin ones
@@ -21,7 +22,7 @@ import bs58 from 'bs58';
 const OLM_RECOVERY_KEY_PREFIX = [0x8B, 0x01];
 
 export function encodeRecoveryKey(key) {
-    const buf = new Uint8Array(OLM_RECOVERY_KEY_PREFIX.length + key.length + 1);
+    const buf = new Buffer(OLM_RECOVERY_KEY_PREFIX.length + key.length + 1);
     buf.set(OLM_RECOVERY_KEY_PREFIX, 0);
     buf.set(key, OLM_RECOVERY_KEY_PREFIX.length);
 


### PR DESCRIPTION
The library `base-x` now expects an explicit `Buffer` instance, so let's change
to that to make things easier.  (Alternatively, we could pin to a previous
version, but it's a small tweak to make.)

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>