### PR TITLE
Refuse splicing the live timeline into a broken position

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -415,14 +415,20 @@ EventTimelineSet.prototype.addEventsToTimeline = function(events, toStartOfTimel
 
         if (direction === EventTimeline.BACKWARDS && existingIsLive) {
             // The live timeline should never be spliced into a non-live position.
-            console.warn("Refusing to splice live timeline as a backwards timeline");
+            console.warn(
+                "Refusing to set a preceding existingTimeLine on our " +
+                "timeline as the existingTimeLine is live",
+            );
         } else {
             timeline.setNeighbouringTimeline(existingTimeline, direction);
         }
 
         if (inverseDirection === EventTimeline.BACKWARDS && timelineIsLive) {
             // The live timeline should never be spliced into a non-live position.
-            console.warn("Refusing to splice live timeline as a forwards timeline");
+            console.warn(
+                "Refusing to set our preceding timeline on a existingTimeLine " +
+                "as our timeline is live",
+            );
         } else {
             existingTimeline.setNeighbouringTimeline(timeline, inverseDirection);
         }

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -409,14 +409,18 @@ EventTimelineSet.prototype.addEventsToTimeline = function(events, toStartOfTimel
                      " - joining timeline " + timeline + " to " +
                      existingTimeline);
 
-        if (direction === EventTimeline.BACKWARDS && existingTimeline === this._liveTimeline) {
+        // Variables to keep the line length limited below.
+        const existingIsLive = existingTimeline === this._liveTimeline;
+        const timelineIsLive = timeline === this._liveTimeline;
+
+        if (direction === EventTimeline.BACKWARDS && existingIsLive) {
             // The live timeline should never be spliced into a non-live position.
             console.warn("Refusing to splice live timeline as a backwards timeline");
         } else {
             timeline.setNeighbouringTimeline(existingTimeline, direction);
         }
 
-        if (inverseDirection === EventTimeline.BACKWARDS && timeline === this._liveTimeline) {
+        if (inverseDirection === EventTimeline.BACKWARDS && timelineIsLive) {
             // The live timeline should never be spliced into a non-live position.
             console.warn("Refusing to splice live timeline as a forwards timeline");
         } else {

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -417,7 +417,7 @@ EventTimelineSet.prototype.addEventsToTimeline = function(events, toStartOfTimel
             // The live timeline should never be spliced into a non-live position.
             console.warn(
                 "Refusing to set a preceding existingTimeLine on our " +
-                "timeline as the existingTimeLine is live",
+                "timeline as the existingTimeLine is live (" + existingTimeline + ")",
             );
         } else {
             timeline.setNeighbouringTimeline(existingTimeline, direction);
@@ -427,7 +427,7 @@ EventTimelineSet.prototype.addEventsToTimeline = function(events, toStartOfTimel
             // The live timeline should never be spliced into a non-live position.
             console.warn(
                 "Refusing to set our preceding timeline on a existingTimeLine " +
-                "as our timeline is live",
+                "as our timeline is live (" + timeline + ")",
             );
         } else {
             existingTimeline.setNeighbouringTimeline(timeline, inverseDirection);

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -408,8 +408,21 @@ EventTimelineSet.prototype.addEventsToTimeline = function(events, toStartOfTimel
         console.info("Already have timeline for " + eventId +
                      " - joining timeline " + timeline + " to " +
                      existingTimeline);
-        timeline.setNeighbouringTimeline(existingTimeline, direction);
-        existingTimeline.setNeighbouringTimeline(timeline, inverseDirection);
+
+        if (direction === EventTimeline.BACKWARDS && existingTimeline === this._liveTimeline) {
+            // The live timeline should never be spliced into a non-live position.
+            console.warn("Refusing to splice live timeline as a backwards timeline");
+        } else {
+            timeline.setNeighbouringTimeline(existingTimeline, direction);
+        }
+
+        if (inverseDirection === EventTimeline.BACKWARDS && timeline === this._liveTimeline) {
+            // The live timeline should never be spliced into a non-live position.
+            console.warn("Refusing to splice live timeline as a forwards timeline");
+        } else {
+            existingTimeline.setNeighbouringTimeline(timeline, inverseDirection);
+        }
+
         timeline = existingTimeline;
         didUpdate = true;
     }


### PR DESCRIPTION
Credit to Matthew for basically solving this.

Theoretically fixes spontaneous timeline corruption: https://github.com/vector-im/riot-web/issues/8593

When the live timeline ends up in a position where it can no longer be live (such as becoming the second timeline in the set, rather than the first) we end up getting neighbouring timeline errors. By refusing to splice the live timeline into such a position, we hopefully keep the live timeline in a position of still being live for when it is next used.

The running theory that leads to this fix is multiple limited syncs coming in, causing holes in the timeline. When trying to patch up the holes, the timeline set would end up splicing all over the place, leading to potentially splicing the live timeline into a broken position.

Disclaimer: I've done light testing on Riot to make sure it doesn't fail in miserable ways, but have not reproduced the case which causes the issue in the first place. The issue is a bit complex to test, hence the word "theory" being littered above.