### PR TITLE
Include the error object when raising Session.logged_out

### DIFF
--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -302,11 +302,32 @@ describe("MatrixClient events", function() {
         });
 
         it("should emit Session.logged_out on M_UNKNOWN_TOKEN", function() {
-            httpBackend.when("GET", "/sync").respond(401, { errcode: 'M_UNKNOWN_TOKEN' });
+            const error = { errcode: 'M_UNKNOWN_TOKEN' };
+            httpBackend.when("GET", "/sync").respond(401, error);
 
             let sessionLoggedOutCount = 0;
-            client.on("Session.logged_out", function(event, member) {
+            client.on("Session.logged_out", function(errObj) {
                 sessionLoggedOutCount++;
+                expect(errObj).toMatchObject(error);
+            });
+
+            client.startClient();
+
+            return httpBackend.flushAllExpected().then(function() {
+                expect(sessionLoggedOutCount).toEqual(
+                    1, "Session.logged_out fired wrong number of times",
+                );
+            });
+        });
+
+        it("should emit Session.logged_out on M_UNKNOWN_TOKEN (soft logout)", function() {
+            const error = { errcode: 'M_UNKNOWN_TOKEN', soft_logout: true };
+            httpBackend.when("GET", "/sync").respond(401, error);
+
+            let sessionLoggedOutCount = 0;
+            client.on("Session.logged_out", function(errObj) {
+                sessionLoggedOutCount++;
+                expect(errObj).toMatchObject(error);
             });
 
             client.startClient();

--- a/spec/integ/matrix-client-event-emitter.spec.js
+++ b/spec/integ/matrix-client-event-emitter.spec.js
@@ -308,7 +308,7 @@ describe("MatrixClient events", function() {
             let sessionLoggedOutCount = 0;
             client.on("Session.logged_out", function(errObj) {
                 sessionLoggedOutCount++;
-                expect(errObj).toMatchObject(error);
+                expect(errObj.data).toEqual(error);
             });
 
             client.startClient();
@@ -327,7 +327,7 @@ describe("MatrixClient events", function() {
             let sessionLoggedOutCount = 0;
             client.on("Session.logged_out", function(errObj) {
                 sessionLoggedOutCount++;
-                expect(errObj).toMatchObject(error);
+                expect(errObj.data).toEqual(error);
             });
 
             client.startClient();

--- a/src/client.js
+++ b/src/client.js
@@ -4555,7 +4555,7 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * when then login session can be renewed by using a refresh token.
  * @event module:client~MatrixClient#"Session.logged_out"
  * @example
- * matrixClient.on("Session.logged_out", function(call){
+ * matrixClient.on("Session.logged_out", function(errorObj){
  *   // show the login screen
  * });
  */

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -470,7 +470,7 @@ module.exports.MatrixHttpApi.prototype = {
         const self = this;
         requestPromise.catch(function(err) {
             if (err.errcode == 'M_UNKNOWN_TOKEN') {
-                self.event_emitter.emit("Session.logged_out");
+                self.event_emitter.emit("Session.logged_out", err);
             } else if (err.errcode == 'M_CONSENT_NOT_GIVEN') {
                 self.event_emitter.emit(
                     "no_consent",


### PR DESCRIPTION
**For https://github.com/matrix-org/matrix-react-sdk/pull/3177**

Note: The `call` argument previously defined in the SDK was never actually populated, and appears to be a documentation error when the definition was copied from `Call.incoming` directly above it.