### PR TITLE
Use the v2 (hashed) lookup for identity server queries

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1891,7 +1891,7 @@ MatrixBaseApis.prototype.identityHashedLookup = async function(
     };
 
     // Get hash information first before trying to do a lookup
-    const hashes = await this.getIdentityHashDetails();
+    const hashes = await this.getIdentityHashDetails(identityAccessToken);
     if (!hashes || !hashes['lookup_pepper'] || !hashes['algorithms']) {
         throw new Error("Unsupported identity server: bad response");
     }

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1860,7 +1860,7 @@ MatrixBaseApis.prototype.submitMsisdnToken = async function(
 /**
  * Gets the V2 hashing information from the identity server. Primarily useful for
  * lookups.
- * @param identityAccessToken The access token for the identity server.
+ * @param {string} identityAccessToken The access token for the identity server.
  * @returns {Promise<object>} The hashing information for the identity server.
  */
 MatrixBaseApis.prototype.getIdentityHashDetails = function(identityAccessToken) {
@@ -1873,10 +1873,10 @@ MatrixBaseApis.prototype.getIdentityHashDetails = function(identityAccessToken) 
 /**
  * Performs a hashed lookup of addresses against the identity server. This is
  * only supported on identity servers which have at least the version 2 API.
- * @param addressPairs An array of 2 element arrays. The first element of each
- * pair is the address, the second is the 3PID medium. Eg: ["email@example.org",
- * "email"]
- * @param identityAccessToken The access token for the identity server.
+ * @param {Array<Array<string,string>>} addressPairs An array of 2 element arrays.
+ * The first element of each pair is the address, the second is the 3PID medium.
+ * Eg: ["email@example.org", "email"]
+ * @param {string} identityAccessToken The access token for the identity server.
  * @returns {Promise<{address, mxid}[]>} A collection of address mappings to
  * found MXIDs. Results where no user could be found will not be listed.
  */

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1908,7 +1908,8 @@ MatrixBaseApis.prototype.identityHashedLookup = async function(
         // Abuse the olm hashing
         const olmutil = new global.Olm.Utility();
         params["addresses"] = addressPairs.map(p => {
-            const hashed = olmutil.sha256(`${p[0]} ${p[1]} ${params['pepper']}`);
+            const hashed = olmutil.sha256(`${p[0]} ${p[1]} ${params['pepper']}`)
+                .replace(/\+/g, '-').replace(/\//g, '_'); // URL-safe base64
             localMapping[hashed] = p[0];
             return hashed;
         });

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1877,7 +1877,7 @@ MatrixBaseApis.prototype.getIdentityHashDetails = function(identityAccessToken) 
  * The first element of each pair is the address, the second is the 3PID medium.
  * Eg: ["email@example.org", "email"]
  * @param {string} identityAccessToken The access token for the identity server.
- * @returns {Promise<{address, mxid}[]>} A collection of address mappings to
+ * @returns {Promise<Array<{address, mxid}>>} A collection of address mappings to
  * found MXIDs. Results where no user could be found will not be listed.
  */
 MatrixBaseApis.prototype.identityHashedLookup = async function(

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -412,7 +412,7 @@ module.exports.MatrixHttpApi.prototype = {
         if (method == 'GET') {
             opts.qs = params;
         } else if (typeof params === "object") {
-            opts.form = params;
+            opts.json = params;
         } else if (typeof params === "string") {
             // Assume the caller has serialised the body to JSON
             opts.body = params;

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -431,7 +431,7 @@ module.exports.MatrixHttpApi.prototype = {
         // option as we do with the home server, but it does return JSON, so
         // parse it manually
         return defer.promise.then(function(response) {
-            return JSON.parse(response);
+            return typeof(response) === 'string' ? JSON.parse(response) : response;
         });
     },
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10556
Implements [MSC2134](https://github.com/matrix-org/matrix-doc/pull/2134) with assistance from [MSC2140](https://github.com/matrix-org/matrix-doc/pull/2140) for auth.

Note: this also changes all identity server requests to use JSON as a request body. URL encoded forms were allowed in v1 but deprecated in favour of JSON. v2 APIs do not allow URL encoded forms.