### PR TITLE
Add additional properties to package.json for riot-web's webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "browser": "./lib/browser-index.js",
+  "matrix_src_main": "./src/index.ts",
+  "matrix_src_browser": "./src/browser-index.js",
   "author": "matrix.org",
   "license": "Apache-2.0",
   "files": [


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-js-sdk/pull/1130

See https://github.com/vector-im/riot-web/pull/11679/commits/a1c9551bc8a1a6d61afed7e87ff7cebb3042a5ac

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d