### PR TITLE
Add flag to force saving sync store

### DIFF
--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -198,11 +198,13 @@ IndexedDBStore.prototype.wantsSave = function() {
 
 /**
  * Possibly write data to the database.
+ *
+ * @param {bool} force True to force a save to happen
  * @return {Promise} Promise resolves after the write completes
  *     (or immediately if no write is performed)
  */
-IndexedDBStore.prototype.save = function() {
-    if (this.wantsSave()) {
+IndexedDBStore.prototype.save = function(force) {
+    if (force || this.wantsSave()) {
         return this._reallySave();
     }
     return Promise.resolve();

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -335,8 +335,10 @@ module.exports.MemoryStore.prototype = {
 
     /**
      * Save does nothing as there is no backing data store.
+     * @param {bool} force True to force a save (but the memory
+     *     store still can't save anything)
      */
-    save: function() {},
+    save: function(force) {},
 
     /**
      * Startup does nothing as this store doesn't require starting up.


### PR DESCRIPTION
Add a 'force' flag to to the save method of the store to force the
store to save its data even if it wouldn't normally.