### PR TITLE
Change ICE fallback server and make fallback opt-in

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4360,9 +4360,6 @@ function checkTurnServers(client) {
             client._checkTurnServersTimeoutID = setTimeout(() => {
                 checkTurnServers(client);
             }, (res.ttl || (60 * 60)) * 1000 * 0.9);
-        } else {
-            logger.warn("No TURN URIs from homeserver");
-            client.emit("Call.noTURNServers");
         }
     }, function(err) {
         logger.error("Failed to get TURN URIs");

--- a/src/client.js
+++ b/src/client.js
@@ -159,6 +159,13 @@ function keyFromRecoverySession(session, decryptionKey) {
  * that the application can handle.  Each element should be an item from {@link
  * module:crypto~verificationMethods verificationMethods}, or a class that
  * implements the {$link module:crypto/verification/Base verifier interface}.
+ *
+ * @param {boolean} [opts.forceTURN]
+ * Optional. Whether relaying calls through a TURN server should be forced.
+ *
+ * @param {boolean} [opts.fallbackICEServerAllowed]
+ * Optional. Whether to allow a fallback ICE server should be used for negotiating a
+ * WebRTC connection if the homeserver doesn't provide any servers. Defaults to false.
  */
 function MatrixClient(opts) {
     opts.baseUrl = utils.ensureNoTrailingSlash(opts.baseUrl);
@@ -221,7 +228,7 @@ function MatrixClient(opts) {
     this._verificationMethods = opts.verificationMethods;
 
     this._forceTURN = opts.forceTURN || false;
-    this._fallbackICEServerAllowed = false;
+    this._fallbackICEServerAllowed = opts.fallbackICEServerAllowed || false;
 
     // List of which rooms have encryption enabled: separate from crypto because
     // we still want to know which rooms are encrypted even if crypto is disabled:

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -665,7 +665,7 @@ MatrixCall.prototype._maybeGotUserMediaForAnswer = function(stream) {
         },
     };
     self.peerConn.createAnswer(function(description) {
-        debuglog("Created answer: " + description);
+        debuglog("Created answer: ", description);
         self.peerConn.setLocalDescription(description, function() {
             self._answerContent = {
                 version: 0,
@@ -754,7 +754,7 @@ MatrixCall.prototype._receivedAnswer = function(msg) {
  */
 MatrixCall.prototype._gotLocalOffer = function(description) {
     const self = this;
-    debuglog("Created offer: " + description);
+    debuglog("Created offer: ", description);
 
     if (self.state == 'ended') {
         debuglog("Ignoring newly created offer on call ID " + self.callId +

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -61,9 +61,9 @@ function MatrixCall(opts) {
     this.URL = opts.URL;
     // Array of Objects with urls, username, credential keys
     this.turnServers = opts.turnServers || [];
-    if (this.turnServers.length === 0) {
+    if (this.turnServers.length === 0 && this.client.isFallbackICEServerAllowed()) {
         this.turnServers.push({
-            urls: [MatrixCall.FALLBACK_STUN_SERVER],
+            urls: [MatrixCall.FALLBACK_ICE_SERVER],
         });
     }
     utils.forEach(this.turnServers, function(server) {
@@ -92,8 +92,8 @@ function MatrixCall(opts) {
 }
 /** The length of time a call can be ringing for. */
 MatrixCall.CALL_TIMEOUT_MS = 60000;
-/** The fallback server to use for STUN. */
-MatrixCall.FALLBACK_STUN_SERVER = 'stun:turn.matrix.org';
+/** The fallback ICE server to use for STUN or TURN protocols. */
+MatrixCall.FALLBACK_ICE_SERVER = 'stun:turn.matrix.org';
 /** An error code when the local client failed to create an offer. */
 MatrixCall.ERR_LOCAL_OFFER_FAILED = "local_offer_failed";
 /**
@@ -1337,7 +1337,9 @@ module.exports.setVideoInput = function(deviceId) { videoInput = deviceId; };
  * @param {MatrixClient} client The client instance to use.
  * @param {string} roomId The room the call is in.
  * @param {Object?} options DEPRECATED optional options map.
- * @param {boolean} options.forceTURN DEPRECATED whether relay through TURN should be forced. This option is deprecated - use opts.forceTURN when creating the matrix client since it's only possible to set this option on outbound calls.
+ * @param {boolean} options.forceTURN DEPRECATED whether relay through TURN should be
+ * forced. This option is deprecated - use opts.forceTURN when creating the matrix client
+ * since it's only possible to set this option on outbound calls.
  * @return {MatrixCall} the call or null if the browser doesn't support calling.
  */
 module.exports.createNewMatrixCall = function(client, roomId, options) {

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -93,7 +93,7 @@ function MatrixCall(opts) {
 /** The length of time a call can be ringing for. */
 MatrixCall.CALL_TIMEOUT_MS = 60000;
 /** The fallback server to use for STUN. */
-MatrixCall.FALLBACK_STUN_SERVER = 'stun:stun.l.google.com:19302';
+MatrixCall.FALLBACK_STUN_SERVER = 'stun:turn.matrix.org';
 /** An error code when the local client failed to create an offer. */
 MatrixCall.ERR_LOCAL_OFFER_FAILED = "local_offer_failed";
 /**

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -1217,24 +1217,9 @@ const _placeCallWithConstraints = function(self, constraints) {
 };
 
 const _createPeerConnection = function(self) {
-    let servers = self.turnServers;
-    if (self.webRtc.vendor === "mozilla") {
-        // modify turnServers struct to match what mozilla expects.
-        servers = [];
-        for (let i = 0; i < self.turnServers.length; i++) {
-            for (let j = 0; j < self.turnServers[i].urls.length; j++) {
-                servers.push({
-                    url: self.turnServers[i].urls[j],
-                    username: self.turnServers[i].username,
-                    credential: self.turnServers[i].credential,
-                });
-            }
-        }
-    }
-
     const pc = new self.webRtc.RtcPeerConnection({
         iceTransportPolicy: self.forceTURN ? 'relay' : undefined,
-        iceServers: servers,
+        iceServers: self.turnServers,
     });
     pc.oniceconnectionstatechange = hookCallback(self, self._onIceConnectionStateChanged);
     pc.onsignalingstatechange = hookCallback(self, self._onSignallingStateChanged);


### PR DESCRIPTION
This changes the STUN fallback server from a Google server to one hosted at
`turn.matrix.org`. This also changes the ICE server fallback to be disabled by default. The SDK consumer will receive a new event in case the homeserver has no ICE servers of its own,
and can prompt the user to agree to the fallback if desired.

Part of https://github.com/vector-im/riot-web/issues/10173
Used by https://github.com/matrix-org/matrix-react-sdk/pull/3309