### PR TITLE
Fix calls in e2e rooms

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4644,8 +4644,11 @@ function setupCallEventHandler(client) {
     // This happens quite often, eg. replaying sync from storage, catchup sync
     // after loading and after we've been offline for a bit.
     let callEventBuffer = [];
-    function onSync(state) {
-        if (state === "SYNCING") {
+    function evaluateEventBuffer() {
+        if (client.getSyncState() === "SYNCING") {
+            // don't process any events until they are all decrypted
+            if (callEventBuffer.some((e) => e.isBeingDecrypted())) return;
+
             const ignoreCallIds = {}; // Set<String>
             // inspect the buffer and mark all calls which have been answered
             // or hung up before passing them to the call event handler.
@@ -4670,20 +4673,31 @@ function setupCallEventHandler(client) {
             callEventBuffer = [];
         }
     }
-    client.on("sync", onSync);
+    client.on("sync", evaluateEventBuffer);
 
     function onEvent(event) {
-        if (event.getType().indexOf("m.call.") !== 0) {
-            // not a call event
-            if (event.isBeingDecrypted() || event.isDecryptionFailure()) {
-                // not *yet* a call event, but might become one...
-                event.once("Event.decrypted", onEvent);
-            }
-            return;
+        // any call events or ones that might be once they're decrypted
+        if (event.getType().indexOf("m.call.") === 0 || event.isBeingDecrypted()) {
+            // queue up for processing once all events from this sync have been
+            // processed (see above).
+            callEventBuffer.push(event);
         }
-        // queue up for processing once all events from this sync have been
-        // processed (see above).
-        callEventBuffer.push(event);
+
+        if (event.isBeingDecrypted() || event.isDecryptionFailure()) {
+            // add an event listener for once the event is decrypted.
+            event.once("Event.decrypted", () => {
+                if (event.getType().indexOf("m.call.") === -1) return;
+
+                if (callEventBuffer.includes(event)) {
+                    // we were waiting for that event to decrypt, so recheck the buffer
+                    evaluateEventBuffer();
+                } else {
+                    // This one wasn't buffered so just run the event handler for it
+                    // straight away
+                    callEventHandler(e);
+                }
+            });
+        }
     }
     client.on("event", onEvent);
 

--- a/src/client.js
+++ b/src/client.js
@@ -4694,7 +4694,7 @@ function setupCallEventHandler(client) {
                 } else {
                     // This one wasn't buffered so just run the event handler for it
                     // straight away
-                    callEventHandler(e);
+                    callEventHandler(event);
                 }
             });
         }


### PR DESCRIPTION
Events will be decrypted after the sync event, so we were having
to wait until the next sync event before they got processed.