### PR TITLE
notify devices when we don't send them keys

### DIFF
--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -617,6 +617,9 @@ describe("megolm", function() {
             ).respond(200, {
                 event_id: '$event_id',
             });
+            aliceTestClient.httpBackend.when(
+                'PUT', '/sendToDevice/org.matrix.room_key.withheld/',
+            ).respond(200, {});
 
             return Promise.all([
                 aliceTestClient.client.sendTextMessage(ROOM_ID, 'test'),
@@ -714,6 +717,9 @@ describe("megolm", function() {
                     event_id: '$event_id',
                 };
             });
+            aliceTestClient.httpBackend.when(
+                'PUT', '/sendToDevice/org.matrix.room_key.withheld/',
+            ).respond(200, {});
 
             return Promise.all([
                 aliceTestClient.client.sendTextMessage(ROOM_ID, 'test2'),

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -361,6 +361,7 @@ describe("MegolmDecryption", function() {
             bobClient1.initCrypto(),
             bobClient2.initCrypto(),
         ]);
+        const aliceDevice = aliceClient._crypto._olmDevice;
         const bobDevice1 = bobClient1._crypto._olmDevice;
         const bobDevice2 = bobClient2._crypto._olmDevice;
 
@@ -415,14 +416,18 @@ describe("MegolmDecryption", function() {
             expect(contentMap).toStrictEqual({
                 '@bob:example.com': {
                     bobdevice1: {
+                        algorithm: "m.megolm.v1.aes-sha2",
                         room_id: roomId,
                         code: 'm.unverified',
                         reason: 'You have not been verified',
+                        sender_key: aliceDevice.deviceCurve25519Key,
                     },
                     bobdevice2: {
+                        algorithm: "m.megolm.v1.aes-sha2",
                         room_id: roomId,
                         code: 'm.blacklisted',
                         reason: 'You have been blocked',
+                        sender_key: aliceDevice.deviceCurve25519Key,
                     },
                 },
             });

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -8,6 +8,9 @@ import testUtils from '../../../test-utils';
 import OlmDevice from '../../../../lib/crypto/OlmDevice';
 import Crypto from '../../../../lib/crypto';
 import logger from '../../../../lib/logger';
+import TestClient from '../../../TestClient';
+import olmlib from '../../../../lib/crypto/olmlib';
+import Room from '../../../../lib/models/room';
 
 const MatrixEvent = sdk.MatrixEvent;
 const MegolmDecryption = algorithms.DECRYPTION_CLASSES['m.megolm.v1.aes-sha2'];
@@ -341,5 +344,106 @@ describe("MegolmDecryption", function() {
             // likewise they should show the same session ID
             expect(ct2.session_id).toEqual(ct1.session_id);
         });
+    });
+
+    it("notifies devices that have been blocked", async function() {
+        const aliceClient = (new TestClient(
+            "@alice:example.com", "alicedevice",
+        )).client;
+        const bobClient1 = (new TestClient(
+            "@bob:example.com", "bobdevice1",
+        )).client;
+        const bobClient2 = (new TestClient(
+            "@bob:example.com", "bobdevice2",
+        )).client;
+        await Promise.all([
+            aliceClient.initCrypto(),
+            bobClient1.initCrypto(),
+            bobClient2.initCrypto(),
+        ]);
+        const bobDevice1 = bobClient1._crypto._olmDevice;
+        const bobDevice2 = bobClient2._crypto._olmDevice;
+
+        const encryptionCfg = {
+            "algorithm": "m.megolm.v1.aes-sha2",
+        };
+        const roomId = "!someroom";
+        const room = new Room(roomId, aliceClient, "@alice:example.com", {});
+        room.getEncryptionTargetMembers = async function() {
+            return [{userId: "@bob:example.com"}];
+        };
+        room.setBlacklistUnverifiedDevices(true);
+        aliceClient.store.storeRoom(room);
+        await aliceClient.setRoomEncryption(roomId, encryptionCfg);
+
+        const BOB_DEVICES = {
+            bobdevice1: {
+                user_id: "@bob:example.com",
+                device_id: "bobdevice1",
+                algorithms: [olmlib.OLM_ALGORITHM, olmlib.MEGOLM_ALGORITHM],
+                keys: {
+                    "ed25519:Dynabook": bobDevice1.deviceEd25519Key,
+                    "curve25519:Dynabook": bobDevice1.deviceCurve25519Key,
+                },
+                verified: 0,
+            },
+            bobdevice2: {
+                user_id: "@bob:example.com",
+                device_id: "bobdevice2",
+                algorithms: [olmlib.OLM_ALGORITHM, olmlib.MEGOLM_ALGORITHM],
+                keys: {
+                    "ed25519:Dynabook": bobDevice2.deviceEd25519Key,
+                    "curve25519:Dynabook": bobDevice2.deviceCurve25519Key,
+                },
+                verified: -1,
+            },
+        };
+
+        aliceClient._crypto._deviceList.storeDevicesForUser(
+            "@bob:example.com", BOB_DEVICES,
+        );
+        aliceClient._crypto._deviceList.downloadKeys = async function(userIds) {
+            return this._getDevicesFromStore(userIds);
+        };
+
+        let run = false;
+        aliceClient.sendToDevice = async (msgtype, contentMap) => {
+            run = true;
+            expect(msgtype).toBe("org.matrix.room_key.withheld");
+            delete contentMap["@bob:example.com"].bobdevice1.session_id;
+            delete contentMap["@bob:example.com"].bobdevice2.session_id;
+            expect(contentMap).toStrictEqual({
+                '@bob:example.com': {
+                    bobdevice1: {
+                        room_id: roomId,
+                        code: 'm.unverified',
+                        reason: 'You have not been verified',
+                    },
+                    bobdevice2: {
+                        room_id: roomId,
+                        code: 'm.blacklisted',
+                        reason: 'You have been blocked',
+                    },
+                },
+            });
+        };
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            sender: "@alice:example.com",
+            room_id: roomId,
+            event_id: "$event",
+            content: {
+                msgtype: "m.text",
+                body: "secret",
+            },
+        });
+        await aliceClient._crypto.encryptEvent(event, room);
+
+        expect(run).toBe(true);
+
+        aliceClient.stopClient();
+        bobClient1.stopClient();
+        bobClient2.stopClient();
     });
 });

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -468,7 +468,7 @@ describe("MegolmDecryption", function() {
         const roomId = "!someroom";
 
         aliceClient._crypto._onToDeviceEvent(new MatrixEvent({
-            type: "m.room_key.withheld",
+            type: "org.matrix.room_key.withheld",
             sender: "@bob:example.com",
             content: {
                 algorithm: "m.megolm.v1.aes-sha2",

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -419,14 +419,15 @@ describe("MegolmDecryption", function() {
                         algorithm: "m.megolm.v1.aes-sha2",
                         room_id: roomId,
                         code: 'm.unverified',
-                        reason: 'You have not been verified',
+                        reason:
+                        'The sender has disabled encrypting to unverified devices.',
                         sender_key: aliceDevice.deviceCurve25519Key,
                     },
                     bobdevice2: {
                         algorithm: "m.megolm.v1.aes-sha2",
                         room_id: roomId,
                         code: 'm.blacklisted',
-                        reason: 'You have been blocked',
+                        reason: 'The sender has blocked you.',
                         sender_key: aliceDevice.deviceCurve25519Key,
                     },
                 },
@@ -480,7 +481,7 @@ describe("MegolmDecryption", function() {
             },
         }));
 
-        expect(aliceClient._crypto.decryptEvent(new MatrixEvent({
+        await expect(aliceClient._crypto.decryptEvent(new MatrixEvent({
             type: "m.room.encrypted",
             sender: "@bob:example.com",
             event_id: "$event",
@@ -492,6 +493,6 @@ describe("MegolmDecryption", function() {
                 sender_key: bobDevice.deviceCurve25519Key,
                 session_id: "session_id",
             },
-        }))).rejects.toThrow("You have been blocked");
+        }))).rejects.toThrow("The sender has blocked you.");
     });
 });

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -460,11 +460,7 @@ describe("MegolmDecryption", function() {
         ]);
         const bobDevice = bobClient._crypto._olmDevice;
 
-        const encryptionCfg = {
-            "algorithm": "m.megolm.v1.aes-sha2",
-        };
         const roomId = "!someroom";
-        const room = new Room(roomId, aliceClient, "@alice:example.com", {});
 
         aliceClient._crypto._onToDeviceEvent(new MatrixEvent({
             type: "m.room_key.withheld",
@@ -476,7 +472,7 @@ describe("MegolmDecryption", function() {
                 sender_key: bobDevice.deviceCurve25519Key,
                 code: "m.blacklisted",
                 reason: "You have been blocked",
-            }
+            },
         }));
 
         expect(aliceClient._crypto.decryptEvent(new MatrixEvent({
@@ -489,8 +485,8 @@ describe("MegolmDecryption", function() {
                 ciphertext: "blablabla",
                 device_id: "bobdevice",
                 sender_key: bobDevice.deviceCurve25519Key,
-                session_id: "session_id"
-            }
+                session_id: "session_id",
+            },
         }))).rejects.toThrow("You have been blocked");
     });
 });

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -919,6 +919,15 @@ OlmDevice.prototype.addInboundGroupSession = async function(
     );
 };
 
+/**
+ * Record in the data store why an inbound group session was withheld.
+ *
+ * @param {string} roomId     room that the session belongs to
+ * @param {string} senderKey  base64-encoded curve25519 key of the sender
+ * @param {string} sessionId  session identifier
+ * @param {string} code       reason code
+ * @param {string} reason     human-readable version of `code`
+ */
 OlmDevice.prototype.addInboundGroupSessionWithheld = async function(
     roomId, senderKey, sessionId, code, reason,
 ) {
@@ -945,6 +954,15 @@ const WITHHELD_MESSAGES = {
     "m.no_olm": "Unable to establish a secure channel",
 };
 
+/**
+ * Calculate the message to use for the exception when a session key is withheld.
+ *
+ * @param {object} withheld  An object that describes why the key was withheld.
+ *
+ * @return {string} the message
+ *
+ * @private
+ */
 function _calculateWithheldMessage(withheld) {
     if (withheld.code && withheld.code in WITHHELD_MESSAGES) {
         return WITHHELD_MESSAGES[withheld.code];

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2016 OpenMarket Ltd
 Copyright 2017, 2019 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -947,11 +948,11 @@ OlmDevice.prototype.addInboundGroupSessionWithheld = async function(
     );
 };
 
-const WITHHELD_MESSAGES = {
-    "m.unverified": "You have not been verified",
-    "m.blacklisted": "You have been blocked",
-    "m.unauthorised": "You are not authorised to read the message",
-    "m.no_olm": "Unable to establish a secure channel",
+export const WITHHELD_MESSAGES = {
+    "m.unverified": "The sender has disabled encrypting to unverified devices.",
+    "m.blacklisted": "The sender has blocked you.",
+    "m.unauthorised": "You are not authorised to read the message.",
+    "m.no_olm": "Unable to establish a secure channel.",
 };
 
 /**

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -177,6 +177,7 @@ utils.inherits(MegolmEncryption, base.EncryptionAlgorithm);
  * @private
  *
  * @param {Object} devicesInRoom The devices in this room, indexed by user ID
+ * @param {Object} blocked The devices that are blocked, indexed by user ID
  *
  * @return {module:client.Promise} Promise which resolves to the
  *    OutboundSessionInfo when setup is complete.
@@ -416,8 +417,6 @@ MegolmEncryption.prototype._splitBlockedDevices = function(
         const userBlockedDevicesToShareWith = devicesByUser[userId];
 
         for (const blockedInfo of userBlockedDevicesToShareWith) {
-            const deviceInfo = blockedInfo.deviceInfo;
-
             if (currentSlice.length > maxToDeviceMessagesPerRequest) {
                 // the current slice is filled up. Start inserting into the next slice
                 currentSlice = [];
@@ -521,7 +520,7 @@ MegolmEncryption.prototype._sendBlockedNotificationsToDevices = async function(
         contentMap[userId][deviceId] = message;
     }
 
-    await this._baseApis.sendToDevice("org.matrix.room_key.withheld", contentMap)
+    await this._baseApis.sendToDevice("org.matrix.room_key.withheld", contentMap);
 
     // store that we successfully uploaded the keys of the current slice
     for (const userId of Object.keys(contentMap)) {
@@ -672,7 +671,7 @@ MegolmEncryption.prototype._notifyBlockedDevices = async function(
         room_id: this._roomId,
         session_id: session.sessionId,
         algorithm: olmlib.MEGOLM_ALGORITHM,
-        session_key: this._olmDevice.deviceCurve25519Key,
+        sender_key: this._olmDevice.deviceCurve25519Key,
     };
 
     const userDeviceMaps = this._splitBlockedDevices(

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import logger from '../../logger';
 const utils = require("../../utils");
 const olmlib = require("../olmlib");
 const base = require("./base");
+
+import {WITHHELD_MESSAGES} from '../OlmDevice';
 
 /**
  * @private
@@ -856,11 +858,11 @@ MegolmEncryption.prototype._getDevicesInRoom = async function(room) {
                 const blockedInfo = userDevices[deviceId].isBlocked()
                     ? {
                         code: "m.blacklisted",
-                        reason: "You have been blocked",
+                        reason: WITHHELD_MESSAGES["m.blacklisted"],
                     }
                     : {
                         code: "m.unverified",
-                        reason: "You have not been verified",
+                        reason: WITHHELD_MESSAGES["m.unverified"],
                     };
                 blockedInfo.deviceInfo = userDevices[deviceId];
                 blocked[userId][deviceId] = blockedInfo;

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -903,6 +903,11 @@ MegolmDecryption.prototype.decryptEvent = async function(event) {
             event.getId(), event.getTs(),
         );
     } catch (e) {
+        if (e.name === "DecryptionError") {
+            // re-throw decryption errors as-is
+            throw e;
+        }
+
         let errorCode = "OLM_DECRYPT_GROUP_MESSAGE_ERROR";
 
         if (e && e.message === 'OLM.UNKNOWN_MESSAGE_INDEX') {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -1148,15 +1148,10 @@ MegolmDecryption.prototype.onRoomKeyEvent = function(event) {
  */
 MegolmDecryption.prototype.onRoomKeyWithheldEvent = async function(event) {
     const content = event.getContent();
-    const sessionId = content.session_id;
-    const senderKey = content.sender_key || event.getSenderKey();
-
-    if (!senderKey) {
-        logger.error("key withheld event is missing fields");
-    }
 
     await this._olmDevice.addInboundGroupSessionWithheld(
-        content.room_id, senderKey, sessionId, content.code, content.reason,
+        content.room_id, content.sender_key, content.session_id, content.code,
+        content.reason,
     );
 };
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -1111,6 +1111,26 @@ MegolmDecryption.prototype.onRoomKeyEvent = function(event) {
 
 /**
  * @inheritdoc
+ *
+ * @param {module:models/event.MatrixEvent} event key event
+ */
+MegolmDecryption.prototype.onRoomKeyWithheldEvent = async function(event) {
+    const content = event.getContent();
+    const sessionId = content.session_id;
+    let senderKey = event.getSenderKey();
+
+    if (!senderKey) {
+        // FIXME:
+        senderKey = content.sender_key;
+    }
+
+    await this._olmDevice.addInboundGroupSessionWithheld(
+        content.room_id, senderKey, sessionId, content.code, content.reason
+    );
+};
+
+/**
+ * @inheritdoc
  */
 MegolmDecryption.prototype.hasKeysForKeyRequest = function(keyRequest) {
     const body = keyRequest.requestBody;

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2,7 +2,7 @@
 Copyright 2016 OpenMarket Ltd
 Copyright 2017 Vector Creations Ltd
 Copyright 2018-2019 New Vector Ltd
-Copyright 2019 The Matrix.org Foundation C.I.C.
+Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2412,6 +2412,12 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
     alg.onRoomKeyEvent(event);
 };
 
+/**
+ * Handle a key withheld event
+ *
+ * @private
+ * @param {module:models/event.MatrixEvent} event key event
+ */
 Crypto.prototype._onRoomKeyWithheldEvent = function(event) {
     const content = event.getContent();
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2371,7 +2371,7 @@ Crypto.prototype._onToDeviceEvent = function(event) {
             this._secretStorage._onRequestReceived(event);
         } else if (event.getType() === "m.secret.send") {
             this._secretStorage._onSecretReceived(event);
-        } else if (event.getType() === "m.room_key.withheld") {
+        } else if (event.getType() === "org.matrix.room_key.withheld") {
             this._onRoomKeyWithheldEvent(event);
         } else if (event.getContent().transaction_id) {
             this._onKeyVerificationMessage(event);

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2415,7 +2415,7 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
 Crypto.prototype._onRoomKeyWithheldEvent = function(event) {
     const content = event.getContent();
 
-    if (!content.room_id || !content.session_id) {
+    if (!content.room_id || !content.session_id || !content.algorithm) {
         logger.error("key withheld event is missing fields");
         return;
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2416,12 +2416,13 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
  * Handle a key withheld event
  *
  * @private
- * @param {module:models/event.MatrixEvent} event key event
+ * @param {module:models/event.MatrixEvent} event key withheld event
  */
 Crypto.prototype._onRoomKeyWithheldEvent = function(event) {
     const content = event.getContent();
 
-    if (!content.room_id || !content.session_id || !content.algorithm) {
+    if (!content.room_id || !content.session_id || !content.algorithm
+        || !content.sender_key) {
         logger.error("key withheld event is missing fields");
         return;
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2371,6 +2371,8 @@ Crypto.prototype._onToDeviceEvent = function(event) {
             this._secretStorage._onRequestReceived(event);
         } else if (event.getType() === "m.secret.send") {
             this._secretStorage._onSecretReceived(event);
+        } else if (event.getType() === "m.room_key.withheld") {
+            this._onRoomKeyWithheldEvent(event);
         } else if (event.getContent().transaction_id) {
             this._onKeyVerificationMessage(event);
         } else if (event.getContent().msgtype === "m.bad.encrypted") {
@@ -2408,6 +2410,20 @@ Crypto.prototype._onRoomKeyEvent = function(event) {
 
     const alg = this._getRoomDecryptor(content.room_id, content.algorithm);
     alg.onRoomKeyEvent(event);
+};
+
+Crypto.prototype._onRoomKeyWithheldEvent = function(event) {
+    const content = event.getContent();
+
+    if (!content.room_id || !content.session_id) {
+        logger.error("key withheld event is missing fields");
+        return;
+    }
+
+    const alg = this._getRoomDecryptor(content.room_id, content.algorithm);
+    if (alg.onRoomKeyWithheldEvent) {
+        alg.onRoomKeyWithheldEvent(event);
+    }
 };
 
 /**

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 Vector Creations Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -79,7 +79,7 @@ export class Backend {
                     `enqueueing key request for ${requestBody.room_id} / ` +
                         requestBody.session_id,
                 );
-                txn.oncomplete = () => { resolve(request); };
+                txn.oncomplete = () => {resolve(request);};
                 const store = txn.objectStore("outgoingRoomKeyRequests");
                 store.add(request);
             });
@@ -438,7 +438,7 @@ export class Backend {
                     } else {
                         resolve(null);
                     }
-                }
+                };
             }),
             new Promise((resolve, reject) => {
                 const objectStore = txn.objectStore("inbound_group_sessions_withheld");
@@ -449,7 +449,7 @@ export class Backend {
                     } else {
                         resolve(null);
                     }
-                }
+                };
             }),
         ]);
         try {
@@ -515,7 +515,9 @@ export class Backend {
         });
     }
 
-    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+    storeEndToEndInboundGroupSessionWithheld(
+        senderCurve25519Key, sessionId, sessionData, txn,
+    ) {
         const objectStore = txn.objectStore("inbound_group_sessions_withheld");
         objectStore.put({
             senderCurve25519Key, sessionId, session: sessionData,

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 Vector Creations Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -471,6 +471,14 @@ export default class IndexedDBCryptoStore {
         });
     }
 
+    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+        this._backendPromise.then(backend => {
+            backend.storeEndToEndInboundGroupSessionWithheld(
+                senderCurve25519Key, sessionId, sessionData, txn,
+            );
+        });
+    }
+
     // End-to-end device tracking
 
     /**
@@ -607,6 +615,8 @@ export default class IndexedDBCryptoStore {
 IndexedDBCryptoStore.STORE_ACCOUNT = 'account';
 IndexedDBCryptoStore.STORE_SESSIONS = 'sessions';
 IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS = 'inbound_group_sessions';
+IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS_WITHHELD
+    = 'inbound_group_sessions_withheld';
 IndexedDBCryptoStore.STORE_DEVICE_DATA = 'device_data';
 IndexedDBCryptoStore.STORE_ROOMS = 'rooms';
 IndexedDBCryptoStore.STORE_BACKUP = 'sessions_needing_backup';

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -104,7 +104,10 @@ export default class IndexedDBCryptoStore {
             // we can fall back to a different backend.
             return backend.doTxn(
                 'readonly',
-                [IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS],
+                [
+                    IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS,
+                    IndexedDBCryptoStore.STORE_INBOUND_GROUP_SESSIONS_WITHHELD,
+                ],
                 (txn) => {
                     backend.getEndToEndInboundGroupSession('', '', txn, () => {});
                 }).then(() => {

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -471,7 +471,9 @@ export default class IndexedDBCryptoStore {
         });
     }
 
-    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+    storeEndToEndInboundGroupSessionWithheld(
+        senderCurve25519Key, sessionId, sessionData, txn,
+    ) {
         this._backendPromise.then(backend => {
             backend.storeEndToEndInboundGroupSessionWithheld(
                 senderCurve25519Key, sessionId, sessionData, txn,

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2017, 2018 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -32,6 +32,7 @@ const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_CROSS_SIGNING_KEYS = E2E_PREFIX + "cross_signing_keys";
 const KEY_DEVICE_DATA = E2E_PREFIX + "device_data";
 const KEY_INBOUND_SESSION_PREFIX = E2E_PREFIX + "inboundgroupsessions/";
+const KEY_INBOUND_SESSION_WITHHELD_PREFIX = E2E_PREFIX + "inboundgroupsessions.withheld/";
 const KEY_ROOMS_PREFIX = E2E_PREFIX + "rooms/";
 const KEY_SESSIONS_NEEDING_BACKUP = E2E_PREFIX + "sessionsneedingbackup";
 
@@ -41,6 +42,10 @@ function keyEndToEndSessions(deviceKey) {
 
 function keyEndToEndInboundGroupSession(senderKey, sessionId) {
     return KEY_INBOUND_SESSION_PREFIX + senderKey + "/" + sessionId;
+}
+
+function keyEndToEndInboundGroupSessionWithheld(senderKey, sessionId) {
+    return KEY_INBOUND_SESSION_WITHHELD_PREFIX + senderKey + "/" + sessionId;
 }
 
 function keyEndToEndRoomsPrefix(roomId) {
@@ -125,10 +130,16 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
     // Inbound Group Sessions
 
     getEndToEndInboundGroupSession(senderCurve25519Key, sessionId, txn, func) {
-        func(getJsonItem(
-            this.store,
-            keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId),
-        ));
+        func(
+            getJsonItem(
+                this.store,
+                keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId),
+            ),
+            getJsonItem(
+                this.store,
+                keyEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId),
+            ),
+        );
     }
 
     getAllEndToEndInboundGroupSessions(txn, func) {
@@ -166,6 +177,14 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
         setJsonItem(
             this.store,
             keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId),
+            sessionData,
+        );
+    }
+
+    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+        setJsonItem(
+            this.store,
+            keyEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId),
             sessionData,
         );
     }

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -181,7 +181,9 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
         );
     }
 
-    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+    storeEndToEndInboundGroupSessionWithheld(
+        senderCurve25519Key, sessionId, sessionData, txn,
+    ) {
         setJsonItem(
             this.store,
             keyEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId),

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -37,6 +37,7 @@ export default class MemoryCryptoStore {
         this._sessions = {};
         // Map of {senderCurve25519Key+'/'+sessionId -> session data object}
         this._inboundGroupSessions = {};
+        this._inboundGroupSessionsWithheld = {};
         // Opaque device data object
         this._deviceData = null;
         // roomId -> Opaque roomInfo object
@@ -276,7 +277,11 @@ export default class MemoryCryptoStore {
     // Inbound Group Sessions
 
     getEndToEndInboundGroupSession(senderCurve25519Key, sessionId, txn, func) {
-        func(this._inboundGroupSessions[senderCurve25519Key+'/'+sessionId] || null);
+        const k = senderCurve25519Key+'/'+sessionId;
+        func(
+            this._inboundGroupSessions[k] || null,
+            this._inboundGroupSessionsWithheld[k] || null,
+        );
     }
 
     getAllEndToEndInboundGroupSessions(txn, func) {
@@ -304,6 +309,10 @@ export default class MemoryCryptoStore {
 
     storeEndToEndInboundGroupSession(senderCurve25519Key, sessionId, sessionData, txn) {
         this._inboundGroupSessions[senderCurve25519Key+'/'+sessionId] = sessionData;
+    }
+
+    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
+        this._inboundGroupSessionsWithheld[senderCurve25519Key+'/'+sessionId] = sessionData;
     }
 
     // Device Data

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -1,6 +1,7 @@
 /*
 Copyright 2017 Vector Creations Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -311,8 +311,11 @@ export default class MemoryCryptoStore {
         this._inboundGroupSessions[senderCurve25519Key+'/'+sessionId] = sessionData;
     }
 
-    storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn) {
-        this._inboundGroupSessionsWithheld[senderCurve25519Key+'/'+sessionId] = sessionData;
+    storeEndToEndInboundGroupSessionWithheld(
+        senderCurve25519Key, sessionId, sessionData, txn,
+    ) {
+        const k = senderCurve25519Key+'/'+sessionId;
+        this._inboundGroupSessionsWithheld[k] = sessionData;
     }
 
     // Device Data


### PR DESCRIPTION
Implements part of [MSC2399](https://github.com/matrix-org/matrix-doc/pull/2399) (notifications on initial key sending, but not on keyshare requests, and does not properly handle `m.no_olm` yet -- the remaining functionality will come in a future PR).