### PR TITLE
README: clarify protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Then visit ``http://localhost:8005`` to see the API docs.
 End-to-end encryption support
 =============================
 
-The SDK supports end-to-end encryption via the and Megolm protocols, using
+The SDK supports end-to-end encryption via the Megolm protocol, using
 [libolm](https://gitlab.matrix.org/matrix-org/olm). It is left up to the 
 application to make libolm available, via the ``Olm`` global.
 


### PR DESCRIPTION
Olm was removed as a supported protocol in this commit: 3b09ab3ca142a45a9be8d2d393053042ec020104 but the sentence no longer makes sense. Changing the sentence so that it clarifies that Megolm is the only protocol supported.