### PR TITLE
add logging when a request is being cancelled

### DIFF
--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -557,6 +557,15 @@ export class VerificationRequest extends EventEmitter {
         } else if (this._observeOnly !== wasObserveOnly) {
             this.emit("change");
         }
+
+        // log cancellations so we can see from rageshakes why riot sometimes cancels
+        // requests on its own
+        if (type === CANCEL_TYPE) {
+            logger.log(`verification request ${this.channel.transactionId}: ` +
+                `.cancel event with ${JSON.stringify(event.getContent())} ` +
+                `sender=${event.getSender()}, isSentByUs=${isSentByUs} ` +
+                `phase=${this.phase}`);
+        }
     }
 
     _setupTimeout(phase) {


### PR DESCRIPTION
so we can more easily see (especially for to_device requests)
why something was cancelled, to debug issues like https://github.com/vector-im/riot-web/issues/12226