### PR TITLE
Remove `sessionStore` to `cryptoStore` migration path

### DIFF
--- a/spec/unit/crypto/DeviceList.spec.js
+++ b/spec/unit/crypto/DeviceList.spec.js
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
-Copyright 2018 New Vector Ltd
+Copyright 2018, 2019 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@ limitations under the License.
 */
 
 import DeviceList from '../../../lib/crypto/DeviceList';
-import MockStorageApi from '../../MockStorageApi';
-import WebStorageSessionStore from '../../../lib/store/session/webstorage';
 import MemoryCryptoStore from '../../../lib/crypto/store/memory-crypto-store.js';
 import testUtils from '../../test-utils';
 import utils from '../../../lib/utils';
@@ -57,7 +55,6 @@ const signedDeviceList = {
 
 describe('DeviceList', function() {
     let downloadSpy;
-    let sessionStore;
     let cryptoStore;
     let deviceLists = [];
 
@@ -67,8 +64,6 @@ describe('DeviceList', function() {
         deviceLists = [];
 
         downloadSpy = expect.createSpy();
-        const mockStorage = new MockStorageApi();
-        sessionStore = new WebStorageSessionStore(mockStorage);
         cryptoStore = new MemoryCryptoStore();
     });
 
@@ -85,7 +80,7 @@ describe('DeviceList', function() {
         const mockOlm = {
             verifySignature: function(key, message, signature) {},
         };
-        const dl = new DeviceList(baseApis, cryptoStore, sessionStore, mockOlm);
+        const dl = new DeviceList(baseApis, cryptoStore, mockOlm);
         deviceLists.push(dl);
         return dl;
     }

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -5,7 +5,6 @@ import Promise from 'bluebird';
 
 import sdk from '../../../..';
 import algorithms from '../../../../lib/crypto/algorithms';
-import WebStorageSessionStore from '../../../../lib/store/session/webstorage';
 import MemoryCryptoStore from '../../../../lib/crypto/store/memory-crypto-store.js';
 import MockStorageApi from '../../../MockStorageApi';
 import testUtils from '../../../test-utils';
@@ -40,10 +39,9 @@ describe("MegolmDecryption", function() {
         mockBaseApis = {};
 
         const mockStorage = new MockStorageApi();
-        const sessionStore = new WebStorageSessionStore(mockStorage);
         const cryptoStore = new MemoryCryptoStore(mockStorage);
 
-        const olmDevice = new OlmDevice(sessionStore, cryptoStore);
+        const olmDevice = new OlmDevice(cryptoStore);
 
         megolmDecryption = new MegolmDecryption({
             userId: '@user:id',
@@ -264,10 +262,9 @@ describe("MegolmDecryption", function() {
 
         it("re-uses sessions for sequential messages", async function() {
             const mockStorage = new MockStorageApi();
-            const sessionStore = new WebStorageSessionStore(mockStorage);
             const cryptoStore = new MemoryCryptoStore(mockStorage);
 
-            const olmDevice = new OlmDevice(sessionStore, cryptoStore);
+            const olmDevice = new OlmDevice(cryptoStore);
             olmDevice.verifySignature = expect.createSpy();
             await olmDevice.init();
 

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -17,7 +17,6 @@ limitations under the License.
 import '../../../olm-loader';
 
 import expect from 'expect';
-import WebStorageSessionStore from '../../../../lib/store/session/webstorage';
 import MemoryCryptoStore from '../../../../lib/crypto/store/memory-crypto-store.js';
 import MockStorageApi from '../../../MockStorageApi';
 import testUtils from '../../../test-utils';
@@ -28,9 +27,8 @@ import DeviceInfo from '../../../../lib/crypto/deviceinfo';
 
 function makeOlmDevice() {
     const mockStorage = new MockStorageApi();
-    const sessionStore = new WebStorageSessionStore(mockStorage);
     const cryptoStore = new MemoryCryptoStore(mockStorage);
-    const olmDevice = new OlmDevice(sessionStore, cryptoStore);
+    const olmDevice = new OlmDevice(cryptoStore);
     return olmDevice;
 }
 

--- a/spec/unit/crypto/backup.spec.js
+++ b/spec/unit/crypto/backup.spec.js
@@ -138,7 +138,7 @@ describe("MegolmBackup", function() {
         sessionStore = new WebStorageSessionStore(mockStorage);
         cryptoStore = new MemoryCryptoStore(mockStorage);
 
-        olmDevice = new OlmDevice(sessionStore, cryptoStore);
+        olmDevice = new OlmDevice(cryptoStore);
 
         // we stub out the olm encryption bits
         mockOlmLib = {};

--- a/src/client.js
+++ b/src/client.js
@@ -106,17 +106,24 @@ function keyFromRecoverySession(session, decryptionKey) {
  *
  * @param {string} opts.userId The user ID for this user.
  *
- * @param {Object=} opts.store The data store to use. If not specified,
- * this client will not store any HTTP responses.
+ * @param {Object=} opts.store
+ *    The data store used for sync data from the homeserver. If not specified,
+ *    this client will not store any HTTP responses. The `createClient` helper
+ *    will create a default store if needed.
+ *
+ * @param {module:store/session/webstorage~WebStorageSessionStore} opts.sessionStore
+ *    A store to be used for end-to-end crypto session data. Most data has been
+ *    migrated out of here to `cryptoStore` instead. If not specified,
+ *    end-to-end crypto will be disabled. The `createClient` helper
+ *    _will not_ create this store at the moment.
+ *
+ * @param {module:crypto.store.base~CryptoStore} opts.cryptoStore
+ *    A store to be used for end-to-end crypto session data. If not specified,
+ *    end-to-end crypto will be disabled. The `createClient` helper will create
+ *    a default store if needed.
  *
  * @param {string=} opts.deviceId A unique identifier for this device; used for
  *    tracking things like crypto keys and access tokens.  If not specified,
- *    end-to-end crypto will be disabled.
- *
- * @param {Object=} opts.sessionStore A store to be used for end-to-end crypto
- *    session data. This should be a {@link
- *    module:store/session/webstorage~WebStorageSessionStore|WebStorageSessionStore},
- *    or an object implementing the same interface. If not specified,
  *    end-to-end crypto will be disabled.
  *
  * @param {Object} opts.scheduler Optional. The scheduler to use. If not
@@ -140,9 +147,6 @@ function keyFromRecoverySession(session, decryptionKey) {
  * disabled by default for compatibility with older clients - in particular to
  * maintain support for back-paginating the live timeline after a '/sync'
  * result with a gap.
- *
- * @param {module:crypto.store.base~CryptoStore} opts.cryptoStore
- *    crypto store implementation.
  *
  * @param {Array} [opts.verificationMethods] Optional. The verification method
  * that the application can handle.  Each element should be an item from {@link

--- a/src/client.js
+++ b/src/client.js
@@ -220,7 +220,7 @@ function MatrixClient(opts) {
     // List of which rooms have encryption enabled: separate from crypto because
     // we still want to know which rooms are encrypted even if crypto is disabled:
     // we don't want to start sending unencrypted events to them.
-    this._roomList = new RoomList(this._cryptoStore, this._sessionStore);
+    this._roomList = new RoomList(this._cryptoStore);
 
     // The pushprocessor caches useful things, so keep one and re-use it
     this._pushProcessor = new PushProcessor(this);


### PR DESCRIPTION
The code to migrate from the `sessionStore` to `cryptoStore` originally appeared in #584 (2017-12-06). At this point, it seems safe to assume most sessions that need migrating have already
done so. Removing this code simplifies store handling and removes the `sessionStore` from most places in JS SDK.