### PR TITLE
Send device messages for the same user in same API call.

### DIFF
--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -331,7 +331,8 @@ MegolmEncryption.prototype._prepareNewSession = async function() {
 
 /**
  * Splits the user device map into multiple chunks to reduce the number of
- * devices we encrypt to per API call.
+ * devices we encrypt to per API call. Also filters out devices we don't have
+ * a session with.
  *
  * @private
  *
@@ -350,7 +351,7 @@ MegolmEncryption.prototype._prepareNewSession = async function() {
 MegolmEncryption.prototype._splitUserDeviceMap = function(
     session, chainIndex, devicemap, devicesByUser,
 ) {
-    const maxToDeviceMessagesPerRequest = 20;
+    const maxUsersPerRequest = 20;
 
     // use an array where the slices of a content map gets stored
     const mapSlices = [];
@@ -406,7 +407,7 @@ MegolmEncryption.prototype._splitUserDeviceMap = function(
         // server (e.g. only have to send one EDU if a remote user, etc). This
         // does mean that if a user has many devices we may go over the desired
         // limit, but its not a hard limit so that is fine.
-        if (entriesInCurrentSlice > maxToDeviceMessagesPerRequest) {
+        if (entriesInCurrentSlice > maxUsersPerRequest) {
             // the current slice is filled up. Start inserting into the next slice
             entriesInCurrentSlice = 0;
             currentSliceId++;

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -417,6 +417,9 @@ MegolmEncryption.prototype._splitUserDeviceMap = function(
 };
 
 /**
+ * Splits the user device map into multiple chunks to reduce the number of
+ * devices we encrypt to per API call.
+ *
  * @private
  *
  * @param {object} devicesByUser map from userid to list of devices
@@ -424,7 +427,7 @@ MegolmEncryption.prototype._splitUserDeviceMap = function(
  * @return {array<array<object>>} the blocked devices, split into chunks
  */
 MegolmEncryption.prototype._splitBlockedDevices = function(devicesByUser) {
-    const maxToDeviceMessagesPerRequest = 20;
+    const maxUsersPerRequest = 20;
 
     // use an array where the slices of a content map gets stored
     let currentSlice = [];
@@ -434,16 +437,21 @@ MegolmEncryption.prototype._splitBlockedDevices = function(devicesByUser) {
         const userBlockedDevicesToShareWith = devicesByUser[userId];
 
         for (const blockedInfo of userBlockedDevicesToShareWith) {
-            if (currentSlice.length > maxToDeviceMessagesPerRequest) {
-                // the current slice is filled up. Start inserting into the next slice
-                currentSlice = [];
-                mapSlices.push(currentSlice);
-            }
-
             currentSlice.push({
                 userId: userId,
                 blockedInfo: blockedInfo,
             });
+        }
+
+        // We do this in the per-user loop as we prefer that all messages to the
+        // same user end up in the same API call to make it easier for the
+        // server (e.g. only have to send one EDU if a remote user, etc). This
+        // does mean that if a user has many devices we may go over the desired
+        // limit, but its not a hard limit so that is fine.
+        if (currentSlice.length > maxUsersPerRequest) {
+            // the current slice is filled up. Start inserting into the next slice
+            currentSlice = [];
+            mapSlices.push(currentSlice);
         }
     }
     if (currentSlice.length === 0) {


### PR DESCRIPTION
Currently we split the device messages up to limit the number per call,
but that can end up splitting messages to a given users device over
separate API calls. This is fine, but means that the server can't e.g.
bundle them into a single EDU for remote users or sanity check that the
client is sending to the right set of devices (i.e. its device list
cache isn't wrong).

---

P.S. I have no idea what I'm doing.