### PR TITLE
Clarify the meaning of 'real name' for contribution

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ works. Develop is the unstable branch where all the development actually
 happens: the workflow is that contributors should fork the develop branch to
 make a 'feature' branch for a particular contribution, and then make a pull
 request to merge this back into the matrix.org 'official' develop branch. We
-use github's pull request workflow to review the contribution, and either ask
+use GitHub's pull request workflow to review the contribution, and either ask
 you to make any refinements needed or merge it and make them ourselves. The
 changes will then land on master when we next do a release.
 
@@ -60,8 +60,8 @@ Sign off
 ~~~~~~~~
 
 In order to have a concrete record that your contribution is intentional
-and you agree to license it under the same terms as the project's license, we've adopted the
-same lightweight approach that the Linux Kernel
+and you agree to license it under the same terms as the project's license, we've
+adopted the same lightweight approach that the Linux Kernel
 (https://www.kernel.org/doc/Documentation/SubmittingPatches), Docker
 (https://github.com/docker/docker/blob/master/CONTRIBUTING.md), and many other
 projects use: the DCO (Developer Certificate of Origin:
@@ -118,7 +118,7 @@ Git allows you to add this signoff automatically when using the ``-s`` flag to
 ``git commit``, which uses the name and email set in your ``user.name`` and
 ``user.email`` git configs.
 
-If you forgot to sign off your commits before making your pull request and are on git 2.17+ 
-you can mass signoff using rebase::
+If you forgot to sign off your commits before making your pull request and are
+on Git 2.17+ you can mass signoff using rebase::
 
     git rebase --signoff origin/develop

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,10 +109,14 @@ include the line in your commit or pull request comment::
 
     Signed-off-by: Your Name <your@email.example.org>
 
-...using your real name; unfortunately pseudonyms and anonymous contributions
-can't be accepted. Git makes this trivial - just use the -s flag when you do
-``git commit``, having first set ``user.name`` and ``user.email`` git configs
-(which you should have done anyway :)
+We accept contributions under a legally identifiable name, such as your name on
+government documentation or common-law names (names claimed by legitimate usage
+or repute). Unfortunately, we cannot accept anonymous contributions at this
+time.
+
+Git allows you to add this signoff automatically when using the ``-s`` flag to
+``git commit``, which uses the name and email set in your ``user.name`` and
+``user.email`` git configs.
 
 If you forgot to sign off your commits before making your pull request and are on git 2.17+ 
 you can mass signoff using rebase::


### PR DESCRIPTION
This applies the clarification already adopted by Synapse in https://github.com/matrix-org/synapse/pull/3467.

(I also reformatted the doc slightly in a separate commit.)