### PR TITLE
Support being fed a .well-known config object for validation

### DIFF
--- a/spec/unit/autodiscovery.spec.js
+++ b/spec/unit/autodiscovery.spec.js
@@ -94,7 +94,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID,
                         base_url: null,
                     },
                     "m.identity_server": {
@@ -117,7 +117,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID,
                         base_url: null,
                     },
                     "m.identity_server": {
@@ -140,7 +140,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID,
                         base_url: null,
                     },
                     "m.identity_server": {
@@ -163,7 +163,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID,
                         base_url: null,
                     },
                     "m.identity_server": {
@@ -191,7 +191,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID_HS_BASE_URL,
                         base_url: null,
                     },
                     "m.identity_server": {
@@ -217,7 +217,7 @@ describe("AutoDiscovery", function() {
                 const expected = {
                     "m.homeserver": {
                         state: "FAIL_PROMPT",
-                        error: AutoDiscovery.ERROR_GENERIC_FAILURE,
+                        error: AutoDiscovery.ERROR_INVALID_HS_BASE_URL,
                         base_url: null,
                     },
                     "m.identity_server": {

--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -226,7 +226,7 @@ export class AutoDiscovery {
             logger.error("No m.homeserver key/base_url in config");
 
             clientConfig["m.homeserver"].state = AutoDiscovery.FAIL_PROMPT;
-            clientConfig["m.homeserver"].error = AutoDiscovery.ERROR_GENERIC_FAILURE;
+            clientConfig["m.homeserver"].error = AutoDiscovery.ERROR_INVALID_HS_BASE_URL;
 
             return Promise.resolve(clientConfig);
         }
@@ -374,7 +374,7 @@ export class AutoDiscovery {
         const clientConfig = {
             "m.homeserver": {
                 state: AutoDiscovery.FAIL_ERROR,
-                error: "Invalid homeserver discovery response",
+                error: AutoDiscovery.ERROR_INVALID,
                 base_url: null,
             },
             "m.identity_server": {
@@ -403,8 +403,7 @@ export class AutoDiscovery {
             } else {
                 // this can only ever be FAIL_PROMPT at this point.
                 clientConfig["m.homeserver"].state = AutoDiscovery.FAIL_PROMPT;
-                clientConfig["m.homeserver"].error =
-                    "Failed to get autodiscovery configuration from server";
+                clientConfig["m.homeserver"].error = AutoDiscovery.ERROR_GENERIC_FAILURE;
             }
             return Promise.resolve(clientConfig);
         }

--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -331,7 +331,7 @@ export class AutoDiscovery {
             .map((k) => {
                 if (k === "m.homeserver" || k === "m.identity_server") {
                     // Only copy selected parts of the config to avoid overwriting
-                    // important information.
+                    // properties computed by the validation logic above.
                     const notProps = ["error", "state", "base_url"];
                     for (const prop of Object.keys(wellknown[k])) {
                         if (notProps.includes(prop)) continue;


### PR DESCRIPTION
Used by Riot to consume the user's provided config. This also includes a change to carry over custom keys on m.homeserver and m.identity_server which aren't intentionally controlled.

Required for https://github.com/vector-im/riot-web/issues/9290