### PR TITLE
Support for replacing message through m.replace relationship.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -153,6 +153,11 @@ function keyFromRecoverySession(session, decryptionKey) {
  * via `EventTimelineSet#getRelationsForEvent`.
  * This feature is currently unstable and the API may change without notice.
  *
+ * @param {boolean} [opts.unstableClientRelationReplacements = false]
+ * Optional. Set to true to enable client-side handling of m.replace event relations,
+ * exposed through the `Room.replaceEvent` event.
+ * This feature is currently unstable and the API may change without notice.
+ *
  * @param {Array} [opts.verificationMethods] Optional. The verification method
  * that the application can handle.  Each element should be an item from {@link
  * module:crypto~verificationMethods verificationMethods}, or a class that
@@ -219,6 +224,7 @@ function MatrixClient(opts) {
     this.urlPreviewCache = {};
     this._notifTimelineSet = null;
     this.unstableClientRelationAggregation = !!opts.unstableClientRelationAggregation;
+    this.unstableClientRelationReplacements = !!opts.unstableClientRelationReplacements;
 
     this._crypto = null;
     this._cryptoStore = opts.cryptoStore;

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -244,6 +244,35 @@ EventTimelineSet.prototype.findEventById = function(eventId) {
 };
 
 /**
+ * Find an event by id which is stored in our timelines and replace it with a new event
+ *
+ * @param {string} eventId  event ID to look for
+ * @param {string} newEvent the event to replace with
+ * @return {?module:models/event~MatrixEvent} the replaced event, or undefined if unknown
+ */
+EventTimelineSet.prototype.tryReplaceEvent = function(eventId, newEvent) {
+    // we can't use this._eventIdToTimeline here to find the matching timeline
+    // because we need to match the original event id,
+    // which might have been replaced by a previous m.replace already.
+    // for now, loop through all timelines. Maybe a separate index would be justifyable.
+    let oldEvent;
+    for(const tl of this._timelines) {
+        oldEvent = tl.tryReplaceEvent(eventId, newEvent);
+        if (oldEvent) {
+            break;
+        }
+    }
+    if (oldEvent) {
+        let originalEvent;
+        if (oldEvent.isReplacement()) {
+            originalEvent = oldEvent.getReplacedEvent();
+        }
+        this.replaceEventId(oldEvent.getId(), newEvent.getId());
+        return oldEvent;
+    }
+};
+
+/**
  * Add a new timeline to this timeline list
  *
  * @return {module:models/event-timeline~EventTimeline} newly-created timeline

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -263,10 +263,6 @@ EventTimelineSet.prototype.tryReplaceEvent = function(eventId, newEvent) {
         }
     }
     if (oldEvent) {
-        let originalEvent;
-        if (oldEvent.isReplacement()) {
-            originalEvent = oldEvent.getReplacedEvent();
-        }
         this.replaceEventId(oldEvent.getId(), newEvent.getId());
         return oldEvent;
     }

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -339,6 +339,27 @@ EventTimeline.prototype.addEvent = function(event, atStart) {
     }
 };
 
+
+/**
+ * Replaces an event in the timeline, if it exists.
+ *
+ * @param {string} eventId  the id of the existing event
+ * @param {boolean} newEvent  the new event
+ * @return {MatrixEvent?} the old event, if found and replaced.
+ */
+EventTimeline.prototype.tryReplaceEvent = function(eventId, newEvent) {
+    const eventIndex = this._events.findIndex(event => event.getOriginalId() === eventId);
+    if (eventIndex === -1) {
+        return;
+    }
+    const oldEvent = this._events[eventIndex];
+    this._events[eventIndex] = newEvent;
+    // copy over metadata, as we don't hold state for random locations in the timeline, only for the end or start
+    // and assuming for now that replacing an event doesn't change the sender that should be shown.
+    newEvent.sender = oldEvent.sender;
+    return oldEvent;
+};
+
 /**
  * Static helper method to set sender and target properties
  *

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1041,9 +1041,6 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
             // report replacedEvent and not originalEvent because replaceEvent was in the timeline so far
             this.emit("Room.replaceEvent", replacedEvent, event, this);
         }
-        else {
-            console.warn(`could not find replaced event for target id ${replacedEventId} and if ${event.getId()}, body: ${event.getContent().body}`);
-        }
         // we don't add the event because the event type would get rendered
         return;
     }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1099,6 +1099,10 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
  * unique transaction id.
  */
 Room.prototype.addPendingEvent = function(event, txnId) {
+    if (event.isReplacement()) {
+        return;
+    }
+
     if (event.status !== EventStatus.SENDING) {
         throw new Error("addPendingEvent called on an event with status " +
                         event.status);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1004,7 +1004,6 @@ Room.prototype.removeFilteredTimelineSet = function(filter) {
  * @private
  */
 Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
-    let i;
     if (event.getType() === "m.room.redaction") {
         const redactId = event.event.redacts;
 
@@ -1059,7 +1058,7 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
     }
 
     // add to our timeline sets
-    for (i = 0; i < this._timelineSets.length; i++) {
+    for (let i = 0; i < this._timelineSets.length; i++) {
         this._timelineSets[i].addLiveEvent(event, duplicateStrategy);
     }
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -99,6 +99,11 @@ function synthesizeReceipt(userId, event, receiptType) {
  * via `EventTimelineSet#getRelationsForEvent`.
  * This feature is currently unstable and the API may change without notice.
  *
+ * @param {boolean} [opts.unstableClientRelationReplacements = false]
+ * Optional. Set to true to enable client-side handling of m.replace event relations,
+ * exposed through the `Room.replaceEvent` event.
+ * This feature is currently unstable and the API may change without notice.
+ *
  * @prop {string} roomId The ID of this room.
  * @prop {string} name The human-readable display name for this room.
  * @prop {Array<MatrixEvent>} timeline The live event timeline for this room,
@@ -1027,7 +1032,7 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
         // this may be needed to trigger an update.
     }
 
-    if (event.isReplacement()) {
+    if (this._opts.unstableClientRelationReplacements && event.isReplacement()) {
         const replacedEventId = event.getOriginalId();
         const replacedEvent = replacedEventId &&
             this.getUnfilteredTimelineSet().tryReplaceEvent(replacedEventId, event);

--- a/src/sync.js
+++ b/src/sync.js
@@ -132,6 +132,7 @@ SyncApi.prototype.createRoom = function(roomId) {
                           "Room.localEchoUpdated",
                           "Room.accountData",
                           "Room.myMembership",
+                          "Room.replaceEvent",
                          ]);
     this._registerStateListeners(room);
     return room;

--- a/src/sync.js
+++ b/src/sync.js
@@ -119,12 +119,14 @@ SyncApi.prototype.createRoom = function(roomId) {
     const {
         timelineSupport,
         unstableClientRelationAggregation,
+        unstableClientRelationReplacements,
     } = client;
     const room = new Room(roomId, client, client.getUserId(), {
         lazyLoadMembers: this.opts.lazyLoadMembers,
         pendingEventOrdering: this.opts.pendingEventOrdering,
         timelineSupport,
         unstableClientRelationAggregation,
+        unstableClientRelationReplacements,
     });
     client.reEmitter.reEmit(room, ["Room.name", "Room.timeline", "Room.redaction",
                           "Room.receipt", "Room.tags",


### PR DESCRIPTION
Initial support for m.replace relationships. Doesn't do local echo yet, and only works if the original event is received before the replacements (e.g. like through sync). Follow-up PRs to follow.

https://github.com/vector-im/riot-web/issues/9671

Accompanying react-sdk PR: https://github.com/matrix-org/matrix-react-sdk/pull/2952