### PR TITLE
Check for r0.6.0 support in addition to unstable feature flags

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4196,6 +4196,13 @@ MatrixClient.prototype.doesServerSupportLazyLoading = async function() {
 MatrixClient.prototype.doesServerRequireIdServerParam = async function() {
     const response = await this.getVersions();
 
+    const versions = response["versions"];
+
+    // Supporting r0.6.0 is the same as having the flag set to false
+    if (versions && versions.includes("r0.6.0")) {
+        return false;
+    }
+
     const unstableFeatures = response["unstable_features"];
     if (unstableFeatures["m.require_identity_server"] === undefined) {
         return true;
@@ -4213,12 +4220,11 @@ MatrixClient.prototype.doesServerRequireIdServerParam = async function() {
 MatrixClient.prototype.doesServerAcceptIdentityAccessToken = async function() {
     const response = await this.getVersions();
 
+    const versions = response["versions"];
     const unstableFeatures = response["unstable_features"];
-    if (unstableFeatures["m.id_access_token"] === undefined) {
-        return false;
-    }
 
-    return unstableFeatures["m.id_access_token"];
+    return (versions && versions.includes("r0.6.0"))
+        || (unstableFeatures && unstableFeatures["m.id_access_token"]);
 };
 
 /*


### PR DESCRIPTION
To avoid the same problem that happened with lazy-loading (see https://github.com/matrix-org/synapse/issues/5528).

Note that as of writing r0.6.0 is not yet released, however it is the next scheduled release of the client-server API.

Fixes https://github.com/vector-im/riot-web/issues/10883