### PR TITLE
Add support for passthrough SSSS secrets

### DIFF
--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -242,12 +242,13 @@ export default class SecretStorage extends EventEmitter {
      * @param {string} name The name of the secret
      * @param {string} keyId The ID of the key whose value will be the
      *     value of the secret
+     * @returns {Promise} resolved when account data is saved
      */
     storePassthrough(name, keyId) {
         return this._baseApis.setAccountData(name, {
             [keyId]: {
                 passthrough: true,
-            }
+            },
         });
     }
 
@@ -296,7 +297,9 @@ export default class SecretStorage extends EventEmitter {
             const encInfo = secretContent.encrypted[keyId];
 
             // fetch private key from app
-            [keyId, decryption] = await this._getSecretStorageKey(keys, encInfo.passthrough);
+            [keyId, decryption] = await this._getSecretStorageKey(
+                keys, encInfo.passthrough,
+            );
 
             if (encInfo.passthrough) return decryption;
 

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -299,7 +299,9 @@ export default class SecretStorage extends EventEmitter {
 
             const encInfo = secretContent.encrypted[keyId];
 
-            if (encInfo.passthrough) return decryption.get_private_key();;
+            // We don't actually need the decryption object if it's a passthrough
+            // since we just want to return the key itself.
+            if (encInfo.passthrough) return decryption.get_private_key();
 
             // decrypt secret
             switch (keys[keyId].algorithm) {

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -585,6 +585,5 @@ export default class SecretStorage extends EventEmitter {
             default:
                 throw new Error("Unknown key type: " + keys[keyId].algorithm);
         }
-p
     }
 }

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -294,14 +294,12 @@ export default class SecretStorage extends EventEmitter {
         let keyId;
         let decryption;
         try {
+            // fetch private key from app
+            [keyId, decryption] = await this._getSecretStorageKey(keys);
+
             const encInfo = secretContent.encrypted[keyId];
 
-            // fetch private key from app
-            [keyId, decryption] = await this._getSecretStorageKey(
-                keys, encInfo.passthrough,
-            );
-
-            if (encInfo.passthrough) return decryption;
+            if (encInfo.passthrough) return decryption.get_private_key();;
 
             // decrypt secret
             switch (keys[keyId].algorithm) {
@@ -544,7 +542,7 @@ export default class SecretStorage extends EventEmitter {
         }
     }
 
-    async _getSecretStorageKey(keys, raw) {
+    async _getSecretStorageKey(keys) {
         if (!this._cryptoCallbacks.getSecretStorageKey) {
             throw new Error("No getSecretStorageKey callback supplied");
         }
@@ -562,8 +560,6 @@ export default class SecretStorage extends EventEmitter {
         if (!keys[keyId]) {
             throw new Error("App returned unknown key from getSecretStorageKey!");
         }
-
-        if (raw) return [keyId, privateKey];
 
         switch (keys[keyId].algorithm) {
             case SECRET_STORAGE_ALGORITHM_V1:
@@ -587,5 +583,6 @@ export default class SecretStorage extends EventEmitter {
             default:
                 throw new Error("Unknown key type: " + keys[keyId].algorithm);
         }
+p
     }
 }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -409,7 +409,9 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     };
                 }
 
-                newKeyId = await cli.addSecretStorageKey(SECRET_STORAGE_ALGORITHM_V1, opts);
+                newKeyId = await this.addSecretStorageKey(
+                    SECRET_STORAGE_ALGORITHM_V1, opts,
+                );
 
                 // Add an entry for the backup key in SSSS as a 'passthrough' key
                 // (ie. the secret is the key itself).

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -386,6 +386,8 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     { authUploadDeviceSigningKeys },
                 );
             }
+        } else {
+            logger.log("Cross signing keys are present in secret storage");
         }
 
         // Check if Secure Secret Storage has a default key. If we don't have one, create
@@ -425,6 +427,8 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                 );
             }
             await this.setDefaultSecretStorageKeyId(newKeyId);
+        } else {
+            logger.log("Have secret storage key");
         }
 
         // If cross-signing keys were reset, store them in Secure Secret Storage.


### PR DESCRIPTION
So we can migrate key backup keys

Adding a passthrough secret itself isn't exposed outside of the
js-sdk: hopefully this should only ever be necessary for this
bootstrap process which the js-sdk handles.