### PR TITLE
Use 'ideal' rather than 'exact' for deviceid

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -88,21 +88,21 @@ module.exports.createNewMatrixCall = require("./webrtc/call").createNewMatrixCal
 
 
 /**
- * Set an audio output device to use for MatrixCalls
+ * Set a preferred audio output device to use for MatrixCalls
  * @function
  * @param {string=} deviceId the identifier for the device
  * undefined treated as unset
  */
 module.exports.setMatrixCallAudioOutput = require('./webrtc/call').setAudioOutput;
 /**
- * Set an audio input device to use for MatrixCalls
+ * Set a preferred audio input device to use for MatrixCalls
  * @function
  * @param {string=} deviceId the identifier for the device
  * undefined treated as unset
  */
 module.exports.setMatrixCallAudioInput = require('./webrtc/call').setAudioInput;
 /**
- * Set a video input device to use for MatrixCalls
+ * Set a preferred video input device to use for MatrixCalls
  * @function
  * @param {string=} deviceId the identifier for the device
  * undefined treated as unset

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -583,7 +583,7 @@ MatrixCall.prototype._maybeGotUserMediaForInvite = function(stream) {
             ' Or possibly you are using an insecure domain. Receiving only.');
         this.peerConn = _createPeerConnection(this);
     } else {
-        debuglog('Failed to getUserMedia.');
+        debuglog('Failed to getUserMedia: ' + error.name);
         this._getUserMediaFailed(error);
         return;
     }
@@ -1274,15 +1274,15 @@ const _getUserMediaVideoContraints = function(callType) {
         case 'voice':
             return {
                 audio: {
-                    deviceId: audioInput ? {exact: audioInput} : undefined,
+                    deviceId: audioInput ? {ideal: audioInput} : undefined,
                 }, video: false,
             };
         case 'video':
             return {
                 audio: {
-                    deviceId: audioInput ? {exact: audioInput} : undefined,
+                    deviceId: audioInput ? {ideal: audioInput} : undefined,
                 }, video: {
-                    deviceId: videoInput ? {exact: videoInput} : undefined,
+                    deviceId: videoInput ? {ideal: videoInput} : undefined,
                     /* We want 640x360.  Chrome will give it only if we ask exactly,
                        FF refuses entirely if we ask exactly, so have to ask for ideal
                        instead */

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -652,7 +652,7 @@ MatrixCall.prototype._maybeGotUserMediaForAnswer = function(stream) {
         debuglog('User denied access to camera/microphone.' +
             ' Or possibly you are using an insecure domain. Receiving only.');
     } else {
-        debuglog('Failed to getUserMedia.');
+        debuglog('Failed to getUserMedia: ' + error.name);
         this._getUserMediaFailed(error);
         return;
     }


### PR DESCRIPTION
We were using 'exact' which means we fail outright if the device
we wanted isn't available. This means if a user selects a specific
device then later unplugs it, we fail to open a capture device
the next time they make a call even if there's one available.
Using 'ideal' uses the chosen device in preference, but something
else if it isn't available.

Also log the name of the exception when we fail to open a capture
device to give us more of an idea of what's gone wrong.

Should help fix vector-im/riot-web#8993