### PR TITLE
Use checkDeviceTrust with key backup

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1068,7 +1068,9 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
         );
         if (device) {
             sigInfo.device = device;
-            sigInfo.deviceTrust = await this.checkDeviceTrust(this._userId, sigInfo.deviceId);
+            sigInfo.deviceTrust = await this.checkDeviceTrust(
+                this._userId, sigInfo.deviceId,
+            );
             try {
                 await olmlib.verifySignature(
                     this._olmDevice,

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1068,6 +1068,7 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
         );
         if (device) {
             sigInfo.device = device;
+            sigInfo.deviceTrust = await this.checkDeviceTrust(this._userId, sigInfo.deviceId);
             try {
                 await olmlib.verifySignature(
                     this._olmDevice,
@@ -1095,7 +1096,7 @@ Crypto.prototype.isKeyBackupTrusted = async function(backupInfo) {
     ret.usable = ret.sigs.some((s) => {
         return (
             s.valid && (
-                (s.device && s.device.isVerified()) ||
+                (s.device && s.deviceTrust.isVerified()) ||
                 (s.crossSigningId)
             )
         );


### PR DESCRIPTION
We did check if it was signed with a cross signing key which should
be the norm going forward, but for completeness, use the proper
cross-signing ernabled check for sigs from individual devices too.

Also adds a deviceTrust member to the signature so the app can see
the cross-signing trust status ofthe device without having to
recalculate it.