### PR TITLE
Release script: commit package-lock.json

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -154,7 +154,15 @@ echo "npm version"
 # only turn off both of these behaviours, so we have to
 # manually commit the result.
 npm version --no-git-tag-version "$release"
-git commit package.json -m "$tag"
+
+# commit package-lock.json if it exists and is versioned
+if [[ -f package-lock.json && -z `git st --porcelain --ignored package-lock.json` ]];
+then
+    pkglock='package-lock.json'
+else
+    pkglock=''
+fi
+git commit package.json $pkglock -m "$tag"
 
 
 # figure out if we should be signing this release

--- a/release.sh
+++ b/release.sh
@@ -156,7 +156,7 @@ echo "npm version"
 npm version --no-git-tag-version "$release"
 
 # commit package-lock.json if it exists and is versioned
-if [[ -f package-lock.json && -z `git st --porcelain --ignored package-lock.json` ]];
+if [[ -f package-lock.json && -z `git status --porcelain --ignored package-lock.json` ]];
 then
     pkglock='package-lock.json'
 else


### PR DESCRIPTION
Commit the package-lock.json when bumping the version, otherwise
the versions get out of sync, and this is going to matter more now
that jenkins runs `npm ci` which is fussy about these things.