### PR TITLE
dont cancel on remote echo of own .request event

### DIFF
--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -296,7 +296,7 @@ export default class VerificationRequest extends EventEmitter {
             this._requestEvent = event;
             this._initiatedByMe = this._wasSentByMe(event);
             this._setPhase(PHASE_REQUESTED);
-        } else {
+        } else if (this._phase !== PHASE_REQUESTED) {
             logger.warn("Ignoring flagged verification request from " +
                 event.getSender());
             await this.cancel(errorFromEvent(newUnexpectedMessageError()));


### PR DESCRIPTION
Should fix https://github.com/vector-im/riot-web/issues/11639

Problem is that `sendRequest` already changes the phase, and when `_handleRequest` would process the remote echo of that event, it would cancel because the phase is not UNSENT anymore. We should not cancel if the phase is already REQUESTED and just ignore.