### PR TITLE
Fix "e is undefined" masking the original error in MegolmDecryption

### DIFF
--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -758,7 +758,7 @@ MegolmDecryption.prototype.decryptEvent = async function(event) {
     } catch (e) {
         let errorCode = "OLM_DECRYPT_GROUP_MESSAGE_ERROR";
 
-        if (e && e.message && e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {
+        if (e && e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {
             this._requestKeysForEvent(event);
 
             errorCode = 'OLM_UNKNOWN_MESSAGE_INDEX';

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -758,7 +758,7 @@ MegolmDecryption.prototype.decryptEvent = async function(event) {
     } catch (e) {
         let errorCode = "OLM_DECRYPT_GROUP_MESSAGE_ERROR";
 
-        if (e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {
+        if (e && e.message && e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {
             this._requestKeysForEvent(event);
 
             errorCode = 'OLM_UNKNOWN_MESSAGE_INDEX';
@@ -766,7 +766,7 @@ MegolmDecryption.prototype.decryptEvent = async function(event) {
 
         throw new base.DecryptionError(
             errorCode,
-            e.toString(), {
+            e ? e.toString() : "Unknown Error: Error is undefined", {
                 session: content.sender_key + '|' + content.session_id,
             },
         );


### PR DESCRIPTION
Someone with a bit of knowledge around the state machine for encryption probably wants to review this.