### PR TITLE
Change the known safe room version to version 4

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -38,7 +38,7 @@ import ReEmitter from '../ReEmitter';
 // room versions which are considered okay for people to run without being asked
 // to upgrade (ie: "stable"). Eventually, we should remove these when all homeservers
 // return an m.room_versions capability.
-const KNOWN_SAFE_ROOM_VERSION = '1';
+const KNOWN_SAFE_ROOM_VERSION = '4';
 const SAFE_ROOM_VERSIONS = ['1', '2', '3', '4'];
 
 function synthesizeReceipt(userId, event, receiptType) {


### PR DESCRIPTION
The default room version in the spec is v4 due to widespread adoption. We should mirror that.