### PR TITLE
Disable guard-for-in rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
         // rules we do not want from the google styleguide
         "object-curly-spacing": ["off"],
         "spaced-comment": ["off"],
+        "guard-for-in": ["off"],
 
         // in principle we prefer single quotes, but life is too short
         quotes: ["off"],


### PR DESCRIPTION
The Google code style config for ESLint turns on `guard-for-in` to require
for-in loops to check own properties. This makes it annoying to iterate objects,
and we seem to disable the rule by line comments when it comes up anyway, so
this just disables it globally.