### PR TITLE
Add v5 as a safe room version

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -37,8 +37,8 @@ import {ReEmitter} from '../ReEmitter';
 // room versions which are considered okay for people to run without being asked
 // to upgrade (ie: "stable"). Eventually, we should remove these when all homeservers
 // return an m.room_versions capability.
-const KNOWN_SAFE_ROOM_VERSION = '4';
-const SAFE_ROOM_VERSIONS = ['1', '2', '3', '4'];
+const KNOWN_SAFE_ROOM_VERSION = '5';
+const SAFE_ROOM_VERSIONS = ['1', '2', '3', '4', '5'];
 
 function synthesizeReceipt(userId, event, receiptType) {
     // console.log("synthesizing receipt for "+event.getId());


### PR DESCRIPTION
Might fix https://github.com/vector-im/riot-web/issues/11820 but I cannot reproduce