### PR TITLE
fix the path in references to logger.js

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -46,7 +46,7 @@ const olmlib = require("./crypto/olmlib");
 
 import ReEmitter from './ReEmitter';
 import RoomList from './crypto/RoomList';
-import logger from '../src/logger';
+import logger from './logger';
 
 import Crypto from './crypto';
 import { isCryptoAvailable } from './crypto';

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -23,7 +23,7 @@ limitations under the License.
  */
 
 import Promise from 'bluebird';
-import logger from '../../../src/logger';
+import logger from '../../logger';
 
 const utils = require("../../utils");
 const olmlib = require("../olmlib");

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -23,7 +23,7 @@ import Promise from 'bluebird';
 const parseContentType = require('content-type').parse;
 
 const utils = require("./utils");
-import logger from '../src/logger';
+import logger from './logger';
 
 // we use our own implementation of setTimeout, so that if we get suspended in
 // the middle of a /sync, we cancel the sync as soon as we awake, rather than

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -22,7 +22,7 @@ import Promise from 'bluebird';
 const url = require("url");
 
 const utils = require("./utils");
-import logger from '../src/logger';
+import logger from './logger';
 
 const EMAIL_STAGE_TYPE = "m.login.email.identity";
 const MSISDN_STAGE_TYPE = "m.login.msisdn";

--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -21,7 +21,7 @@ const EventEmitter = require("events").EventEmitter;
 const utils = require("../utils");
 const EventTimeline = require("./event-timeline");
 import {EventStatus} from "./event";
-import logger from '../../src/logger';
+import logger from '../logger';
 import Relations from './relations';
 
 // var DEBUG = false;

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -24,7 +24,7 @@ limitations under the License.
 import Promise from 'bluebird';
 import {EventEmitter} from 'events';
 import utils from '../utils.js';
-import logger from '../../src/logger';
+import logger from '../logger';
 
 /**
  * Enum for event statuses.

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -21,7 +21,7 @@ const EventEmitter = require("events").EventEmitter;
 
 const utils = require("../utils");
 const RoomMember = require("./room-member");
-import logger from '../../src/logger';
+import logger from '../logger';
 
 // possible statuses for out-of-band member loading
 const OOB_STATUS_NOTSTARTED = 1;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -30,7 +30,7 @@ const ContentRepo = require("../content-repo");
 const EventTimeline = require("./event-timeline");
 const EventTimelineSet = require("./event-timeline-set");
 
-import logger from '../../src/logger';
+import logger from '../logger';
 import ReEmitter from '../ReEmitter';
 
 // These constants are used as sane defaults when the homeserver doesn't support

--- a/src/realtime-callbacks.js
+++ b/src/realtime-callbacks.js
@@ -24,7 +24,7 @@ limitations under the License.
  */
 
 "use strict";
-import logger from '../src/logger';
+import logger from './logger';
 
 // we schedule a callback at least this often, to check if we've missed out on
 // some wall-clock time due to being suspended.

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -21,7 +21,7 @@ limitations under the License.
  */
 const utils = require("./utils");
 import Promise from 'bluebird';
-import logger from '../src/logger';
+import logger from './logger';
 
 const DEBUG = false;  // set true to enable console logging.
 

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -19,7 +19,7 @@ import Promise from 'bluebird';
 import SyncAccumulator from "../sync-accumulator";
 import utils from "../utils";
 import * as IndexedDBHelpers from "../indexeddb-helpers";
-import logger from '../../src/logger';
+import logger from '../logger';
 
 const VERSION = 3;
 

--- a/src/store/indexeddb-remote-backend.js
+++ b/src/store/indexeddb-remote-backend.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import Promise from 'bluebird';
-import logger from '../../src/logger';
+import logger from '../logger';
 
 /**
  * An IndexedDB store backend where the actual backend sits in a web

--- a/src/store/indexeddb-store-worker.js
+++ b/src/store/indexeddb-store-worker.js
@@ -17,7 +17,7 @@ limitations under the License.
 
 import Promise from 'bluebird';
 import LocalIndexedDBStoreBackend from "./indexeddb-local-backend.js";
-import logger from '../../src/logger';
+import logger from '../logger';
 
 /**
  * This class lives in the webworker and drives a LocalIndexedDBStoreBackend

--- a/src/store/indexeddb.js
+++ b/src/store/indexeddb.js
@@ -25,7 +25,7 @@ import LocalIndexedDBStoreBackend from "./indexeddb-local-backend.js";
 import RemoteIndexedDBStoreBackend from "./indexeddb-remote-backend.js";
 import User from "../models/user";
 import {MatrixEvent} from "../models/event";
-import logger from '../../src/logger';
+import logger from '../logger';
 
 /**
  * This is an internal module. See {@link IndexedDBStore} for the public class.

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -21,7 +21,7 @@ limitations under the License.
  */
 
 import utils from "./utils";
-import logger from '../src/logger';
+import logger from './logger';
 
 
 /**

--- a/src/sync.js
+++ b/src/sync.js
@@ -33,7 +33,7 @@ const utils = require("./utils");
 const Filter = require("./filter");
 const EventTimeline = require("./models/event-timeline");
 const PushProcessor = require("./pushprocessor");
-import logger from '../src/logger';
+import logger from './logger';
 
 import {InvalidStoreError} from './errors';
 

--- a/src/timeline-window.js
+++ b/src/timeline-window.js
@@ -19,7 +19,7 @@ limitations under the License.
 
 import Promise from 'bluebird';
 const EventTimeline = require("./models/event-timeline");
-import logger from '../src/logger';
+import logger from './logger';
 
 /**
  * @private

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -21,7 +21,7 @@ limitations under the License.
  */
 const utils = require("../utils");
 const EventEmitter = require("events").EventEmitter;
-import logger from '../../src/logger';
+import logger from '../logger';
 const DEBUG = true;  // set true to enable console logging.
 
 // events: hangup, error(err), replaced(call), state(state, oldState)


### PR DESCRIPTION
Currently, some logger imports force it to import the file from `/src`, which means that babel-ified code will try to import non-babel-ified code.  While `/src/logger.js` current doesn't have anything weird in it, it's probably not a good idea to depend on that, and we should drop the `../src` from the path.