### PR TITLE
Remove console.log lines from sendEvent

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1670,8 +1670,6 @@ MatrixClient.prototype.sendEvent = function(roomId, eventType, content, txnId,
         txnId = this.makeTxnId();
     }
 
-    console.log(`sendEvent of type ${eventType} in ${roomId} with txnId ${txnId}`);
-
     // we always construct a MatrixEvent when sending because the store and
     // scheduler use them. We'll extract the params back out if it turns out
     // the client has no scheduler or store.
@@ -1846,9 +1844,6 @@ function _sendEventHttpRequest(client, event) {
     return client._http.authedRequest(
         undefined, "PUT", path, undefined, event.getWireContent(),
     ).then((res) => {
-        console.log(
-            `Event sent to ${event.getRoomId()} with event id ${res.event_id}`,
-        );
         return res;
     });
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1843,9 +1843,7 @@ function _sendEventHttpRequest(client, event) {
 
     return client._http.authedRequest(
         undefined, "PUT", path, undefined, event.getWireContent(),
-    ).then((res) => {
-        return res;
-    });
+    );
 }
 
 /**


### PR DESCRIPTION
This has been plaguing the `matrix-appservice-bridge` project for years, as it means any events sent will go to stdout whereas most bridges run their own logging system. I'd gently push for Riot to log this inside it's own code.