### PR TITLE
Remove check for `file.stream` in HttpApi.uploadContent

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -165,10 +165,6 @@ module.exports.MatrixHttpApi.prototype = {
         const contentType = opts.type || file.type || 'application/octet-stream';
         const fileName = opts.name || file.name;
 
-        // we used to recommend setting file.stream to the thing to upload on
-        // nodejs.
-        const body = file.stream ? file.stream : file;
-
         // backwards-compatibility hacks where we used to do different things
         // between browser and node.
         let rawResponse = opts.rawResponse;


### PR DESCRIPTION
This fixes an incompatibility with the latest draft of the W3C File API and fixes #949, which is related to vector-im/riot-web#9924 and makes progress towards closing that issue. I believe simply removing these lines is reasonable, as the functionality they implement is undocumented.

Signed-off-by: Katie Wolfe <katie@dnaf.moe>