### PR TITLE
End the verification timer when verification is done

### DIFF
--- a/spec/unit/crypto/verification/request.spec.js
+++ b/spec/unit/crypto/verification/request.spec.js
@@ -69,8 +69,14 @@ describe("verification request", function() {
         bob.on("crypto.verification.request", (request) => {
             const bobVerifier = request.beginKeyVerification(verificationMethods.SAS);
             bobVerifier.verify();
+
+            // XXX: Private function access (but it's a test, so we're okay)
+            bobVerifier._endTimer();
         });
         const aliceVerifier = await alice.requestVerification("@bob:example.com");
         expect(aliceVerifier).toBeAn(SAS);
+
+        // XXX: Private function access (but it's a test, so we're okay)
+        aliceVerifier._endTimer();
     });
 });

--- a/spec/unit/crypto/verification/sas.spec.js
+++ b/spec/unit/crypto/verification/sas.spec.js
@@ -57,6 +57,9 @@ describe("SAS verification", function() {
         await sas.verify()
             .catch(spy);
         expect(spy).toHaveBeenCalled();
+
+        // Cancel the SAS for cleanup (we started a verification, so abort)
+        sas.cancel();
     });
 
     describe("verification", function() {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/980

This also improves cleanliness in the tests to cancel/terminate timers when needed. The tests have complicated mocks which prevent some conditions from hitting the `_endTimer` function in their test functionality, therefore we need to call it directly.