### PR TITLE
ignore m.key.verification.done messages when we don't expect any more messages

### DIFF
--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -173,10 +173,14 @@ export default class VerificationBase extends EventEmitter {
         if (this._done) {
             return;
         } else if (e.getType() === this._expectedEvent) {
-            this._expectedEvent = undefined;
-            this._rejectEvent = undefined;
-            this._resetTimer();
-            this._resolveEvent(e);
+            // if we receive an expected m.key.verification.done, then just
+            // ignore it, since we don't need to do anything about it
+            if (this._expectedEvent !== "m.key.verification.done") {
+                this._expectedEvent = undefined;
+                this._rejectEvent = undefined;
+                this._resetTimer();
+                this._resolveEvent(e);
+            }
         } else if (e.getType() === "m.key.verification.cancel") {
             const reject = this._reject;
             this._reject = undefined;

--- a/src/crypto/verification/SAS.js
+++ b/src/crypto/verification/SAS.js
@@ -270,7 +270,14 @@ export default class SAS extends Base {
 
 
             [e] = await Promise.all([
-                this._waitForEvent("m.key.verification.mac"),
+                this._waitForEvent("m.key.verification.mac")
+                    .then((e) => {
+                        // we don't expect any more messages from the other
+                        // party, and they may send a m.key.verification.done
+                        // when they're done on their end
+                        this._expectedEvent = "m.key.verification.done";
+                        return e;
+                    }),
                 verifySAS,
             ]);
             content = e.getContent();
@@ -347,7 +354,14 @@ export default class SAS extends Base {
 
 
             [e] = await Promise.all([
-                this._waitForEvent("m.key.verification.mac"),
+                this._waitForEvent("m.key.verification.mac")
+                    .then((e) => {
+                        // we don't expect any more messages from the other
+                        // party, and they may send a m.key.verification.done
+                        // when they're done on their end
+                        this._expectedEvent = "m.key.verification.done";
+                        return e;
+                    }),
                 verifySAS,
             ]);
             content = e.getContent();


### PR DESCRIPTION
This should fix some test flakiness.