### PR TITLE
Fix device list's cross-signing storage path

### DIFF
--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -122,7 +122,8 @@ export default class DeviceList extends EventEmitter {
             'readonly', [IndexedDBCryptoStore.STORE_DEVICE_DATA], (txn) => {
                 this._cryptoStore.getEndToEndDeviceData(txn, (deviceData) => {
                     this._devices = deviceData ? deviceData.devices : {},
-                    this._ssks = deviceData ? deviceData.self_signing_keys || {} : {};
+                    this._crossSigningInfo = deviceData ?
+                        deviceData.crossSigningInfo || {} : {};
                     this._deviceTrackingStatus = deviceData ?
                         deviceData.trackingStatus : {};
                     this._syncToken = deviceData ? deviceData.syncToken : null;
@@ -213,7 +214,7 @@ export default class DeviceList extends EventEmitter {
                     'readwrite', [IndexedDBCryptoStore.STORE_DEVICE_DATA], (txn) => {
                         this._cryptoStore.storeEndToEndDeviceData({
                             devices: this._devices,
-                            self_signing_keys: this._ssks,
+                            crossSigningInfo: this._crossSigningInfo,
                             trackingStatus: this._deviceTrackingStatus,
                             syncToken: this._syncToken,
                         }, txn);


### PR DESCRIPTION
Some variables were changed during the course of the initial cross-signing PR
(https://github.com/matrix-org/matrix-js-sdk/pull/832) without updating the
storage path to match, so we weren't storing / loading cross-signing info for
devices in the end.

This updates storage and loading to match where the data now lives in memory.