### PR TITLE
Log state of Olm sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,13 @@ To provide the Olm library in a browser application:
  
 To provide the Olm library in a node.js application:
 
- * ``yarn add https://packages.matrix.org/npm/olm/olm-3.0.0.tgz``
+ * ``yarn add https://packages.matrix.org/npm/olm/olm-3.1.4.tgz``
    (replace the URL with the latest version you want to use from
     https://packages.matrix.org/npm/olm/)
  * ``global.Olm = require('olm');`` *before* loading ``matrix-js-sdk``.
 
 If you want to package Olm as dependency for your node.js application, you can
-use ``yarn add https://packages.matrix.org/npm/olm/olm-3.0.0.tgz``. If your
+use ``yarn add https://packages.matrix.org/npm/olm/olm-3.1.4.tgz``. If your
 application also works without e2e crypto enabled, add ``--optional`` to mark it
 as an optional dependency.
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "matrix-mock-request": "^1.2.3",
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.0",
-    "olm": "/Users/dave/Downloads/olm-3.1.4.tgz",
+    "olm": "https://packages.matrix.org/npm/olm/olm-3.1.4.tgz",
     "rimraf": "^2.5.4",
     "source-map-support": "^0.4.11",
     "sourceify": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "matrix-mock-request": "^1.2.3",
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.0",
-    "olm": "https://packages.matrix.org/npm/olm/olm-3.1.0.tgz",
+    "olm": "/Users/dave/Downloads/olm-3.1.4.tgz",
     "rimraf": "^2.5.4",
     "source-map-support": "^0.4.11",
     "sourceify": "^0.1.0",

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -594,6 +594,11 @@ OlmDevice.prototype.encryptMessage = async function(
         'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
         (txn) => {
             this._getSession(theirDeviceIdentityKey, sessionId, txn, (sessionInfo) => {
+                const sessionDesc = sessionInfo.session.describe();
+                console.log(
+                    "Session ID " + sessionId + " to " +
+                    theirDeviceIdentityKey + ": " + sessionDesc,
+                );
                 res = sessionInfo.session.encrypt(payloadString);
                 this._saveSession(theirDeviceIdentityKey, sessionInfo, txn);
             });
@@ -621,6 +626,11 @@ OlmDevice.prototype.decryptMessage = async function(
         'readwrite', [IndexedDBCryptoStore.STORE_SESSIONS],
         (txn) => {
             this._getSession(theirDeviceIdentityKey, sessionId, txn, (sessionInfo) => {
+                const sessionDesc = sessionInfo.session.describe();
+                console.log(
+                    "Session ID " + sessionId + " to " +
+                    theirDeviceIdentityKey + ": " + sessionDesc,
+                );
                 payloadString = sessionInfo.session.decrypt(messageType, ciphertext);
                 sessionInfo.lastReceivedMessageTs = Date.now();
                 this._saveSession(theirDeviceIdentityKey, sessionInfo, txn);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3530,6 +3530,10 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+olm@/Users/dave/Downloads/olm-3.1.4.tgz:
+  version "3.1.4"
+  resolved "/Users/dave/Downloads/olm-3.1.4.tgz#0f03128b7d3b2f614d2216409a1dfccca765fdb3"
+
 "olm@https://packages.matrix.org/npm/olm/olm-3.1.0.tgz":
   version "3.1.0"
   resolved "https://packages.matrix.org/npm/olm/olm-3.1.0.tgz#2c8fc2a42b7ea12febc31baa73ec03d9b601da16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3530,13 +3530,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-olm@/Users/dave/Downloads/olm-3.1.4.tgz:
+"olm@https://packages.matrix.org/npm/olm/olm-3.1.4.tgz":
   version "3.1.4"
-  resolved "/Users/dave/Downloads/olm-3.1.4.tgz#0f03128b7d3b2f614d2216409a1dfccca765fdb3"
-
-"olm@https://packages.matrix.org/npm/olm/olm-3.1.0.tgz":
-  version "3.1.0"
-  resolved "https://packages.matrix.org/npm/olm/olm-3.1.0.tgz#2c8fc2a42b7ea12febc31baa73ec03d9b601da16"
+  resolved "https://packages.matrix.org/npm/olm/olm-3.1.4.tgz#0f03128b7d3b2f614d2216409a1dfccca765fdb3"
 
 once@1.x, once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
...whenever we encrypt or decrypt a message on them. This adds
another line of logging for every device in the room, so will
be reasonably verbose if you're in large encrypted rooms, but
the information ought to be valuable.

Requires https://gitlab.matrix.org/matrix-org/olm/merge_requests/9

Don't merge before a new version of Olm is released with this merge
request (it won't work).