### PR TITLE
Ensure cross-signing keys are downloaded when checking trust

### DIFF
--- a/spec/unit/crypto/secrets.spec.js
+++ b/spec/unit/crypto/secrets.spec.js
@@ -34,6 +34,9 @@ async function makeTestClient(userInfo, options) {
 
     await client.initCrypto();
 
+    // No need to download keys for these tests
+    client._crypto.downloadKeys = async function() {};
+
     return client;
 }
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -819,6 +819,10 @@ Crypto.prototype._onDeviceListUserCrossSigningUpdated = async function(userId) {
 Crypto.prototype.checkOwnCrossSigningTrust = async function() {
     const userId = this._userId;
 
+    // Before proceeding, ensure our cross-signing public keys have been
+    // downloaded via the device list.
+    await this.downloadKeys([this._userId]);
+
     // If we see an update to our own master key, check it against the master
     // key we have and, if it matches, mark it as verified
 


### PR DESCRIPTION
When checking cross-signing trust during login, we may not have downloaded keys
yet. This ensures we make an attempt first if needed.

Fixes https://github.com/vector-im/riot-web/issues/12068