### PR TITLE
Remove unused user verification event

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -672,7 +672,6 @@ MatrixClient.prototype.initCrypto = async function() {
         "crypto.warning",
         "crypto.devicesUpdated",
         "deviceVerificationChanged",
-        "userVerificationChanged",
         "crossSigning.keysChanged",
     ]);
 


### PR DESCRIPTION
This was added with cross-signing work, but nothing actually emits it. Let's
remove it until we find a need.