### PR TITLE
Add a function to flag keys for backup without scheduling a backup

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1208,6 +1208,19 @@ MatrixClient.prototype.scheduleAllGroupSessionsForBackup = async function() {
     await this._crypto.scheduleAllGroupSessionsForBackup();
 };
 
+/**
+ * Marks all group sessions as needing to be backed up without scheduling
+ * them to upload in the background.
+ * @returns {Promise<int>} Resolves to the number of sessions requiring a backup.
+ */
+MatrixClient.prototype.flagAllGroupSessionsForBackup = function() {
+    if (this._crypto === null) {
+        throw new Error("End-to-end encryption disabled");
+    }
+
+    return this._crypto.flagAllGroupSessionsForBackup();
+};
+
 MatrixClient.prototype.isValidRecoveryKey = function(recoveryKey) {
     try {
         decodeRecoveryKey(recoveryKey);

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1288,6 +1288,18 @@ Crypto.prototype.backupGroupSession = async function(
  * upload in the background as soon as possible.
  */
 Crypto.prototype.scheduleAllGroupSessionsForBackup = async function() {
+    await this.flagAllGroupSessionsForBackup();
+
+    // Schedule keys to upload in the background as soon as possible.
+    this.scheduleKeyBackupSend(0 /* maxDelay */);
+};
+
+/**
+ * Marks all group sessions as needing to be backed up without scheduling
+ * them to upload in the background.
+ * @returns {Promise<int>} Resolves to the number of sessions requiring a backup.
+ */
+Crypto.prototype.flagAllGroupSessionsForBackup = async function() {
     await this._cryptoStore.doTxn(
         'readwrite',
         [
@@ -1305,9 +1317,7 @@ Crypto.prototype.scheduleAllGroupSessionsForBackup = async function() {
 
     const remaining = await this._cryptoStore.countSessionsNeedingBackup();
     this.emit("crypto.keyBackupSessionsRemaining", remaining);
-
-    // Schedule keys to upload in the background as soon as possible.
-    this.scheduleKeyBackupSend(0 /* maxDelay */);
+    return remaining;
 };
 
 /* eslint-disable valid-jsdoc */    //https://github.com/eslint/eslint/issues/7307


### PR DESCRIPTION
For https://github.com/vector-im/riot-web/issues/10263 / https://github.com/matrix-org/matrix-react-sdk/pull/3187

Starting/scheduling the backup won't help us because the token would be invalid from a server perspective. Instead, we should update what needs to be done and return a count.