### PR TITLE
record, report, and notify about olm errors

### DIFF
--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -11,6 +11,7 @@ import logger from '../../../../lib/logger';
 import TestClient from '../../../TestClient';
 import olmlib from '../../../../lib/crypto/olmlib';
 import Room from '../../../../lib/models/room';
+import DeviceInfo from '../../../../lib/crypto/deviceinfo';
 
 const MatrixEvent = sdk.MatrixEvent;
 const MegolmDecryption = algorithms.DECRYPTION_CLASSES['m.megolm.v1.aes-sha2'];
@@ -453,6 +454,99 @@ describe("MegolmDecryption", function() {
         bobClient2.stopClient();
     });
 
+    it("notifies devices when unable to create olm session", async function() {
+        const aliceClient = (new TestClient(
+            "@alice:example.com", "alicedevice",
+        )).client;
+        const bobClient = (new TestClient(
+            "@bob:example.com", "bobdevice",
+        )).client;
+        await Promise.all([
+            aliceClient.initCrypto(),
+            bobClient.initCrypto(),
+        ]);
+        const aliceDevice = aliceClient._crypto._olmDevice;
+        const bobDevice = bobClient._crypto._olmDevice;
+
+        const encryptionCfg = {
+            "algorithm": "m.megolm.v1.aes-sha2",
+        };
+        const roomId = "!someroom";
+        const aliceRoom = new Room(roomId, aliceClient, "@alice:example.com", {});
+        const bobRoom = new Room(roomId, bobClient, "@bob:example.com", {});
+        aliceClient.store.storeRoom(aliceRoom);
+        bobClient.store.storeRoom(bobRoom);
+        await aliceClient.setRoomEncryption(roomId, encryptionCfg);
+        await bobClient.setRoomEncryption(roomId, encryptionCfg);
+
+        aliceRoom.getEncryptionTargetMembers = async () => {
+            return [
+                {
+                    userId: "@alice:example.com",
+                    membership: "join",
+                },
+                {
+                    userId: "@bob:example.com",
+                    membership: "join",
+                },
+            ];
+        };
+        const BOB_DEVICES = {
+            bobdevice: {
+                user_id: "@bob:example.com",
+                device_id: "bobdevice",
+                algorithms: [olmlib.OLM_ALGORITHM, olmlib.MEGOLM_ALGORITHM],
+                keys: {
+                    "ed25519:bobdevice": bobDevice.deviceEd25519Key,
+                    "curve25519:bobdevice": bobDevice.deviceCurve25519Key,
+                },
+                known: true,
+                verified: 1,
+            },
+        };
+
+        aliceClient._crypto._deviceList.storeDevicesForUser(
+            "@bob:example.com", BOB_DEVICES,
+        );
+        aliceClient._crypto._deviceList.downloadKeys = async function(userIds) {
+            return this._getDevicesFromStore(userIds);
+        };
+
+        aliceClient.claimOneTimeKeys = async () => {
+            // Bob has no one-time keys
+            return {
+                one_time_keys: {},
+            };
+        };
+
+        let run = false;
+        aliceClient.sendToDevice = async (msgtype, contentMap) => {
+            run = true;
+            expect(msgtype).toBe("org.matrix.room_key.withheld");
+            expect(contentMap).toStrictEqual({
+                '@bob:example.com': {
+                    bobdevice: {
+                        algorithm: "m.megolm.v1.aes-sha2",
+                        code: 'm.no_olm',
+                        reason: 'Unable to establish a secure channel.',
+                        sender_key: aliceDevice.deviceCurve25519Key,
+                    },
+                },
+            });
+        };
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            sender: "@alice:example.com",
+            room_id: roomId,
+            event_id: "$event",
+            content: {},
+        });
+        await aliceClient._crypto.encryptEvent(event, aliceRoom);
+
+        expect(run).toBe(true);
+    });
+
     it("throws an error describing why it doesn't have a key", async function() {
         const aliceClient = (new TestClient(
             "@alice:example.com", "alicedevice",
@@ -494,5 +588,104 @@ describe("MegolmDecryption", function() {
                 session_id: "session_id",
             },
         }))).rejects.toThrow("The sender has blocked you.");
+    });
+
+    it("throws an error describing the lack of an olm session", async function() {
+        const aliceClient = (new TestClient(
+            "@alice:example.com", "alicedevice",
+        )).client;
+        const bobClient = (new TestClient(
+            "@bob:example.com", "bobdevice",
+        )).client;
+        await Promise.all([
+            aliceClient.initCrypto(),
+            bobClient.initCrypto(),
+        ]);
+        const bobDevice = bobClient._crypto._olmDevice;
+
+        const roomId = "!someroom";
+
+        const now = Date.now();
+
+        aliceClient._crypto._onToDeviceEvent(new MatrixEvent({
+            type: "org.matrix.room_key.withheld",
+            sender: "@bob:example.com",
+            content: {
+                algorithm: "m.megolm.v1.aes-sha2",
+                room_id: roomId,
+                session_id: "session_id",
+                sender_key: bobDevice.deviceCurve25519Key,
+                code: "m.no_olm",
+                reason: "Unable to establish a secure channel.",
+            },
+        }));
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+        });
+
+        await expect(aliceClient._crypto.decryptEvent(new MatrixEvent({
+            type: "m.room.encrypted",
+            sender: "@bob:example.com",
+            event_id: "$event",
+            room_id: roomId,
+            content: {
+                algorithm: "m.megolm.v1.aes-sha2",
+                ciphertext: "blablabla",
+                device_id: "bobdevice",
+                sender_key: bobDevice.deviceCurve25519Key,
+                session_id: "session_id",
+            },
+            origin_server_ts: now,
+        }))).rejects.toThrow("The sender was unable to establish a secure channel.");
+    });
+
+    it("throws an error to indicate a wedged olm session", async function() {
+        const aliceClient = (new TestClient(
+            "@alice:example.com", "alicedevice",
+        )).client;
+        const bobClient = (new TestClient(
+            "@bob:example.com", "bobdevice",
+        )).client;
+        await Promise.all([
+            aliceClient.initCrypto(),
+            bobClient.initCrypto(),
+        ]);
+        const bobDevice = bobClient._crypto._olmDevice;
+
+        const roomId = "!someroom";
+
+        const now = Date.now();
+
+        // pretend we got an event that we can't decrypt
+        aliceClient._crypto._onToDeviceEvent(new MatrixEvent({
+            type: "m.room.encrypted",
+            sender: "@bob:example.com",
+            content: {
+                msgtype: "m.bad.encrypted",
+                algorithm: "m.megolm.v1.aes-sha2",
+                session_id: "session_id",
+                sender_key: bobDevice.deviceCurve25519Key,
+            },
+        }));
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+        });
+
+        await expect(aliceClient._crypto.decryptEvent(new MatrixEvent({
+            type: "m.room.encrypted",
+            sender: "@bob:example.com",
+            event_id: "$event",
+            room_id: roomId,
+            content: {
+                algorithm: "m.megolm.v1.aes-sha2",
+                ciphertext: "blablabla",
+                device_id: "bobdevice",
+                sender_key: bobDevice.deviceCurve25519Key,
+                session_id: "session_id",
+            },
+            origin_server_ts: now,
+        }))).rejects.toThrow("The secure channel with the sender was corrupted.");
     });
 });

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -11,7 +11,6 @@ import logger from '../../../../lib/logger';
 import TestClient from '../../../TestClient';
 import olmlib from '../../../../lib/crypto/olmlib';
 import Room from '../../../../lib/models/room';
-import DeviceInfo from '../../../../lib/crypto/deviceinfo';
 
 const MatrixEvent = sdk.MatrixEvent;
 const MegolmDecryption = algorithms.DECRYPTION_CLASSES['m.megolm.v1.aes-sha2'];

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -674,6 +674,18 @@ OlmDevice.prototype.matchesSession = async function(
     return matches;
 };
 
+OlmDevice.prototype.recordSessionProblem = async function(deviceKey, type, fixed) {
+    await this._cryptoStore.storeEndToEndSessionProblem(deviceKey, type, fixed);
+};
+
+OlmDevice.prototype.sessionMayHaveProblems = async function(deviceKey, timestamp) {
+    return await this._cryptoStore.getEndToEndSessionProblem(deviceKey, timestamp);
+};
+
+OlmDevice.prototype.filterOutNotifiedErrorDevices = async function(devices) {
+    return await this._cryptoStore.filterOutNotifiedErrorDevices(devices);
+};
+
 
 // Outbound group session
 // ======================

--- a/src/crypto/algorithms/base.js
+++ b/src/crypto/algorithms/base.js
@@ -159,6 +159,16 @@ class DecryptionAlgorithm {
     shareKeysWithDevice(keyRequest) {
         throw new Error("shareKeysWithDevice not supported for this DecryptionAlgorithm");
     }
+
+    /**
+     * Retry decrypting all the events from a sender that haven't been
+     * decrypted yet.
+     *
+     * @param {string} senderKey the sender's key
+     */
+    async retryDecryptionFromSender(senderKey) {
+        // ignore by default
+    }
 }
 export {DecryptionAlgorithm}; // https://github.com/jsdoc3/jsdoc/issues/1272
 

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -356,6 +356,10 @@ MegolmEncryption.prototype._prepareNewSession = async function() {
  * @param {object<string, module:crypto/deviceinfo[]>} devicesByUser
  *    map from userid to list of devices
  *
+ * @param {array<object>} errorDevices
+ *    array that will be populated with the devices that can't get an
+ *    olm session for
+ *
  * @return {array<object<userid, deviceInfo>>}
  */
 MegolmEncryption.prototype._splitUserDeviceMap = function(
@@ -665,6 +669,10 @@ MegolmEncryption.prototype.reshareKeyWithDevice = async function(
  *
  * @param {object<string, module:crypto/deviceinfo[]>} devicesByUser
  *    map from userid to list of devices
+ *
+ * @param {array<object>} errorDevices
+ *    array that will be populated with the devices that we can't get an
+ *    olm session for
  */
 MegolmEncryption.prototype._shareKeyWithDevices = async function(
     session, devicesByUser, errorDevices,

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -467,6 +467,7 @@ export class Backend {
         return result;
     }
 
+    // FIXME: we should probably prune this when devices get deleted
     async filterOutNotifiedErrorDevices(devices) {
         const txn = this._db.transaction("notified_error_devices", "readwrite");
         const objectStore = txn.objectStore("notified_error_devices");

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -450,6 +450,9 @@ export class Backend {
                 result = null;
                 return;
             }
+            problems.sort((a, b) => {
+                return a.time - b.time;
+            });
             const lastProblem = problems[problems.length - 1];
             for (const problem of problems) {
                 if (problem.time > timestamp) {
@@ -768,7 +771,7 @@ export function upgradeDatabase(db, oldVersion) {
         const problemsStore = db.createObjectStore("session_problems", {
             keyPath: ["deviceKey", "time"],
         });
-        problemsStore.createIndex("deviceKey");
+        problemsStore.createIndex("deviceKey", "deviceKey");
 
         db.createObjectStore("notified_error_devices", {
             keyPath: ["userId", "deviceId"],

--- a/src/crypto/store/indexeddb-crypto-store-backend.js
+++ b/src/crypto/store/indexeddb-crypto-store-backend.js
@@ -19,7 +19,7 @@ limitations under the License.
 import logger from '../../logger';
 import utils from '../../utils';
 
-export const VERSION = 8;
+export const VERSION = 9;
 
 /**
  * Implementation of a CryptoStore which is backed by an existing
@@ -426,6 +426,70 @@ export class Backend {
         });
     }
 
+    async storeEndToEndSessionProblem(deviceKey, type, fixed) {
+        const txn = this._db.transaction("session_problems", "readwrite");
+        const objectStore = txn.objectStore("session_problems");
+        objectStore.put({
+            deviceKey,
+            type,
+            fixed,
+            time: Date.now(),
+        });
+        return promiseifyTxn(txn);
+    }
+
+    async getEndToEndSessionProblem(deviceKey, timestamp) {
+        let result;
+        const txn = this._db.transaction("session_problems", "readwrite");
+        const objectStore = txn.objectStore("session_problems");
+        const index = objectStore.index("deviceKey");
+        const req = index.getAll(deviceKey);
+        req.onsuccess = (event) => {
+            const problems = req.result;
+            if (!problems.length) {
+                result = null;
+                return;
+            }
+            const lastProblem = problems[problems.length - 1];
+            for (const problem of problems) {
+                if (problem.time > timestamp) {
+                    result = Object.assign({}, problem, {fixed: lastProblem.fixed});
+                    return;
+                }
+            }
+            if (lastProblem.fixed) {
+                result = null;
+            } else {
+                result = lastProblem;
+            }
+        };
+        await promiseifyTxn(txn);
+        return result;
+    }
+
+    async filterOutNotifiedErrorDevices(devices) {
+        const txn = this._db.transaction("notified_error_devices", "readwrite");
+        const objectStore = txn.objectStore("notified_error_devices");
+
+        const ret = [];
+
+        await Promise.all(devices.map((device) => {
+            return new Promise((resolve) => {
+                const {userId, deviceInfo} = device;
+                const getReq = objectStore.get([userId, deviceInfo.deviceId]);
+                getReq.onsuccess = function() {
+                    if (!getReq.result) {
+                        objectStore.put({userId, deviceId: deviceInfo.deviceId});
+                        ret.push(device);
+                    }
+                    resolve();
+                };
+            });
+        }));
+
+        return ret;
+    }
+
     // Inbound group sessions
 
     getEndToEndInboundGroupSession(senderCurve25519Key, sessionId, txn, func) {
@@ -697,6 +761,16 @@ export function upgradeDatabase(db, oldVersion) {
     if (oldVersion < 8) {
         db.createObjectStore("inbound_group_sessions_withheld", {
             keyPath: ["senderCurve25519Key", "sessionId"],
+        });
+    }
+    if (oldVersion < 9) {
+        const problemsStore = db.createObjectStore("session_problems", {
+            keyPath: ["deviceKey", "time"],
+        });
+        problemsStore.createIndex("deviceKey");
+
+        db.createObjectStore("notified_error_devices", {
+            keyPath: ["userId", "deviceId"],
         });
     }
     // Expand as needed.

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -409,6 +409,24 @@ export default class IndexedDBCryptoStore {
         });
     }
 
+    storeEndToEndSessionProblem(deviceKey, type, fixed) {
+        return this._backendPromise.then(async (backend) => {
+            await backend.storeEndToEndSessionProblem(deviceKey, type, fixed);
+        });
+    }
+
+    getEndToEndSessionProblem(deviceKey, timestamp) {
+        return this._backendPromise.then(async (backend) => {
+            await backend.getEndToEndSessionProblem(deviceKey, timestamp);
+        });
+    }
+
+    filterOutNotifiedErrorDevices(devices) {
+        return this._backendPromise.then(async (backend) => {
+            return await backend.filterOutNotifiedErrorDevices(devices);
+        });
+    }
+
     // Inbound group sessions
 
     /**

--- a/src/crypto/store/indexeddb-crypto-store.js
+++ b/src/crypto/store/indexeddb-crypto-store.js
@@ -417,7 +417,7 @@ export default class IndexedDBCryptoStore {
 
     getEndToEndSessionProblem(deviceKey, timestamp) {
         return this._backendPromise.then(async (backend) => {
-            await backend.getEndToEndSessionProblem(deviceKey, timestamp);
+            return await backend.getEndToEndSessionProblem(deviceKey, timestamp);
         });
     }
 

--- a/src/crypto/store/localStorage-crypto-store.js
+++ b/src/crypto/store/localStorage-crypto-store.js
@@ -31,6 +31,7 @@ import MemoryCryptoStore from './memory-crypto-store';
 const E2E_PREFIX = "crypto.";
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_CROSS_SIGNING_KEYS = E2E_PREFIX + "cross_signing_keys";
+const KEY_NOTIFIED_ERROR_DEVICES = E2E_PREFIX + "notified_error_devices";
 const KEY_DEVICE_DATA = E2E_PREFIX + "device_data";
 const KEY_INBOUND_SESSION_PREFIX = E2E_PREFIX + "inboundgroupsessions/";
 const KEY_INBOUND_SESSION_WITHHELD_PREFIX = E2E_PREFIX + "inboundgroupsessions.withheld/";
@@ -39,6 +40,10 @@ const KEY_SESSIONS_NEEDING_BACKUP = E2E_PREFIX + "sessionsneedingbackup";
 
 function keyEndToEndSessions(deviceKey) {
     return E2E_PREFIX + "sessions/" + deviceKey;
+}
+
+function keyEndToEndSessionProblems(deviceKey) {
+    return E2E_PREFIX + "session.problems/" + deviceKey;
 }
 
 function keyEndToEndInboundGroupSession(senderKey, sessionId) {
@@ -126,6 +131,58 @@ export default class LocalStorageCryptoStore extends MemoryCryptoStore {
         setJsonItem(
             this.store, keyEndToEndSessions(deviceKey), sessions,
         );
+    }
+
+    async storeEndToEndSessionProblem(deviceKey, type, fixed) {
+        const key = keyEndToEndSessionProblems(deviceKey);
+        const problems = getJsonItem(this.store, key) || [];
+        problems.push({type, fixed, time: Date.now()});
+        problems.sort((a, b) => {
+            return a.time - b.time;
+        });
+        setJsonItem(this.store, key, problems);
+    }
+
+    async getEndToEndSessionProblem(deviceKey, timestamp) {
+        const key = keyEndToEndSessionProblems(deviceKey);
+        const problems = getJsonItem(this.store, key) || [];
+        if (!problems.length) {
+            return null;
+        }
+        const lastProblem = problems[problems.length - 1];
+        for (const problem of problems) {
+            if (problem.time > timestamp) {
+                return Object.assign({}, problem, {fixed: lastProblem.fixed});
+            }
+        }
+        if (lastProblem.fixed) {
+            return null;
+        } else {
+            return lastProblem;
+        }
+    }
+
+    async filterOutNotifiedErrorDevices(devices) {
+        const notifiedErrorDevices =
+              getJsonItem(this.store, KEY_NOTIFIED_ERROR_DEVICES) || {};
+        const ret = [];
+
+        for (const device of devices) {
+            const {userId, deviceInfo} = device;
+            if (userId in notifiedErrorDevices) {
+                if (!(deviceInfo.deviceId in notifiedErrorDevices[userId])) {
+                    ret.push(device);
+                    notifiedErrorDevices[userId][deviceInfo.deviceId] = true;
+                }
+            } else {
+                ret.push(device);
+                notifiedErrorDevices[userId] = {[deviceInfo.deviceId]: true };
+            }
+        }
+
+        setJsonItem(this.store, KEY_NOTIFIED_ERROR_DEVICES, notifiedErrorDevices);
+
+        return ret;
     }
 
     // Inbound Group Sessions

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -36,6 +36,10 @@ export default class MemoryCryptoStore {
 
         // Map of {devicekey -> {sessionId -> session pickle}}
         this._sessions = {};
+        // Map of {devicekey -> array of problems}
+        this._sessionProblems = {};
+        // Map of {userId -> deviceId -> true}
+        this._notifiedErrorDevices = {};
         // Map of {senderCurve25519Key+'/'+sessionId -> session data object}
         this._inboundGroupSessions = {};
         this._inboundGroupSessionsWithheld = {};
@@ -273,6 +277,53 @@ export default class MemoryCryptoStore {
             this._sessions[deviceKey] = deviceSessions;
         }
         deviceSessions[sessionId] = sessionInfo;
+    }
+
+    async storeEndToEndSessionProblem(deviceKey, type, fixed) {
+        const problems = this._sessionProblems[deviceKey]
+              = this._sessionProblems[deviceKey] || [];
+        problems.push({type, fixed, time: Date.now()});
+        problems.sort((a, b) => {
+            return a.time - b.time;
+        });
+    }
+
+    async getEndToEndSessionProblem(deviceKey, timestamp) {
+        const problems = this._sessionProblems[deviceKey] || [];
+        if (!problems.length) {
+            return null;
+        }
+        const lastProblem = problems[problems.length - 1];
+        for (const problem of problems) {
+            if (problem.time > timestamp) {
+                return Object.assign({}, problem, {fixed: lastProblem.fixed});
+            }
+        }
+        if (lastProblem.fixed) {
+            return null;
+        } else {
+            return lastProblem;
+        }
+    }
+
+    async filterOutNotifiedErrorDevices(devices) {
+        const notifiedErrorDevices = this._notifiedErrorDevices;
+        const ret = [];
+
+        for (const device of devices) {
+            const {userId, deviceInfo} = device;
+            if (userId in notifiedErrorDevices) {
+                if (!(deviceInfo.deviceId in notifiedErrorDevices[userId])) {
+                    ret.push(device);
+                    notifiedErrorDevices[userId][deviceInfo.deviceId] = true;
+                }
+            } else {
+                ret.push(device);
+                notifiedErrorDevices[userId] = {[deviceInfo.deviceId]: true };
+            }
+        }
+
+        return ret;
     }
 
     // Inbound Group Sessions


### PR DESCRIPTION
Implements the `no_olm` part of [MSC2399](https://github.com/matrix-org/matrix-doc/pull/2399), and tells the user when the olm session got wedged.

The general algorithm is that when there's a problem with the olm session (either it's wedged, or the sender tells us they can't establish a session), then we try to recover by creating a session ourselves.  Then we record the problem, timestamp, and whether we (think we) fixed the problem.  When we have a megolm event that we can't decrypt, we check if it was sent within the time that we had a problem, and if so, tell the user what the problem was, and whether we were able to fix it.