### PR TITLE
Add support for key backups using secret storage

### DIFF
--- a/spec/unit/crypto/backup.spec.js
+++ b/spec/unit/crypto/backup.spec.js
@@ -336,7 +336,7 @@ describe("MegolmBackup", function() {
             });
             await client.resetCrossSigningKeys();
             let numCalls = 0;
-            await new Promise(async (resolve, reject) => {
+            await new Promise((resolve, reject) => {
                 client._http.authedRequest = function(
                     callback, method, path, queryParams, data, opts,
                 ) {
@@ -361,7 +361,7 @@ describe("MegolmBackup", function() {
                     resolve();
                     return Promise.resolve({});
                 };
-                await client.createKeyBackupVersion({
+                client.createKeyBackupVersion({
                     algorithm: "m.megolm_backup.v1",
                     auth_data: {
                         public_key: "hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo",

--- a/src/client.js
+++ b/src/client.js
@@ -1519,7 +1519,7 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
     // sessions.
     await this.checkKeyBackup();
     if (!this.getKeyBackupEnabled()) {
-        throw new Error("Key backup not usable even though we just created it");
+        logger.error("Key backup not usable even though we just created it");
     }
 
     return res;

--- a/src/client.js
+++ b/src/client.js
@@ -1477,6 +1477,7 @@ MatrixClient.prototype.prepareKeyBackupVersion = async function(
 
 /**
  * Check whether the key backup private key is stored in secret storage.
+ * @return {Promise<boolean>} Whether the backup key is stored.
  */
 MatrixClient.prototype.isKeyBackupKeyStored = async function() {
     return this.isSecretStored("m.megolm_backup.v1", false /* checkKey */);
@@ -1625,6 +1626,18 @@ MatrixClient.prototype.isValidRecoveryKey = function(recoveryKey) {
 
 MatrixClient.RESTORE_BACKUP_ERROR_BAD_KEY = 'RESTORE_BACKUP_ERROR_BAD_KEY';
 
+/**
+ * Restore from an existing key backup via a passphrase.
+ *
+ * @param {string} password Passphrase
+ * @param {string} [targetRoomId] Room ID to target a specific room.
+ * Restores all rooms if omitted.
+ * @param {string} [targetSessionId] Session ID to target a specific session.
+ * Restores all sessions if omitted.
+ * @param {object} backupInfo Backup metadata from `checkKeyBackup`
+ * @return {Promise<object>} Status of restoration with `total` and `imported`
+ * key counts.
+ */
 MatrixClient.prototype.restoreKeyBackupWithPassword = async function(
     password, targetRoomId, targetSessionId, backupInfo,
 ) {
@@ -1634,6 +1647,18 @@ MatrixClient.prototype.restoreKeyBackupWithPassword = async function(
     );
 };
 
+/**
+ * Restore from an existing key backup via a private key stored in secret
+ * storage.
+ *
+ * @param {object} backupInfo Backup metadata from `checkKeyBackup`
+ * @param {string} [targetRoomId] Room ID to target a specific room.
+ * Restores all rooms if omitted.
+ * @param {string} [targetSessionId] Session ID to target a specific session.
+ * Restores all sessions if omitted.
+ * @return {Promise<object>} Status of restoration with `total` and `imported`
+ * key counts.
+ */
 MatrixClient.prototype.restoreKeyBackupWithSecretStorage = async function(
     backupInfo, targetRoomId, targetSessionId,
 ) {
@@ -1643,6 +1668,18 @@ MatrixClient.prototype.restoreKeyBackupWithSecretStorage = async function(
     );
 };
 
+/**
+ * Restore from an existing key backup via an encoded recovery key.
+ *
+ * @param {string} recoveryKey Encoded recovery key
+ * @param {string} [targetRoomId] Room ID to target a specific room.
+ * Restores all rooms if omitted.
+ * @param {string} [targetSessionId] Session ID to target a specific session.
+ * Restores all sessions if omitted.
+ * @param {object} backupInfo Backup metadata from `checkKeyBackup`
+ * @return {Promise<object>} Status of restoration with `total` and `imported`
+ * key counts.
+ */
 MatrixClient.prototype.restoreKeyBackupWithRecoveryKey = function(
     recoveryKey, targetRoomId, targetSessionId, backupInfo,
 ) {

--- a/src/client.js
+++ b/src/client.js
@@ -1506,11 +1506,15 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
         undefined, "POST", "/room_keys/version", undefined, data,
         {prefix: httpApi.PREFIX_UNSTABLE},
     );
-    this.enableKeyBackup({
-        algorithm: info.algorithm,
-        auth_data: info.auth_data,
-        version: res.version,
-    });
+
+    // We could assume everything's okay and enable directly, but this ensures
+    // we run the same signature verification that will be used for future
+    // sessions.
+    await this.checkKeyBackup();
+    if (!this.getKeyBackupEnabled()) {
+        throw new Error("Key backup not usable even though we just created it");
+    }
+
     return res;
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -1476,6 +1476,13 @@ MatrixClient.prototype.prepareKeyBackupVersion = async function(
 };
 
 /**
+ * Check whether the key backup private key is stored in secret storage.
+ */
+MatrixClient.prototype.isKeyBackupKeyStored = async function() {
+    return this.isSecretStored("m.megolm_backup.v1", false /* checkKey */);
+};
+
+/**
  * Create a new key backup version and enable it, using the information return
  * from prepareKeyBackupVersion.
  *

--- a/src/client.js
+++ b/src/client.js
@@ -673,6 +673,7 @@ MatrixClient.prototype.initCrypto = async function() {
         "crypto.warning",
         "crypto.devicesUpdated",
         "deviceVerificationChanged",
+        "userTrustStatusChanged",
         "crossSigning.keysChanged",
     ]);
 

--- a/src/client.js
+++ b/src/client.js
@@ -1492,13 +1492,13 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
         auth_data: info.auth_data,
     };
 
-    // Now sign the backup auth data. Do it as this device first because crypto._signObject
-    // is dumb and bluntly replaces the whole signatures block...
-    // this can probably go away very soon in favour of just signing with the SSK.
+    // Sign the backup auth data with the device key for backwards compat with
+    // older devices with cross-signing. This can probably go away very soon in
+    // favour of just signing with the cross-singing master key.
     await this._crypto._signObject(data.auth_data);
 
     if (this._crypto._crossSigningInfo.getId()) {
-        // now also sign the auth data with the master key
+        // now also sign the auth data with the cross-signing master key
         await this._crypto._crossSigningInfo.signObject(data.auth_data, "master");
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -53,7 +53,7 @@ import { isCryptoAvailable } from './crypto';
 import { decodeRecoveryKey } from './crypto/recoverykey';
 import { keyFromAuthData } from './crypto/key_passphrase';
 import { randomString } from './randomstring';
-import { encodeBase64 } from '../lib/crypto/olmlib';
+import { encodeBase64, decodeBase64 } from '../lib/crypto/olmlib';
 
 const SCROLLBACK_DELAY_MS = 3000;
 const CRYPTO_ENABLED = isCryptoAvailable();
@@ -1629,6 +1629,15 @@ MatrixClient.prototype.restoreKeyBackupWithPassword = async function(
     password, targetRoomId, targetSessionId, backupInfo,
 ) {
     const privKey = await keyFromAuthData(backupInfo.auth_data, password);
+    return this._restoreKeyBackup(
+        privKey, targetRoomId, targetSessionId, backupInfo,
+    );
+};
+
+MatrixClient.prototype.restoreKeyBackupWithSecretStorage = async function(
+    backupInfo, targetRoomId, targetSessionId,
+) {
+    const privKey = decodeBase64(await this.getSecret("m.megolm_backup.v1"));
     return this._restoreKeyBackup(
         privKey, targetRoomId, targetSessionId, backupInfo,
     );

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -952,8 +952,7 @@ Crypto.prototype.setTrustedBackupPubKey = async function(trustedPubKey) {
  */
 Crypto.prototype.checkKeyBackup = async function() {
     this._checkedForBackup = false;
-    const returnInfo = await this._checkAndStartKeyBackup();
-    return returnInfo;
+    return this._checkAndStartKeyBackup();
 };
 
 /**

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1006,7 +1006,7 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
         // first check to see if it's from our cross-signing key
         const crossSigningId = this._crossSigningInfo.getId();
         if (crossSigningId === sigInfo.deviceId) {
-            sigInfo.cross_signing_key = crossSigningId;
+            sigInfo.crossSigningId = true;
             try {
                 await olmlib.verifySignature(
                     this._olmDevice,
@@ -1062,7 +1062,7 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
         return (
             s.valid && (
                 (s.device && s.device.isVerified()) ||
-                (s.cross_signing_key)
+                (s.crossSigningId)
             )
         );
     });

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -319,7 +319,7 @@ Crypto.prototype.createRecoveryKeyFromPassphrase = async function(password) {
         const encodedPrivateKey = encodeRecoveryKey(privateKey);
         return [keyInfo, encodedPrivateKey, privateKey];
     } finally {
-        decryption.free();
+        if (decryption) decryption.free();
     }
 };
 
@@ -790,7 +790,7 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
                 throw new Error("Cross-signing master private key not available");
             }
         } finally {
-            signing.free();
+            if (signing) signing.free();
         }
 
         logger.info("Got matching private key from callback for new public master key");

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -296,8 +296,9 @@ Crypto.prototype.init = async function() {
  * @param {string} password Passphrase string that can be entered by the user
  *     when restoring the backup as an alternative to entering the recovery key.
  *     Optional.
- * @returns {Promise<Array>} Array with public key metadata and encoded private
- *     recovery key which should be disposed of after displaying to the user.
+ * @returns {Promise<Array>} Array with public key metadata, encoded private
+ *     recovery key which should be disposed of after displaying to the user,
+ *     and raw private key to avoid round tripping if needed.
  */
 Crypto.prototype.createRecoveryKeyFromPassphrase = async function(password) {
     const decryption = new global.Olm.PkDecryption();
@@ -314,8 +315,9 @@ Crypto.prototype.createRecoveryKeyFromPassphrase = async function(password) {
         } else {
             keyInfo.pubkey = decryption.generate_key();
         }
-        const encodedPrivateKey = encodeRecoveryKey(decryption.get_private_key());
-        return [keyInfo, encodedPrivateKey];
+        const privateKey = decryption.get_private_key();
+        const encodedPrivateKey = encodeRecoveryKey(privateKey);
+        return [keyInfo, encodedPrivateKey, privateKey];
     } finally {
         decryption.free();
     }

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -303,8 +303,7 @@ async function _verifyKeyAndStartSession(olmDevice, oneTimeKey, userId, deviceIn
  *
  * @param {module:crypto/OlmDevice} olmDevice olm wrapper to use for verify op
  *
- * @param {Object} obj object to check signature on. Note that this will be
- * stripped of its 'signatures' and 'unsigned' properties.
+ * @param {Object} obj object to check signature on.
  *
  * @param {string} signingUserId  ID of the user whose signature should be checked
  *


### PR DESCRIPTION
This add various helpers for creating and restoring key backups where the private key is stored in secret storage.

Part of https://github.com/vector-im/riot-web/issues/11209
Used by https://github.com/matrix-org/matrix-react-sdk/pull/3720