### PR TITLE
Fix backup sig validation with multiple sigs

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -371,7 +371,9 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
             try {
                 await olmlib.verifySignature(
                     this._olmDevice,
-                    backupInfo.auth_data,
+                    // verifySignature modifies the object so we need to copy
+                    // if we verify more than one sig
+                    Object.assign({}, backupInfo.auth_data),
                     this._userId,
                     device.deviceId,
                     device.getFingerprint(),


### PR DESCRIPTION
verifySignature modifies the object so we need to clone if we're
verifying more than one signature.

Fixes https://github.com/vector-im/riot-web/issues/9357