### PR TITLE
Emit original errcode by default in http-api

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -477,6 +477,8 @@ module.exports.MatrixHttpApi.prototype = {
                     err.message,
                     err.data.consent_uri,
                 );
+            } else {
+                self.event_emitter.emit(err.errcode);
             }
         });
 


### PR DESCRIPTION
In http-api emit the errcode by default.

Please advise if you want an other format of the emitted event.

Signed-off-by: Léo Mora l.mora@outlook.fr