### PR TITLE
Fix empty string handling in push notifications

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -268,7 +268,7 @@ function PushProcessor(client) {
         }
 
         const val = valueForDottedKey(cond.key, ev);
-        if (isNullOrUndefined(val) || typeof val != 'string') {
+        if (typeof val !== 'string') {
             return false;
         }
 

--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {escapeRegExp, globToRegexp} from "./utils";
+import {escapeRegExp, globToRegexp, isNullOrUndefined} from "./utils";
 
 /**
  * @module pushprocessor
@@ -268,7 +268,7 @@ function PushProcessor(client) {
         }
 
         const val = valueForDottedKey(cond.key, ev);
-        if (!val || typeof val != 'string') {
+        if (isNullOrUndefined(val) || typeof val != 'string') {
             return false;
         }
 
@@ -304,10 +304,10 @@ function PushProcessor(client) {
 
         // special-case the first component to deal with encrypted messages
         const firstPart = parts[0];
-        if (firstPart == 'content') {
+        if (firstPart === 'content') {
             val = ev.getContent();
             parts.shift();
-        } else if (firstPart == 'type') {
+        } else if (firstPart === 'type') {
             val = ev.getType();
             parts.shift();
         } else {
@@ -316,11 +316,11 @@ function PushProcessor(client) {
         }
 
         while (parts.length > 0) {
-            const thispart = parts.shift();
-            if (!val[thispart]) {
+            const thisPart = parts.shift();
+            if (isNullOrUndefined(val[thisPart])) {
                 return null;
             }
-            val = val[thispart];
+            val = val[thisPart];
         }
         return val;
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -714,3 +714,7 @@ module.exports.ensureNoTrailingSlash = function(url) {
 module.exports.sleep = (ms, value) => new Promise((resolve => {
     setTimeout(resolve, ms, value);
 }));
+
+module.exports.isNullOrUndefined = function(val) {
+    return val === null || val === undefined;
+};


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11460

Empty strings are falsey, and the state key match for a tombstone event is an empty string. Ergo, nothing happens because all the conditions fail. 

This PR also does a small amount of drive-by cleanup.

Evidence of this working:
![image](https://user-images.githubusercontent.com/1190097/69587063-af18a280-0fa1-11ea-8386-e4985505c777.png)
