### PR TITLE
Fix: always return a valid string from InRoomChannel.getEventType

### DIFF
--- a/spec/unit/crypto/verification/InRoomChannel.spec.js
+++ b/spec/unit/crypto/verification/InRoomChannel.spec.js
@@ -46,8 +46,9 @@ describe("InRoomChannel tests", function() {
             type: "m.room.message",
             content: { msgtype: "m.text" },
         });
+        // XXX: The event type doesn't matter too much, just as long as it's not a verification event
         expect(InRoomChannel.getEventType(messageEvent)).
-            toBeTruthy();
+            toStrictEqual("m.room.message");
     });
 
     it("getEventType should return actual type for non-message events", function() {

--- a/spec/unit/crypto/verification/InRoomChannel.spec.js
+++ b/spec/unit/crypto/verification/InRoomChannel.spec.js
@@ -29,7 +29,7 @@ describe("InRoomChannel tests", function() {
         const invalidEvent = new MatrixEvent({
             type: "m.key.verification.request",
         });
-        expect(InRoomChannel.getEventType(invalidEvent)).toStrictEqual(undefined);
+        expect(InRoomChannel.getEventType(invalidEvent)).toStrictEqual("");
         const validEvent = new MatrixEvent({
             type: "m.room.message",
             content: { msgtype: "m.key.verification.request" },
@@ -39,6 +39,24 @@ describe("InRoomChannel tests", function() {
         const validFooEvent = new MatrixEvent({ type: "m.foo" });
         expect(InRoomChannel.getEventType(validFooEvent)).
             toStrictEqual("m.foo");
+    });
+
+    it("getEventType should return m.room.message for messages", function() {
+        const messageEvent = new MatrixEvent({
+            type: "m.room.message",
+            content: { msgtype: "m.text" },
+        });
+        expect(InRoomChannel.getEventType(messageEvent)).
+            toBeTruthy();
+    });
+
+    it("getEventType should return actual type for non-message events", function() {
+        const event = new MatrixEvent({
+            type: "m.room.member",
+            content: { },
+        });
+        expect(InRoomChannel.getEventType(event)).
+            toStrictEqual("m.room.member");
     });
 
     it("getOtherPartyUserId should not return anything for a request not " +

--- a/src/crypto/verification/request/InRoomChannel.js
+++ b/src/crypto/verification/request/InRoomChannel.js
@@ -167,8 +167,11 @@ export class InRoomChannel {
                     return REQUEST_TYPE;
                 }
             }
-        } else if (type && type !== REQUEST_TYPE) {
+        }
+        if (type && type !== REQUEST_TYPE) {
             return type;
+        } else {
+            return "";
         }
     }
 


### PR DESCRIPTION
More permanent fix for https://github.com/vector-im/riot-web/issues/12231, which is already fixed in https://github.com/matrix-org/matrix-js-sdk/pull/1194/
Regressed in https://github.com/matrix-org/matrix-js-sdk/pull/1193