### PR TITLE
Key verification request fixes

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -734,19 +734,19 @@ async function _setDeviceVerification(
  * Request a key verification from another user.
  *
  * @param {string} userId the user to request verification with
- * @param {Array} devices array of device IDs to send requests to.  Defaults to
- *    all devices owned by the user
  * @param {Array} methods array of verification methods to use.  Defaults to
  *    all known methods
+ * @param {Array} devices array of device IDs to send requests to.  Defaults to
+ *    all devices owned by the user
  *
  * @returns {Promise<module:crypto/verification/Base>} resolves to a verifier
  *    when the request is accepted by the other user
  */
-MatrixClient.prototype.requestVerification = function(userId, devices, methods) {
+MatrixClient.prototype.requestVerification = function(userId, methods, devices) {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
-    return this._crypto.requestVerification(userId, devices);
+    return this._crypto.requestVerification(userId, methods, devices);
 };
 
 /**

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1665,6 +1665,11 @@ Crypto.prototype._onKeyVerificationRequest = function(event) {
     }
 
     const sender = event.getSender();
+    if (sender === this._userId && content.from_device === this._deviceId) {
+        // ignore requests from ourselves, because it doesn't make sense for a
+        // device to verify itself
+        return;
+    }
     if (this._verificationTransactions.has(sender)) {
         if (this._verificationTransactions.get(sender).has(content.transaction_id)) {
             // transaction already exists: cancel it and drop the existing
@@ -1717,7 +1722,7 @@ Crypto.prototype._onKeyVerificationRequest = function(event) {
             },
         );
     } else {
-        // notify the application that of the verification request, so it can
+        // notify the application of the verification request, so it can
         // decide what to do with it
         const request = {
             event: event,


### PR DESCRIPTION
- fix requestVerification in MatrixClient to match the function in crypto
  - reorder the arguments so that the arguments actually do what they say they
    do
  - pass through the third argument, which was accidentally omitted
- ignore verification requests from ourselves
- also fix a comment