### PR TITLE
Track e2e highlights better, particularly in 'Mentions Only' rooms

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1076,9 +1076,17 @@ SyncApi.prototype._processSyncResponse = async function(
             room.setUnreadNotificationCount(
                 'total', joinObj.unread_notifications.notification_count,
             );
-            room.setUnreadNotificationCount(
-                'highlight', joinObj.unread_notifications.highlight_count,
-            );
+
+            // We track unread notifications ourselves in encrypted rooms, so don't
+            // bother setting it here. We trust our calculations better than the
+            // server's for this case, and therefore will assume that our non-zero
+            // count is accurate.
+            if (client.isRoomEncrypted(room.roomId)
+                && room.getUnreadNotificationCount('highlight') <= 0) {
+                room.setUnreadNotificationCount(
+                    'highlight', joinObj.unread_notifications.highlight_count,
+                );
+            }
         }
 
         room.updateMyMembership("join");


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9280

The server is unable to calculate encrypted highlights for us, so we calculate them. This also means the server always sends a zero for highlight_count, and therefore in sync.js we now trust our judgement over the server's. In future, this check will need to be altered to support server-side encrypted notifications if that happens. This fixes the part of 9280 where the badge count ends up disappearing unless the message received also happens to be a mention.

The changes in client.js are more to support rooms which are mentions only. Because the server doesn't send an unread_count for these rooms, the total notifications will always be zero. Therefore, we try and calculate that. In order to do that, we need to assume that our highlight count is also wrong and calculate it appropriately.