### PR TITLE
Degrade `IndexedDBStore` back to memory only on failure

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1318,6 +1318,9 @@ describe("Room", function() {
                     // events should already be MatrixEvents
                     return function(event) {return event;};
                 },
+                isCryptoEnabled() {
+                    return true;
+                },
                 isRoomEncrypted: function() {
                     return false;
                 },

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -496,7 +496,7 @@ Room.prototype.loadMembersIfNeeded = function() {
     const inMemoryUpdate = this._loadMembers().then((result) => {
         this.currentState.setOutOfBandMembers(result.memberEvents);
         // now the members are loaded, start to track the e2e devices if needed
-        if (this._client.isRoomEncrypted(this.roomId)) {
+        if (this._client.isCryptoEnabled() && this._client.isRoomEncrypted(this.roomId)) {
             this._client._crypto.trackRoomDevices(this.roomId);
         }
         return result.fromServer;

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -253,10 +253,12 @@ IndexedDBStore.prototype.setOutOfBandMembers = degradable(function(
     roomId,
     membershipEvents,
 ) {
+    MemoryStore.prototype.setOutOfBandMembers.call(this, roomId, membershipEvents);
     return this.backend.setOutOfBandMembers(roomId, membershipEvents);
 }, "setOutOfBandMembers");
 
 IndexedDBStore.prototype.clearOutOfBandMembers = degradable(function(roomId) {
+    MemoryStore.prototype.clearOutOfBandMembers.call(this);
     return this.backend.clearOutOfBandMembers(roomId);
 }, "clearOutOfBandMembers");
 
@@ -265,6 +267,7 @@ IndexedDBStore.prototype.getClientOptions = degradable(function() {
 }, "getClientOptions");
 
 IndexedDBStore.prototype.storeClientOptions = degradable(function(options) {
+    MemoryStore.prototype.storeClientOptions.call(this, options);
     return this.backend.storeClientOptions(options);
 }, "storeClientOptions");
 

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -300,6 +300,13 @@ function degradable(func, fallback) {
             } catch (e) {
                 console.warn("IndexedDBStore delete after degrading failed", e);
             }
+            // Degrade the store from being an instance of `IndexedDBStore` to instead be
+            // an instance of `MemoryStore` so that future API calls use the memory path
+            // directly and skip IndexedDB entirely. This should be safe as
+            // `IndexedDBStore` already extends from `MemoryStore`, so we are making the
+            // store become its parent type in a way. The mutator methods of
+            // `IndexedDBStore` also maintain the state that `MemoryStore` uses (many are
+            // not overridden at all).
             Object.setPrototypeOf(this, MemoryStore.prototype);
             if (fallback) {
                 return await MemoryStore.prototype[fallback].call(this, ...args);

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -20,6 +20,7 @@ limitations under the License.
 import Promise from 'bluebird';
 import {MemoryStore} from "./memory";
 import utils from "../utils";
+import {EventEmitter} from 'events';
 import LocalIndexedDBStoreBackend from "./indexeddb-local-backend.js";
 import RemoteIndexedDBStoreBackend from "./indexeddb-remote-backend.js";
 import User from "../models/user";
@@ -112,6 +113,7 @@ const IndexedDBStore = function IndexedDBStore(opts) {
     };
 };
 utils.inherits(IndexedDBStore, MemoryStore);
+utils.extend(IndexedDBStore.prototype, EventEmitter.prototype);
 
 IndexedDBStore.exists = function(indexedDB, dbName) {
     return LocalIndexedDBStoreBackend.exists(indexedDB, dbName);
@@ -286,6 +288,7 @@ function degradable(func, fallback) {
             return await func.call(this, ...args);
         } catch (e) {
             console.error("IndexedDBStore failure, degrading to MemoryStore", e);
+            this.emit("degraded", e);
             try {
                 // We try to delete IndexedDB after degrading since this store is only a
                 // cache (the app will still function correctly without the data).

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -385,6 +385,7 @@ module.exports.MemoryStore.prototype = {
         };
         return Promise.resolve();
     },
+
     /**
      * Returns the out-of-band membership events for this room that
      * were previously loaded.
@@ -395,6 +396,7 @@ module.exports.MemoryStore.prototype = {
     getOutOfBandMembers: function(roomId) {
         return Promise.resolve(this._oobMembers[roomId] || null);
     },
+
     /**
      * Stores the out-of-band membership events for this room. Note that
      * it still makes sense to store an empty array as the OOB status for the room is
@@ -405,6 +407,11 @@ module.exports.MemoryStore.prototype = {
      */
     setOutOfBandMembers: function(roomId, membershipEvents) {
         this._oobMembers[roomId] = membershipEvents;
+        return Promise.resolve();
+    },
+
+    clearOutOfBandMembers: function() {
+        this._oobMembers = {};
         return Promise.resolve();
     },
 


### PR DESCRIPTION
IndexedDB may fail at any moment with `QuoteExceededError` when space is low or
other random issues we can't control. Since `IndexedDBStore` is just a cache for
improving performance, we can give up on it if it fails.

This causes `IndexedDBStore` to degrade in place back to using memory only. This
allow (for example) login to complete even if IndexedDB is exploding.

Hopefully improves https://github.com/vector-im/riot-web/issues/7769