### PR TITLE
increase timeout on flush to fix failing unit test

### DIFF
--- a/spec/unit/crypto/verification/sas.spec.js
+++ b/spec/unit/crypto/verification/sas.spec.js
@@ -275,9 +275,7 @@ describe("SAS verification", function() {
             expect(aliceDevice.isVerified()).toBeTruthy();
         });
 
-        // TODO: Turn this test back on by fixing it.
-        // See https://github.com/vector-im/riot-web/issues/11545 and related issues.
-        xit("should verify a cross-signing key", async () => {
+        it("should verify a cross-signing key", async () => {
             alice.httpBackend.when('POST', '/keys/device_signing/upload').respond(
                 200, {},
             );
@@ -296,32 +294,16 @@ describe("SAS verification", function() {
                 },
             );
 
-            alice.httpBackend.when('POST', '/keys/query').respond(200, {
-                failures: {},
-                device_keys: {
-                    "@bob:example.com": BOB_DEVICES,
-                },
-            });
-            bob.httpBackend.when('POST', '/keys/query').respond(200, {
-                failures: {},
-                device_keys: {
-                    "@alice:example.com": ALICE_DEVICES,
-                },
-            });
-
             const verifyProm = Promise.all([
                 aliceVerifier.verify(),
                 bobPromise.then((verifier) => {
                     bob.httpBackend.when(
                         'POST', '/keys/signatures/upload',
                     ).respond(200, {});
-                    bob.httpBackend.flush(undefined, 2);
+                    bob.httpBackend.flush(undefined, 1, 2000);
                     return verifier.verify();
                 }),
             ]);
-
-            await alice.httpBackend.flush(undefined, 1);
-            console.log("alice reqs flushed");
 
             await verifyProm;
 


### PR DESCRIPTION
It took more than 0.1 seconds between when `bob.httpBackend.flush` is called and when the request is actually made, so `flush` stops trying to respond to the message, which means that when it does finally make the request, it never gets a response.  Increasing the timeout on `flush` makes it keep trying for longer.

Also the requests to `/keys/query` are apparently never made, so remove them.

fixes: vector-im/riot-web#11545