### PR TITLE
Convert secret storage to new account data API

### DIFF
--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -113,10 +113,10 @@ export class CrossSigningInfo extends EventEmitter {
      * @param {SecretStorage} secretStorage The secret store using account data
      * @returns {boolean} Whether all private keys were found in storage
      */
-    isStoredInSecretStorage(secretStorage) {
+    async isStoredInSecretStorage(secretStorage) {
         let stored = true;
         for (const type of ["master", "self_signing", "user_signing"]) {
-            stored &= secretStorage.isStored(`m.cross_signing.${type}`, false);
+            stored &= await secretStorage.isStored(`m.cross_signing.${type}`, false);
         }
         return stored;
     }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -359,15 +359,14 @@ Crypto.prototype.bootstrapSecretStorage = async function({
     const appCallbacks = Object.assign({}, this._baseApis._cryptoCallbacks);
 
     try {
-        if (
-            !this._crossSigningInfo.getId() ||
-            !this._crossSigningInfo.isStoredInSecretStorage(this._secretStorage)
-        ) {
+        const inStorage =
+            await this._crossSigningInfo.isStoredInSecretStorage(this._secretStorage);
+        if (!this._crossSigningInfo.getId() || !inStorage) {
             logger.log(
                 "Cross-signing public and/or private keys not found, " +
                 "checking secret storage for private keys",
             );
-            if (this._crossSigningInfo.isStoredInSecretStorage(this._secretStorage)) {
+            if (inStorage) {
                 logger.log("Cross-signing private keys found in secret storage");
                 await this.checkOwnCrossSigningTrust();
             } else {
@@ -390,7 +389,7 @@ Crypto.prototype.bootstrapSecretStorage = async function({
 
         // Check if Secure Secret Storage has a default key. If we don't have one, create
         // the default key (which will also be signed by the cross-signing master key).
-        if (!this.hasSecretStorageKey()) {
+        if (!await this.hasSecretStorageKey()) {
             let newKeyId;
             if (keyBackupInfo) {
                 logger.log("Secret storage default key not found, using key backup key");


### PR DESCRIPTION
This converts all secret storage to use a newer account data API which uses
cached data in stored when available, but also knows how to ask the homeserver
in case it's invoked during early client startup before the initial sync.

As a consequence, it means most secret storage APIs are now async.

Part of https://github.com/vector-im/riot-web/issues/11901
Used by https://github.com/matrix-org/matrix-react-sdk/pull/3864