### PR TITLE
Monitor verification request over DM as well

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5201,6 +5201,8 @@ module.exports.CRYPTO_ENABLED = CRYPTO_ENABLED;
  * @param {object} data
  * @param {MatrixEvent} data.event the original verification request message
  * @param {Array} data.methods the verification methods that can be used
+ * @param {Number} data.timeout the amount of milliseconds that should be waited
+ *                 before cancelling the request automatically.
  * @param {Function} data.beginKeyVerification a function to call if a key
  *     verification should be performed.  The function takes one argument: the
  *     name of the key verification method (taken from data.methods) to use.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -930,11 +930,8 @@ Crypto.prototype.registerEventHandlers = function(eventEmitter) {
         crypto._onToDeviceEvent(event);
     });
 
-    // only sync timeline events, not events when backpaginating, loading, ...
     eventEmitter.on("Room.timeline", function(event) {
-        if (event.getRoomId()) {
-            crypto._onTimelineEvent(event);
-        }
+        crypto._onTimelineEvent(event);
     });
 
     eventEmitter.on("Event.decrypted", function(event) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -65,7 +65,14 @@ export const verificationMethods = {
     SAS: SAS.NAME,
 };
 
+// the recommended amount of time before a verification request
+// should be (automatically) cancelled without user interaction
+// and ignored.
 const VERIFICATION_REQUEST_TIMEOUT = 5 * 60 * 1000; //5m
+// to avoid almost expired verification notifications
+// from showing a notification and almost immediately
+// disappearing, also ignore verification requests that
+// are this amount of time away from expiring.
 const VERIFICATION_REQUEST_MARGIN = 3 * 1000; //3s
 
 export function isCryptoAvailable() {

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -298,6 +298,15 @@ utils.extend(module.exports.MatrixEvent.prototype, {
     },
 
     /**
+     * Get the age of the event when this function was called.
+     * Relies on the local clock being in sync with the clock of the original homeserver.
+     * @return {Number} The age of this event in milliseconds.
+     */
+    getLocalAge: function() {
+        return Date.now() - this.getTs();
+    },
+
+    /**
      * Get the event state_key if it has one. This will return <code>undefined
      * </code> for message events.
      * @return {string} The event's <code>state_key</code>.


### PR DESCRIPTION
And emit `crypto.verification.request` events for both verification over DM and mock it (see commit messages) for to_device verifications.

Required for https://github.com/matrix-org/matrix-react-sdk/pull/3661