### PR TITLE
Don't include .js in the import string.

### DIFF
--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -17,7 +17,7 @@ limitations under the License.
 import Promise from 'bluebird';
 
 import logger from '../../logger';
-import MemoryCryptoStore from './memory-crypto-store.js';
+import MemoryCryptoStore from './memory-crypto-store';
 
 /**
  * Internal module. Partial localStorage backed storage for e2e.


### PR DESCRIPTION
This removes a `.js` from one of the imports. This was causing me issues while trying to update the SDK used in Thunderbird and it seems unnecessary. Running the tests locally pass and I'm pretty sure there's no need for it since none of the other imports use it.