### PR TITLE
Don't overlap auth submissions with polls

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -49,11 +49,11 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  * @param {object?} opts.authData error response from the last request. If
  *    null, a request will be made with no auth before starting.
  *
- * @param {function(object?, bool?): module:client.Promise} opts.doRequest
- *     called with the new auth dict to submit the request and a flag set
- *     to true if this request is a background request. Should return a
- *     promise which resolves to the successful response or rejects with a
- *     MatrixError.
+ * @param {function(object?): module:client.Promise} opts.doRequest
+ *     called with the new auth dict to submit the request. Also passes a
+ *     second deprecated arg which is a flag set to true if this request
+ *     is a background request. Should return a promise which resolves
+ *     to the successful response or rejects with a MatrixError.
  *
  * @param {function(bool): module:client.Promise} opts.busyChanged
  *     called whenever the interactive auth logic becomes busy submitting

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -147,9 +147,9 @@ InteractiveAuth.prototype = {
             // if we have no flows, try a request (we'll have
             // just a session ID in _data if resuming)
             if (!this._data.flows) {
-                this._busyChangedCallback(true);
+                if (this._busyChangedCallback) this._busyChangedCallback(true);
                 this._doRequest(this._data).finally(() => {
-                    this._busyChangedCallback(false);
+                    if (this._busyChangedCallback) this._busyChangedCallback(false);
                 });
             } else {
                 this._startNextAuthStage();
@@ -273,7 +273,7 @@ InteractiveAuth.prototype = {
             await this._submitPromise;
         } finally {
             this._submitPromise = null;
-            if (!background) this._busyChangedCallback(false);
+            if (!background && this._busyChangedCallback) this._busyChangedCallback(false);
         }
     },
 

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -52,7 +52,8 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  * @param {function(object?): module:client.Promise} opts.doRequest
  *     called with the new auth dict to submit the request. Also passes a
  *     second deprecated arg which is a flag set to true if this request
- *     is a background request. Should return a promise which resolves
+ *     is a background request. The busyChanged callback should be used
+ *     instead of the backfround flag. Should return a promise which resolves
  *     to the successful response or rejects with a MatrixError.
  *
  * @param {function(bool): module:client.Promise} opts.busyChanged

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -273,7 +273,9 @@ InteractiveAuth.prototype = {
             await this._submitPromise;
         } finally {
             this._submitPromise = null;
-            if (!background && this._busyChangedCallback) this._busyChangedCallback(false);
+            if (!background && this._busyChangedCallback) {
+                this._busyChangedCallback(false);
+            }
         }
     },
 

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -126,7 +126,7 @@ function InteractiveAuth(opts) {
 
     // if we are currently trying to submit an auth dict (which includes polling)
     // the promise the will resolve/reject when it completes
-    this._submitPromise = false;
+    this._submitPromise = null;
 }
 
 InteractiveAuth.prototype = {


### PR DESCRIPTION
Wait for polls to complete before submitting auth dicts, otherwise
we risk the requests overlapping and both returning a 200.

Also introduces a setBusy interface to interactive-auth to explicitly
set the busy status, since otherwise it doesn't get set until the
request actually starts.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/3085