### PR TITLE
Change initial key backup to background

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -843,6 +843,10 @@ MatrixClient.prototype.enableKeyBackup = function(info) {
     this._crypto.backupKey.set_recipient_key(info.auth_data.public_key);
 
     this.emit('crypto.keyBackupStatus', true);
+
+    // There may be keys left over from a partially completed backup, so
+    // schedule a send to check.
+    this._crypto.scheduleKeyBackupSend();
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -997,12 +997,16 @@ MatrixClient.prototype.sendKeyBackup = function(roomId, sessionId, version, data
     );
 };
 
-MatrixClient.prototype.backupAllGroupSessions = function(version) {
+/**
+ * Marks all group sessions as needing to be backed up and schedules them to
+ * upload in the background as soon as possible.
+ */
+MatrixClient.prototype.scheduleAllGroupSessionsForBackup = async function() {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
 
-    return this._crypto.backupAllGroupSessions(version);
+    await this._crypto.scheduleAllGroupSessionsForBackup();
 };
 
 MatrixClient.prototype.isValidRecoveryKey = function(recoveryKey) {

--- a/src/client.js
+++ b/src/client.js
@@ -448,6 +448,7 @@ MatrixClient.prototype.initCrypto = async function() {
 
     this.reEmitter.reEmit(crypto, [
         "crypto.keyBackupFailed",
+        "crypto.keyBackupSessionsRemaining",
         "crypto.roomKeyRequest",
         "crypto.roomKeyRequestCancellation",
         "crypto.warning",

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -989,7 +989,7 @@ Crypto.prototype.importRoomKeys = function(keys) {
  * Schedules sending all keys waiting to be sent to the backup, if not already
  * scheduled. Retries if necessary.
  */
-Crypto.prototype._scheduleKeyBackupSend = async function() {
+Crypto.prototype.scheduleKeyBackupSend = async function() {
     if (this._sendingBackups) return;
 
     try {
@@ -1115,7 +1115,7 @@ Crypto.prototype.backupGroupSession = async function(
 
     // don't wait for this to complete: it will delay so
     // happens in the background
-    this._scheduleKeyBackupSend();
+    this.scheduleKeyBackupSend();
 };
 
 Crypto.prototype.backupAllGroupSessions = async function(version) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1052,6 +1052,9 @@ Crypto.prototype._backupPendingKeys = async function(limit) {
         return 0;
     }
 
+    let remaining = await this._cryptoStore.countSessionsNeedingBackup();
+    this.emit("crypto.keyBackupSessionsRemaining", remaining);
+
     const data = {};
     for (const session of sessions) {
         const roomId = session.sessionData.room_id;
@@ -1088,7 +1091,10 @@ Crypto.prototype._backupPendingKeys = async function(limit) {
         undefined, undefined, this.backupInfo.version,
         {rooms: data},
     );
+
     await this._cryptoStore.unmarkSessionsNeedingBackup(sessions);
+    remaining = await this._cryptoStore.countSessionsNeedingBackup();
+    this.emit("crypto.keyBackupSessionsRemaining", remaining);
 
     return sessions.length;
 };
@@ -1127,6 +1133,9 @@ Crypto.prototype.backupAllGroupSessions = async function(version) {
             });
         },
     );
+
+    const remaining = await this._cryptoStore.countSessionsNeedingBackup();
+    this.emit("crypto.keyBackupSessionsRemaining", remaining);
 
     let numKeysBackedUp;
     do {

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -563,8 +563,22 @@ export class Backend {
         });
     }
 
-    unmarkSessionsNeedingBackup(sessions) {
-        const txn = this._db.transaction("sessions_needing_backup", "readwrite");
+    countSessionsNeedingBackup(txn) {
+        if (!txn) {
+            txn = this._db.transaction("sessions_needing_backup", "readonly");
+        }
+        const objectStore = txn.objectStore("sessions_needing_backup");
+        return new Promise((resolve, reject) => {
+            const req = objectStore.count();
+            req.onerror = reject;
+            req.onsuccess = () => resolve(req.result);
+        });
+    }
+
+    unmarkSessionsNeedingBackup(sessions, txn) {
+        if (!txn) {
+            txn = this._db.transaction("sessions_needing_backup", "readwrite");
+        }
         const objectStore = txn.objectStore("sessions_needing_backup");
         return Promise.all(sessions.map((session) => {
             return new Promise((resolve, reject) => {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -481,13 +481,25 @@ export default class IndexedDBCryptoStore {
     }
 
     /**
+     * Count the inbound group sessions that need to be backed up.
+     * @param {*} txn An active transaction. See doTxn(). (optional)
+     * @returns {Promise} resolves to the number of sessions
+     */
+    countSessionsNeedingBackup(txn) {
+        return this._connect().then((backend) => {
+            return backend.countSessionsNeedingBackup(txn);
+        });
+    }
+
+    /**
      * Unmark sessions as needing to be backed up.
      * @param {Array<object>} sessions The sessions that need to be backed up.
+     * @param {*} txn An active transaction. See doTxn(). (optional)
      * @returns {Promise} resolves when the sessions are unmarked
      */
-    unmarkSessionsNeedingBackup(sessions) {
+    unmarkSessionsNeedingBackup(sessions, txn) {
         return this._connect().then((backend) => {
-            return backend.unmarkSessionsNeedingBackup(sessions);
+            return backend.unmarkSessionsNeedingBackup(sessions, txn);
         });
     }
 

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -221,6 +221,12 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
         return Promise.resolve(sessions);
     }
 
+    countSessionsNeedingBackup() {
+        const sessionsNeedingBackup
+              = getJsonItem(this.store, KEY_SESSIONS_NEEDING_BACKUP) || {};
+        return Promise.resolve(Object.keys(sessionsNeedingBackup).length);
+    }
+
     unmarkSessionsNeedingBackup(sessions) {
         const sessionsNeedingBackup
               = getJsonItem(this.store, KEY_SESSIONS_NEEDING_BACKUP) || {};

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -336,6 +336,10 @@ export default class MemoryCryptoStore {
         return Promise.resolve(sessions);
     }
 
+    countSessionsNeedingBackup() {
+        return Promise.resolve(Object.keys(this._sessionsNeedingBackup).length);
+    }
+
     unmarkSessionsNeedingBackup(sessions) {
         for (const session of sessions) {
             const sessionKey = session.senderKey + '/' + session.sessionId;


### PR DESCRIPTION
Alters the APIs used for initial key backup so that the actual upload happens in
the background after all session are marked for backup.

In addition, this also emits a counts of sessions remaining to backup to drive an upload progress UI.

Needed for https://github.com/vector-im/riot-web/issues/7863.
Used in https://github.com/matrix-org/matrix-react-sdk/pull/2416.