### PR TITLE
 Support redactions and relations of/with unsent events.

### DIFF
--- a/spec/unit/scheduler.spec.js
+++ b/spec/unit/scheduler.spec.js
@@ -105,8 +105,7 @@ describe("MatrixScheduler", function() {
         });
 
         scheduler.queueEvent(eventA);
-        // as queueing doesn't start processing
-        // synchronously anymore (see commit bbdb5ac)
+        // as queueing doesn't start processing synchronously anymore (see commit bbdb5ac)
         // wait just long enough before it does
         await Promise.resolve();
         expect(procCount).toEqual(1);
@@ -147,8 +146,7 @@ describe("MatrixScheduler", function() {
 
         const globalA = scheduler.queueEvent(eventA);
         scheduler.queueEvent(eventB);
-        // as queing doesn't start processing
-        // synchronously anymore (see commit bbdb5ac)
+        // as queueing doesn't start processing synchronously anymore (see commit bbdb5ac)
         // wait just long enough before it does
         await Promise.resolve();
         expect(procCount).toEqual(1);
@@ -310,8 +308,7 @@ describe("MatrixScheduler", function() {
                 expect(ev).toEqual(eventA);
                 return defer.promise;
             });
-            // as queueing doesn't start processing
-            // synchronously anymore (see commit bbdb5ac)
+            // as queueing doesn't start processing synchronously anymore (see commit bbdb5ac)
             // wait just long enough before it does
             Promise.resolve().then(() => {
                 expect(procCount).toEqual(1);

--- a/spec/unit/scheduler.spec.js
+++ b/spec/unit/scheduler.spec.js
@@ -48,7 +48,7 @@ describe("MatrixScheduler", function() {
         clock.uninstall();
     });
 
-    it("should process events in a queue in a FIFO manner", function(done) {
+    it("should process events in a queue in a FIFO manner", async function() {
         retryFn = function() {
             return 0;
         };
@@ -57,28 +57,30 @@ describe("MatrixScheduler", function() {
         };
         const deferA = Promise.defer();
         const deferB = Promise.defer();
-        let resolvedA = false;
+        let yieldedA = false;
         scheduler.setProcessFunction(function(event) {
-            if (resolvedA) {
+            if (yieldedA) {
                 expect(event).toEqual(eventB);
                 return deferB.promise;
             } else {
+                yieldedA = true;
                 expect(event).toEqual(eventA);
                 return deferA.promise;
             }
         });
-        scheduler.queueEvent(eventA);
-        scheduler.queueEvent(eventB).done(function() {
-            expect(resolvedA).toBe(true);
-            done();
-        });
-        deferA.resolve({});
-        resolvedA = true;
-        deferB.resolve({});
+        const abPromise = Promise.all([
+            scheduler.queueEvent(eventA),
+            scheduler.queueEvent(eventB),
+        ]);
+        deferB.resolve({b: true});
+        deferA.resolve({a: true});
+        const [a, b] = await abPromise;
+        expect(a.a).toEqual(true);
+        expect(b.b).toEqual(true);
     });
 
     it("should invoke the retryFn on failure and wait the amount of time specified",
-    function(done) {
+    async function() {
         const waitTimeMs = 1500;
         const retryDefer = Promise.defer();
         retryFn = function() {
@@ -97,24 +99,27 @@ describe("MatrixScheduler", function() {
                 return defer.promise;
             } else if (procCount === 2) {
                 // don't care about this defer
-                return Promise.defer().promise;
+                return new Promise();
             }
             expect(procCount).toBeLessThan(3);
         });
 
         scheduler.queueEvent(eventA);
+        // as queing doesn't start processing
+        // synchronously anymore (see commit bbdb5ac)
+        // wait just long enough before it does
+        await Promise.resolve();
         expect(procCount).toEqual(1);
         defer.reject({});
-        retryDefer.promise.done(function() {
-            expect(procCount).toEqual(1);
-            clock.tick(waitTimeMs);
-            expect(procCount).toEqual(2);
-            done();
-        });
+        await retryDefer.promise;
+        expect(procCount).toEqual(1);
+        clock.tick(waitTimeMs);
+        await Promise.resolve();
+        expect(procCount).toEqual(2);
     });
 
     it("should give up if the retryFn on failure returns -1 and try the next event",
-    function(done) {
+    async function() {
         // Queue A & B.
         // Reject A and return -1 on retry.
         // Expect B to be tried next and the promise for A to be rejected.
@@ -122,8 +127,8 @@ describe("MatrixScheduler", function() {
             return -1;
         };
         queueFn = function() {
- return "yep";
-};
+            return "yep";
+        };
 
         const deferA = Promise.defer();
         const deferB = Promise.defer();
@@ -142,13 +147,18 @@ describe("MatrixScheduler", function() {
 
         const globalA = scheduler.queueEvent(eventA);
         scheduler.queueEvent(eventB);
-
+        // as queing doesn't start processing
+        // synchronously anymore (see commit bbdb5ac)
+        // wait just long enough before it does
+        await Promise.resolve();
         expect(procCount).toEqual(1);
         deferA.reject({});
-        globalA.catch(function() {
+        try {
+            await globalA;
+        } catch(err) {
+            await Promise.resolve();
             expect(procCount).toEqual(2);
-            done();
-        });
+        }
     });
 
     it("should treat each queue separately", function(done) {
@@ -300,7 +310,12 @@ describe("MatrixScheduler", function() {
                 expect(ev).toEqual(eventA);
                 return defer.promise;
             });
-            expect(procCount).toEqual(1);
+            // as queing doesn't start processing
+            // synchronously anymore (see commit bbdb5ac)
+            // wait just long enough before it does
+            Promise.resolve().then(() => {
+                expect(procCount).toEqual(1);
+            });
         });
 
         it("should not call the processFn if there are no queued events", function() {

--- a/spec/unit/scheduler.spec.js
+++ b/spec/unit/scheduler.spec.js
@@ -105,7 +105,7 @@ describe("MatrixScheduler", function() {
         });
 
         scheduler.queueEvent(eventA);
-        // as queing doesn't start processing
+        // as queueing doesn't start processing
         // synchronously anymore (see commit bbdb5ac)
         // wait just long enough before it does
         await Promise.resolve();

--- a/spec/unit/scheduler.spec.js
+++ b/spec/unit/scheduler.spec.js
@@ -310,7 +310,7 @@ describe("MatrixScheduler", function() {
                 expect(ev).toEqual(eventA);
                 return defer.promise;
             });
-            // as queing doesn't start processing
+            // as queueing doesn't start processing
             // synchronously anymore (see commit bbdb5ac)
             // wait just long enough before it does
             Promise.resolve().then(() => {

--- a/src/client.js
+++ b/src/client.js
@@ -1898,7 +1898,7 @@ function _sendEventHttpRequest(client, event) {
             pathTemplate = "/rooms/$roomId/state/$eventType/$stateKey";
         }
         path = utils.encodeUri(pathTemplate, pathParams);
-    } else if (event.getType() === "m.room.redaction") {
+    } else if (event.isRedaction()) {
         const pathTemplate = `/rooms/$roomId/redact/$redactsEventId/$txnId`;
         path = utils.encodeUri(pathTemplate, Object.assign({
             $redactsEventId: event.event.redacts,

--- a/src/client.js
+++ b/src/client.js
@@ -1730,11 +1730,11 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
     }));
 
     const room = this.getRoom(roomId);
-    const targetId = localEvent.getTargetId();
+    const targetId = localEvent.getRelatedId();
     if (targetId && targetId.startsWith("~")) {
         const target = room.getPendingEvents().find(e => e.getId() === targetId);
         target.once("Event.localEventIdReplaced", () => {
-            localEvent.updateTargetId(target.getId());
+            localEvent.updateRelatedId(target.getId());
         });
     }
     const type = localEvent.getType();

--- a/src/client.js
+++ b/src/client.js
@@ -1742,6 +1742,7 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
             localEvent.updateAssociatedId(target.getId());
         });
     }
+
     const type = localEvent.getType();
     logger.log(`sendEvent of type ${type} in ${roomId} with txnId ${txnId}`);
 

--- a/src/client.js
+++ b/src/client.js
@@ -1730,6 +1730,11 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
     }));
 
     const room = this.getRoom(roomId);
+
+    // if this is a relation or redaction of an event
+    // that hasn't been sent yet (e.g. with a local id starting with a ~)
+    // then listen for the remote echo of that event so that by the time
+    // this event does get sent, we have the correct event_id
     const targetId = localEvent.getRelatedId();
     if (targetId && targetId.startsWith("~")) {
         const target = room.getPendingEvents().find(e => e.getId() === targetId);

--- a/src/client.js
+++ b/src/client.js
@@ -1735,11 +1735,11 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
     // that hasn't been sent yet (e.g. with a local id starting with a ~)
     // then listen for the remote echo of that event so that by the time
     // this event does get sent, we have the correct event_id
-    const targetId = localEvent.getRelatedId();
+    const targetId = localEvent.getAssociatedId();
     if (targetId && targetId.startsWith("~")) {
         const target = room.getPendingEvents().find(e => e.getId() === targetId);
         target.once("Event.localEventIdReplaced", () => {
-            localEvent.updateRelatedId(target.getId());
+            localEvent.updateAssociatedId(target.getId());
         });
     }
     const type = localEvent.getType();

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -20,6 +20,7 @@ limitations under the License.
 const EventEmitter = require("events").EventEmitter;
 const utils = require("../utils");
 const EventTimeline = require("./event-timeline");
+import {EventStatus} from "./event";
 import logger from '../../src/logger';
 import Relations from './relations';
 
@@ -749,7 +750,7 @@ EventTimelineSet.prototype.aggregateRelations = function(event) {
         return;
     }
 
-    if (event.isRedacted()) {
+    if (event.isRedacted() || event.status === EventStatus.CANCELLED) {
         return;
     }
 

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -749,6 +749,10 @@ EventTimelineSet.prototype.aggregateRelations = function(event) {
         return;
     }
 
+    if (event.isRedacted()) {
+        return;
+    }
+
     // If the event is currently encrypted, wait until it has been decrypted.
     if (event.isBeingDecrypted()) {
         event.once("Event.decrypted", () => {

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -788,8 +788,11 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         const oldUnsigned = this.getUnsigned();
         const oldId = this.getId();
         this.event = event;
-        // keep being redacted if
-        // the event was redacted as a local echo
+        // if this event was redacted before it was sent, it's locally marked as redacted.
+        // At this point, we've received the remote echo for the event, but not yet for
+        // the redaction that we are sending ourselves. Preserve the locally redacted
+        // state by copying over redacted_because so we don't get a flash of
+        // redacted, not-redacted, redacted as remote echos come in
         if (oldUnsigned.redacted_because) {
             if (!this.event.unsigned) {
                 this.event.unsigned = {};

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -922,6 +922,15 @@ utils.extend(module.exports.MatrixEvent.prototype, {
     },
 
     /**
+     * Checks if this event is associated with another event. See `getAssociatedId`.
+     *
+     * @return {bool}
+     */
+    hasAssocation() {
+        return !!this.getAssociatedId();
+    },
+
+    /**
      * Update the related id with a new one.
      *
      * Used to replace a local id with remote one before sending

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -881,8 +881,12 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         return this._replacingEvent;
     },
 
-
-    getTargetId() {
+    /**
+     * For relations and redactions, returns the event_id this event is referring to.
+     *
+     * @return {string?}
+     */
+    getRelatedId() {
         const relation = this.getRelation();
         if (relation) {
             return relation.event_id;
@@ -891,7 +895,15 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         }
     },
 
-    updateTargetId(eventId) {
+    /**
+     * Update the related id with a new one.
+     *
+     * Used to replace a local id with remote one before sending
+     * an event with a related id.
+     *
+     * @param {string} eventId the new event id
+     */
+    updateRelatedId(eventId) {
         const relation = this.getRelation();
         if (relation) {
             relation.event_id = eventId;

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -776,9 +776,23 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @param {Object} event the object to assign to the `event` property
      */
     handleRemoteEcho: function(event) {
+        const oldUnsigned = this.getUnsigned();
+        const oldId = this.getId();
         this.event = event;
+        // keep being redacted if
+        // the event was redacted as a local echo
+        if (oldUnsigned.redacted_because) {
+            if (!this.event.unsigned) {
+                this.event.unsigned = {};
+            }
+            this.event.unsigned.redacted_because = oldUnsigned.redacted_because;
+        }
         // successfully sent.
         this.setStatus(null);
+        if (this.getId() !== oldId) {
+            // emit the event if it changed
+            this.emit("Event.localEventIdReplaced", this);
+        }
     },
 
     /**

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -754,6 +754,15 @@ utils.extend(module.exports.MatrixEvent.prototype, {
     },
 
     /**
+     * Check if this event is a redaction of another event
+     *
+     * @return {boolean} True if this event is a redaction
+     */
+    isRedaction: function() {
+        return this.getType() === "m.room.redaction";
+    },
+
+    /**
      * Get the push actions, if known, for this event
      *
      * @return {?Object} push actions
@@ -904,7 +913,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         const relation = this.getRelation();
         if (relation) {
             return relation.event_id;
-        } else if (this.getType() === "m.room.redaction") {
+        } else if (this.isRedaction()) {
             return this.event.redacts;
         }
     },
@@ -921,7 +930,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         const relation = this.getRelation();
         if (relation) {
             relation.event_id = eventId;
-        } else if (this.getType() === "m.room.redaction") {
+        } else if (this.isRedaction()) {
             this.event.redacts = eventId;
         }
     },

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -801,6 +801,11 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         this.emit("Event.status", this, status);
     },
 
+    replaceLocalEventId(eventId) {
+        this.event.event_id = eventId;
+        this.emit("Event.localEventIdReplaced", this);
+    },
+
     /**
      * Get whether the event is a relation event, and of a given type if
      * `relType` is passed in.
@@ -874,6 +879,25 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      */
     replacingEvent() {
         return this._replacingEvent;
+    },
+
+
+    getTargetId() {
+        const relation = this.getRelation();
+        if (relation) {
+            return relation.event_id;
+        } else if (this.getType() === "m.room.redaction") {
+            return this.event.redacts;
+        }
+    },
+
+    updateTargetId(eventId) {
+        const relation = this.getRelation();
+        if (relation) {
+            relation.event_id = eventId;
+        } else if (this.getType() === "m.room.redaction") {
+            this.event.redacts = eventId;
+        }
     },
 
     /**

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -900,7 +900,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      *
      * @return {string?}
      */
-    getRelatedId() {
+    getAssociatedId() {
         const relation = this.getRelation();
         if (relation) {
             return relation.event_id;
@@ -917,7 +917,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      *
      * @param {string} eventId the new event id
      */
-    updateRelatedId(eventId) {
+    updateAssociatedId(eventId) {
         const relation = this.getRelation();
         if (relation) {
             relation.event_id = eventId;

--- a/src/models/relations.js
+++ b/src/models/relations.js
@@ -242,12 +242,7 @@ export default class Relations extends EventEmitter {
 
         redactedEvent.removeListener("Event.beforeRedaction", this._onBeforeRedaction);
 
-        // Dispatch a redaction event on this collection. `setTimeout` is used
-        // to wait until the next event loop iteration by which time the event
-        // has actually been marked as redacted.
-        setTimeout(() => {
-            this.emit("Relations.redaction");
-        }, 0);
+        this.emit("Relations.redaction");
     }
 
     /**

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1356,7 +1356,10 @@ Room.prototype._revertRedactionLocalEcho = function(redactionEvent) {
         // re-render after undoing redaction
         this.emit("Room.redactionCancelled", redactionEvent, this);
         // reapply relation now redaction failed
-        if (redactedEvent.isRelation()) {
+        if (
+            redactedEvent.isRelation() &&
+            redactedEvent.status !== EventStatus.CANCELLED
+        ) {
             this._aggregateNonLiveRelation(redactedEvent);
         }
     }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1032,7 +1032,7 @@ Room.prototype.removeFilteredTimelineSet = function(filter) {
  * @private
  */
 Room.prototype._addLiveEvent = function(event, duplicateStrategy) {
-    if (event.getType() === "m.room.redaction") {
+    if (event.isRedaction()) {
         const redactId = event.event.redacts;
 
         // if we know about this event, redact its contents now.
@@ -1141,7 +1141,7 @@ Room.prototype.addPendingEvent = function(event, txnId) {
             this._aggregateNonLiveRelation(event);
         }
 
-        if (event.getType() === "m.room.redaction") {
+        if (event.isRedaction()) {
             const redactId = event.event.redacts;
             let redactedEvent = this._pendingEventList &&
                 this._pendingEventList.find(e => e.getId() === redactId);
@@ -1333,7 +1333,7 @@ Room.prototype.updatePendingEvent = function(event, newStatus, newEventId) {
             const idx = this._pendingEventList.findIndex(ev => ev.getId() === oldEventId);
             if (idx !== -1) {
                 const [removedEvent] = this._pendingEventList.splice(idx, 1);
-                if (removedEvent.getType() === "m.room.redaction") {
+                if (removedEvent.isRedaction()) {
                     this._revertRedactionLocalEcho(removedEvent);
                 }
             }
@@ -1442,7 +1442,7 @@ Room.prototype.removeEvent = function(eventId) {
     for (let i = 0; i < this._timelineSets.length; i++) {
         const removed = this._timelineSets[i].removeEvent(eventId);
         if (removed) {
-            if (removed.getType() === "m.room.redaction") {
+            if (removed.isRedaction()) {
                 this._revertRedactionLocalEcho(removed);
             }
             removedAny = true;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1356,10 +1356,7 @@ Room.prototype._revertRedactionLocalEcho = function(redactionEvent) {
         // re-render after undoing redaction
         this.emit("Room.redactionCancelled", redactionEvent, this);
         // reapply relation now redaction failed
-        if (
-            redactedEvent.isRelation() &&
-            redactedEvent.status !== EventStatus.CANCELLED
-        ) {
+        if (redactedEvent.isRelation()) {
             this._aggregateNonLiveRelation(redactedEvent);
         }
     }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1318,7 +1318,7 @@ Room.prototype.updatePendingEvent = function(event, newStatus, newEventId) {
 
     if (newStatus == EventStatus.SENT) {
         // update the event id
-        event.event.event_id = newEventId;
+        event.replaceLocalEventId(newEventId);
 
         // if the event was already in the timeline (which will be the case if
         // opts.pendingEventOrdering==chronological), we need to update the

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1215,7 +1215,7 @@ Room.prototype._handleRemoteEcho = function(remoteEvent, localEvent) {
     const oldStatus = localEvent.status;
 
     // no longer pending
-    delete this._txnToEvent[remoteEvent.transaction_id];
+    delete this._txnToEvent[remoteEvent.getUnsigned().transaction_id];
 
     // if it's in the pending list, remove it
     if (this._pendingEventList) {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1143,7 +1143,10 @@ Room.prototype.addPendingEvent = function(event, txnId) {
 
         if (event.getType() === "m.room.redaction") {
             const redactId = event.event.redacts;
-            const redactedEvent = this.getUnfilteredTimelineSet().findEventById(redactId);
+            let redactedEvent = this._pendingEventList && this._pendingEventList.find(e => e.getId() === redactId);
+            if (!redactedEvent) {
+                redactedEvent = this.getUnfilteredTimelineSet().findEventById(redactId);
+            }
             if (redactedEvent) {
                 redactedEvent.markLocallyRedacted(event);
                 this.emit("Room.redaction", event, this);

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1143,7 +1143,8 @@ Room.prototype.addPendingEvent = function(event, txnId) {
 
         if (event.getType() === "m.room.redaction") {
             const redactId = event.event.redacts;
-            let redactedEvent = this._pendingEventList && this._pendingEventList.find(e => e.getId() === redactId);
+            let redactedEvent = this._pendingEventList &&
+                this._pendingEventList.find(e => e.getId() === redactId);
             if (!redactedEvent) {
                 redactedEvent = this.getUnfilteredTimelineSet().findEventById(redactId);
             }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -177,7 +177,8 @@ MatrixScheduler.RETRY_BACKOFF_RATELIMIT = function(event, attempts, err) {
  * @see module:scheduler~queueAlgorithm
  */
 MatrixScheduler.QUEUE_MESSAGES = function(event) {
-    if (event.getType() === "m.room.message" || !!event.getRelatedId()) {
+    // enqueue messages or events that associate with another event (redactions and relations)
+    if (event.getType() === "m.room.message" || !!event.getAssociatedId()) {
         // put these events in the 'message' queue.
         return "message";
     }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -178,7 +178,7 @@ MatrixScheduler.RETRY_BACKOFF_RATELIMIT = function(event, attempts, err) {
  */
 MatrixScheduler.QUEUE_MESSAGES = function(event) {
     // enqueue messages or events that associate with another event (redactions and relations)
-    if (event.getType() === "m.room.message" || !!event.getAssociatedId()) {
+    if (event.getType() === "m.room.message" || event.hasAssocation()) {
         // put these events in the 'message' queue.
         return "message";
     }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -177,7 +177,7 @@ MatrixScheduler.RETRY_BACKOFF_RATELIMIT = function(event, attempts, err) {
  * @see module:scheduler~queueAlgorithm
  */
 MatrixScheduler.QUEUE_MESSAGES = function(event) {
-    if (event.getType() === "m.room.message") {
+    if (event.getType() === "m.room.message" || !!event.getTargetId()) {
         // put these events in the 'message' queue.
         return "message";
     }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -177,7 +177,7 @@ MatrixScheduler.RETRY_BACKOFF_RATELIMIT = function(event, attempts, err) {
  * @see module:scheduler~queueAlgorithm
  */
 MatrixScheduler.QUEUE_MESSAGES = function(event) {
-    if (event.getType() === "m.room.message" || !!event.getTargetId()) {
+    if (event.getType() === "m.room.message" || !!event.getRelatedId()) {
         // put these events in the 'message' queue.
         return "message";
     }


### PR DESCRIPTION
PR does several things to make this work:
 - fix scheduler assigning queue for redactions and relations
 - ensure queued relations and redactions to an unsent target have their local id replaced with a remote id before being sent:
    - have one method to return the related id for redactions and relations (getRelatedId) on Event
    - emit event on MatrixEvent once remote id is known
    - make the scheduler start sending a new event asynchronously, so the above code gets a chance to run before the next event is sent. (not entirely happy with this, we're relying on async implementation details that make this work, suggestions welcome)
 - preserve the locally redacted state when receiving the remote echo
 - don't re-add a locally redacted reaction when receiving remote echo

Hammering the react button now works as expected with local echo:
![hammertime2](https://user-images.githubusercontent.com/274386/59335066-5bfcad00-8ceb-11e9-9780-be84d5646f99.gif)


Part of: https://github.com/vector-im/riot-web/issues/9860
Fixes: https://github.com/vector-im/riot-web/issues/10034