### PR TITLE
Refresh safe room versions when the server looks more modern than us

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -448,13 +448,14 @@ MatrixClient.prototype.setNotifTimelineSet = function(notifTimelineSet) {
 /**
  * Gets the capabilities of the homeserver. Always returns an object of
  * capability keys and their options, which may be empty.
+ * @param {boolean} fresh True to ignore any cached values.
  * @return {module:client.Promise} Resolves to the capabilities of the homeserver
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixClient.prototype.getCapabilities = function() {
+MatrixClient.prototype.getCapabilities = function(fresh=false) {
     const now = new Date().getTime();
 
-    if (this._cachedCapabilities) {
+    if (this._cachedCapabilities && !fresh) {
         if (now < this._cachedCapabilities.expiration) {
             logger.log("Returning cached capabilities");
             return Promise.resolve(this._cachedCapabilities.capabilities);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -263,6 +263,33 @@ Room.prototype.getRecommendedVersion = async function() {
         }
     }
 
+    let result = this._checkVersionAgainstCapability(versionCap);
+    if (result.urgent && result.needsUpgrade) {
+        // Something doesn't feel right: we shouldn't need to update
+        // because the version we're on should be in the protocol's
+        // namespace. This usually means that the server was updated
+        // before the client was, making us think the newest possible
+        // room version is not stable. As a solution, we'll refresh
+        // the capability we're using to determine this.
+        logger.warn(
+            "Refreshing room version capability because the server looks " +
+            "to be supporting a newer room version we don't know about.",
+        );
+
+        const caps = await this._client.getCapabilities(true);
+        if (!caps) {
+            logger.warn("No server capabilities - assuming upgrade needed");
+            return result;
+        } else {
+            versionCap = caps["m.room_versions"];
+            result = this._checkVersionAgainstCapability(versionCap);
+        }
+    }
+
+    return result;
+};
+
+Room.prototype._checkVersionAgainstCapability = function(versionCap) {
     const currentVersion = this.getVersion();
     logger.log(`[${this.roomId}] Current version: ${currentVersion}`);
     logger.log(`[${this.roomId}] Version capability: `, versionCap);
@@ -291,12 +318,12 @@ Room.prototype.getRecommendedVersion = async function() {
         } else {
             logger.warn(`Non-urgent upgrade required on ${this.roomId}`);
         }
-        return Promise.resolve(result);
+        return result;
     }
 
     // The room is on a stable, but non-default, version by this point.
     // No upgrade needed.
-    return Promise.resolve(result);
+    return result;
 };
 
 /**

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -277,11 +277,11 @@ Room.prototype.getRecommendedVersion = async function() {
         );
 
         const caps = await this._client.getCapabilities(true);
-        if (!caps) {
-            logger.warn("No server capabilities - assuming upgrade needed");
+        versionCap = caps["m.room_versions"];
+        if (!versionCap) {
+            logger.warn("No room version capability - assuming upgrade required.");
             return result;
         } else {
-            versionCap = caps["m.room_versions"];
             result = this._checkVersionAgainstCapability(versionCap);
         }
     }
@@ -301,7 +301,7 @@ Room.prototype._checkVersionAgainstCapability = function(versionCap) {
     };
 
     // If the room is on the default version then nothing needs to change
-    if (currentVersion === versionCap.default) return Promise.resolve(result);
+    if (currentVersion === versionCap.default) return result;
 
     const stableVersions = Object.keys(versionCap.available)
         .filter((v) => versionCap.available[v] === 'stable');


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9845