### PR TITLE
Add v4 as a safe room version

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -39,7 +39,7 @@ import ReEmitter from '../ReEmitter';
 // to upgrade (ie: "stable"). Eventually, we should remove these when all homeservers
 // return an m.room_versions capability.
 const KNOWN_SAFE_ROOM_VERSION = '1';
-const SAFE_ROOM_VERSIONS = ['1', '2', '3'];
+const SAFE_ROOM_VERSIONS = ['1', '2', '3', '4'];
 
 function synthesizeReceipt(userId, event, receiptType) {
     // console.log("synthesizing receipt for "+event.getId());


### PR DESCRIPTION
It's listed as stable in the spec, and this is for our fallback.