### PR TITLE
Don't accept any locally known edits earlier than the last known server-side aggregated edit

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -898,7 +898,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
         return this.status;
     },
 
-    _getServerAggregatedRelation(relType) {
+    getServerAggregatedRelation(relType) {
         const relations = this.getUnsigned()["m.relations"];
         if (relations) {
             return relations[relType];
@@ -911,7 +911,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {string?}
      */
     replacingEventId() {
-        const replaceRelation = this._getServerAggregatedRelation("m.replace");
+        const replaceRelation = this.getServerAggregatedRelation("m.replace");
         if (replaceRelation) {
             return replaceRelation.event_id;
         } else if (this._replacingEvent) {
@@ -936,7 +936,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
      * @return {Date?}
      */
     replacingEventDate() {
-        const replaceRelation = this._getServerAggregatedRelation("m.replace");
+        const replaceRelation = this.getServerAggregatedRelation("m.replace");
         if (replaceRelation) {
             const ts = replaceRelation.origin_server_ts;
             if (Number.isFinite(ts)) {

--- a/src/models/relations.js
+++ b/src/models/relations.js
@@ -301,8 +301,18 @@ export default class Relations extends EventEmitter {
             // event is known anyway.
             return null;
         }
+
+        // the all-knowning server tells us that the event at some point had
+        // this timestamp for its replacement, so any following replacement should definitely not be less
+        const replaceRelation =
+            this._targetEvent.getServerAggregatedRelation("m.replace");
+        const minTs = replaceRelation && replaceRelation.origin_server_ts;
+
         return this.getRelations().reduce((last, event) => {
             if (event.getSender() !== this._targetEvent.getSender()) {
+                return last;
+            }
+            if (minTs && minTs > event.getTs()) {
                 return last;
             }
             if (last && last.getTs() > event.getTs()) {


### PR DESCRIPTION
This will prevent riot showing the wrong content for an edit event if we have a later SSA edit. This *does* trigger https://github.com/vector-im/riot-web/issues/10290 when redacting the last edit but that is a lesser issue IMO, and needs fixing separately.