### PR TITLE
Remove id_server from creds for interactive auth

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -174,16 +174,19 @@ InteractiveAuth.prototype = {
             // The email can be validated out-of-band, but we need to provide the
             // creds so the HS can go & check it.
             if (this._emailSid) {
-                const idServerParsedUrl = url.parse(
-                    this._matrixClient.getIdentityServerUrl(),
-                );
+                const creds = {
+                    sid: this._emailSid,
+                    client_secret: this._clientSecret,
+                };
+                if (await this._matrixClient.doesServerRequireIdServerParam()) {
+                    const idServerParsedUrl = url.parse(
+                        this._matrixClient.getIdentityServerUrl(),
+                    );
+                    creds.id_server = idServerParsedUrl.host;
+                }
                 authDict = {
                     type: EMAIL_STAGE_TYPE,
-                    threepid_creds: {
-                        sid: this._emailSid,
-                        client_secret: this._clientSecret,
-                        id_server: idServerParsedUrl.host,
-                    },
+                    threepid_creds: creds,
                 };
             }
         }


### PR DESCRIPTION
For HSes that do not require an IS, we can remove `id_server` from the auth
params.

Fixes https://github.com/vector-im/riot-web/issues/10959