### PR TITLE
WIP: Oauth support

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -291,6 +291,16 @@ MatrixBaseApis.prototype.loginFlows = function(callback) {
 };
 
 /**
+ * @param {module:client.callback} callback Optional.
+ * @return {module:client.Promise} Resolves: TODO
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixBaseApis.prototype.oauthFlows = function(callback) {
+    console.log("Fetch oauth flows");
+    return this._http.request(callback, "GET", "/oauth");
+};
+
+/**
  * @param {string} loginType
  * @param {Object} data
  * @param {module:client.callback} callback Optional.


### PR DESCRIPTION
Issue: https://github.com/vector-im/riot-web/issues/4610

This adds an API to fetch the supported OAuth providers from the server. This is similar to the endpoint that gets the supported login flows.

Part of these pull requests:
- matrix-react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/3623
- riot-web: https://github.com/vector-im/riot-web/pull/11401
- synapse: https://github.com/matrix-org/synapse/pull/6371
