### PR TITLE
Pin to base-x 3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-js-sdk",
-  "version": "0.13.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "another-json": "^0.2.0",
     "babel-runtime": "^6.26.0",
+    "base-x": "3.0.4",
     "bluebird": "^3.5.0",
     "browser-request": "^0.3.3",
     "bs58": "^4.0.1",


### PR DESCRIPTION
This avoids API changes in 3.0.5 (requiring `Buffer` instances), but more
importantly also avoids dealing with ES6 in dependencies for another day.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>