### PR TITLE
Do not try to request thumbnails with non-integer sizes

### DIFF
--- a/src/content-repo.js
+++ b/src/content-repo.js
@@ -51,10 +51,10 @@ module.exports = {
         const params = {};
 
         if (width) {
-            params.width = width;
+            params.width = Math.round(width);
         }
         if (height) {
-            params.height = height;
+            params.height = Math.round(height);
         }
         if (resizeMethod) {
             params.method = resizeMethod;


### PR DESCRIPTION
Issue described in: https://github.com/vector-im/riot-web/issues/9690

matrix-react-sdk was patched separately, so that it won't call `mxcUrlToHttp()`
(and in turn `getHttpUriForMxc()`) with non-integer sizes.

This patch fixes the JS SDK as well, hoping to prevent the same issue
from happening on other clients (besides matrix-react-sdk / riot-web).

Signed-off-by: Slavi Pantaleev <slavi@devture.com>