### PR TITLE
add missing logger

### DIFF
--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -21,6 +21,7 @@ limitations under the License.
 
 import {MatrixEvent} from '../../models/event';
 import {EventEmitter} from 'events';
+import logger from '../../logger';
 
 export default class VerificationBase extends EventEmitter {
     /**


### PR DESCRIPTION
#939 adds a use of `logger`, but `logger` wasn't imported into that file.  This PR fixes that.