### PR TITLE
Don't assume aborts are always from txn.abort()

### DIFF
--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -705,6 +705,6 @@ function promiseifyTxn(txn) {
                 console.log("Error performing indexeddb txn", event);
                 reject(event.target.error);
             }
-        }
+        };
     });
 }

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -698,6 +698,13 @@ function promiseifyTxn(txn) {
                 reject(event.target.error);
             }
         };
-        txn.onabort = () => reject(txn._mx_abortexception);
+        txn.onabort = (event) => {
+            if (txn._mx_abortexception !== undefined) {
+                reject(txn._mx_abortexception);
+            } else {
+                console.log("Error performing indexeddb txn", event);
+                reject(event.target.error);
+            }
+        }
     });
 }


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/abort_event
a txn can abort for any number of reasons, not just because of an
abort call, so we can't assume our abort error is set.

This should give us more info on https://github.com/vector-im/riot-web/issues/7769