### PR TITLE
Use stable API prefix for 3PID APIs when supported

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -1374,12 +1374,12 @@ MatrixBaseApis.prototype.addThreePid = function(creds, bind, callback) {
  * @return {module:client.Promise} Resolves: on success
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixBaseApis.prototype.addThreePidOnly = function(data) {
+MatrixBaseApis.prototype.addThreePidOnly = async function(data) {
     const path = "/account/3pid/add";
+    const prefix = await this.isVersionSupported("r0.6.0") ?
+        httpApi.PREFIX_R0 : httpApi.PREFIX_UNSTABLE;
     return this._http.authedRequest(
-        undefined, "POST", path, null, data, {
-            prefix: httpApi.PREFIX_UNSTABLE,
-        },
+        undefined, "POST", path, null, data, { prefix },
     );
 };
 
@@ -1397,12 +1397,12 @@ MatrixBaseApis.prototype.addThreePidOnly = function(data) {
  * @return {module:client.Promise} Resolves: on success
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixBaseApis.prototype.bindThreePid = function(data) {
+MatrixBaseApis.prototype.bindThreePid = async function(data) {
     const path = "/account/3pid/bind";
+    const prefix = await this.isVersionSupported("r0.6.0") ?
+        httpApi.PREFIX_R0 : httpApi.PREFIX_UNSTABLE;
     return this._http.authedRequest(
-        undefined, "POST", path, null, data, {
-            prefix: httpApi.PREFIX_UNSTABLE,
-        },
+        undefined, "POST", path, null, data, { prefix },
     );
 };
 
@@ -1417,17 +1417,17 @@ MatrixBaseApis.prototype.bindThreePid = function(data) {
  * @return {module:client.Promise} Resolves: on success
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
-MatrixBaseApis.prototype.unbindThreePid = function(medium, address) {
+MatrixBaseApis.prototype.unbindThreePid = async function(medium, address) {
     const path = "/account/3pid/unbind";
     const data = {
         medium,
         address,
         id_server: this.getIdentityServerUrl(true),
     };
+    const prefix = await this.isVersionSupported("r0.6.0") ?
+        httpApi.PREFIX_R0 : httpApi.PREFIX_UNSTABLE;
     return this._http.authedRequest(
-        undefined, "POST", path, null, data, {
-            prefix: httpApi.PREFIX_UNSTABLE,
-        },
+        undefined, "POST", path, null, data, { prefix },
     );
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -4211,6 +4211,16 @@ MatrixClient.prototype.getVersions = async function() {
 };
 
 /**
+ * Check if a particular spec version is supported by the server.
+ * @param {string} version The spec version (such as "r0.5.0") to check for.
+ * @return {Promise<bool>} Whether it is supported
+ */
+MatrixClient.prototype.isVersionSupported = async function(version) {
+    const { versions } = await this.getVersions();
+    return versions && versions.includes(version);
+};
+
+/**
  * Query the server to see if it support members lazy loading
  * @return {Promise<boolean>} true if server supports lazy loading
  */


### PR DESCRIPTION
If the server advertises spec version r0.6.0, it must have the 3PID APIs
available under the stable API prefix.

Fixes https://github.com/vector-im/riot-web/issues/11246