### PR TITLE
Clean up JSON handling in identity server requests

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1783,8 +1783,7 @@ MatrixBaseApis.prototype.requestEmailToken = async function(
     try {
         const response = await this._http.idServerRequest(
             undefined, "POST", "/validate/email/requestToken",
-            JSON.stringify(params), httpApi.PREFIX_IDENTITY_V2,
-            identityAccessToken,
+            params, httpApi.PREFIX_IDENTITY_V2, identityAccessToken,
         );
         // TODO: Fold callback into above call once v1 path below is removed
         if (callback) callback(null, response);
@@ -1839,8 +1838,7 @@ MatrixBaseApis.prototype.submitMsisdnToken = async function(
     try {
         return await this._http.idServerRequest(
             undefined, "POST", "/validate/msisdn/submitToken",
-            JSON.stringify(params), httpApi.PREFIX_IDENTITY_V2,
-            identityAccessToken,
+            params, httpApi.PREFIX_IDENTITY_V2, identityAccessToken,
         );
     } catch (err) {
         if (err.cors === "rejected" || err.httpStatus === 404) {
@@ -2064,7 +2062,7 @@ MatrixBaseApis.prototype.bulkLookupThreePids = async function(
             };
             logger.warn("IS doesn't support v2, falling back to deprecated v1");
             return await this._http.idServerRequest(
-                undefined, "POST", "/bulk_lookup", JSON.stringify(params),
+                undefined, "POST", "/bulk_lookup", params,
                 httpApi.PREFIX_IDENTITY_V1, identityAccessToken,
             );
         }

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -405,18 +405,14 @@ module.exports.MatrixHttpApi.prototype = {
             uri: fullUri,
             method: method,
             withCredentials: false,
-            json: false,
+            json: true, // we want a JSON response if we can
             _matrix_opts: this.opts,
             headers: {},
         };
-        if (method == 'GET') {
+        if (method === 'GET') {
             opts.qs = params;
         } else if (typeof params === "object") {
             opts.json = params;
-        } else if (typeof params === "string") {
-            // Assume the caller has serialised the body to JSON
-            opts.body = params;
-            opts.headers['Content-Type'] = "application/json";
         }
         if (accessToken) {
             opts.headers['Authorization'] = `Bearer ${accessToken}`;
@@ -427,12 +423,7 @@ module.exports.MatrixHttpApi.prototype = {
             opts,
             requestCallback(defer, callback, this.opts.onlyData),
         );
-        // ID server does not always take JSON, so we can't use requests' 'json'
-        // option as we do with the home server, but it does return JSON, so
-        // parse it manually
-        return defer.promise.then(function(response) {
-            return typeof(response) === 'string' ? JSON.parse(response) : response;
-        });
+        return defer.promise;
     },
 
     /**


### PR DESCRIPTION
JSON is JSON, so use JSON when dealing with JSON for JSON things because it's JSON.