### PR TITLE
Fix import for indexeddb crypto store

### DIFF
--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -18,7 +18,7 @@ limitations under the License.
 import {logger} from '../../logger';
 import {LocalStorageCryptoStore} from './localStorage-crypto-store';
 import {MemoryCryptoStore} from './memory-crypto-store';
-import {Backend as IndexedDBCryptoStoreBackend} from './indexeddb-crypto-store-backend';
+import * as IndexedDBCryptoStoreBackend from './indexeddb-crypto-store-backend';
 import {InvalidCryptoStoreError} from '../../errors';
 import * as IndexedDBHelpers from "../../indexeddb-helpers";
 


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/matrix-org/matrix-js-sdk/pull/1130

This is just a bug - we are using `IndexedDBCryptoStoreBackend.Backend` later in the file, so we should import the right value.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d