### PR TITLE
Make displayName disambiguation more fuzzy especially against RTL/LTR content

### DIFF
--- a/src/models/room-member.js
+++ b/src/models/room-member.js
@@ -311,10 +311,18 @@ function calculateDisplayName(selfUserId, displayName, roomState) {
     // Next check if the name contains something that look like a mxid
     // If it does, it may be someone trying to impersonate someone else
     // Show full mxid in this case
-    // Also show mxid if there are other people with the same or similar
-    // displayname, after hidden character removal.
     let disambiguate = /@.+:.+/.test(displayName);
+
     if (!disambiguate) {
+        // Also show mxid if the display name contains any LTR/RTL characters as these
+        // make it very difficult for us to find similar *looking* display names
+        // E.g "Mark" could be cloned by writing "kraM" but in RTL.
+        disambiguate = /[\u200E\u200F\u202A-\u202F]/.test(displayName);
+    }
+
+    if (!disambiguate) {
+        // Also show mxid if there are other people with the same or similar
+        // displayname, after hidden character removal.
         const userIds = roomState.getUserIdsWithDisplayName(displayName);
         disambiguate = userIds.some((u) => u !== selfUserId);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -675,7 +675,14 @@ module.exports.isNumber = function(value) {
 module.exports.removeHiddenChars = function(str) {
     return unhomoglyph(str.normalize('NFD').replace(removeHiddenCharsRegex, ''));
 };
-const removeHiddenCharsRegex = /[\u200B-\u200D\u0300-\u036f\uFEFF\s]/g;
+// Regex matching bunch of unicode control characters and otherwise misleading/invisible characters.
+// Includes:
+// various width spaces U+2000 - U+200D
+// LTR and RTL marks U+200E and U+200F
+// LTR/RTL and other directional formatting marks U+202A - U+202F
+// Combining characters U+0300 - U+036F
+// Zero width no-break space (BOM) U+FEFF
+const removeHiddenCharsRegex = /[\u2000-\u200F\u202A-\u202F\u0300-\u036f\uFEFF\s]/g;
 
 function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
It may be a little too strict but better that than letting people pretend to be others

The exact push for this was someone with an invisible displayName which was just U+202E (RTL Override)

Before:
![image](https://user-images.githubusercontent.com/2403652/71785093-7c77b600-2ff3-11ea-8876-79bfbbda58b9.png)
After:
![image](https://user-images.githubusercontent.com/2403652/71785105-96b19400-2ff3-11ea-9379-77727cd007c7.png)


Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>