### PR TITLE
use a separate object for each encrypted content

### DIFF
--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -460,15 +460,15 @@ MegolmEncryption.prototype._splitBlockedDevices = function(devicesByUser) {
 MegolmEncryption.prototype._encryptAndSendKeysToDevices = function(
     session, chainIndex, userDeviceMap, payload,
 ) {
-    const encryptedContent = {
-        algorithm: olmlib.OLM_ALGORITHM,
-        sender_key: this._olmDevice.deviceCurve25519Key,
-        ciphertext: {},
-    };
     const contentMap = {};
 
     const promises = [];
     for (let i = 0; i < userDeviceMap.length; i++) {
+        const encryptedContent = {
+            algorithm: olmlib.OLM_ALGORITHM,
+            sender_key: this._olmDevice.deviceCurve25519Key,
+            ciphertext: {},
+        };
         const val = userDeviceMap[i];
         const userId = val.userId;
         const deviceInfo = val.deviceInfo;


### PR DESCRIPTION
so that we don't duplicate the ciphertext for everyone.

Because right now, we're sending everyone's ciphertext to everyone in the same batch, when we should only be sending the ciphertext that's encrypted for that one device.  Which means that our payload is 20x what it should be.