### PR TITLE
Stabilize usage of stably stable APIs (in a stable way)

### DIFF
--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -396,7 +396,7 @@ describe("MatrixClient", function() {
         const auth = {a: 1};
         it("should pass through an auth dict", function(done) {
             httpBackend.when(
-                "DELETE", "/_matrix/client/unstable/devices/my_device",
+                "DELETE", "/_matrix/client/r0/devices/my_device",
             ).check(function(req) {
                 expect(req.data).toEqual({auth: auth});
             }).respond(200);

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -48,7 +48,7 @@ describe("MatrixClient", function() {
         const buf = new Buffer('hello world');
         it("should upload the file", function(done) {
             httpBackend.when(
-                "POST", "/_matrix/media/v1/upload",
+                "POST", "/_matrix/media/r0/upload",
             ).check(function(req) {
                 expect(req.rawData).toEqual(buf);
                 expect(req.queryParams.filename).toEqual("hi.txt");
@@ -87,7 +87,7 @@ describe("MatrixClient", function() {
 
         it("should parse the response if rawResponse=false", function(done) {
             httpBackend.when(
-                "POST", "/_matrix/media/v1/upload",
+                "POST", "/_matrix/media/r0/upload",
             ).check(function(req) {
                 expect(req.opts.json).toBeFalsy();
             }).respond(200, { "content_uri": "uri" });
@@ -107,7 +107,7 @@ describe("MatrixClient", function() {
 
         it("should parse errors into a MatrixError", function(done) {
             httpBackend.when(
-                "POST", "/_matrix/media/v1/upload",
+                "POST", "/_matrix/media/r0/upload",
             ).check(function(req) {
                 expect(req.rawData).toEqual(buf);
                 expect(req.opts.json).toBeFalsy();

--- a/spec/unit/content-repo.spec.js
+++ b/spec/unit/content-repo.spec.js
@@ -31,7 +31,7 @@ describe("ContentRepo", function() {
         function() {
             const mxcUri = "mxc://server.name/resourceid";
             expect(ContentRepo.getHttpUriForMxc(baseUrl, mxcUri)).toEqual(
-                baseUrl + "/_matrix/media/v1/download/server.name/resourceid",
+                baseUrl + "/_matrix/media/r0/download/server.name/resourceid",
             );
         });
 
@@ -43,7 +43,7 @@ describe("ContentRepo", function() {
         function() {
             const mxcUri = "mxc://server.name/resourceid";
             expect(ContentRepo.getHttpUriForMxc(baseUrl, mxcUri, 32, 64, "crop")).toEqual(
-                baseUrl + "/_matrix/media/v1/thumbnail/server.name/resourceid" +
+                baseUrl + "/_matrix/media/r0/thumbnail/server.name/resourceid" +
                 "?width=32&height=64&method=crop",
             );
         });
@@ -52,7 +52,7 @@ describe("ContentRepo", function() {
         function() {
             const mxcUri = "mxc://server.name/resourceid#automade";
             expect(ContentRepo.getHttpUriForMxc(baseUrl, mxcUri, 32)).toEqual(
-                baseUrl + "/_matrix/media/v1/thumbnail/server.name/resourceid" +
+                baseUrl + "/_matrix/media/r0/thumbnail/server.name/resourceid" +
                 "?width=32#automade",
             );
         });
@@ -61,7 +61,7 @@ describe("ContentRepo", function() {
         function() {
             const mxcUri = "mxc://server.name/resourceid#automade";
             expect(ContentRepo.getHttpUriForMxc(baseUrl, mxcUri)).toEqual(
-                baseUrl + "/_matrix/media/v1/download/server.name/resourceid#automade",
+                baseUrl + "/_matrix/media/r0/download/server.name/resourceid#automade",
             );
         });
     });
@@ -73,21 +73,21 @@ describe("ContentRepo", function() {
 
         it("should set w/h by default to 96", function() {
             expect(ContentRepo.getIdenticonUri(baseUrl, "foobar")).toEqual(
-                baseUrl + "/_matrix/media/v1/identicon/foobar" +
+                baseUrl + "/_matrix/media/unstable/identicon/foobar" +
                 "?width=96&height=96",
             );
         });
 
         it("should be able to set custom w/h", function() {
             expect(ContentRepo.getIdenticonUri(baseUrl, "foobar", 32, 64)).toEqual(
-                baseUrl + "/_matrix/media/v1/identicon/foobar" +
+                baseUrl + "/_matrix/media/unstable/identicon/foobar" +
                 "?width=32&height=64",
             );
         });
 
         it("should URL encode the identicon string", function() {
             expect(ContentRepo.getIdenticonUri(baseUrl, "foo#bar", 32, 64)).toEqual(
-                baseUrl + "/_matrix/media/v1/identicon/foo%23bar" +
+                baseUrl + "/_matrix/media/unstable/identicon/foo%23bar" +
                 "?width=32&height=64",
             );
         });

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -391,9 +391,8 @@ MatrixBaseApis.prototype.deactivateAccount = function(auth, erase) {
         body.erase = erase;
     }
 
-    return this._http.authedRequestWithPrefix(
+    return this._http.authedRequest(
         undefined, "POST", '/account/deactivate', undefined, body,
-        httpApi.PREFIX_R0,
     );
 };
 
@@ -1329,9 +1328,7 @@ MatrixBaseApis.prototype.deleteThreePid = function(medium, address) {
         'medium': medium,
         'address': address,
     };
-    return this._http.authedRequestWithPrefix(
-        undefined, "POST", path, null, data, httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "POST", path, null, data);
 };
 
 /**
@@ -1365,10 +1362,7 @@ MatrixBaseApis.prototype.setPassword = function(authDict, newPassword, callback)
  */
 MatrixBaseApis.prototype.getDevices = function() {
     const path = "/devices";
-    return this._http.authedRequestWithPrefix(
-        undefined, "GET", path, undefined, undefined,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, path, undefined, undefined);
 };
 
 /**
@@ -1384,11 +1378,7 @@ MatrixBaseApis.prototype.setDeviceDetails = function(device_id, body) {
         $device_id: device_id,
     });
 
-
-    return this._http.authedRequestWithPrefix(
-        undefined, "PUT", path, undefined, body,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "PUT", path, undefined, body);
 };
 
 /**
@@ -1410,10 +1400,7 @@ MatrixBaseApis.prototype.deleteDevice = function(device_id, auth) {
         body.auth = auth;
     }
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "DELETE", path, undefined, body,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "DELETE", path, undefined, body);
 };
 
 /**
@@ -1431,10 +1418,8 @@ MatrixBaseApis.prototype.deleteMultipleDevices = function(devices, auth) {
         body.auth = auth;
     }
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "POST", "/delete_devices", undefined, body,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    const path = "/delete_devices";
+    return this._http.authedRequest(undefined, "POST", path, undefined, body);
 };
 
 
@@ -1610,9 +1595,7 @@ MatrixBaseApis.prototype.uploadKeysRequest = function(content, opts, callback) {
     } else {
         path = "/keys/upload";
     }
-    return this._http.authedRequestWithPrefix(
-        callback, "POST", path, undefined, content, httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(callback, "POST", path, undefined, content);
 };
 
 /**
@@ -1647,10 +1630,7 @@ MatrixBaseApis.prototype.downloadKeysForUsers = function(userIds, opts) {
         content.device_keys[u] = {};
     });
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "POST", "/keys/query", undefined, content,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "POST", "/keys/query", undefined, content);
 };
 
 /**
@@ -1678,10 +1658,8 @@ MatrixBaseApis.prototype.claimOneTimeKeys = function(devices, key_algorithm) {
         query[deviceId] = key_algorithm;
     }
     const content = {one_time_keys: queries};
-    return this._http.authedRequestWithPrefix(
-        undefined, "POST", "/keys/claim", undefined, content,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    const path = "/keys/claim";
+    return this._http.authedRequest(undefined, "POST", path, undefined, content);
 };
 
 /**
@@ -1700,10 +1678,8 @@ MatrixBaseApis.prototype.getKeyChanges = function(oldToken, newToken) {
         to: newToken,
     };
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "GET", "/keys/changes", qps, undefined,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    const path = "/keys/changes";
+    return this._http.authedRequest(undefined, "GET", path, qps, undefined);
 };
 
 
@@ -1821,10 +1797,7 @@ MatrixBaseApis.prototype.sendToDevice = function(
         messages: contentMap,
     };
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "PUT", path, undefined, body,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "PUT", path, undefined, body);
 };
 
 // Third party Lookup API
@@ -1836,9 +1809,8 @@ MatrixBaseApis.prototype.sendToDevice = function(
  * @return {module:client.Promise} Resolves to the result object
  */
 MatrixBaseApis.prototype.getThirdpartyProtocols = function() {
-    return this._http.authedRequestWithPrefix(
+    return this._http.authedRequest(
         undefined, "GET", "/thirdparty/protocols", undefined, undefined,
-        httpApi.PREFIX_UNSTABLE,
     ).then((response) => {
         // sanity check
         if (!response || typeof(response) !== 'object') {
@@ -1863,10 +1835,7 @@ MatrixBaseApis.prototype.getThirdpartyLocation = function(protocol, params) {
         $protocol: protocol,
     });
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "GET", path, params, undefined,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "GET", path, params, undefined);
 };
 
 /**
@@ -1882,10 +1851,7 @@ MatrixBaseApis.prototype.getThirdpartyUser = function(protocol, params) {
         $protocol: protocol,
     });
 
-    return this._http.authedRequestWithPrefix(
-        undefined, "GET", path, params, undefined,
-        httpApi.PREFIX_UNSTABLE,
-    );
+    return this._http.authedRequest(undefined, "GET", path, params, undefined);
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -979,7 +979,8 @@ MatrixClient.prototype.checkKeyBackup = function() {
  */
 MatrixClient.prototype.getKeyBackupVersion = function() {
     return this._http.authedRequest(
-        undefined, "GET", "/room_keys/version",
+        undefined, "GET", "/room_keys/version", undefined, undefined,
+        {prefix: httpApi.PREFIX_UNSTABLE},
     ).then((res) => {
         if (res.algorithm !== olmlib.MEGOLM_BACKUP_ALGORITHM) {
             const err = "Unknown backup algorithm: " + res.algorithm;
@@ -1123,6 +1124,7 @@ MatrixClient.prototype.createKeyBackupVersion = function(info) {
     return this._crypto._signObject(data.auth_data).then(() => {
         return this._http.authedRequest(
             undefined, "POST", "/room_keys/version", undefined, data,
+            {prefix: httpApi.PREFIX_UNSTABLE},
         );
     }).then((res) => {
         this.enableKeyBackup({
@@ -1152,6 +1154,7 @@ MatrixClient.prototype.deleteKeyBackupVersion = function(version) {
 
     return this._http.authedRequest(
         undefined, "DELETE", path, undefined, undefined,
+        {prefix: httpApi.PREFIX_UNSTABLE},
     );
 };
 
@@ -1193,6 +1196,7 @@ MatrixClient.prototype.sendKeyBackup = function(roomId, sessionId, version, data
     const path = this._makeKeyBackupPath(roomId, sessionId, version);
     return this._http.authedRequest(
         undefined, "PUT", path.path, path.queryData, data,
+        {prefix: httpApi.PREFIX_UNSTABLE},
     );
 };
 
@@ -1280,7 +1284,8 @@ MatrixClient.prototype._restoreKeyBackup = function(
     }
 
     return this._http.authedRequest(
-        undefined, "GET", path.path, path.queryData,
+        undefined, "GET", path.path, path.queryData, undefined,
+        {prefix: httpApi.PREFIX_UNSTABLE},
     ).then((res) => {
         if (res.rooms) {
             for (const [roomId, roomData] of Object.entries(res.rooms)) {
@@ -1329,7 +1334,8 @@ MatrixClient.prototype.deleteKeysFromBackup = function(roomId, sessionId, versio
 
     const path = this._makeKeyBackupPath(roomId, sessionId, version);
     return this._http.authedRequest(
-        undefined, "DELETE", path.path, path.queryData,
+        undefined, "DELETE", path.path, path.queryData, undefined,
+        {prefix: httpApi.PREFIX_UNSTABLE},
     );
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -3065,9 +3065,8 @@ MatrixClient.prototype.paginateEventTimeline = function(eventTimeline, opts) {
             params.from = token;
         }
 
-        promise =
-            this._http.authedRequestWithPrefix(undefined, "GET", path, params,
-                undefined, httpApi.PREFIX_UNSTABLE,
+        promise = this._http.authedRequest(
+            undefined, "GET", path, params, undefined,
         ).then(function(res) {
             const token = res.next_token;
             const matrixEvents = [];

--- a/src/content-repo.js
+++ b/src/content-repo.js
@@ -47,7 +47,7 @@ module.exports = {
             }
         }
         let serverAndMediaId = mxc.slice(6); // strips mxc://
-        let prefix = "/_matrix/media/v1/download/";
+        let prefix = "/_matrix/media/r0/download/";
         const params = {};
 
         if (width) {
@@ -62,7 +62,7 @@ module.exports = {
         if (utils.keys(params).length > 0) {
             // these are thumbnailing params so they probably want the
             // thumbnailing API...
-            prefix = "/_matrix/media/v1/thumbnail/";
+            prefix = "/_matrix/media/r0/thumbnail/";
         }
 
         const fragmentOffset = serverAndMediaId.indexOf("#");
@@ -83,6 +83,7 @@ module.exports = {
      * @param {Number} width The desired width of the image in pixels. Default: 96.
      * @param {Number} height The desired height of the image in pixels. Default: 96.
      * @return {string} The complete URL to the identicon.
+     * @deprecated This is no longer in the specification.
      */
     getIdenticonUri: function(baseUrl, identiconString, width, height) {
         if (!identiconString) {
@@ -99,7 +100,7 @@ module.exports = {
             height: height,
         };
 
-        const path = utils.encodeUri("/_matrix/media/v1/identicon/$ident", {
+        const path = utils.encodeUri("/_matrix/media/unstable/identicon/$ident", {
             $ident: identiconString,
         });
         return baseUrl + path +

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -102,7 +102,7 @@ module.exports.MatrixHttpApi.prototype = {
         };
         return {
             base: this.opts.baseUrl,
-            path: "/_matrix/media/v1/upload",
+            path: "/_matrix/media/r0/upload",
             params: params,
         };
     },
@@ -291,7 +291,7 @@ module.exports.MatrixHttpApi.prototype = {
                     });
                 }
             });
-            let url = this.opts.baseUrl + "/_matrix/media/v1/upload";
+            let url = this.opts.baseUrl + "/_matrix/media/r0/upload";
 
             const queryArgs = [];
 
@@ -327,7 +327,7 @@ module.exports.MatrixHttpApi.prototype = {
 
             promise = this.authedRequest(
                 opts.callback, "POST", "/upload", queryParams, body, {
-                    prefix: "/_matrix/media/v1",
+                    prefix: "/_matrix/media/r0",
                     headers: {"Content-Type": contentType},
                     json: false,
                     bodyParser: bodyParser,

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -1053,7 +1053,7 @@ utils.extend(module.exports.MatrixEvent.prototype, {
 /* _REDACT_KEEP_KEY_MAP gives the keys we keep when an event is redacted
  *
  * This is specified here:
- *  http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#redactions
+ *  http://matrix.org/speculator/spec/HEAD/client_server/latest.html#redactions
  *
  * Also:
  *  - We keep 'unsigned' since that is created by the local server

--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -249,7 +249,7 @@ RoomMember.prototype.getDMInviter = function() {
  * "crop" or "scale".
  * @param {Boolean} allowDefault (optional) Passing false causes this method to
  * return null if the user has no avatar image. Otherwise, a default image URL
- * will be returned. Default: true.
+ * will be returned. Default: true. (Deprecated)
  * @param {Boolean} allowDirectLinks (optional) If true, the avatar URL will be
  * returned even if it is a direct hyperlink rather than a matrix content URL.
  * If false, any non-matrix content URLs will be ignored. Setting this option to

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -781,7 +781,7 @@ Room.prototype.getBlacklistUnverifiedDevices = function() {
  * @param {string} resizeMethod The thumbnail resize method to use, either
  * "crop" or "scale".
  * @param {boolean} allowDefault True to allow an identicon for this room if an
- * avatar URL wasn't explicitly set. Default: true.
+ * avatar URL wasn't explicitly set. Default: true. (Deprecated)
  * @return {?string} the avatar URL or null.
  */
 Room.prototype.getAvatarUrl = function(baseUrl, width, height, resizeMethod,


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/5325
**Please review with https://github.com/matrix-org/matrix-react-sdk/pull/3202**

Done:
* Where stable, use stable over unstable
* Where unstable, use unstable (key backup; identicons)
* Deprecate identicon usage (I'm also pretty sure Synapse 1.0 doesn't have this support anymore - https://github.com/matrix-org/matrix-js-sdk/issues/992)
* Fix media URLs to use stable versions (v1 is technically valid, but we're on the v2 (r0) CS spec now)