### PR TITLE
Send id_access_token to HS for use in proxied IS requests

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -63,6 +63,14 @@ function termsUrlForService(serviceType, baseUrl) {
  *
  * @param {string} opts.accessToken The access_token for this user.
  *
+ * @param {Function} [opts.getIdentityAccessToken]
+ * Optional. A callback that returns a Promise<String> of an identity access
+ * token to supply with identity requests. If the callback is unset, no access
+ * token will be supplied.
+ * See also https://github.com/vector-im/riot-web/issues/10615 which seeks to
+ * replace the previous approach of manual access tokens params with this
+ * callback throughout the SDK.
+ *
  * @param {Number=} opts.localTimeoutMs Optional. The default maximum amount of
  * time to wait before timing out HTTP requests. If not specified, there is no
  * timeout.
@@ -79,6 +87,7 @@ function MatrixBaseApis(opts) {
 
     this.baseUrl = opts.baseUrl;
     this.idBaseUrl = opts.idBaseUrl;
+    this.getIdentityAccessToken = opts.getIdentityAccessToken;
 
     const httpOpts = {
         baseUrl: opts.baseUrl,

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -63,10 +63,11 @@ function termsUrlForService(serviceType, baseUrl) {
  *
  * @param {string} opts.accessToken The access_token for this user.
  *
- * @param {Function} [opts.getIdentityAccessToken]
- * Optional. A callback that returns a Promise<String> of an identity access
- * token to supply with identity requests. If the callback is unset, no access
- * token will be supplied.
+ * @param {IdentityServerProvider} [opts.identityServer]
+ * Optional. A provider object with one function `getAccessToken`, which is a
+ * callback that returns a Promise<String> of an identity access token to supply
+ * with identity requests. If the object is unset, no access token will be
+ * supplied.
  * See also https://github.com/vector-im/riot-web/issues/10615 which seeks to
  * replace the previous approach of manual access tokens params with this
  * callback throughout the SDK.
@@ -87,7 +88,7 @@ function MatrixBaseApis(opts) {
 
     this.baseUrl = opts.baseUrl;
     this.idBaseUrl = opts.idBaseUrl;
-    this.getIdentityAccessToken = opts.getIdentityAccessToken;
+    this.identityServer = opts.identityServer;
 
     const httpOpts = {
         baseUrl: opts.baseUrl,

--- a/src/client.js
+++ b/src/client.js
@@ -108,6 +108,14 @@ function keyFromRecoverySession(session, decryptionKey) {
  *
  * @param {string} opts.userId The user ID for this user.
  *
+ * @param {Function} [opts.getIdentityAccessToken]
+ * Optional. A callback that returns a Promise<String> of an identity access
+ * token to supply with identity requests. If the callback is unset, no access
+ * token will be supplied.
+ * See also https://github.com/vector-im/riot-web/issues/10615 which seeks to
+ * replace the previous approach of manual access tokens params with this
+ * callback throughout the SDK.
+ *
  * @param {Object=} opts.store
  *    The data store used for sync data from the homeserver. If not specified,
  *    this client will not store any HTTP responses. The `createClient` helper
@@ -2438,7 +2446,12 @@ MatrixClient.prototype.inviteByEmail = function(roomId, email, callback) {
  * @return {module:client.Promise} Resolves: TODO
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixClient.prototype.inviteByThreePid = function(roomId, medium, address, callback) {
+MatrixClient.prototype.inviteByThreePid = async function(
+    roomId,
+    medium,
+    address,
+    callback,
+) {
     const path = utils.encodeUri(
         "/rooms/$roomId/invite",
         { $roomId: roomId },
@@ -2451,12 +2464,23 @@ MatrixClient.prototype.inviteByThreePid = function(roomId, medium, address, call
             errcode: "ORG.MATRIX.JSSDK_MISSING_PARAM",
         }));
     }
-
-    return this._http.authedRequest(callback, "POST", path, undefined, {
+    const params = {
         id_server: identityServerUrl,
         medium: medium,
         address: address,
-    });
+    };
+
+    if (
+        this.getIdentityAccessToken &&
+        await this.doesServerAcceptIdentityAccessToken()
+    ) {
+        const identityAccessToken = await this.getIdentityAccessToken();
+        if (identityAccessToken) {
+            params.id_access_token = identityAccessToken;
+        }
+    }
+
+    return this._http.authedRequest(callback, "POST", path, undefined, params);
 };
 
 /**
@@ -3423,7 +3447,7 @@ MatrixClient.prototype.requestPasswordMsisdnToken = function(phoneCountry, phone
  * @param {object} params Parameters for the POST request
  * @return {module:client.Promise} Resolves: As requestEmailToken
  */
-MatrixClient.prototype._requestTokenFromEndpoint = function(endpoint, params) {
+MatrixClient.prototype._requestTokenFromEndpoint = async function(endpoint, params) {
     const postParams = Object.assign({}, params);
 
     if (this.idBaseUrl) {
@@ -3432,6 +3456,16 @@ MatrixClient.prototype._requestTokenFromEndpoint = function(endpoint, params) {
             throw new Error("Invalid ID server URL: " + this.idBaseUrl);
         }
         postParams.id_server = idServerUrl.host;
+
+        if (
+            this.getIdentityAccessToken &&
+            await this.doesServerAcceptIdentityAccessToken()
+        ) {
+            const identityAccessToken = await this.getIdentityAccessToken();
+            if (identityAccessToken) {
+                postParams.id_access_token = identityAccessToken;
+            }
+        }
     }
 
     return this._http.request(
@@ -4090,6 +4124,23 @@ MatrixClient.prototype.doesServerRequireIdServerParam = async function() {
     } else {
         return unstableFeatures["m.require_identity_server"];
     }
+};
+
+/*
+ * Query the server to see if the `id_access_token` parameter can be safely
+ * passed to the homeserver. Some homeservers may trigger errors if they are not
+ * prepared for the new parameter.
+ * @return {Promise<boolean>} true if id_access_token can be sent
+ */
+MatrixClient.prototype.doesServerAcceptIdentityAccessToken = async function() {
+    const response = await this.getVersions();
+
+    const unstableFeatures = response["unstable_features"];
+    if (unstableFeatures["m.id_access_token"] === undefined) {
+        return false;
+    }
+
+    return unstableFeatures["m.id_access_token"];
 };
 
 /*

--- a/src/client.js
+++ b/src/client.js
@@ -108,10 +108,11 @@ function keyFromRecoverySession(session, decryptionKey) {
  *
  * @param {string} opts.userId The user ID for this user.
  *
- * @param {Function} [opts.getIdentityAccessToken]
- * Optional. A callback that returns a Promise<String> of an identity access
- * token to supply with identity requests. If the callback is unset, no access
- * token will be supplied.
+ * @param {IdentityServerProvider} [opts.identityServer]
+ * Optional. A provider object with one function `getAccessToken`, which is a
+ * callback that returns a Promise<String> of an identity access token to supply
+ * with identity requests. If the object is unset, no access token will be
+ * supplied.
  * See also https://github.com/vector-im/riot-web/issues/10615 which seeks to
  * replace the previous approach of manual access tokens params with this
  * callback throughout the SDK.
@@ -2471,10 +2472,11 @@ MatrixClient.prototype.inviteByThreePid = async function(
     };
 
     if (
-        this.getIdentityAccessToken &&
+        this.identityServer &&
+        this.identityServer.getAccessToken &&
         await this.doesServerAcceptIdentityAccessToken()
     ) {
-        const identityAccessToken = await this.getIdentityAccessToken();
+        const identityAccessToken = await this.identityServer.getAccessToken();
         if (identityAccessToken) {
             params.id_access_token = identityAccessToken;
         }
@@ -3458,10 +3460,11 @@ MatrixClient.prototype._requestTokenFromEndpoint = async function(endpoint, para
         postParams.id_server = idServerUrl.host;
 
         if (
-            this.getIdentityAccessToken &&
+            this.identityServer &&
+            this.identityServer.getAccessToken &&
             await this.doesServerAcceptIdentityAccessToken()
         ) {
-            const identityAccessToken = await this.getIdentityAccessToken();
+            const identityAccessToken = await this.identityServer.getAccessToken();
             if (identityAccessToken) {
                 postParams.id_access_token = identityAccessToken;
             }


### PR DESCRIPTION
This passes along the `id_access_token` to the HS, which it will need when
speaking v2 IS APIs to the IS.

Unfortunately, some HSes seem to explode when given this new parameter, so we
only pass it along for the moment if an unstable feature `m.id_access_token` is
also set.

Part of https://github.com/vector-im/riot-web/issues/10525
Used by https://github.com/matrix-org/matrix-react-sdk/pull/3337
Defined in [MSC2140](https://github.com/matrix-org/matrix-doc/pull/2140)