### PR TITLE
Don't explode verification validation if we don't have an event type

### DIFF
--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -85,7 +85,7 @@ export class VerificationRequest extends EventEmitter {
         const content = event.getContent();
 
 
-        if (!type.startsWith(EVENT_PREFIX)) {
+        if (!type || !type.startsWith(EVENT_PREFIX)) {
             return false;
         }
 


### PR DESCRIPTION
I don't know why this is undefined at this point, or why membership events are ending up here, but this fixes develop for people.

See https://github.com/vector-im/riot-web/issues/12231