### PR TITLE
Fix Olm unwedging test

### DIFF
--- a/spec/unit/crypto.spec.js
+++ b/spec/unit/crypto.spec.js
@@ -110,6 +110,7 @@ describe("Crypto", function() {
             });
 
             fakeEmitter.emit('toDeviceEvent', {
+                getId: jest.fn().mockReturnValue("$wedged"),
                 getType: jest.fn().mockReturnValue('m.room.message'),
                 getContent: jest.fn().mockReturnValue({
                     msgtype: 'm.bad.encrypted',


### PR DESCRIPTION
Deep within the crypto layers we call `getId()`, and when we don't have that function the async call on the emitter fails but doesn't fail the test. This manifests as a timeout because the code path that would call the thing blew up.

Part of https://github.com/vector-im/riot-web/issues/11520