### PR TITLE
Fix highlight notifications for unencrypted rooms

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1106,7 +1106,8 @@ SyncApi.prototype._processSyncResponse = async function(
             // server's for this case, and therefore will assume that our non-zero
             // count is accurate.
             const encrypted = client.isRoomEncrypted(room.roomId);
-            if (!encrypted || (encrypted && room.getUnreadNotificationCount('highlight') <= 0)) {
+            if (!encrypted
+                || (encrypted && room.getUnreadNotificationCount('highlight') <= 0)) {
                 room.setUnreadNotificationCount(
                     'highlight', joinObj.unread_notifications.highlight_count,
                 );

--- a/src/sync.js
+++ b/src/sync.js
@@ -1105,8 +1105,8 @@ SyncApi.prototype._processSyncResponse = async function(
             // bother setting it here. We trust our calculations better than the
             // server's for this case, and therefore will assume that our non-zero
             // count is accurate.
-            if (client.isRoomEncrypted(room.roomId)
-                && room.getUnreadNotificationCount('highlight') <= 0) {
+            const encrypted = client.isRoomEncrypted(room.roomId);
+            if (!encrypted || (encrypted && room.getUnreadNotificationCount('highlight') <= 0)) {
                 room.setUnreadNotificationCount(
                     'highlight', joinObj.unread_notifications.highlight_count,
                 );


### PR DESCRIPTION
A logic error introduced by https://github.com/matrix-org/matrix-js-sdk/pull/886 meant that all unencrypted rooms were not getting highlight notifications.