### PR TITLE
Properly documented the function possible returns

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -689,8 +689,9 @@ EventTimelineSet.prototype.compareEventOrdering = function(eventId1, eventId2) {
  * @param {String} eventType
  * The relation event's type, such as "m.reaction", etc.
  *
- * @returns {Relations}
- * A container for relation events.
+ * @returns {?Relations}
+ * A container for relation events, or undefined if either an event argument is invalid or
+ * aggregation is disabled.
  */
 EventTimelineSet.prototype.getRelationsForEvent = function(
     eventId, relationType, eventType,


### PR DESCRIPTION
Added the `nullable` possibility of return to the documentation of the function and described when that could happen, solving issue #1004. The tests made were visual by generating the docs everytime a change was made.

Signed-off-by: rcsm cascalhoeng@gmail.com