### PR TITLE
Don't double cancel verification request

### DIFF
--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -152,11 +152,11 @@ export default class VerificationBase extends EventEmitter {
             this._resetTimer();
             this._resolveEvent(e);
         } else {
-            this._expectedEvent = undefined;
             const exception = new Error(
                 "Unexpected message: expecting " + this._expectedEvent
                     + " but got " + e.getType(),
             );
+            this._expectedEvent = undefined;
             if (this._rejectEvent) {
                 const reject = this._rejectEvent;
                 this._rejectEvent = undefined;

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -151,6 +151,10 @@ export default class VerificationBase extends EventEmitter {
             this._rejectEvent = undefined;
             this._resetTimer();
             this._resolveEvent(e);
+        } else if (e.getType() === "m.key.verification.cancel") {
+            const reject = this._reject;
+            this._reject = undefined;
+            reject(new Error("Other side cancelled verification"));
         } else {
             const exception = new Error(
                 "Unexpected message: expecting " + this._expectedEvent


### PR DESCRIPTION
This fixes the verifier not handling incoming `m.key.verification.cancel` events, and just treating them as unexpected and sending a `m.key.verification.cancel` event of its own with an error. These double `m.key.verification.cancel` events make it harder to detect which user actually pressed cancel.

Initial PR for verification over DM was https://github.com/matrix-org/matrix-js-sdk/pull/1050 