### PR TITLE
Add Synapse admin functions for deactivating a user

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3985,7 +3985,7 @@ MatrixClient.prototype.whoisSynapseUser = function(userId) {
  * Deactivates a user using Synapse's administrator API. <strong>This
  * function is implementation specific and may change as a result.</strong>
  * @param {string} userId the User ID to deactivate.
- * @return {object} the deactive response - see Synapse docs for information.
+ * @return {object} the deactivate response - see Synapse docs for information.
  */
 MatrixClient.prototype.deactivateSynapseUser = function(userId) {
     const path = utils.encodeUri(

--- a/src/client.js
+++ b/src/client.js
@@ -3948,6 +3948,55 @@ MatrixClient.prototype.isFallbackICEServerAllowed = function() {
     return this._fallbackICEServerAllowed;
 };
 
+// Synapse-specific APIs
+// =====================
+
+/**
+ * Determines if the current user is an administrator of the Synapse homeserver.
+ * Returns false if untrue or the homeserver does not appear to be a Synapse
+ * homeserver. <strong>This function is implementation specific and may change
+ * as a result.</strong>
+ * @return {boolean} true if the user appears to be a Synapse administrator.
+ */
+MatrixClient.prototype.isSynapseAdministrator = function() {
+    return this.whoisSynapseUser(this.getUserId())
+        .then(() => true)
+        .catch(() => false);
+};
+
+/**
+ * Performs a whois lookup on a user using Synapse's administrator API.
+ * <strong>This function is implementation specific and may change as a
+ * result.</strong>
+ * @param {string} userId the User ID to look up.
+ * @return {object} the whois response - see Synapse docs for information.
+ */
+MatrixClient.prototype.whoisSynapseUser = function(userId) {
+    const path = utils.encodeUri(
+        "/_synapse/admin/v1/whois/$userId",
+        { $userId: userId },
+    );
+    return this._http.authedRequest(
+        undefined, 'GET', path, undefined, undefined, {prefix: ''},
+    );
+};
+
+/**
+ * Deactivates a user using Synapse's administrator API. <strong>This
+ * function is implementation specific and may change as a result.</strong>
+ * @param {string} userId the User ID to deactivate.
+ * @return {object} the deactive response - see Synapse docs for information.
+ */
+MatrixClient.prototype.deactivateSynapseUser = function(userId) {
+    const path = utils.encodeUri(
+        "/_synapse/admin/v1/deactivate/$userId",
+        { $userId: userId },
+    );
+    return this._http.authedRequest(
+        undefined, 'POST', path, undefined, undefined, {prefix: ''},
+    );
+};
+
 // Higher level APIs
 // =================
 


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/3371

Note: they're all intentionally named to have "Synapse" somewhere in the function name. These are implementation-specific endpoints that we don't want to be perceived as Matrix spec.