### PR TITLE
Relax identity server discovery checks to FAIL_PROMPT

### DIFF
--- a/spec/unit/autodiscovery.spec.js
+++ b/spec/unit/autodiscovery.spec.js
@@ -416,8 +416,8 @@ describe("AutoDiscovery", function() {
         ]);
     });
 
-    it("should return FAIL_ERROR when the identity server configuration is wrong " +
-        "(missing base_url)", function() {
+    it("should return SUCCESS / FAIL_PROMPT when the identity server configuration " +
+        "is wrong (missing base_url)", function() {
         httpBackend.when("GET", "/_matrix/client/versions").check((req) => {
             expect(req.opts.uri)
                 .toEqual("https://chat.example.org/_matrix/client/versions");
@@ -438,14 +438,14 @@ describe("AutoDiscovery", function() {
             AutoDiscovery.findClientConfig("example.org").then((conf) => {
                 const expected = {
                     "m.homeserver": {
-                        state: "FAIL_ERROR",
-                        error: AutoDiscovery.ERROR_INVALID_IS,
+                        state: "SUCCESS",
+                        error: null,
 
                         // We still expect the base_url to be here for debugging purposes.
                         base_url: "https://chat.example.org",
                     },
                     "m.identity_server": {
-                        state: "FAIL_ERROR",
+                        state: "FAIL_PROMPT",
                         error: AutoDiscovery.ERROR_INVALID_IS_BASE_URL,
                         base_url: null,
                     },
@@ -456,8 +456,8 @@ describe("AutoDiscovery", function() {
         ]);
     });
 
-    it("should return FAIL_ERROR when the identity server configuration is wrong " +
-        "(empty base_url)", function() {
+    it("should return SUCCESS / FAIL_PROMPT when the identity server configuration " +
+        "is wrong (empty base_url)", function() {
         httpBackend.when("GET", "/_matrix/client/versions").check((req) => {
             expect(req.opts.uri)
                 .toEqual("https://chat.example.org/_matrix/client/versions");
@@ -478,14 +478,14 @@ describe("AutoDiscovery", function() {
             AutoDiscovery.findClientConfig("example.org").then((conf) => {
                 const expected = {
                     "m.homeserver": {
-                        state: "FAIL_ERROR",
-                        error: AutoDiscovery.ERROR_INVALID_IS,
+                        state: "SUCCESS",
+                        error: null,
 
                         // We still expect the base_url to be here for debugging purposes.
                         base_url: "https://chat.example.org",
                     },
                     "m.identity_server": {
-                        state: "FAIL_ERROR",
+                        state: "FAIL_PROMPT",
                         error: AutoDiscovery.ERROR_INVALID_IS_BASE_URL,
                         base_url: null,
                     },
@@ -496,8 +496,8 @@ describe("AutoDiscovery", function() {
         ]);
     });
 
-    it("should return FAIL_ERROR when the identity server configuration is wrong " +
-        "(validation error: 404)", function() {
+    it("should return SUCCESS / FAIL_PROMPT when the identity server configuration " +
+        "is wrong (validation error: 404)", function() {
         httpBackend.when("GET", "/_matrix/client/versions").check((req) => {
             expect(req.opts.uri)
                 .toEqual("https://chat.example.org/_matrix/client/versions");
@@ -519,14 +519,14 @@ describe("AutoDiscovery", function() {
             AutoDiscovery.findClientConfig("example.org").then((conf) => {
                 const expected = {
                     "m.homeserver": {
-                        state: "FAIL_ERROR",
-                        error: AutoDiscovery.ERROR_INVALID_IS,
+                        state: "SUCCESS",
+                        error: null,
 
                         // We still expect the base_url to be here for debugging purposes.
                         base_url: "https://chat.example.org",
                     },
                     "m.identity_server": {
-                        state: "FAIL_ERROR",
+                        state: "FAIL_PROMPT",
                         error: AutoDiscovery.ERROR_INVALID_IDENTITY_SERVER,
                         base_url: "https://identity.example.org",
                     },
@@ -537,8 +537,8 @@ describe("AutoDiscovery", function() {
         ]);
     });
 
-    it("should return FAIL_ERROR when the identity server configuration is wrong " +
-        "(validation error: 500)", function() {
+    it("should return SUCCESS / FAIL_PROMPT when the identity server configuration " +
+        "is wrong (validation error: 500)", function() {
         httpBackend.when("GET", "/_matrix/client/versions").check((req) => {
             expect(req.opts.uri)
                 .toEqual("https://chat.example.org/_matrix/client/versions");
@@ -560,14 +560,14 @@ describe("AutoDiscovery", function() {
             AutoDiscovery.findClientConfig("example.org").then((conf) => {
                 const expected = {
                     "m.homeserver": {
-                        state: "FAIL_ERROR",
-                        error: AutoDiscovery.ERROR_INVALID_IS,
+                        state: "SUCCESS",
+                        error: null,
 
                         // We still expect the base_url to be here for debugging purposes
                         base_url: "https://chat.example.org",
                     },
                     "m.identity_server": {
-                        state: "FAIL_ERROR",
+                        state: "FAIL_PROMPT",
                         error: AutoDiscovery.ERROR_INVALID_IDENTITY_SERVER,
                         base_url: "https://identity.example.org",
                     },

--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -275,21 +276,11 @@ export class AutoDiscovery {
         let isUrl = "";
         if (wellknown["m.identity_server"]) {
             // We prepare a failing identity server response to save lines later
-            // in this branch. Note that we also fail the homeserver check in the
-            // object because according to the spec we're supposed to FAIL_ERROR
-            // if *anything* goes wrong with the IS validation, including invalid
-            // format. This means we're supposed to stop discovery completely.
+            // in this branch.
             const failingClientConfig = {
-                "m.homeserver": {
-                    state: AutoDiscovery.FAIL_ERROR,
-                    error: AutoDiscovery.ERROR_INVALID_IS,
-
-                    // We'll provide the base_url that was previously valid for
-                    // debugging purposes.
-                    base_url: clientConfig["m.homeserver"].base_url,
-                },
+                "m.homeserver": clientConfig["m.homeserver"],
                 "m.identity_server": {
-                    state: AutoDiscovery.FAIL_ERROR,
+                    state: AutoDiscovery.FAIL_PROMPT,
                     error: AutoDiscovery.ERROR_INVALID_IS,
                     base_url: null,
                 },


### PR DESCRIPTION
As discussed in MSC2284, this relaxes the identity server discovery to a
`FAIL_PROMPT` state so that clients can choose to warn and continue.

Part of https://github.com/vector-im/riot-web/issues/11102
Implements https://github.com/matrix-org/matrix-doc/pull/2284