### PR TITLE
Publish pre-releases as a separate tag on npm

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -294,9 +294,14 @@ fi
 rm "${release_text}"
 rm "${latest_changes}"
 
+npm_publish_flags=''
+if [ $prerelease -eq 1 ]; then
+    # Tag prereleases as `next` so the last stable release remains the default
+    npm_publish_flags='--tag next'
+fi
 # Login and publish continues to use `npm`, as it seems to have more clearly
 # defined options and semantics than `yarn` for writing to the registry.
-npm publish
+npm publish $npm_publish_flags
 
 if [ -z "$skip_jsdoc" ]; then
     echo "generating jsdocs"


### PR DESCRIPTION
npm will install the newest version a package has published to the `latest` tag,
including pre-releases, which is not ideal since those may not be ready for
production use yet.

This uses an alternate tag (`next` is a common convention, but it can be
anything) for pre-releases so the default installs only get stable versions.

Fixes https://github.com/vector-im/riot-web/issues/12029