### PR TITLE
fix(login): saves access_token and user_id after login for all login types

### DIFF
--- a/spec/unit/login.spec.js
+++ b/spec/unit/login.spec.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+import TestClient from '../TestClient';
+
+describe('Login request', function() {
+    let client;
+
+    beforeEach(function() {
+        client = new TestClient();
+    });
+
+    afterEach(function() {
+        client.stop();
+    });
+
+    it('should store "access_token" and "user_id" if found in response', async function() {
+        const response = { user_id: 1, access_token: Date.now().toString(16) };
+
+        client.httpBackend.when('POST', '/login').respond(200, response);
+        client.httpBackend.flush('/login', 1, 100);
+        await client.client.login('m.login.any', { user: 'test', password: '12312za' });
+
+        expect(client.client.getAccessToken()).toBe(response.access_token);
+        expect(client.client.getUserId()).toBe(response.user_id);
+    });
+});

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -263,8 +263,7 @@ MatrixBaseApis.prototype.login = function(loginType, data, callback) {
 
     return this._http.authedRequest(
         (error, response) => {
-            if (loginType === "m.login.password" && response &&
-                response.access_token && response.user_id) {
+            if (response && response.access_token && response.user_id) {
                 this._http.opts.accessToken = response.access_token;
                 this.credentials = {
                     userId: response.user_id,


### PR DESCRIPTION
Signed-off-by: Sergii Stotskyi <sergiy.stotskiy@gmail.com>

Fixes #876