### PR TITLE
Verification: resolve race between .start events from both parties

### DIFF
--- a/spec/unit/crypto/verification/verification_request.spec.js
+++ b/spec/unit/crypto/verification/verification_request.spec.js
@@ -99,6 +99,10 @@ class MockVerifier {
             await this._channel.send(DONE_TYPE, {});
         }
     }
+
+    canSwitchStartEvent() {
+        return false;
+    }
 }
 
 function makeRemoteEcho(event) {

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -27,6 +27,13 @@ import {newTimeoutError} from "./Error";
 
 const timeoutException = new Error("Verification timed out");
 
+export class SwitchStartEventError extends Error {
+    constructor(startEvent) {
+        super();
+        this.startEvent = startEvent;
+    }
+}
+
 export class VerificationBase extends EventEmitter {
     /**
      * Base class for verification methods.
@@ -69,6 +76,19 @@ export class VerificationBase extends EventEmitter {
         this._transactionTimeoutTimer = null;
     }
 
+    get initiatedByMe() {
+        // if there is no start event yet,
+        // we probably want to send it,
+        // which happens if we initiate
+        if (!this.startEvent) {
+            return true;
+        }
+        const sender = this.startEvent.getSender();
+        const content = this.startEvent.getContent();
+        return sender === this._baseApis.getUserId() &&
+            content.from_device === this._baseApis.getDeviceId();
+    }
+
     _resetTimer() {
         logger.info("Refreshing/starting the verification transaction timeout timer");
         if (this._transactionTimeoutTimer !== null) {
@@ -102,6 +122,22 @@ export class VerificationBase extends EventEmitter {
             this._resolveEvent = resolve;
             this._rejectEvent = reject;
         });
+    }
+
+    canSwitchStartEvent() {
+        return false;
+    }
+
+    switchStartEvent(event) {
+        if (this.canSwitchStartEvent(event)) {
+            if (this._rejectEvent) {
+                const reject = this._rejectEvent;
+                this._rejectEvent = undefined;
+                reject(new SwitchStartEventError(event));
+            } else {
+                this.startEvent = event;
+            }
+        }
     }
 
     handleEvent(e) {

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -582,7 +582,7 @@ export class VerificationRequest extends EventEmitter {
         try {
             this.cancel({reason: "Other party didn't accept in time", code: "m.timeout"});
         } catch (err) {
-            console.error("Error while cancelling verification request", err);
+            logger.error("Error while cancelling verification request", err);
         }
     };
 
@@ -660,7 +660,7 @@ export class VerificationRequest extends EventEmitter {
 
         const VerifierCtor = this._verificationMethods.get(method);
         if (!VerifierCtor) {
-            console.warn("could not find verifier constructor for method", method);
+            logger.warn("could not find verifier constructor for method", method);
             return;
         }
         return new VerifierCtor(

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -323,7 +323,7 @@ export class VerificationRequest extends EventEmitter {
     async cancel({reason = "User declined", code = "m.user"} = {}) {
         if (!this.observeOnly && this._phase !== PHASE_CANCELLED) {
             if (this._verifier) {
-                return this._verifier.cancel(errorFactory(code, reason));
+                return this._verifier.cancel(errorFactory(code, reason)());
             } else {
                 this._cancellingUserId = this._client.getUserId();
                 await this.channel.send(CANCEL_TYPE, {code, reason});

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -421,9 +421,20 @@ export class VerificationRequest extends EventEmitter {
             transitions.push({phase: PHASE_READY, event: readyEvent});
         }
 
-        const startEvent = readyEvent || !requestEvent ?
-            this._getEventByEither(START_TYPE) : // any party can send .start after a .ready or unsent
-            this._getEventByOther(START_TYPE, requestEvent.getSender());
+        let startEvent;
+        if (readyEvent || !requestEvent) {
+            const theirStartEvent = this._eventsByThem.get(START_TYPE);
+            const ourStartEvent = this._eventsByUs.get(START_TYPE);
+            // any party can send .start after a .ready or unsent
+            if (theirStartEvent && ourStartEvent) {
+                startEvent = theirStartEvent.getSender() < ourStartEvent.getSender() ?
+                    theirStartEvent : ourStartEvent;
+            } else {
+                startEvent = theirStartEvent ? theirStartEvent : ourStartEvent;
+            }
+        } else {
+            startEvent = this._getEventByOther(START_TYPE, requestEvent.getSender());
+        }
         if (startEvent) {
             const fromRequestPhase = phase() === PHASE_REQUESTED &&
                 requestEvent.getSender() !== startEvent.getSender();

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -521,10 +521,18 @@ export class VerificationRequest extends EventEmitter {
         }
         // only pass events from the other side to the verifier,
         // no remote echos of our own events
-        if (this._verifier && !isRemoteEcho && !this.observeOnly) {
-            if (type === CANCEL_TYPE || (this._verifier.events
-                && this._verifier.events.includes(type))) {
-                this._verifier.handleEvent(event);
+        if (this._verifier && !this.observeOnly) {
+            const oldEvent = this._verifier.startEvent;
+            // if the verifier does not have a startEvent, it is because it's still sending and we are on the initator side
+            const oldSender = oldEvent ? oldEvent.getSender() : this._client.getUserId();
+            const newEventWinsRace = event.getSender() < oldSender;
+            if (this._verifier.canSwitchStartEvent(event) && newEventWinsRace) {
+                this._verifier.switchStartEvent(event);
+            } else if (!isRemoteEcho) {
+                 if (type === CANCEL_TYPE || (this._verifier.events
+                    && this._verifier.events.includes(type))) {
+                    this._verifier.handleEvent(event);
+                }
             }
         }
 

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -644,7 +644,6 @@ export class VerificationRequest extends EventEmitter {
     }
 
     _createVerifier(method, startEvent = null, targetDevice = null) {
-        const startedByMe = !startEvent || this._wasSentByOwnDevice(startEvent);
         if (!targetDevice) {
             const theirFirstEvent =
                 this._eventsByThem.get(REQUEST_TYPE) ||
@@ -669,7 +668,7 @@ export class VerificationRequest extends EventEmitter {
             this._client,
             userId,
             deviceId,
-            startedByMe ? null : startEvent,
+            startEvent,
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11991
React-SDK PR: https://github.com/matrix-org/matrix-react-sdk/pull/3976

During SAS verification, the messages sent back and forth are not symmetrical. There is the initiating side (sending the `.start` event) and the receiving side (sending the `.accept` event).
When both parties click "verify by emoji", they create a verifier and nominate themselves as the initiating side, resulting in a deadlock where both sides await the `.accept` event.

We can't just create a new verifier in this case, as we've already returned the verifier from `beginKeyVerification`, so we need to switch to the new `.start` internally, and retry, deciding as which side we should act depending on who sent the start event.


The [MSC](https://github.com/matrix-org/matrix-doc/pull/2366/files#diff-a93af9e8be5c7b08435b246a9a692ec2R36-R39) defines that clients should pick the event with the sender userId that has the smallest sorting order, so that's how we pick a .start event in the case where each side sent one.

The solution used here is a bit hacky. We throw a `SwitchStartEventError` to interrupt the verification flow, catch that, and retry now acting as the other side depending on the sender of the start event. I couldn't come up with something nicer.