### PR TITLE
Remove 'check' npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test:watch": "jest spec/ --coverage --testEnvironment node --watch",
     "test": "jest spec/ --coverage --testEnvironment node",
-    "check": "yarn test:build && _mocha --recursive specbuild --colors",
     "gendoc": "babel --no-babelrc --plugins transform-class-properties -d .jsdocbuild src && jsdoc -r .jsdocbuild -P package.json -R README.md -d .jsdoc",
     "start": "yarn start:init && yarn start:watch",
     "start:watch": "babel -s -w --skip-initial-build -d lib src",


### PR DESCRIPTION
...whose only purpose was to run the tests without coverage because
the coverage tool was awful and ruined all the line numbers (moreso).