### PR TITLE
Fix creating a key backup with cross signing diabled

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1506,7 +1506,7 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
     await this._crypto._signObject(data.auth_data);
 
     if (
-        this._cryptoCallbacks.getSecretStorageKey &&
+        this._cryptoCallbacks.getCrossSigningKey &&
         this._crypto._crossSigningInfo.getId()
     ) {
         // now also sign the auth data with the cross-signing master key

--- a/src/client.js
+++ b/src/client.js
@@ -1505,8 +1505,11 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
     // favour of just signing with the cross-singing master key.
     await this._crypto._signObject(data.auth_data);
 
-    if (this._crypto._crossSigningInfo.getId()) {
+    if (this._cryptoCallbacks.getSecretStorageKey && this._crypto._crossSigningInfo.getId()) {
         // now also sign the auth data with the cross-signing master key
+        // we check for the callback explicitly here because we still want to be able
+        // to create an un-cross-signed key backup if there is a cross-signing key but
+        // no callback supplied.
         await this._crypto._crossSigningInfo.signObject(data.auth_data, "master");
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1505,7 +1505,10 @@ MatrixClient.prototype.createKeyBackupVersion = async function(info) {
     // favour of just signing with the cross-singing master key.
     await this._crypto._signObject(data.auth_data);
 
-    if (this._cryptoCallbacks.getSecretStorageKey && this._crypto._crossSigningInfo.getId()) {
+    if (
+        this._cryptoCallbacks.getSecretStorageKey &&
+        this._crypto._crossSigningInfo.getId()
+    ) {
         // now also sign the auth data with the cross-signing master key
         // we check for the callback explicitly here because we still want to be able
         // to create an un-cross-signed key backup if there is a cross-signing key but

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -218,7 +218,7 @@ export default function Crypto(baseApis, sessionStore, userId, deviceId,
     );
 
     // Assuming no app-supplied callback, default to getting from SSSS.
-    if (!cryptoCallbacks.getCrossSigningKey) {
+    if (!cryptoCallbacks.getCrossSigningKey && cryptoCallbacks.getSecretStorageKey) {
         cryptoCallbacks.getCrossSigningKey = async (type) => {
             return CrossSigningInfo.getFromSecretStorage(type, this._secretStorage);
         };


### PR DESCRIPTION
It broke if no secret key callback was supplied but a cross-signing
identity did exist (as hopefully explained in comment).

Fixes https://github.com/vector-im/riot-web/issues/11763