### PR TITLE
Message editing: mark original event as replaced instead of replacing the event object

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -244,31 +244,6 @@ EventTimelineSet.prototype.findEventById = function(eventId) {
 };
 
 /**
- * Find an event by id which is stored in our timelines and replace it with a new event
- *
- * @param {string} eventId  event ID to look for
- * @param {string} newEvent the event to replace with
- * @return {?module:models/event~MatrixEvent} the replaced event, or undefined if unknown
- */
-EventTimelineSet.prototype.tryReplaceEvent = function(eventId, newEvent) {
-    // we can't use this._eventIdToTimeline here to find the matching timeline
-    // because we need to match the original event id,
-    // which might have been replaced by a previous m.replace already.
-    // for now, loop through all timelines. Maybe a separate index would be justifyable.
-    let oldEvent;
-    for(const tl of this._timelines) {
-        oldEvent = tl.tryReplaceEvent(eventId, newEvent);
-        if (oldEvent) {
-            break;
-        }
-    }
-    if (oldEvent) {
-        this.replaceEventId(oldEvent.getId(), newEvent.getId());
-        return oldEvent;
-    }
-};
-
-/**
  * Add a new timeline to this timeline list
  *
  * @return {module:models/event-timeline~EventTimeline} newly-created timeline

--- a/src/models/event-timeline.js
+++ b/src/models/event-timeline.js
@@ -339,27 +339,6 @@ EventTimeline.prototype.addEvent = function(event, atStart) {
     }
 };
 
-
-/**
- * Replaces an event in the timeline, if it exists.
- *
- * @param {string} eventId  the id of the existing event
- * @param {boolean} newEvent  the new event
- * @return {MatrixEvent?} the old event, if found and replaced.
- */
-EventTimeline.prototype.tryReplaceEvent = function(eventId, newEvent) {
-    const eventIndex = this._events.findIndex(event => event.getOriginalId() === eventId);
-    if (eventIndex === -1) {
-        return;
-    }
-    const oldEvent = this._events[eventIndex];
-    this._events[eventIndex] = newEvent;
-    // copy over metadata, as we don't hold state for random locations in the timeline, only for the end or start
-    // and assuming for now that replacing an event doesn't change the sender that should be shown.
-    newEvent.sender = oldEvent.sender;
-    return oldEvent;
-};
-
 /**
  * Static helper method to set sender and target properties
  *

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -226,13 +226,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {Object} The event content JSON, or an empty object.
      */
     getContent: function() {
-        const content = this._clearEvent.content || this.event.content || {};
-        if (this._replacingEvent) {
-            const newContent = this._replacingEvent.getContent()["m.new_content"];
-            return Object.assign({}, newContent, content["m.relates_to"]);
-        } else {
-            return content;
-        }
+        return this._clearEvent.content || this.event.content || {};
     },
 
     /**
@@ -764,6 +758,13 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         if (this.isRedacted()) {
             return;
         }
+        const oldContent = this.getContent();
+        const newContent = newEvent.getContent()["m.new_content"];
+        // need to always replace m.relates_to with the old one,
+        // even if there is none, as the m.replace relation should
+        // not be exposed on the target event m.relates_to (that's what the server does).
+        Object.assign(oldContent, newContent,
+            {"m.relates_to": oldContent["m.relates_to"]});
         this._replacingEvent = newEvent;
     },
 

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -758,6 +758,10 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         if (this.isRedacted()) {
             return;
         }
+        if (newEvent.isBeingDecrypted()) {
+            throw new Error("Trying to replace event when " +
+                "new content hasn't been decrypted yet");
+        }
         const oldContent = this.getContent();
         const newContent = newEvent.getContent()["m.new_content"];
         // need to always replace m.relates_to with the old one,

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -761,6 +761,9 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @param {MatrixEvent} newEvent the event with the replacing content.
      */
     makeReplaced(newEvent) {
+        if (this.isRedacted()) {
+            return;
+        }
         this._replacingEvent = newEvent;
     },
 

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -758,6 +758,10 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         if (this.isRedacted()) {
             return;
         }
+        // ignore previous replacements
+        if (this._replacingEvent && this._replacingEvent.getTs() > newEvent.getTs()) {
+            return;
+        }
         if (newEvent.isBeingDecrypted()) {
             throw new Error("Trying to replace event when " +
                 "new content hasn't been decrypted yet");

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -747,7 +747,9 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {boolean}
      */
     isRelation(relType = undefined) {
-        const content = this.getContent();
+        // must use event.content as m.relates_to is not encrypted
+        // and _clearEvent doesn't have it.
+        const content = this.event.content;
         const relation = content && content["m.relates_to"];
         return relation && relation.rel_type && relation.event_id &&
             ((relType && relation.rel_type === relType) || !relType);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1038,8 +1038,16 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
         const replacedId = relatesTo && relatesTo.event_id;
         const replacedEvent = this.getUnfilteredTimelineSet().findEventById(replacedId);
         if (replacedEvent) {
-            replacedEvent.makeReplaced(event);
-            this.emit("Room.replaceEvent", replacedEvent, this);
+            const doAndEmitReplacement = () => {
+                replacedEvent.makeReplaced(event);
+                this.emit("Room.replaceEvent", replacedEvent, this);
+            };
+
+            if (event.isBeingDecrypted()) {
+                event.once("Event.decrypted", doAndEmitReplacement);
+            } else {
+                doAndEmitReplacement();
+            }
         }
     }
 


### PR DESCRIPTION
this is more in line with what happens on the server-side,
and also doesn't break existing reply relations,
and is a simpler approach as well.