### PR TITLE
Refactor verification request code

### DIFF
--- a/spec/unit/crypto/verification/qr_code.spec.js
+++ b/spec/unit/crypto/verification/qr_code.spec.js
@@ -39,7 +39,10 @@ describe("QR code verification", function() {
 
     describe("showing", function() {
         it("should emit an event to show a QR code", async function() {
-            const qrCode = new ShowQRCode({
+            const channel = {
+                send: jest.fn(),
+            };
+            const qrCode = new ShowQRCode(channel, {
                 getUserId: () => "@alice:example.com",
                 deviceId: "ABCDEFG",
                 getDeviceEd25519Key: function() {
@@ -79,7 +82,10 @@ describe("QR code verification", function() {
                 getStoredDevice: jest.fn().mockReturnValue(device),
                 setDeviceVerified: jest.fn(),
             };
-            const qrCode = new ScanQRCode(client);
+            const channel = {
+                send: jest.fn(),
+            };
+            const qrCode = new ScanQRCode(channel, client);
             qrCode.on("confirm_user_id", ({userId, confirm}) => {
                 if (userId === "@alice:example.com") {
                     confirm();
@@ -102,13 +108,17 @@ describe("QR code verification", function() {
                 getStoredDevice: jest.fn(),
                 setDeviceVerified: jest.fn(),
             };
-            const qrCode = new ScanQRCode(client, "@bob:example.com", "ABCDEFG");
+            const channel = {
+                send: jest.fn(),
+            };
+            const qrCode = new ScanQRCode(channel, client, "@bob:example.com", "ABCDEFG");
             qrCode.on("scan", ({done}) => {
                 done(QR_CODE_URL);
             });
             const spy = jest.fn();
             await qrCode.verify().catch(spy);
             expect(spy).toHaveBeenCalled();
+            expect(channel.send).toHaveBeenCalled();
             expect(client.getStoredDevice).not.toHaveBeenCalled();
             expect(client.setDeviceVerified).not.toHaveBeenCalled();
         });
@@ -131,13 +141,18 @@ describe("QR code verification", function() {
                 getStoredDevice: jest.fn().mockReturnValue(device),
                 setDeviceVerified: jest.fn(),
             };
-            const qrCode = new ScanQRCode(client, "@alice:example.com", "ABCDEFG");
+            const channel = {
+                send: jest.fn(),
+            };
+            const qrCode = new ScanQRCode(
+                channel, client, "@alice:example.com", "ABCDEFG");
             qrCode.on("scan", ({done}) => {
                 done(QR_CODE_URL);
             });
             const spy = jest.fn();
             await qrCode.verify().catch(spy);
             expect(spy).toHaveBeenCalled();
+            expect(channel.send).toHaveBeenCalled();
             expect(client.getStoredDevice).toHaveBeenCalled();
             expect(client.setDeviceVerified).not.toHaveBeenCalled();
         });

--- a/spec/unit/crypto/verification/util.js
+++ b/spec/unit/crypto/verification/util.js
@@ -60,7 +60,7 @@ export async function makeTestClients(userInfos, options) {
         });
         for (const tc of clients) {
             setTimeout(
-                () => tc.client.emit("event", event),
+                () => tc.client.emit("Room.timeline", event),
                 0,
             );
         }

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -40,15 +40,13 @@ export default class VerificationBase extends EventEmitter {
      *
      * @class
      *
+     * @param {module:base-apis~Channel} channel the verification channel to send verification messages over.
+     *
      * @param {module:base-apis~MatrixBaseApis} baseApis base matrix api interface
      *
      * @param {string} userId the user ID that is being verified
      *
      * @param {string} deviceId the device ID that is being verified
-     *
-     * @param {string} transactionId the transaction ID to be used when sending events
-     *
-     * @param {string} [roomId] the room to use for verification
      *
      * @param {object} [startEvent] the m.key.verification.start event that
      * initiated this verification, if any
@@ -56,35 +54,22 @@ export default class VerificationBase extends EventEmitter {
      * @param {object} [request] the key verification request object related to
      * this verification, if any
      */
-    constructor(baseApis, userId, deviceId, transactionId, roomId, startEvent, request) {
+    constructor(channel, baseApis, userId, deviceId, startEvent, request) {
         super();
+        this._channel = channel;
         this._baseApis = baseApis;
         this.userId = userId;
         this.deviceId = deviceId;
-        this.transactionId = transactionId;
-        if (typeof(roomId) === "string" || roomId instanceof String) {
-            this.roomId = roomId;
-            this.startEvent = startEvent;
-            this.request = request;
-        } else {
-            // if room ID was omitted, but start event and request were not
-            this.startEvent= roomId;
-            this.request = startEvent;
-        }
+        this.startEvent = startEvent;
+        this.request = request;
+
         this.cancelled = false;
         this._done = false;
         this._promise = null;
         this._transactionTimeoutTimer = null;
-        this._eventsSubscription = null;
 
         // At this point, the verification request was received so start the timeout timer.
         this._resetTimer();
-
-        if (this.roomId) {
-            this._sendWithTxnId = this._sendMessage;
-        } else {
-            this._sendWithTxnId = this._sendToDevice;
-        }
     }
 
     _resetTimer() {
@@ -107,55 +92,8 @@ export default class VerificationBase extends EventEmitter {
         }
     }
 
-    _contentFromEventWithTxnId(event) {
-        if (this.roomId) {  // verification as timeline event
-            // ensure m.related_to is included in e2ee rooms
-            // as the field is excluded from encryption
-            const content = Object.assign({}, event.getContent());
-            content["m.relates_to"] = event.getRelation();
-            return content;
-        } else { // verification as to_device event
-            return event.getContent();
-        }
-    }
-
-    /* creates a content object with the transaction id added to it */
-    _contentWithTxnId(content) {
-        const copy = Object.assign({}, content);
-        if (this.roomId) { // verification as timeline event
-            copy["m.relates_to"] = {
-                rel_type: "m.reference",
-                event_id: this.transactionId,
-            };
-        } else { // verification as to_device event
-            copy.transaction_id = this.transactionId;
-        }
-        return copy;
-    }
-
-    _send(type, contentWithoutTxnId) {
-        const content = this._contentWithTxnId(contentWithoutTxnId);
-        return this._sendWithTxnId(type, content);
-    }
-
-    /* send a message to the other participant, using to-device messages
-     */
-    _sendToDevice(type, content) {
-        if (this._done) {
-            return Promise.reject(new Error("Verification is already done"));
-        }
-        return this._baseApis.sendToDevice(type, {
-            [this.userId]: { [this.deviceId]: content },
-        });
-    }
-
-    /* send a message to the other participant, using in-roomm messages
-     */
-    _sendMessage(type, content) {
-        if (this._done) {
-            return Promise.reject(new Error("Verification is already done"));
-        }
-        return this._baseApis.sendEvent(this.roomId, type, content);
+    _send(type, uncompletedContent) {
+        return this._channel.send(type, uncompletedContent);
     }
 
     _waitForEvent(type) {
@@ -199,7 +137,7 @@ export default class VerificationBase extends EventEmitter {
     done() {
         this._endTimer(); // always kill the activity timer
         if (!this._done) {
-            if (this.roomId) {
+            if (this._channel.needsDoneMessage) {
                 // verification in DM requires a done message
                 this._send("m.key.verification.done", {});
             }
@@ -211,7 +149,7 @@ export default class VerificationBase extends EventEmitter {
         this._endTimer(); // always kill the activity timer
         if (!this._done) {
             this.cancelled = true;
-            if (this.userId && this.deviceId && this.transactionId) {
+            if (this.userId && this.deviceId) {
                 // send a cancellation to the other user (if it wasn't
                 // cancelled by the other user)
                 if (e === timeoutException) {
@@ -225,13 +163,11 @@ export default class VerificationBase extends EventEmitter {
                             content.code = content.code || "m.unknown";
                             content.reason = content.reason || content.body
                                 || "Unknown reason";
-                            content.transaction_id = this.transactionId;
                             this._send("m.key.verification.cancel", content);
                         } else {
                             this._send("m.key.verification.cancel", {
                                 code: "m.unknown",
                                 reason: content.body || "Unknown reason",
-                                transaction_id: this.transactionId,
                             });
                         }
                     }
@@ -239,7 +175,6 @@ export default class VerificationBase extends EventEmitter {
                     this._send("m.key.verification.cancel", {
                         code: "m.unknown",
                         reason: e.toString(),
-                        transaction_id: this.transactionId,
                     });
                 }
             }
@@ -248,10 +183,6 @@ export default class VerificationBase extends EventEmitter {
                 // but no reject function. If cancel is called again, we'd error.
                 if (this._reject) this._reject(e);
             } else {
-                // unsubscribe from events, this happens in _reject usually but we don't have one here
-                if (this._eventsSubscription) {
-                    this._eventsSubscription = this._eventsSubscription();
-                }
                 // FIXME: this causes an "Uncaught promise" console message
                 // if nothing ends up chaining this promise.
                 this._promise = Promise.reject(e);
@@ -275,23 +206,11 @@ export default class VerificationBase extends EventEmitter {
             this._resolve = (...args) => {
                 this._done = true;
                 this._endTimer();
-                if (this.handler) {
-                    // these listeners are attached in Crypto.acceptVerificationDM
-                    if (this._eventsSubscription) {
-                        this._eventsSubscription = this._eventsSubscription();
-                    }
-                }
                 resolve(...args);
             };
             this._reject = (...args) => {
                 this._done = true;
                 this._endTimer();
-                if (this.handler) {
-                    // these listeners are attached in Crypto.acceptVerificationDM
-                    if (this._eventsSubscription) {
-                        this._eventsSubscription = this._eventsSubscription();
-                    }
-                }
                 reject(...args);
             };
         });
@@ -343,9 +262,5 @@ export default class VerificationBase extends EventEmitter {
         for (const deviceId of verifiedDevices) {
             await this._baseApis.setDeviceVerified(userId, deviceId);
         }
-    }
-
-    setEventsSubscription(subscription) {
-        this._eventsSubscription = subscription;
     }
 }

--- a/src/crypto/verification/Error.js
+++ b/src/crypto/verification/Error.js
@@ -85,3 +85,13 @@ export const newUserMismatchError = errorFactory("m.user_error", "User mismatch"
 export const newInvalidMessageError = errorFactory(
     "m.invalid_message", "Invalid message",
 );
+
+export function errorFromEvent(event) {
+    const content = event.getContent();
+    if (content) {
+        const {code, reason} = content;
+        return {code, reason};
+    } else {
+        return {code: "Unknown error", reason: "m.unknown"};
+    }
+}

--- a/src/crypto/verification/SAS.js
+++ b/src/crypto/verification/SAS.js
@@ -205,7 +205,8 @@ export default class SAS extends Base {
     }
 
     async _doSendVerification() {
-        const initialMessage = this._contentWithTxnId({
+        const type = "m.key.verification.start";
+        const initialMessage = this._channel.completeContent(type, {
             method: SAS.NAME,
             from_device: this._baseApis.deviceId,
             key_agreement_protocols: KEY_AGREEMENT_LIST,
@@ -216,8 +217,7 @@ export default class SAS extends Base {
         });
         // add the transaction id to the message beforehand because
         // it needs to be included in the commitment hash later on
-        this._sendWithTxnId("m.key.verification.start", initialMessage);
-
+        this._channel.sendCompleted(type, initialMessage);
 
         let e = await this._waitForEvent("m.key.verification.accept");
         let content = e.getContent();
@@ -254,7 +254,7 @@ export default class SAS extends Base {
             const sasInfo = "MATRIX_KEY_VERIFICATION_SAS"
                   + this._baseApis.getUserId() + this._baseApis.deviceId
                   + this.userId + this.deviceId
-                  + this.transactionId;
+                  + this._channel.transactionId;
             const sasBytes = olmSAS.generate_bytes(sasInfo, 6);
             const verifySAS = new Promise((resolve, reject) => {
                 this.emit("show_sas", {
@@ -283,7 +283,7 @@ export default class SAS extends Base {
     async _doRespondVerification() {
         // as m.related_to is not included in the encrypted content in e2e rooms,
         // we need to make sure it is added
-        let content = this._contentFromEventWithTxnId(this.startEvent);
+        let content = this._channel.completedContentFromEvent(this.startEvent);
 
         // Note: we intersect using our pre-made lists, rather than the sets,
         // so that the result will be in our order of preference.  Then
@@ -331,7 +331,7 @@ export default class SAS extends Base {
             const sasInfo = "MATRIX_KEY_VERIFICATION_SAS"
                   + this.userId + this.deviceId
                   + this._baseApis.getUserId() + this._baseApis.deviceId
-                  + this.transactionId;
+                  + this._channel.transactionId;
             const sasBytes = olmSAS.generate_bytes(sasInfo, 6);
             const verifySAS = new Promise((resolve, reject) => {
                 this.emit("show_sas", {
@@ -363,7 +363,7 @@ export default class SAS extends Base {
         const baseInfo = "MATRIX_KEY_VERIFICATION_MAC"
               + this._baseApis.getUserId() + this._baseApis.deviceId
               + this.userId + this.deviceId
-              + this.transactionId;
+              + this._channel.transactionId;
 
         const deviceKeyId = `ed25519:${this._baseApis.deviceId}`;
         mac[deviceKeyId] = olmSAS[macMethods[method]](
@@ -393,7 +393,7 @@ export default class SAS extends Base {
         const baseInfo = "MATRIX_KEY_VERIFICATION_MAC"
               + this.userId + this.deviceId
               + this._baseApis.getUserId() + this._baseApis.deviceId
-              + this.transactionId;
+              + this._channel.transactionId;
 
         if (content.keys !== olmSAS[macMethods[method]](
             Object.keys(content.mac).sort().join(","),

--- a/src/crypto/verification/request/InRoomChannel.js
+++ b/src/crypto/verification/request/InRoomChannel.js
@@ -1,0 +1,233 @@
+/*
+Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import VerificationRequest, {REQUEST_TYPE, START_TYPE} from "./VerificationRequest";
+const MESSAGE_TYPE = "m.room.message";
+const M_REFERENCE = "m.reference";
+const M_RELATES_TO = "m.relates_to";
+
+/**
+ * A key verification channel that sends verification events in the timeline of a room.
+ * Uses the event id of the initial m.key.verification.request event as a transaction id.
+ */
+export default class InRoomChannel {
+    /**
+     * @param {MatrixClient} client the matrix client, to send messages with and get current user & device from.
+     * @param {string} roomId id of the room where verification events should be posted in, should be a DM with the given user.
+     * @param {string} userId id of user that the verification request is directed at, should be present in the room.
+     */
+    constructor(client, roomId, userId) {
+        this._client = client;
+        this._roomId = roomId;
+        this._userId = userId;
+        this._requestEventId = null;
+    }
+
+    /** Whether this channel needs m.key.verification.done messages to be sent after a successful verification */
+    get needsDoneMessage() {
+        return true;
+    }
+
+    /** The transaction id generated/used by this verification channel */
+    get transactionId() {
+        return this._requestEventId;
+    }
+
+    /**
+     * @param {MatrixEvent} event the event to get the timestamp of
+     * @return {number} the timestamp when the event was sent
+     */
+    static getTimestamp(event) {
+        return event.getTs();
+    }
+
+    /**
+     * Checks whether the given event type should be allowed to initiate a new VerificationRequest over this channel
+     * @param {string} type the event type to check
+     * @returns {bool} boolean flag
+     */
+    static canCreateRequest(type) {
+        return type === REQUEST_TYPE;
+    }
+
+    /**
+     * Extract the transaction id used by a given key verification event, if any
+     * @param {MatrixEvent} event the event
+     * @returns {string} the transaction id
+     */
+    static getTransactionId(event) {
+        if (InRoomChannel.getEventType(event) === REQUEST_TYPE) {
+            return event.getId();
+        } else {
+            const relation = event.getRelation();
+            if (relation && relation.rel_type === M_REFERENCE) {
+                return relation.event_id;
+            }
+        }
+    }
+
+    /**
+     * Checks whether this event is a well-formed key verification event.
+     * This only does checks that don't rely on the current state of a potentially already channel
+     * so we can prevent channels being created by invalid events.
+     * `handleEvent` can do more checks and choose to ignore invalid events.
+     * @param {MatrixEvent} event the event to validate
+     * @param {MatrixClient} client the client to get the current user and device id from
+     * @returns {bool} whether the event is valid and should be passed to handleEvent
+     */
+    static validateEvent(event, client) {
+        const txnId = InRoomChannel.getTransactionId(event);
+        if (typeof txnId !== "string" || txnId.length === 0) {
+            return false;
+        }
+        const type = InRoomChannel.getEventType(event);
+        const content = event.getContent();
+        if (type === REQUEST_TYPE) {
+            if (typeof content.to !== "string" || !content.to.length) {
+                return false;
+            }
+            const ownUserId = client.getUserId();
+            // ignore requests that are not direct to or sent by the syncing user
+            if (event.getSender() !== ownUserId && content.to !== ownUserId) {
+                return false;
+            }
+        }
+
+        return VerificationRequest.validateEvent(
+            type, event, InRoomChannel.getTimestamp(event), client);
+    }
+
+    /**
+     * As m.key.verification.request events are as m.room.message events with the InRoomChannel
+     * to have a fallback message in non-supporting clients, we map the real event type
+     * to the symbolic one to keep things in unison with ToDeviceChannel
+     * @param {MatrixEvent} event the event to get the type of
+     * @returns {string} the "symbolic" event type
+     */
+    static getEventType(event) {
+        const type = event.getType();
+        if (type === MESSAGE_TYPE) {
+            const content = event.getContent();
+            if (content) {
+                const {msgtype} = content;
+                if (msgtype === REQUEST_TYPE) {
+                    return REQUEST_TYPE;
+                }
+            }
+        }
+        return type;
+    }
+
+    /**
+     * Changes the state of the channel, request, and verifier in response to a key verification event.
+     * @param {MatrixEvent} event to handle
+     * @param {VerificationRequest} request the request to forward handling to
+     * @returns {Promise} a promise that resolves when any requests as an anwser to the passed-in event are sent.
+     */
+    async handleEvent(event, request) {
+        const type = InRoomChannel.getEventType(event);
+        // do validations that need state (roomId, userId),
+        // ignore if invalid
+        if (event.getRoomId() !== this._roomId || event.getSender() !== this._userId) {
+            return;
+        }
+        // set transactionId when receiving a .request
+        if (!this._requestEventId && type === REQUEST_TYPE) {
+            this._requestEventId = event.getId();
+        }
+
+        return await request.handleEvent(type, event, InRoomChannel.getTimestamp(event));
+    }
+
+    /**
+     * Adds the transaction id (relation) back to a received event
+     * so it has the same format as returned by `completeContent` before sending.
+     * The relation can not appear on the event content because of encryption,
+     * relations are excluded from encryption.
+     * @param {MatrixEvent} event the received event
+     * @returns {Object} the content object with the relation added again
+     */
+    completedContentFromEvent(event) {
+        // ensure m.related_to is included in e2ee rooms
+        // as the field is excluded from encryption
+        const content = Object.assign({}, event.getContent());
+        content[M_RELATES_TO] = event.getRelation();
+        return content;
+    }
+    /**
+     * Add all the fields to content needed for sending it over this channel.
+     * This is public so verification methods (SAS uses this) can get the exact
+     * content that will be sent independent of the used channel,
+     * as they need to calculate the hash of it.
+     * @param {string} type the event type
+     * @param {object} content the (incomplete) content
+     * @returns {object} the complete content, as it will be sent.
+     */
+    completeContent(type, content) {
+        content = Object.assign({}, content);
+        if (type === REQUEST_TYPE || type === START_TYPE) {
+            content.from_device = this._client.getDeviceId();
+        }
+        if (type === REQUEST_TYPE) {
+            // type is mapped to m.room.message in the send method
+            content = {
+                body: this._client.getUserId() + " is requesting to verify " +
+                    "your key, but your client does not support in-chat key " +
+                    "verification.  You will need to use legacy key " +
+                    "verification to verify keys.",
+                msgtype: REQUEST_TYPE,
+                to: this._userId,
+                from_device: content.from_device,
+                methods: content.methods,
+            };
+        } else {
+            content[M_RELATES_TO] = {
+                rel_type: M_REFERENCE,
+                event_id: this.transactionId,
+            };
+        }
+        return content;
+    }
+
+    /**
+     * Send an event over the channel with the content not having gone through `completeContent`.
+     * @param {string} type the event type
+     * @param {object} uncompletedContent the (incomplete) content
+     * @returns {Promise} the promise of the request
+     */
+    send(type, uncompletedContent) {
+        const content = this.completeContent(type, uncompletedContent);
+        return this.sendCompleted(type, content);
+    }
+
+    /**
+     * Send an event over the channel with the content having gone through `completeContent` already.
+     * @param {string} type the event type
+     * @param {object} content
+     * @returns {Promise} the promise of the request
+     */
+    async sendCompleted(type, content) {
+        let sendType = type;
+        if (type === REQUEST_TYPE) {
+            sendType = MESSAGE_TYPE;
+        }
+        const response = await this._client.sendEvent(this._roomId, sendType, content);
+        if (type === REQUEST_TYPE) {
+            this._requestEventId = response.event_id;
+        }
+    }
+}

--- a/src/crypto/verification/request/RequestCallbackChannel.js
+++ b/src/crypto/verification/request/RequestCallbackChannel.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/** a key verification channel that wraps over an actual channel to pass it to a verifier,
+ * to notify the VerificationRequest when the verifier tries to send anything over the channel.
+ * This way, the VerificationRequest can update its state based on events sent by the verifier.
+ * Anything that is not sending is just routing through to the wrapped channel.
+ */
+export default class RequestCallbackChannel {
+    constructor(request, channel) {
+        this._request = request;
+        this._channel = channel;
+    }
+
+    get transactionId() {
+        return this._channel.transactionId;
+    }
+
+    get needsDoneMessage() {
+        return this._channel.needsDoneMessage;
+    }
+
+    handleEvent(event, request) {
+        return this._channel.handleEvent(event, request);
+    }
+
+    completedContentFromEvent(event) {
+        return this._channel.completedContentFromEvent(event);
+    }
+
+    completeContent(type, content) {
+        return this._channel.completeContent(type, content);
+    }
+
+    async send(type, uncompletedContent) {
+        this._request.handleVerifierSend(type, uncompletedContent);
+        const result = await this._channel.send(type, uncompletedContent);
+        return result;
+    }
+
+    async sendCompleted(type, content) {
+        this._request.handleVerifierSend(type, content);
+        const result = await this._channel.sendCompleted(type, content);
+        return result;
+    }
+}

--- a/src/crypto/verification/request/ToDeviceChannel.js
+++ b/src/crypto/verification/request/ToDeviceChannel.js
@@ -1,0 +1,249 @@
+/*
+Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { randomString } from '../../../randomstring';
+import logger from '../../../logger';
+import VerificationRequest, {
+    PHASE_STARTED,
+    REQUEST_TYPE,
+    START_TYPE,
+    CANCEL_TYPE,
+} from "./VerificationRequest";
+
+import {
+    newUnexpectedMessageError,
+    errorFromEvent,
+} from "../Error";
+/**
+ * A key verification channel that sends verification events over to_device messages.
+ * Generates its own transaction ids.
+ */
+export default class ToDeviceChannel {
+    // userId and devices of user we're about to verify
+    constructor(client, userId, devices, transactionId = null, deviceId = null) {
+        this._client = client;
+        this._userId = userId;
+        this._devices = devices;
+        this.transactionId = transactionId;
+        this._deviceId = deviceId;
+    }
+
+    static getEventType(event) {
+        return event.getType();
+    }
+
+    /**
+     * Extract the transaction id used by a given key verification event, if any
+     * @param {MatrixEvent} event the event
+     * @returns {string} the transaction id
+     */
+    static getTransactionId(event) {
+        const content = event.getContent();
+        return content && content.transaction_id;
+    }
+
+    /**
+     * Checks whether the given event type should be allowed to initiate a new VerificationRequest over this channel
+     * @param {string} type the event type to check
+     * @returns {bool} boolean flag
+     */
+    static canCreateRequest(type) {
+        return type === REQUEST_TYPE || type === START_TYPE;
+    }
+
+    /**
+     * Checks whether this event is a well-formed key verification event.
+     * This only does checks that don't rely on the current state of a potentially already channel
+     * so we can prevent channels being created by invalid events.
+     * `handleEvent` can do more checks and choose to ignore invalid events.
+     * @param {MatrixEvent} event the event to validate
+     * @param {MatrixClient} client the client to get the current user and device id from
+     * @returns {bool} whether the event is valid and should be passed to handleEvent
+     */
+    static validateEvent(event, client) {
+        if (event.isCancelled()) {
+            logger.warn("Ignoring flagged verification request from "
+                 + event.getSender());
+            return false;
+        }
+        const content = event.getContent();
+        if (!content) {
+            return false;
+        }
+
+        if (!content.transaction_id) {
+            return false;
+        }
+
+        const type = event.getType();
+
+        if (type === REQUEST_TYPE) {
+            if (!Number.isFinite(content.timestamp)) {
+                return false;
+            }
+            if (event.getSender() === client.getUserId() &&
+                    content.from_device == client.getDeviceId()
+            ) {
+                // ignore requests from ourselves, because it doesn't make sense for a
+                // device to verify itself
+                return false;
+            }
+        }
+
+        return VerificationRequest.validateEvent(
+            type, event, ToDeviceChannel.getTimestamp(event), client);
+    }
+
+    /**
+     * @param {MatrixEvent} event the event to get the timestamp of
+     * @return {number} the timestamp when the event was sent
+     */
+    static getTimestamp(event) {
+        const content = event.getContent();
+        return content && content.timestamp;
+    }
+
+    /**
+     * Changes the state of the channel, request, and verifier in response to a key verification event.
+     * @param {MatrixEvent} event to handle
+     * @param {VerificationRequest} request the request to forward handling to
+     * @returns {Promise} a promise that resolves when any requests as an anwser to the passed-in event are sent.
+     */
+    async handleEvent(event, request) {
+        const type = event.getType();
+        const content = event.getContent();
+        if (type === REQUEST_TYPE || type === START_TYPE) {
+            if (!this.transactionId) {
+                this.transactionId = content.transaction_id;
+            }
+            const deviceId = content.from_device;
+            // adopt deviceId if not set before and valid
+            if (!this._deviceId && this._devices.includes(deviceId)) {
+                this._deviceId = deviceId;
+            }
+            // if no device id or different from addopted one, cancel with sender
+            if (!this._deviceId || this._deviceId !== deviceId) {
+                // also check that message came from the device we sent the request to earlier on
+                // and do send a cancel message to that device
+                // (but don't cancel the request for the device we should be talking to)
+                const cancelContent =
+                    this.completeContent(errorFromEvent(newUnexpectedMessageError()));
+                return this._sendToDevices(CANCEL_TYPE, cancelContent, [deviceId]);
+            }
+        }
+
+        const wasStarted = request.phase === PHASE_STARTED;
+        await request.handleEvent(
+            event.getType(), event, ToDeviceChannel.getTimestamp(event));
+        const isStarted = request.phase === PHASE_STARTED;
+
+        // the request has picked a start event, tell the other devices about it
+        if (type === START_TYPE && !wasStarted && isStarted && this._deviceId) {
+            const nonChosenDevices = this._devices.filter(d => d !== this._deviceId);
+            if (nonChosenDevices.length) {
+                const message = this.completeContent({
+                    code: "m.accepted",
+                    reason: "Verification request accepted by another device",
+                });
+                await this._sendToDevices(CANCEL_TYPE, message, nonChosenDevices);
+            }
+        }
+    }
+
+    /**
+     * See {InRoomChannel.completedContentFromEvent} why this is needed.
+     * @param {MatrixEvent} event the received event
+     * @returns {Object} the content object
+     */
+    completedContentFromEvent(event) {
+        return event.getContent();
+    }
+
+    /**
+     * Add all the fields to content needed for sending it over this channel.
+     * This is public so verification methods (SAS uses this) can get the exact
+     * content that will be sent independent of the used channel,
+     * as they need to calculate the hash of it.
+     * @param {string} type the event type
+     * @param {object} content the (incomplete) content
+     * @returns {object} the complete content, as it will be sent.
+     */
+    completeContent(type, content) {
+        // make a copy
+        content = Object.assign({}, content);
+        if (this.transactionId) {
+            content.transaction_id = this.transactionId;
+        }
+        if (type === REQUEST_TYPE || type === START_TYPE) {
+            content.from_device = this._client.getDeviceId();
+        }
+        if (type === REQUEST_TYPE) {
+            content.timestamp = Date.now();
+        }
+        return content;
+    }
+
+    /**
+     * Send an event over the channel with the content not having gone through `completeContent`.
+     * @param {string} type the event type
+     * @param {object} uncompletedContent the (incomplete) content
+     * @returns {Promise} the promise of the request
+     */
+    send(type, uncompletedContent = {}) {
+        // create transaction id when sending request
+        if ((type === REQUEST_TYPE || type === START_TYPE) && !this.transactionId) {
+            this.transactionId = ToDeviceChannel.makeTransactionId();
+        }
+        const content = this.completeContent(type, uncompletedContent);
+        return this.sendCompleted(type, content);
+    }
+
+    /**
+     * Send an event over the channel with the content having gone through `completeContent` already.
+     * @param {string} type the event type
+     * @param {object} content
+     * @returns {Promise} the promise of the request
+     */
+    sendCompleted(type, content) {
+        if (type === REQUEST_TYPE) {
+            return this._sendToDevices(type, content, this._devices);
+        } else {
+            return this._sendToDevices(type, content, [this._deviceId]);
+        }
+    }
+
+    _sendToDevices(type, content, devices) {
+        if (devices.length) {
+            const msgMap = {};
+            for (const deviceId of devices) {
+                msgMap[deviceId] = content;
+            }
+
+            return this._client.sendToDevice(type, {[this._userId]: msgMap});
+        } else {
+            return Promise.resolve();
+        }
+    }
+
+    /**
+     * Allow Crypto module to create and know the transaction id before the .start event gets sent.
+     * @returns {string} the transaction id
+     */
+    static makeTransactionId() {
+        return randomString(32);
+    }
+}

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -1,0 +1,414 @@
+/*
+Copyright 2018 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import logger from '../../../logger';
+import RequestCallbackChannel from "./RequestCallbackChannel";
+import {EventEmitter} from 'events';
+import {
+    newUnknownMethodError,
+    newUnexpectedMessageError,
+    errorFromEvent,
+    errorFactory,
+} from "../Error";
+
+// the recommended amount of time before a verification request
+// should be (automatically) cancelled without user interaction
+// and ignored.
+const VERIFICATION_REQUEST_TIMEOUT = 10 * 60 * 1000; //10m
+// to avoid almost expired verification notifications
+// from showing a notification and almost immediately
+// disappearing, also ignore verification requests that
+// are this amount of time away from expiring.
+const VERIFICATION_REQUEST_MARGIN = 3 * 1000; //3s
+
+
+export const EVENT_PREFIX = "m.key.verification.";
+export const REQUEST_TYPE = EVENT_PREFIX + "request";
+export const START_TYPE = EVENT_PREFIX + "start";
+export const CANCEL_TYPE = EVENT_PREFIX + "cancel";
+export const DONE_TYPE = EVENT_PREFIX + "done";
+// export const READY_TYPE = EVENT_PREFIX + "ready";
+
+export const PHASE_UNSENT = 1;
+export const PHASE_REQUESTED = 2;
+// const PHASE_READY = 3;
+export const PHASE_STARTED = 4;
+export const PHASE_CANCELLED = 5;
+export const PHASE_DONE = 6;
+
+
+/**
+ * State machine for verification requests.
+ * Things that differ based on what channel is used to
+ * send and receive verification events are put in `InRoomChannel` or `ToDeviceChannel`.
+ * @event "change" whenever the state of the request object has changed.
+ */
+export default class VerificationRequest extends EventEmitter {
+    constructor(channel, verificationMethods, userId, client) {
+        super();
+        this.channel = channel;
+        this._verificationMethods = verificationMethods;
+        this._client = client;
+        this._commonMethods = [];
+        this._setPhase(PHASE_UNSENT, false);
+        this._requestEvent = null;
+        this._otherUserId = userId;
+        this._initiatedByMe = null;
+        this._startTimestamp = null;
+    }
+
+    /**
+     * Stateless validation logic not specific to the channel.
+     * Invoked by the same static method in either channel.
+     * @param {string} type the "symbolic" event type, as returned by the `getEventType` function on the channel.
+     * @param {MatrixEvent} event the event to validate. Don't call getType() on it but use the `type` parameter instead.
+     * @param {number} timestamp the timestamp in milliseconds when this event was sent.
+     * @param {MatrixClient} client the client to get the current user and device id from
+     * @returns {bool} whether the event is valid and should be passed to handleEvent
+     */
+    static validateEvent(type, event, timestamp, client) {
+        const content = event.getContent();
+
+        if (!type.startsWith(EVENT_PREFIX)) {
+            return false;
+        }
+
+        if (type === REQUEST_TYPE) {
+            if (!Array.isArray(content.methods)) {
+                return false;
+            }
+        }
+        if (type === REQUEST_TYPE || type === START_TYPE) {
+            if (typeof content.from_device !== "string" ||
+                content.from_device.length === 0
+            ) {
+                return false;
+            }
+        }
+
+        // a timestamp is not provided on all to_device events
+        if (Number.isFinite(timestamp)) {
+            const elapsed = Date.now() - timestamp;
+            // ignore if event is too far in the past or too far in the future
+            if (elapsed > (VERIFICATION_REQUEST_TIMEOUT - VERIFICATION_REQUEST_MARGIN) ||
+                elapsed < -(VERIFICATION_REQUEST_TIMEOUT / 2)) {
+                logger.log("received verification that is too old or from the future");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** once the phase is PHASE_STARTED, common methods supported by both sides */
+    get methods() {
+        return this._commonMethods;
+    }
+
+    /** the timeout of the request, provided for compatibility with previous verification code */
+    get timeout() {
+        const elapsed = Date.now() - this._startTimestamp;
+        return Math.max(0, VERIFICATION_REQUEST_TIMEOUT - elapsed);
+    }
+
+    /** the m.key.verification.request event that started this request, provided for compatibility with previous verification code */
+    get event() {
+        return this._requestEvent;
+    }
+
+    /** current phase of the request. Some properties might only be defined in a current phase. */
+    get phase() {
+        return this._phase;
+    }
+
+    /** The verifier to do the actual verification, once the method has been established. Only defined when the `phase` is PHASE_STARTED. */
+    get verifier() {
+        return this._verifier;
+    }
+
+    /** whether this request has sent it's initial event and needs more events to complete */
+    get pending() {
+        return this._phase !== PHASE_UNSENT
+            && this._phase !== PHASE_DONE
+            && this._phase !== PHASE_CANCELLED;
+    }
+
+    /** Whether this request was initiated by the syncing user.
+     * For InRoomChannel, this is who sent the .request event.
+     * For ToDeviceChannel, this is who sent the .start event
+     */
+    get initiatedByMe() {
+        return this._initiatedByMe;
+    }
+
+    /** the id of the user that initiated the request */
+    get requestingUserId() {
+        if (this.initiatedByMe) {
+            return this._client.getUserId();
+        } else {
+            return this._otherUserId;
+        }
+    }
+
+    /** the id of the user that (will) receive(d) the request */
+    get receivingUserId() {
+        if (this.initiatedByMe) {
+            return this._otherUserId;
+        } else {
+            return this._client.getUserId();
+        }
+    }
+
+    /* Start the key verification, creating a verifier and sending a .start event.
+     * If no previous events have been sent, pass in `targetDevice` to set who to direct this request to.
+     * @param {string} method the name of the verification method to use.
+     * @param {string?} targetDevice.userId the id of the user to direct this request to
+     * @param {string?} targetDevice.deviceId the id of the device to direct this request to
+     * @returns {VerifierBase} the verifier of the given method
+     */
+    beginKeyVerification(method, targetDevice = null) {
+        // need to allow also when unsent in case of to_device
+        if (!this._verifier) {
+            if (this._hasValidPreStartPhase()) {
+                // when called on a request that was initiated with .request event
+                // check the method is supported by both sides
+                if (this._commonMethods.length && !this._commonMethods.includes(method)) {
+                    throw newUnknownMethodError();
+                }
+                this._verifier = this._createVerifier(method, null, targetDevice);
+                if (!this._verifier) {
+                    throw newUnknownMethodError();
+                }
+            }
+        }
+        return this._verifier;
+    }
+
+    /**
+     * sends the initial .request event.
+     * @returns {Promise} resolves when the event has been sent.
+     */
+    async sendRequest() {
+        if (this._phase === PHASE_UNSENT) {
+            this._initiatedByMe = true;
+            this._setPhase(PHASE_REQUESTED, false);
+            const methods = [...this._verificationMethods.keys()];
+            await this.channel.send(REQUEST_TYPE, {methods});
+            this.emit("change");
+        }
+    }
+
+    /**
+     * Cancels the request, sending a cancellation to the other party
+     * @param {string?} error.reason the error reason to send the cancellation with
+     * @param {string?} error.code the error code to send the cancellation with
+     * @returns {Promise} resolves when the event has been sent.
+     */
+    async cancel({reason = "User declined", code = "m.user"} = {}) {
+        if (this._phase !== PHASE_CANCELLED) {
+            if (this._verifier) {
+                return this._verifier.cancel(errorFactory(code, reason));
+            } else {
+                this._setPhase(PHASE_CANCELLED, false);
+                await this.channel.send(CANCEL_TYPE, {code, reason});
+            }
+            this.emit("change");
+        }
+    }
+
+    /** @returns {Promise} with the verifier once it becomes available. Can be used after calling `sendRequest`. */
+    waitForVerifier() {
+        if (this.verifier) {
+            return Promise.resolve(this.verifier);
+        } else {
+            return new Promise(resolve => {
+                const checkVerifier = () => {
+                    if (this.verifier) {
+                        this.off("change", checkVerifier);
+                        resolve(this.verifier);
+                    }
+                };
+                this.on("change", checkVerifier);
+            });
+        }
+    }
+
+    _setPhase(phase, notify = true) {
+        this._phase = phase;
+        if (notify) {
+            this.emit("change");
+        }
+    }
+
+    /**
+     * Changes the state of the request and verifier in response to a key verification event.
+     * @param {string} type the "symbolic" event type, as returned by the `getEventType` function on the channel.
+     * @param {MatrixEvent} event the event to handle. Don't call getType() on it but use the `type` parameter instead.
+     * @param {number} timestamp the timestamp in milliseconds when this event was sent.
+     * @returns {Promise} a promise that resolves when any requests as an anwser to the passed-in event are sent.
+     */
+    async handleEvent(type, event, timestamp) {
+        const content = event.getContent();
+        if (type === REQUEST_TYPE || type === START_TYPE) {
+            if (this._startTimestamp === null) {
+                this._startTimestamp = timestamp;
+            }
+        }
+        if (type === REQUEST_TYPE) {
+            await this._handleRequest(content, event);
+        } else if (type === START_TYPE) {
+            await this._handleStart(content, event);
+        }
+
+        if (this._verifier) {
+            if (type === CANCEL_TYPE || (this._verifier.events
+                && this._verifier.events.includes(type))) {
+                this._verifier.handleEvent(event);
+            }
+        }
+
+        if (type === CANCEL_TYPE) {
+            this._handleCancel();
+        } else if (type === DONE_TYPE) {
+            this._handleDone();
+        }
+    }
+
+    async _handleRequest(content, event) {
+        if (this._phase === PHASE_UNSENT) {
+            const otherMethods = content.methods;
+            this._commonMethods = otherMethods.
+                filter(m => this._verificationMethods.has(m));
+            this._requestEvent = event;
+            this._initiatedByMe = this._wasSentByMe(event);
+            this._setPhase(PHASE_REQUESTED);
+        } else {
+            logger.warn("Ignoring flagged verification request from " +
+                event.getSender());
+            await this.cancel(errorFromEvent(newUnexpectedMessageError()));
+        }
+    }
+
+    _hasValidPreStartPhase() {
+        return this._phase === PHASE_REQUESTED ||
+            (
+                this.channel.constructor.canCreateRequest(START_TYPE) &&
+                this._phase === PHASE_UNSENT
+            );
+    }
+
+    async _handleStart(content, event) {
+        if (this._hasValidPreStartPhase()) {
+            const {method} = content;
+            if (!this._verificationMethods.has(method)) {
+                await this.cancel(errorFromEvent(newUnknownMethodError()));
+            } else {
+                // if not in requested phase
+                if (this.phase === PHASE_UNSENT) {
+                    this._initiatedByMe = this._wasSentByMe(event);
+                }
+                this._verifier = this._createVerifier(method, event);
+                this._setPhase(PHASE_STARTED);
+            }
+        }
+    }
+
+    /**
+     * Called by RequestCallbackChannel when the verifier sends an event
+     * @param {string} type the "symbolic" event type
+     * @param {object} content the completed or uncompleted content for the event to be sent
+     */
+    handleVerifierSend(type, content) {
+        if (type === CANCEL_TYPE) {
+            this._handleCancel();
+        } else if (type === START_TYPE) {
+            if (this._phase === PHASE_UNSENT || this._phase === PHASE_REQUESTED) {
+                // if unsent, we're sending a (first) .start event and hence requesting the verification.
+                // in any other situation, the request was initiated by the other party.
+                this._initiatedByMe = this.phase === PHASE_UNSENT;
+                this._setPhase(PHASE_STARTED);
+            }
+        }
+    }
+
+    _handleCancel() {
+        if (this._phase !== PHASE_CANCELLED) {
+            this._setPhase(PHASE_CANCELLED);
+        }
+    }
+
+    _handleDone() {
+        if (this._phase === PHASE_STARTED) {
+            this._setPhase(PHASE_DONE);
+        }
+    }
+
+    _createVerifier(method, startEvent = null, targetDevice = null) {
+        const startSentByMe = startEvent && this._wasSentByMe(startEvent);
+        const {userId, deviceId} = this._getVerifierTarget(startEvent, targetDevice);
+
+        const VerifierCtor = this._verificationMethods.get(method);
+        if (!VerifierCtor) {
+            console.warn("could not find verifier constructor for method", method);
+            return;
+        }
+        // invokes handleVerifierSend when verifier sends something
+        const callbackMedium = new RequestCallbackChannel(this, this.channel);
+        return new VerifierCtor(
+            callbackMedium,
+            this._client,
+            userId,
+            deviceId,
+            startSentByMe ? null : startEvent,
+        );
+    }
+
+    _getVerifierTarget(startEvent, targetDevice) {
+        // targetDevice should be set when creating a verifier for to_device before the .start event has been sent,
+        // so the userId and deviceId are provided
+        if (targetDevice) {
+            return targetDevice;
+        } else {
+            let targetEvent;
+            if (startEvent && !this._wasSentByMe(startEvent)) {
+                targetEvent = startEvent;
+            } else if (this._requestEvent && !this._wasSentByMe(this._requestEvent)) {
+                targetEvent = this._requestEvent;
+            } else {
+                throw new Error(
+                    "can't determine who the verifier should be targeted at. " +
+                    "No .request or .start event and no targetDevice");
+            }
+            const userId = targetEvent.getSender();
+            const content = targetEvent.getContent();
+            const deviceId = content && content.from_device;
+            return {userId, deviceId};
+        }
+    }
+
+    // only for .request and .start
+    _wasSentByMe(event) {
+        if (event.getSender() !== this._client.getUserId()) {
+            return false;
+        }
+        const content = event.getContent();
+        if (!content || content.from_device !== this._client.getDeviceId()) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Part of https://github.com/vector-im/riot-web/issues/11224

This extracts most of the verification request code from `crypto/index` and puts it into it's own `VerificationRequest` class with the specificities of whether to use to_device verification or verification over DM into a `Channel` class. Care has been taken to maintain the same public API from the crypto module and the request object passed as an argument of the crypto.verification.request event.

The next step will be add support for the `m.key.verification.ready` event, and to decorate verification events with a `verificationRequest` property and use this to drive toasts and verification timeline tiles in the react-sdk, removing the `KeyVerificationStateObserver`.