### PR TITLE
Explicitly guard store usage during sync startup

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -499,9 +499,16 @@ SyncApi.prototype.sync = function() {
             const supported = await client.doesServerSupportLazyLoading();
             if (supported) {
                 debuglog("Creating and storing lazy load sync filter...");
-                this.opts.filter = await client.createFilter(
-                    Filter.LAZY_LOADING_SYNC_FILTER,
-                );
+                try {
+                    this.opts.filter = await client.createFilter(
+                        Filter.LAZY_LOADING_SYNC_FILTER,
+                    );
+                } catch (err) {
+                    console.error(
+                        "Creating and storing lazy load sync filter failed",
+                        err,
+                    );
+                }
                 debuglog("Created and stored lazy load sync filter");
             } else {
                 debuglog("LL: lazy loading requested but not supported " +
@@ -528,7 +535,11 @@ SyncApi.prototype.sync = function() {
             this.opts.crypto.enableLazyLoading();
         }
         debuglog("Storing client options...");
-        await this.client._storeClientOptions();
+        try {
+            await this.client._storeClientOptions();
+        } catch (err) {
+            console.error("Storing client options failed", err);
+        }
         debuglog("Stored client options");
 
         getFilter(); // Now get the filter and start syncing

--- a/src/sync.js
+++ b/src/sync.js
@@ -498,18 +498,18 @@ SyncApi.prototype.sync = function() {
             debuglog("Checking server lazy load support...");
             const supported = await client.doesServerSupportLazyLoading();
             if (supported) {
-                debuglog("Creating and storing lazy load sync filter...");
                 try {
+                    debuglog("Creating and storing lazy load sync filter...");
                     this.opts.filter = await client.createFilter(
                         Filter.LAZY_LOADING_SYNC_FILTER,
                     );
+                    debuglog("Created and stored lazy load sync filter");
                 } catch (err) {
                     console.error(
                         "Creating and storing lazy load sync filter failed",
                         err,
                     );
                 }
-                debuglog("Created and stored lazy load sync filter");
             } else {
                 debuglog("LL: lazy loading requested but not supported " +
                     "by server, so disabling");
@@ -534,13 +534,13 @@ SyncApi.prototype.sync = function() {
         if (this.opts.lazyLoadMembers && this.opts.crypto) {
             this.opts.crypto.enableLazyLoading();
         }
-        debuglog("Storing client options...");
         try {
+            debuglog("Storing client options...");
             await this.client._storeClientOptions();
+            debuglog("Stored client options");
         } catch (err) {
             console.error("Storing client options failed", err);
         }
-        debuglog("Stored client options");
 
         getFilter(); // Now get the filter and start syncing
     };

--- a/src/sync.js
+++ b/src/sync.js
@@ -509,6 +509,7 @@ SyncApi.prototype.sync = function() {
                         "Creating and storing lazy load sync filter failed",
                         err,
                     );
+                    throw err;
                 }
             } else {
                 debuglog("LL: lazy loading requested but not supported " +
@@ -540,6 +541,7 @@ SyncApi.prototype.sync = function() {
             debuglog("Stored client options");
         } catch (err) {
             console.error("Storing client options failed", err);
+            throw err;
         }
 
         getFilter(); // Now get the filter and start syncing


### PR DESCRIPTION
This adds explicit `try` blocks in the spots where we interact with the store
during sync startup. This shouldn't be necessary as the store should already be
catching this and degrading as of
https://github.com/matrix-org/matrix-js-sdk/pull/884, but that doesn't seem to
have been enough for the affected user in
https://github.com/vector-im/riot-web/issues/7769, as they are seeing sync just
stop when storing without any further detail.