### PR TITLE
Rename `MatrixInMemoryStore` to `MemoryStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ client.on("Room.timeline", function(event, room, toStartOfTimeline) {
 });
 ```
 
-By default, the `matrix-js-sdk` client uses the `MatrixInMemoryStore` to store events as they are received. For example to iterate through the currently stored timeline for a room:
+By default, the `matrix-js-sdk` client uses the `MemoryStore` to store events as they are received. For example to iterate through the currently stored timeline for a room:
 
 ```javascript
 Object.keys(client.store.rooms).forEach((roomId) => {

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -4,7 +4,7 @@ const sdk = require("../..");
 const HttpBackend = require("matrix-mock-request");
 const publicGlobals = require("../../lib/matrix");
 const Room = publicGlobals.Room;
-const MatrixInMemoryStore = publicGlobals.MatrixInMemoryStore;
+const MemoryStore = publicGlobals.MemoryStore;
 const Filter = publicGlobals.Filter;
 const utils = require("../test-utils");
 const MockStorageApi = require("../MockStorageApi");
@@ -23,7 +23,7 @@ describe("MatrixClient", function() {
     beforeEach(function() {
         utils.beforeEach(this); // eslint-disable-line no-invalid-this
         httpBackend = new HttpBackend();
-        store = new MatrixInMemoryStore();
+        store = new MemoryStore();
 
         const mockStorage = new MockStorageApi();
         sessionStore = new sdk.WebStorageSessionStore(mockStorage);

--- a/spec/integ/matrix-client-opts.spec.js
+++ b/spec/integ/matrix-client-opts.spec.js
@@ -128,7 +128,7 @@ describe("MatrixClient opts", function() {
         beforeEach(function() {
             client = new MatrixClient({
                 request: httpBackend.requestFn,
-                store: new sdk.MatrixInMemoryStore(),
+                store: new sdk.MemoryStore(),
                 baseUrl: baseUrl,
                 userId: userId,
                 accessToken: accessToken,

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -27,6 +27,7 @@ module.exports.MemoryStore = require("./store/memory").MemoryStore;
 /**
  * The {@link module:store/memory.MemoryStore|MemoryStore} class was previously
  * exported as `MatrixInMemoryStore`, so this is preserved for SDK consumers.
+ * @deprecated Prefer `MemoryStore` going forward.
  */
 module.exports.MatrixInMemoryStore = module.exports.MemoryStore;
 /** The {@link module:store/indexeddb.IndexedDBStore|IndexedDBStore} class. */

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -22,8 +22,13 @@ module.exports.ContentHelpers = require("./content-helpers");
 module.exports.MatrixEvent = require("./models/event").MatrixEvent;
 /** The {@link module:models/event.EventStatus|EventStatus} enum. */
 module.exports.EventStatus = require("./models/event").EventStatus;
-/** The {@link module:store/memory.MatrixInMemoryStore|MatrixInMemoryStore} class. */
-module.exports.MatrixInMemoryStore = require("./store/memory").MatrixInMemoryStore;
+/** The {@link module:store/memory.MemoryStore|MemoryStore} class. */
+module.exports.MemoryStore = require("./store/memory").MemoryStore;
+/**
+ * The {@link module:store/memory.MemoryStore|MemoryStore} class was previously
+ * exported as `MatrixInMemoryStore`, so this is preserved for SDK consumers.
+ */
+module.exports.MatrixInMemoryStore = module.exports.MemoryStore;
 /** The {@link module:store/indexeddb.IndexedDBStore|IndexedDBStore} class. */
 module.exports.IndexedDBStore = require("./store/indexeddb").IndexedDBStore;
 /** The {@link module:store/indexeddb.IndexedDBStoreBackend|IndexedDBStoreBackend} class. */
@@ -164,7 +169,7 @@ module.exports.setCryptoStoreFactory = function(fac) {
  * this is a string, it is assumed to be the base URL. These configuration
  * options will be passed directly to {@link module:client~MatrixClient}.
  * @param {Object} opts.store If not set, defaults to
- * {@link module:store/memory.MatrixInMemoryStore}.
+ * {@link module:store/memory.MemoryStore}.
  * @param {Object} opts.scheduler If not set, defaults to
  * {@link module:scheduler~MatrixScheduler}.
  * @param {requestFunction} opts.request If not set, defaults to the function
@@ -187,7 +192,7 @@ module.exports.createClient = function(opts) {
         };
     }
     opts.request = opts.request || request;
-    opts.store = opts.store || new module.exports.MatrixInMemoryStore({
+    opts.store = opts.store || new module.exports.MemoryStore({
       localStorage: global.localStorage,
     });
     opts.scheduler = opts.scheduler || new module.exports.MatrixScheduler();

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Promise from 'bluebird';
-import {MatrixInMemoryStore} from "./memory";
+import {MemoryStore} from "./memory";
 import utils from "../utils";
 import LocalIndexedDBStoreBackend from "./indexeddb-local-backend.js";
 import RemoteIndexedDBStoreBackend from "./indexeddb-remote-backend.js";
@@ -37,9 +37,9 @@ const WRITE_DELAY_MS = 1000 * 60 * 5; // once every 5 minutes
 
 
 /**
- * Construct a new Indexed Database store, which extends MatrixInMemoryStore.
+ * Construct a new Indexed Database store, which extends MemoryStore.
  *
- * This store functions like a MatrixInMemoryStore except it periodically persists
+ * This store functions like a MemoryStore except it periodically persists
  * the contents of the store to an IndexedDB backend.
  *
  * All data is still kept in-memory but can be loaded from disk by calling
@@ -62,7 +62,7 @@ const WRITE_DELAY_MS = 1000 * 60 * 5; // once every 5 minutes
  * </pre>
  *
  * @constructor
- * @extends MatrixInMemoryStore
+ * @extends MemoryStore
  * @param {Object} opts Options object.
  * @param {Object} opts.indexedDB The Indexed DB interface e.g.
  * <code>window.indexedDB</code>
@@ -79,7 +79,7 @@ const WRITE_DELAY_MS = 1000 * 60 * 5; // once every 5 minutes
  * database.
  */
 const IndexedDBStore = function IndexedDBStore(opts) {
-    MatrixInMemoryStore.call(this, opts);
+    MemoryStore.call(this, opts);
 
     if (!opts.indexedDB) {
         throw new Error('Missing required option: indexedDB');
@@ -109,7 +109,7 @@ const IndexedDBStore = function IndexedDBStore(opts) {
         // user_id : timestamp
     };
 };
-utils.inherits(IndexedDBStore, MatrixInMemoryStore);
+utils.inherits(IndexedDBStore, MemoryStore);
 
 /**
  * @return {Promise} Resolved when loaded from indexed db.
@@ -164,7 +164,7 @@ IndexedDBStore.prototype.getSavedSyncToken = function() {
  * @return {Promise} Resolves if the data was deleted from the database.
  */
 IndexedDBStore.prototype.deleteAllData = function() {
-    MatrixInMemoryStore.prototype.deleteAllData.call(this);
+    MemoryStore.prototype.deleteAllData.call(this);
     return this.backend.clearDatabase().then(() => {
         console.log("Deleted indexeddb data.");
     }, (err) => {

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -17,7 +17,7 @@ limitations under the License.
 */
 "use strict";
 /**
- * This is an internal module. See {@link MatrixInMemoryStore} for the public class.
+ * This is an internal module. See {@link MemoryStore} for the public class.
  * @module store/memory
  */
 const utils = require("../utils");
@@ -31,7 +31,7 @@ import Promise from 'bluebird';
  * @param {LocalStorage} opts.localStorage The local storage instance to persist
  * some forms of data such as tokens. Rooms will NOT be stored.
  */
-module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
+module.exports.MemoryStore = function MemoryStore(opts) {
     opts = opts || {};
     this.rooms = {
         // roomId: Room
@@ -58,7 +58,7 @@ module.exports.MatrixInMemoryStore = function MatrixInMemoryStore(opts) {
     this._clientOptions = {};
 };
 
-module.exports.MatrixInMemoryStore.prototype = {
+module.exports.MemoryStore.prototype = {
 
     /**
      * Retrieve the token to stream from.


### PR DESCRIPTION
None of the other store classes use the `Matrix` prefix, and I find the mismatch
confusing (it leads me to think it might have a different purpose than the
others).

This change removes the prefix from the store for consistency. The old name is
left as an export for existing SDK consumers.