### PR TITLE
Use the right request when creating clients

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -131,7 +131,7 @@ export function createClient(opts) {
             "baseUrl": opts,
         };
     }
-    opts.request = opts.request || request;
+    opts.request = opts.request || requestInstance;
     opts.store = opts.store || new MemoryStore({
       localStorage: global.localStorage,
     });


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-js-sdk/pull/1130

`request` is a function in the context of this file, though it's the function to set the `request` function and not the `request` function itself. We store the `request` function under `requestInstance`.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d