### PR TITLE
Remove IS details from requestToken to HS

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3478,7 +3478,9 @@ MatrixClient.prototype.requestPasswordMsisdnToken = function(phoneCountry, phone
 MatrixClient.prototype._requestTokenFromEndpoint = async function(endpoint, params) {
     const postParams = Object.assign({}, params);
 
-    if (this.idBaseUrl) {
+    // If the HS supports separate add and bind, then requestToken endpoints
+    // don't need an IS as they are all validated by the HS directly.
+    if (!await this.doesServerSupportSeparateAddAndBind() && this.idBaseUrl) {
         const idServerUrl = url.parse(this.idBaseUrl);
         if (!idServerUrl.host) {
             throw new Error("Invalid ID server URL: " + this.idBaseUrl);


### PR DESCRIPTION
This removes the IS details (server and access token) from `requestToken` calls
to the HS, as long as the HS supports the new separate add and bind mode. In
this mode, all of the 3PID validation is handled by the HS, so the IS details
are not used.

Fixes https://github.com/vector-im/riot-web/issues/10933