### PR TITLE
Always track our own devices

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -185,7 +185,11 @@ TestClient.prototype.expectKeyQuery = function(response) {
     this.httpBackend.when('POST', '/keys/query').respond(
         200, (path, content) => {
             Object.keys(response.device_keys).forEach((userId) => {
-                expect(content.device_keys[userId]).toEqual({});
+                expect(content.device_keys[userId]).toEqual(
+                    {},
+                    "Expected key query for " + userId + ", got " +
+                    Object.keys(content.device_keys),
+                );
             });
             return response;
         });

--- a/spec/integ/devicelist-integ-spec.js
+++ b/spec/integ/devicelist-integ-spec.js
@@ -101,6 +101,7 @@ describe("DeviceList management:", function() {
     });
 
     it("Alice shouldn't do a second /query for non-e2e-capable devices", function() {
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(function() {
             const syncResponse = getSyncResponse(['@bob:xyz']);
             aliceTestClient.httpBackend.when('GET', '/sync').respond(200, syncResponse);
@@ -143,6 +144,7 @@ describe("DeviceList management:", function() {
     it("We should not get confused by out-of-order device query responses",
        () => {
            // https://github.com/vector-im/riot-web/issues/3126
+           aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
            return aliceTestClient.start().then(() => {
                aliceTestClient.httpBackend.when('GET', '/sync').respond(
                    200, getSyncResponse(['@bob:xyz', '@chris:abc']));

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -499,6 +499,7 @@ describe("megolm", function() {
     it('Alice sends a megolm message', function() {
         let p2pSession;
 
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);
@@ -581,6 +582,7 @@ describe("megolm", function() {
     });
 
     it("We shouldn't attempt to send to blocked devices", function() {
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);
@@ -634,6 +636,7 @@ describe("megolm", function() {
         let p2pSession;
         let megolmSessionId;
 
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);
@@ -843,6 +846,7 @@ describe("megolm", function() {
         let downloadPromise;
         let sendPromise;
 
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);
@@ -886,6 +890,7 @@ describe("megolm", function() {
     it("Alice exports megolm keys and imports them to a new device", function() {
         let messageEncrypted;
 
+        aliceTestClient.expectKeyQuery({device_keys: {'@alice:localhost': {}}});
         return aliceTestClient.start().then(() => {
             // establish an olm session with alice
             return createOlmSession(testOlmAccount, aliceTestClient);

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1468,6 +1468,10 @@ Crypto.prototype.onSyncCompleted = async function(syncData) {
 
     // catch up on any new devices we got told about during the sync.
     this._deviceList.lastKnownSyncToken = nextSyncToken;
+
+    // we always track our own device list (for key backups etc)
+    this._deviceList.startTrackingDeviceList(this._userId);
+
     this._deviceList.refreshOutdatedDeviceLists();
 
     // we don't start uploading one-time keys until we've caught up with


### PR DESCRIPTION
It's generally a reasonable assumption that we'll be interested in
them, and important for key backup.

This requires adding the expected /keys/query to just about every place in the crypto integration tests. :( I would add it somewhere common like starting the test client but in theory the request could be aggregated with requesting keys for another user.

Fixes https://github.com/vector-im/riot-web/issues/8213