### PR TITLE
Fix typo

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -507,7 +507,7 @@ MatrixClient.prototype.isInitialSyncComplete = function() {
     if (!state) {
         return false;
     }
-    return state === "PREPAED" || state === "SYNCING";
+    return state === "PREPARED" || state === "SYNCING";
 };
 
 /**


### PR DESCRIPTION
This would probably just cause apps to wait until the first live
sync had finished rather than the one from the store, so slowing
them down / breaking offline support.