### PR TITLE
Add default push rule to ignore reactions

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -52,6 +52,22 @@ const DEFAULT_OVERRIDE_RULES = [
             },
         ],
     },
+    {
+        // For homeservers which don't support MSC2153 yet
+        rule_id: ".m.rule.reaction",
+        default: true,
+        enabled: true,
+        conditions: [
+            {
+                kind: "event_match",
+                key: "type",
+                pattern: "m.reaction",
+            },
+        ],
+        actions: [
+            "dont_notify",
+        ],
+    },
 ];
 
 /**


### PR DESCRIPTION
This adds a default push rule to ignore reactions as proposed in
[MSC2153](https://github.com/matrix-org/matrix-doc/pull/2153). By adding it here
in the client directly, we can try out the idea early even if it hasn't appeared
in the user's HS yet.

Part of https://github.com/vector-im/riot-web/issues/10208