### PR TITLE
add export/import of Olm devices

### DIFF
--- a/examples/crypto-browser/lib/.gitignore
+++ b/examples/crypto-browser/lib/.gitignore
@@ -1,0 +1,2 @@
+olm.js
+olm.wasm

--- a/examples/crypto-browser/lib/matrix.js
+++ b/examples/crypto-browser/lib/matrix.js
@@ -1,0 +1,1 @@
+../../../dist/browser-matrix.js

--- a/examples/crypto-browser/olm-device-export-import.html
+++ b/examples/crypto-browser/olm-device-export-import.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Test Crypto in Browser</title>
+    <script src="lib/olm.js"></script>
+    <script src="lib/matrix.js"></script>
+</head>
+<body>
+    <h1>Testing export/import of Olm devices in the browser</h1>
+    <ul>
+        <li>
+            Make sure you built the current version of the Matrix JS SDK
+            (<code>yarn build</code>)
+        </li>
+        <li>
+            copy <code>olm.js</code> and <code>olm.wasm</code>
+            from a recent release of Olm (was tested with version 3.1.4)
+            in directory <code>lib/</code>
+        </li>
+        <li>start a local Matrix homeserver (on port 8008, or change the port in the code)</li>
+        <li>Serve this HTML file (e.g. <code>python3 -m http.server</code>) and go to it through your browser</li>
+        <li>
+            in the JS console, do:
+            <pre>
+aliceMatrixClient = await newMatrixClient("alice-"+randomHex());
+await aliceMatrixClient.exportDevice();
+await aliceMatrixClient.getAccessToken();
+            </pre>
+        </li>
+        <li>
+            copy the result of <code>exportDevice</code> and <code>getAccessToken</code> somewhere
+            (<strong>not</strong> in a JS variable as it will be destroyed when you refresh the page)
+        </li>
+        <li><strong>refresh the page (F5)</strong> to make sure the client is destroyed</li>
+        <li>
+            Do the following, replacing <code>ALICE_ID</code>
+            with the user ID of Alice (you can find it in the exported data)
+            <pre>
+bobMatrixClient = await newMatrixClient("bob-"+randomHex());
+roomId = await bobMatrixClient.createEncryptedRoom([ALICE_ID]);
+await bobMatrixClient.sendTextMessage('Hi Alice!', roomId);
+            </pre>
+        </li>
+        <li>Again, <strong>refresh the page (F5)</strong>. You may want to clear your console as well.</li>
+        <li>
+            Now do the following, using the exported data and the access token you saved previously:
+            <pre>
+aliceMatrixClient = await importMatrixClient(EXPORTED_DATA, ACCESS_TOKEN);
+            </pre>
+        </li>
+        <li>You should see the message sent by Bob printed in the console.</li>
+    </ul>
+
+    <script src="olm-device-export-import.js"></script>
+</body>
+</html>

--- a/examples/crypto-browser/olm-device-export-import.js
+++ b/examples/crypto-browser/olm-device-export-import.js
@@ -1,63 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Test Crypto in Browser</title>
-    <script src="lib/olm.js"></script>
-    <script src="lib/matrix.js"></script>
-</head>
-<body>
-    <h1>Testing export/import of Olm devices in the browser</h1>
-    <p>
-        Inspired by <code>examples/browser</code>
-    </p>
-    <ul>
-        <li>
-            Make sure you built the current version of the Matrix JS SDK
-            (<code>yarn build</code>)
-        </li>
-        <li>
-            make sure there is
-            <code>matrix.js</code>, <code>olm.js</code> and <code>olm.wasm</code>
-            in directory <code>lib/</code>
-        </li>
-        <li>start a local Matrix homeserver (on port 8008, or change the port in the code)</li>
-        <li>Serve this HTML file (e.g. <code>python3 -m http.server</code>) and go to it through your browser</li>
-        <li>
-            in the JS console, do:
-            <pre>
-aliceMatrixClient = await newMatrixClient("alice-"+randomHex());
-await aliceMatrixClient.exportDevice();
-await aliceMatrixClient.getAccessToken();
-            </pre>
-        </li>
-        <li>
-            copy the result of <code>exportDevice</code> and <code>getAccessToken</code> somewhere
-            (<strong>not</strong> in a JS variable as it will be destroyed when you refresh the page)
-        </li>
-        <li><strong>refresh the page (F5)</strong> to make sure the client is destroyed</li>
-        <li>
-            Do the following, replacing <code>ALICE_ID</code>
-            with the user ID of Alice (you can find it in the exported data)
-            <pre>
-bobMatrixClient = await newMatrixClient("bob-"+randomHex());
-roomId = await bobMatrixClient.createEncryptedRoom([ALICE_ID]);
-await bobMatrixClient.sendTextMessage('Hi Alice!', roomId);
-            </pre>
-        </li>
-        <li>Again, <strong>refresh the page (F5)</strong>. You may want to clear your console as well.</li>
-        <li>
-            Now do the following, using the exported data and the access token you saved previously:
-            <pre>
-aliceMatrixClient = await importMatrixClient(EXPORTED_DATA, ACCESS_TOKEN);
-            </pre>
-        </li>
-        <li>You should see the message sent by Bob printed in the console.</li>
-    </ul>
-
-    <script>
 if (!Olm) {
     console.error(
         "global.Olm does not seem to be present."
@@ -180,6 +120,3 @@ function extendMatrixClient(matrixClient) {
         )
     }
 }
-    </script>
-</body>
-</html>

--- a/examples/olm-device-export-import.html
+++ b/examples/olm-device-export-import.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Test Crypto in Browser</title>
+    <script src="lib/olm.js"></script>
+    <script src="lib/matrix.js"></script>
+</head>
+<body>
+    <h1>Testing export/import of Olm devices in the browser</h1>
+    <p>
+        Inspired by <code>examples/browser</code>
+    </p>
+    <ul>
+        <li>
+            Make sure you built the current version of the Matrix JS SDK
+            (<code>yarn build</code>)
+        </li>
+        <li>
+            make sure there is
+            <code>matrix.js</code>, <code>olm.js</code> and <code>olm.wasm</code>
+            in directory <code>lib/</code>
+        </li>
+        <li>start a local Matrix homeserver (on port 8008, or change the port in the code)</li>
+        <li>Serve this HTML file (e.g. <code>python3 -m http.server</code>) and go to it through your browser</li>
+        <li>
+            in the JS console, do:
+            <pre>
+aliceMatrixClient = await newMatrixClient("alice-"+randomHex());
+await aliceMatrixClient.exportDevice();
+await aliceMatrixClient.getAccessToken();
+            </pre>
+        </li>
+        <li>
+            copy the result of <code>exportDevice</code> and <code>getAccessToken</code> somewhere
+            (<strong>not</strong> in a JS variable as it will be destroyed when you refresh the page)
+        </li>
+        <li><strong>refresh the page (F5)</strong> to make sure the client is destroyed</li>
+        <li>
+            Do the following, replacing <code>ALICE_ID</code>
+            with the user ID of Alice (you can find it in the exported data)
+            <pre>
+bobMatrixClient = await newMatrixClient("bob-"+randomHex());
+roomId = await bobMatrixClient.createEncryptedRoom([ALICE_ID]);
+await bobMatrixClient.sendTextMessage('Hi Alice!', roomId);
+            </pre>
+        </li>
+        <li>Again, <strong>refresh the page (F5)</strong>. You may want to clear your console as well.</li>
+        <li>
+            Now do the following, using the exported data and the access token you saved previously:
+            <pre>
+aliceMatrixClient = await importMatrixClient(EXPORTED_DATA, ACCESS_TOKEN);
+            </pre>
+        </li>
+        <li>You should see the message sent by Bob printed in the console.</li>
+    </ul>
+
+    <script>
+if (!Olm) {
+    console.error(
+        "global.Olm does not seem to be present."
+        + " Did you forget to add olm in the lib/ directory?"
+    );
+}
+
+const BASE_URL = 'http://localhost:8008';
+const ROOM_CRYPTO_CONFIG = { algorithm: 'm.megolm.v1.aes-sha2' };
+const PASSWORD = 'password';
+
+// useful to create new usernames
+window.randomHex = () => Math.floor(Math.random() * (10**6)).toString(16);
+
+window.newMatrixClient = async function (username) {
+    const registrationClient = matrixcs.createClient(BASE_URL);
+
+    const userRegisterResult = await registrationClient.register(
+      username,
+      PASSWORD,
+      null,
+      { type: 'm.login.dummy' }
+    );
+  
+    const matrixClient = matrixcs.createClient({
+      baseUrl: BASE_URL,
+      userId: userRegisterResult.user_id,
+      accessToken: userRegisterResult.access_token,
+      deviceId: userRegisterResult.device_id,
+      sessionStore: new matrixcs.WebStorageSessionStore(window.localStorage),
+      cryptoStore: new matrixcs.MemoryCryptoStore(),
+    });
+
+    extendMatrixClient(matrixClient);
+
+    await matrixClient.initCrypto();
+    await matrixClient.startClient();
+    return matrixClient;
+}
+
+window.importMatrixClient = async function (exportedDevice, accessToken) {
+    const matrixClient = matrixcs.createClient({
+      baseUrl: BASE_URL,
+      deviceToImport: exportedDevice,
+      accessToken,
+      sessionStore: new matrixcs.WebStorageSessionStore(window.localStorage),
+      cryptoStore: new matrixcs.MemoryCryptoStore(),
+    });
+
+    extendMatrixClient(matrixClient);
+
+    await matrixClient.initCrypto();
+    await matrixClient.startClient();
+    return matrixClient;
+}
+
+function extendMatrixClient(matrixClient) {
+    // automatic join
+    matrixClient.on('RoomMember.membership', async (event, member) => {
+        if (member.membership === 'invite' && member.userId === matrixClient.getUserId()) {
+            await matrixClient.joinRoom(member.roomId);
+            // setting up of room encryption seems to be triggered automatically
+            // but if we don't wait for it the first messages we send are unencrypted
+            await matrixClient.setRoomEncryption(member.roomId, { algorithm: 'm.megolm.v1.aes-sha2' })
+        }
+    });
+
+    matrixClient.onDecryptedMessage = message => {
+        console.log('Got encrypted message: ', message);
+    }
+
+    matrixClient.on('Event.decrypted', (event) => {
+        if (event.getType() === 'm.room.message'){
+            matrixClient.onDecryptedMessage(event.getContent().body);
+        } else {
+            console.log('decrypted an event of type', event.getType());
+            console.log(event);
+        }
+    });
+  
+    matrixClient.createEncryptedRoom = async function(usersToInvite) {
+        const {
+          room_id: roomId,
+        } = await this.createRoom({
+          visibility: 'private',
+          invite: usersToInvite,
+        });
+
+        // matrixClient.setRoomEncryption() only updates local state
+        // but does not send anything to the server
+        // (see https://github.com/matrix-org/matrix-js-sdk/issues/905)
+        // so we do it ourselves with 'sendStateEvent'
+        await this.sendStateEvent(
+          roomId, 'm.room.encryption', ROOM_CRYPTO_CONFIG,
+        );
+        await this.setRoomEncryption(
+          roomId, ROOM_CRYPTO_CONFIG,
+        );
+
+        // Marking all devices as verified
+        let room = this.getRoom(roomId);
+        let members = (await room.getEncryptionTargetMembers()).map(x => x["userId"])
+        let memberkeys = await this.downloadKeys(members);
+        for (const userId in memberkeys) {
+          for (const deviceId in memberkeys[userId]) {
+            await this.setDeviceVerified(userId, deviceId);
+          }
+        }
+
+        return roomId;
+    }
+
+    matrixClient.sendTextMessage = async function(message, roomId) {
+        return matrixClient.sendMessage(
+            roomId,
+            {
+                body: message,
+                msgtype: 'm.text',
+            }
+        )
+    }
+}
+    </script>
+</body>
+</html>

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -41,6 +41,28 @@ async function setupSession(initiator, opponent) {
     return sid;
 }
 
+describe("OlmDevice", () => {
+    if (!global.Olm) {
+        logger.warn('Not running megolm unit tests: libolm not present');
+        return;
+    }
+
+    beforeAll(function() {
+        return global.Olm.init();
+    });
+
+    let olmDevice;
+
+    beforeEach(async function() {
+        olmDevice = makeOlmDevice();
+        await olmDevice.init();
+    });
+
+    it('exports picked account and olm sessions', async function() {
+        console.log('EXPORT RESULT:', await olmDevice.export());
+    });
+});
+
 describe("OlmDecryption", function() {
     if (!global.Olm) {
         logger.warn('Not running megolm unit tests: libolm not present');

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -116,7 +116,7 @@ describe("OlmDevice", function() {
                 "In contrast to most amphibians,"
                 + " the olm is entirely aquatic"
             );
-            const ciphertext_2 = await aliceOlmDevice.encryptMessage(
+            const ciphertext2 = await aliceOlmDevice.encryptMessage(
                 bobOlmDevice.deviceCurve25519Key,
                 sessionId,
                 MESSAGE_2,
@@ -126,13 +126,13 @@ describe("OlmDevice", function() {
             bobRecreatedAgainOlmDevice.init(exportedAgain);
 
             // Note: "decrypted_2" does not have the same structure as "decrypted"
-            const decrypted_2 = await bobRecreatedAgainOlmDevice.decryptMessage(
+            const decrypted2 = await bobRecreatedAgainOlmDevice.decryptMessage(
                 aliceOlmDevice.deviceCurve25519Key,
                 decrypted.session_id,
-                ciphertext_2.type,
-                ciphertext_2.body,
+                ciphertext2.type,
+                ciphertext2.body,
             );
-            expect(decrypted_2).toEqual(MESSAGE_2);
+            expect(decrypted2).toEqual(MESSAGE_2);
         });
 
         it("creates only one session at a time", async function() {

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -88,7 +88,10 @@ describe("OlmDevice", function() {
             // At this moment only Alice (the “initiator” in setupSession) has a session
             expect(exported.sessions).toEqual([]);
 
-            const MESSAGE = "The olm or proteus is an aquatic salamander in the family Proteidae";
+            const MESSAGE = (
+                "The olm or proteus is an aquatic salamander"
+                + " in the family Proteidae"
+            );
             const ciphertext = await aliceOlmDevice.encryptMessage(
                 bobOlmDevice.deviceCurve25519Key,
                 sessionId,
@@ -109,7 +112,10 @@ describe("OlmDevice", function() {
             // this time we expect Bob to have a session to export
             expect(exportedAgain.sessions).toHaveLength(1);
 
-            const MESSAGE_2 = "In contrast to most amphibians, the olm is entirely aquatic";
+            const MESSAGE_2 = (
+                "In contrast to most amphibians,"
+                + " the olm is entirely aquatic"
+            );
             const ciphertext_2 = await aliceOlmDevice.encryptMessage(
                 bobOlmDevice.deviceCurve25519Key,
                 sessionId,

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -99,7 +99,7 @@ describe("OlmDevice", function() {
             );
 
             const bobRecreatedOlmDevice = makeOlmDevice();
-            bobRecreatedOlmDevice.init(exported);
+            bobRecreatedOlmDevice.init({ fromExportedDevice: exported });
 
             const decrypted = await bobRecreatedOlmDevice.createInboundSession(
                 aliceOlmDevice.deviceCurve25519Key,
@@ -123,7 +123,7 @@ describe("OlmDevice", function() {
             );
 
             const bobRecreatedAgainOlmDevice = makeOlmDevice();
-            bobRecreatedAgainOlmDevice.init(exportedAgain);
+            bobRecreatedAgainOlmDevice.init({ fromExportedDevice: exportedAgain });
 
             // Note: "decrypted_2" does not have the same structure as "decrypted"
             const decrypted2 = await bobRecreatedAgainOlmDevice.decryptMessage(

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -41,29 +41,7 @@ async function setupSession(initiator, opponent) {
     return sid;
 }
 
-describe("OlmDevice", () => {
-    if (!global.Olm) {
-        logger.warn('Not running megolm unit tests: libolm not present');
-        return;
-    }
-
-    beforeAll(function() {
-        return global.Olm.init();
-    });
-
-    let olmDevice;
-
-    beforeEach(async function() {
-        olmDevice = makeOlmDevice();
-        await olmDevice.init();
-    });
-
-    it('exports picked account and olm sessions', async function() {
-        console.log('EXPORT RESULT:', await olmDevice.export());
-    });
-});
-
-describe("OlmDecryption", function() {
+describe("OlmDevice", function() {
     if (!global.Olm) {
         logger.warn('Not running megolm unit tests: libolm not present');
         return;
@@ -100,6 +78,24 @@ describe("OlmDecryption", function() {
             );
             expect(result.payload).toEqual(
                 "The olm or proteus is an aquatic salamander in the family Proteidae",
+            );
+        });
+
+        it('exports picked account and olm sessions', async function() {
+            await setupSession(aliceOlmDevice, bobOlmDevice);
+
+            let exported = await aliceOlmDevice.export();
+            expect(exported).toHaveProperty('pickleKey');
+            expect(exported).toHaveProperty('pickledAccount');
+            expect(exported).toHaveProperty('sessions');
+            expect(Array.isArray(exported.sessions)).toBe(true);
+            expect(exported.sessions[0]).toEqual(
+                expect.objectContaining({
+                    session: expect.any(String),
+                    lastReceivedMessageTs: expect.any(Number),
+                    deviceKey: expect.any(String),
+                    sessionId: expect.any(String),
+                })
             );
         });
 

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -84,15 +84,8 @@ describe("OlmDevice", function() {
         it('exports picked account and olm sessions', async function() {
             const sessionId = await setupSession(aliceOlmDevice, bobOlmDevice);
 
-            // At the time of writing, Jest only tests with in-memory DB,
-            // but I manually checked that the exported data has the same structure
-            // when coming from indexed DB
             const exported = await bobOlmDevice.export();
-            expect(exported).toHaveProperty('pickleKey');
-            expect(exported).toHaveProperty('pickledAccount');
-            expect(exported).toHaveProperty('sessions');
-            // At this moment only Alice (the “initiator” in setupSession)
-            // has a session
+            // At this moment only Alice (the “initiator” in setupSession) has a session
             expect(exported.sessions).toEqual([]);
 
             const MESSAGE = "The olm or proteus is an aquatic salamander in the family Proteidae";
@@ -113,19 +106,8 @@ describe("OlmDevice", function() {
             expect(decrypted.payload).toEqual(MESSAGE);
 
             const exportedAgain = await bobRecreatedOlmDevice.export();
-            expect(exportedAgain).toHaveProperty('pickleKey');
-            expect(exportedAgain).toHaveProperty('pickledAccount');
-            expect(exportedAgain).toHaveProperty('sessions');
-            expect(Array.isArray(exportedAgain.sessions)).toBe(true);
             // this time we expect Bob to have a session to export
-            expect(exportedAgain.sessions[0]).toEqual(
-                expect.objectContaining({
-                    session: expect.any(String),
-                    lastReceivedMessageTs: expect.any(Number),
-                    deviceKey: expect.any(String),
-                    sessionId: expect.any(String),
-                })
-            );
+            expect(exportedAgain.sessions).toHaveLength(1);
 
             const MESSAGE_2 = "In contrast to most amphibians, the olm is entirely aquatic";
             const ciphertext_2 = await aliceOlmDevice.encryptMessage(
@@ -137,7 +119,7 @@ describe("OlmDevice", function() {
             const bobRecreatedAgainOlmDevice = makeOlmDevice();
             bobRecreatedAgainOlmDevice.init(exportedAgain);
 
-            // Note: decrypted_2 does not have the same structure than decrypted
+            // Note: "decrypted_2" does not have the same structure as "decrypted"
             const decrypted_2 = await bobRecreatedAgainOlmDevice.decryptMessage(
                 aliceOlmDevice.deviceCurve25519Key,
                 decrypted.session_id,
@@ -145,7 +127,6 @@ describe("OlmDevice", function() {
                 ciphertext_2.body,
             );
             expect(decrypted_2).toEqual(MESSAGE_2);
-
         });
 
         it("creates only one session at a time", async function() {

--- a/spec/unit/crypto/algorithms/olm.spec.js
+++ b/spec/unit/crypto/algorithms/olm.spec.js
@@ -82,14 +82,43 @@ describe("OlmDevice", function() {
         });
 
         it('exports picked account and olm sessions', async function() {
-            await setupSession(aliceOlmDevice, bobOlmDevice);
+            const sessionId = await setupSession(aliceOlmDevice, bobOlmDevice);
 
-            let exported = await aliceOlmDevice.export();
+            // At the time of writing, Jest only tests with in-memory DB,
+            // but I manually checked that the exported data has the same structure
+            // when coming from indexed DB
+            const exported = await bobOlmDevice.export();
             expect(exported).toHaveProperty('pickleKey');
             expect(exported).toHaveProperty('pickledAccount');
             expect(exported).toHaveProperty('sessions');
-            expect(Array.isArray(exported.sessions)).toBe(true);
-            expect(exported.sessions[0]).toEqual(
+            // At this moment only Alice (the “initiator” in setupSession)
+            // has a session
+            expect(exported.sessions).toEqual([]);
+
+            const MESSAGE = "The olm or proteus is an aquatic salamander in the family Proteidae";
+            const ciphertext = await aliceOlmDevice.encryptMessage(
+                bobOlmDevice.deviceCurve25519Key,
+                sessionId,
+                MESSAGE,
+            );
+
+            const bobRecreatedOlmDevice = makeOlmDevice();
+            bobRecreatedOlmDevice.init(exported);
+
+            const decrypted = await bobRecreatedOlmDevice.createInboundSession(
+                aliceOlmDevice.deviceCurve25519Key,
+                ciphertext.type,
+                ciphertext.body,
+            );
+            expect(decrypted.payload).toEqual(MESSAGE);
+
+            const exportedAgain = await bobRecreatedOlmDevice.export();
+            expect(exportedAgain).toHaveProperty('pickleKey');
+            expect(exportedAgain).toHaveProperty('pickledAccount');
+            expect(exportedAgain).toHaveProperty('sessions');
+            expect(Array.isArray(exportedAgain.sessions)).toBe(true);
+            // this time we expect Bob to have a session to export
+            expect(exportedAgain.sessions[0]).toEqual(
                 expect.objectContaining({
                     session: expect.any(String),
                     lastReceivedMessageTs: expect.any(Number),
@@ -97,6 +126,26 @@ describe("OlmDevice", function() {
                     sessionId: expect.any(String),
                 })
             );
+
+            const MESSAGE_2 = "In contrast to most amphibians, the olm is entirely aquatic";
+            const ciphertext_2 = await aliceOlmDevice.encryptMessage(
+                bobOlmDevice.deviceCurve25519Key,
+                sessionId,
+                MESSAGE_2,
+            );
+
+            const bobRecreatedAgainOlmDevice = makeOlmDevice();
+            bobRecreatedAgainOlmDevice.init(exportedAgain);
+
+            // Note: decrypted_2 does not have the same structure than decrypted
+            const decrypted_2 = await bobRecreatedAgainOlmDevice.decryptMessage(
+                aliceOlmDevice.deviceCurve25519Key,
+                decrypted.session_id,
+                ciphertext_2.type,
+                ciphertext_2.body,
+            );
+            expect(decrypted_2).toEqual(MESSAGE_2);
+
         });
 
         it("creates only one session at a time", async function() {

--- a/src/client.js
+++ b/src/client.js
@@ -97,7 +97,7 @@ function keyFromRecoverySession(session, decryptionKey) {
  * @param {string} opts.accessToken The access_token for this user.
  *
  * @param {string} opts.userId The user ID for this user.
- * 
+ *
  * @param {Object} opts.deviceToImport Device data exported with
  *     (TODO link to export method) that must be imported to recreate this device.
  *     Should only be useful for deviced with end-to-end crypto enabled.
@@ -256,10 +256,18 @@ export function MatrixClient(opts) {
 
     if (opts.deviceToImport) {
         if (this.deviceId) {
-            logger.warn('not importing device because device ID is provided to constructor independently of exported data');
+            logger.warn(
+                'not importing device because'
+                + ' device ID is provided to constructor'
+                + ' independently of exported data',
+            );
         } else if (this.credentials.userId) {
-            logger.warn('not importing device because user ID is provided to constructor independently of exported data');
-        } else if (!(opts.deviceToImport.deviceId)){
+            logger.warn(
+                'not importing device because'
+                + ' user ID is provided to constructor'
+                + ' independently of exported data',
+            );
+        } else if (!(opts.deviceToImport.deviceId)) {
             logger.warn('not importing device because no device ID in exported data');
         } else {
             this.deviceId = opts.deviceToImport.deviceId;

--- a/src/client.js
+++ b/src/client.js
@@ -99,7 +99,7 @@ function keyFromRecoverySession(session, decryptionKey) {
  * @param {string} opts.userId The user ID for this user.
  *
  * @param {Object} opts.deviceToImport Device data exported with
- *     (TODO link to export method) that must be imported to recreate this device.
+ *     "exportDevice" method that must be imported to recreate this device.
  *     Should only be useful for devices with end-to-end crypto enabled.
  *     If provided, opts.deviceId and opts.userId should **NOT** be provided
  *     (they are present in the exported data).

--- a/src/client.js
+++ b/src/client.js
@@ -100,7 +100,7 @@ function keyFromRecoverySession(session, decryptionKey) {
  *
  * @param {Object} opts.deviceToImport Device data exported with
  *     (TODO link to export method) that must be imported to recreate this device.
- *     Should only be useful for deviced with end-to-end crypto enabled.
+ *     Should only be useful for devices with end-to-end crypto enabled.
  *     If provided, opts.deviceId and opts.userId should **NOT** be provided
  *     (they are present in the exported data).
  *

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -123,7 +123,7 @@ export function OlmDevice(cryptoStore) {
  *     (exported data already provides a pickle key)
  * @param {object} opts.pickleKey (Optional) pickle key to set instead of default one
  */
-OlmDevice.prototype.init = async function(opts) {
+OlmDevice.prototype.init = async function(opts = {}) {
     let e2eKeys;
     const account = new global.Olm.Account();
 

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -157,7 +157,7 @@ OlmDevice.prototype.init = async function(fromExportedDevice) {
  * @param {Object} exportedData Data exported from another device
  *     through the “export” method.
  * @param {module:crypto/store/base~CryptoStore} cryptoStore storage for the crypto layer
- * @param {*} pickleKey
+ * @param {string} pickleKey the key that was used to pickle the exported data
  * @param {*} account
  */
 async function _initialiseFromExportedDevice(

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -111,6 +111,9 @@ export function OlmDevice(cryptoStore) {
  * Initialise the OlmAccount. This must be called before any other operations
  * on the OlmDevice.
  *
+ * Data from an exported Olm device can be provided
+ * in order to re-create this device.
+ *
  * Attempts to load the OlmAccount from the crypto store, or creates one if none is
  * found.
  *

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -158,7 +158,7 @@ OlmDevice.prototype.init = async function(fromExportedDevice) {
  *     through the “export” method.
  * @param {module:crypto/store/base~CryptoStore} cryptoStore storage for the crypto layer
  * @param {string} pickleKey the key that was used to pickle the exported data
- * @param {*} account
+ * @param {Olm.Account} account an olm account to initialize
  */
 async function _initialiseFromExportedDevice(
     exportedData,

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -156,7 +156,7 @@ OlmDevice.prototype.init = async function(fromExportedDevice) {
  *
  * @param {Object} exportedData Data exported from another device
  *     through the “export” method.
- * @param {*} cryptoStore
+ * @param {module:crypto/store/base~CryptoStore} cryptoStore storage for the crypto layer
  * @param {*} pickleKey
  * @param {*} account
  */

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -116,14 +116,27 @@ export function OlmDevice(cryptoStore) {
  *
  * Reads the device keys from the OlmAccount object.
  *
- * @param {object} fromExportedDevice (Optional) data from exported device
+ * @param {object} opts
+ * @param {object} opts.fromExportedDevice (Optional) data from exported device
  *     that must be re-created.
+ *     If present, opts.pickleKey is ignored
+ *     (exported data already provides a pickle key)
+ * @param {object} opts.pickleKey (Optional) pickle key to set instead of default one
  */
-OlmDevice.prototype.init = async function(fromExportedDevice) {
+OlmDevice.prototype.init = async function(opts) {
     let e2eKeys;
     const account = new global.Olm.Account();
+
+    const { pickleKey, fromExportedDevice } = opts;
+
     try {
         if (fromExportedDevice) {
+            if (pickleKey) {
+                console.warn(
+                    'ignoring opts.pickleKey'
+                    + ' because opts.fromExportedDevice is present.',
+                );
+            }
             this._pickleKey = fromExportedDevice.pickleKey;
             await _initialiseFromExportedDevice(
                 fromExportedDevice,
@@ -132,6 +145,9 @@ OlmDevice.prototype.init = async function(fromExportedDevice) {
                 account,
             );
         } else {
+            if (pickleKey) {
+                this._pickleKey = pickleKey;
+            }
             await _initialiseAccount(
                 this._cryptoStore,
                 this._pickleKey,

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -225,7 +225,7 @@ OlmDevice.prototype._storeAccount = function(txn, account) {
  * Export data for re-creating the Olm device later.
  * TODO export data other than just account and (P2P) sessions.
  * 
- * @return {Promise<object>} The export data (see specs for structure)
+ * @return {Promise<object>} The exported data
 */
 OlmDevice.prototype.export = async function() {
     const result = {

--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -191,8 +191,11 @@ OlmDevice.prototype._storeAccount = function(txn, account) {
     this._cryptoStore.storeAccount(txn, account.pickle(this._pickleKey));
 };
 
-/*
+/**
  * Export data for re-creating the Olm device later.
+ * TODO export data other than just account and (P2P) sessions.
+ * 
+ * @return {Promise<object>} The export data (see specs for structure)
 */
 OlmDevice.prototype.export = async function() {
     const result = {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -236,7 +236,7 @@ utils.inherits(Crypto, EventEmitter);
 Crypto.prototype.init = async function(kwargs) {
     const {
         exportedOlmDevice,
-    } = kwargs;
+    } = kwargs || {};
 
     logger.log("Crypto: initialising Olm...");
     await global.Olm.init();

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -228,7 +228,7 @@ utils.inherits(Crypto, EventEmitter);
  * Initialise the crypto module so that it is ready for use
  *
  * Returns a promise which resolves once the crypto module is ready for use.
- * 
+ *
  * @param {Object} kwargs keyword arguments.
  * @param {string} kwargs.exportedOlmDevice (Optional) data from exported device
  *     that must be re-created.
@@ -243,7 +243,7 @@ Crypto.prototype.init = async function(kwargs) {
     logger.log(
         exportedOlmDevice
             ? "Crypto: initialising Olm device from exported device..."
-            : "Crypto: initialising Olm device..."
+            : "Crypto: initialising Olm device...",
     );
     await this._olmDevice.init(exportedOlmDevice);
     logger.log("Crypto: loading device list...");

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -228,12 +228,24 @@ utils.inherits(Crypto, EventEmitter);
  * Initialise the crypto module so that it is ready for use
  *
  * Returns a promise which resolves once the crypto module is ready for use.
+ * 
+ * @param {Object} kwargs keyword arguments.
+ * @param {string} kwargs.exportedOlmDevice (Optional) data from exported device
+ *     that must be re-created.
  */
-Crypto.prototype.init = async function() {
+Crypto.prototype.init = async function(kwargs) {
+    const {
+        exportedOlmDevice,
+    } = kwargs;
+
     logger.log("Crypto: initialising Olm...");
     await global.Olm.init();
-    logger.log("Crypto: initialising Olm device...");
-    await this._olmDevice.init();
+    logger.log(
+        exportedOlmDevice
+            ? "Crypto: initialising Olm device from exported device..."
+            : "Crypto: initialising Olm device..."
+    );
+    await this._olmDevice.init(exportedOlmDevice);
     logger.log("Crypto: loading device list...");
     await this._deviceList.load();
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -245,7 +245,7 @@ Crypto.prototype.init = async function(opts) {
             ? "Crypto: initialising Olm device from exported device..."
             : "Crypto: initialising Olm device...",
     );
-    await this._olmDevice.init(exportedOlmDevice);
+    await this._olmDevice.init({ fromExportedDevice: exportedOlmDevice });
     logger.log("Crypto: loading device list...");
     await this._deviceList.load();
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -229,14 +229,14 @@ utils.inherits(Crypto, EventEmitter);
  *
  * Returns a promise which resolves once the crypto module is ready for use.
  *
- * @param {Object} kwargs keyword arguments.
- * @param {string} kwargs.exportedOlmDevice (Optional) data from exported device
+ * @param {Object} opts keyword arguments.
+ * @param {string} opts.exportedOlmDevice (Optional) data from exported device
  *     that must be re-created.
  */
-Crypto.prototype.init = async function(kwargs) {
+Crypto.prototype.init = async function(opts) {
     const {
         exportedOlmDevice,
-    } = kwargs || {};
+    } = opts || {};
 
     logger.log("Crypto: initialising Olm...");
     await global.Olm.init();

--- a/src/crypto/store/memory-crypto-store.js
+++ b/src/crypto/store/memory-crypto-store.js
@@ -263,11 +263,15 @@ export class MemoryCryptoStore {
     }
 
     getAllEndToEndSessions(txn, func) {
-        for (const deviceSessions of Object.values(this._sessions)) {
-            for (const sess of Object.values(deviceSessions)) {
-                func(sess);
-            }
-        }
+        Object.entries(this._sessions).forEach(([deviceKey, deviceSessions]) => {
+            Object.entries(deviceSessions).forEach(([sessionId, session]) => {
+                func({
+                    ...session,
+                    deviceKey,
+                    sessionId,
+                });
+            });
+        });
     }
 
     storeEndToEndSession(deviceKey, sessionId, sessionInfo, txn) {


### PR DESCRIPTION
Adds an `export` method to Olm device that exports the device “account” and “sessions”.

Adds a parameter to the asynchronous initialization of the Olm device to import data that was exported with the said export method.

Adds methods to Matrix Client to expose these methods at a high level, including the device ID and user ID in the exported data (and using them during import).

Adds Jest tests for export/import at the Olm device level, and a HTML + JS document to try the mechanism in the browser at a high level in a non-automated way.