### PR TITLE
Fix exception whilst syncing

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -310,7 +310,7 @@ function MatrixClient(opts) {
                     break;
                 }
 
-                highlightCount += event.getPushActions().tweaks.highlight ? 1 : 0;
+                highlightCount += this.getPushActionsForEvent(event).tweaks.highlight ? 1 : 0;
             }
 
             // Note: we don't need to handle 'total' notifications because the counts

--- a/src/client.js
+++ b/src/client.js
@@ -310,7 +310,9 @@ function MatrixClient(opts) {
                     break;
                 }
 
-                highlightCount += this.getPushActionsForEvent(event).tweaks.highlight ? 1 : 0;
+                highlightCount += this.getPushActionsForEvent(
+                    event,
+                ).tweaks.highlight ? 1 : 0;
             }
 
             // Note: we don't need to handle 'total' notifications because the counts


### PR DESCRIPTION
event.getPushRules() may return null (for better or worse...).
Use client.getPushRulesForEvent which will calculate them if they
haven't already been calculated.

Fixes https://github.com/vector-im/riot-web/issues/10269