### PR TITLE
Add API for bulk lookup on the Identity Server

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1892,7 +1892,8 @@ MatrixBaseApis.prototype.lookupThreePid = async function(
 /**
  * Looks up the public Matrix ID mappings for multiple 3PIDs.
  *
- * @param {array} query Array of arrays containing [medium, address]
+ * @param {Array.<Array.<string>>} query Array of arrays containing
+ * [medium, address]
  * @param {string} identityAccessToken The `access_token` field of the Identity
  * Server `/account/register` response (see {@link registerWithIdentityServer}).
  *

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -396,16 +396,19 @@ module.exports.MatrixHttpApi.prototype = {
             withCredentials: false,
             json: false,
             _matrix_opts: this.opts,
+            headers: {},
         };
         if (method == 'GET') {
             opts.qs = params;
-        } else {
+        } else if (typeof params === "object") {
             opts.form = params;
+        } else if (typeof params === "string") {
+            // Assume the caller has serialised the body to JSON
+            opts.body = params;
+            opts.headers['Content-Type'] = "application/json";
         }
         if (accessToken) {
-            opts.headers = {
-                Authorization: `Bearer ${accessToken}`,
-            };
+            opts.headers['Authorization'] = `Bearer ${accessToken}`;
         }
 
         const defer = Promise.defer();


### PR DESCRIPTION
This adds support for querying `/bulk_lookup` on the IS to check several 3PIDs
at the same time.

Part of https://github.com/vector-im/riot-web/issues/10159