### PR TITLE
Remove methods argument to verification

### DIFF
--- a/spec/unit/crypto/verification/sas.spec.js
+++ b/spec/unit/crypto/verification/sas.spec.js
@@ -448,7 +448,7 @@ describe("SAS verification", function() {
             });
 
             const aliceRequest = await alice.client.requestVerificationDM(
-                bob.client.getUserId(), "!room_id", [verificationMethods.SAS],
+                bob.client.getUserId(), "!room_id",
             );
             await aliceRequest.waitFor(r => r.started);
             aliceVerifier = aliceRequest.verifier;

--- a/src/client.js
+++ b/src/client.js
@@ -907,36 +907,32 @@ async function _setDeviceVerification(
  *
  * @param {string} userId the user to request verification with
  * @param {string} roomId the room to use for verification
- * @param {Array} methods array of verification methods to use.  Defaults to
- *    all known methods
  *
  * @returns {Promise<module:crypto/verification/request/VerificationRequest>} resolves to a VerificationRequest
  *    when the request has been sent to the other party.
  */
-MatrixClient.prototype.requestVerificationDM = function(userId, roomId, methods) {
+MatrixClient.prototype.requestVerificationDM = function(userId, roomId) {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
-    return this._crypto.requestVerificationDM(userId, roomId, methods);
+    return this._crypto.requestVerificationDM(userId, roomId);
 };
 
 /**
  * Request a key verification from another user.
  *
  * @param {string} userId the user to request verification with
- * @param {Array} methods array of verification methods to use.  Defaults to
- *    all known methods
  * @param {Array} devices array of device IDs to send requests to.  Defaults to
  *    all devices owned by the user
  *
  * @returns {Promise<module:crypto/verification/request/VerificationRequest>} resolves to a VerificationRequest
  *    when the request has been sent to the other party.
  */
-MatrixClient.prototype.requestVerification = function(userId, methods, devices) {
+MatrixClient.prototype.requestVerification = function(userId, devices) {
     if (this._crypto === null) {
         throw new Error("End-to-end encryption disabled");
     }
-    return this._crypto.requestVerification(userId, methods, devices);
+    return this._crypto.requestVerification(userId, devices);
 };
 
 /**

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -126,8 +126,8 @@ export function Crypto(baseApis, sessionStore, userId, deviceId,
     this._clientStore = clientStore;
     this._cryptoStore = cryptoStore;
     this._roomList = roomList;
-    this._verificationMethods = new Map();
     if (verificationMethods) {
+        this._verificationMethods = new Map();
         for (const method of verificationMethods) {
             if (typeof method === "string") {
                 if (defaultVerificationMethods[method]) {
@@ -145,8 +145,9 @@ export function Crypto(baseApis, sessionStore, userId, deviceId,
                 console.warn(`Excluding unknown verification method ${method}`);
             }
         }
+    } else {
+        this._verificationMethods = defaultVerificationMethods;
     }
-
     // track whether this device's megolm keys are being backed up incrementally
     // to the server or not.
     // XXX: this should probably have a single source of truth from OlmAccount

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1619,46 +1619,32 @@ Crypto.prototype.setDeviceVerification = async function(
     return deviceObj;
 };
 
-Crypto.prototype.requestVerificationDM = function(userId, roomId, methods) {
+Crypto.prototype.requestVerificationDM = function(userId, roomId) {
     const channel = new InRoomChannel(this._baseApis, roomId, userId);
     return this._requestVerificationWithChannel(
         userId,
-        methods,
         channel,
         this._inRoomVerificationRequests,
     );
 };
 
-Crypto.prototype.requestVerification = function(userId, methods, devices) {
+Crypto.prototype.requestVerification = function(userId, devices) {
     if (!devices) {
         devices = Object.keys(this._deviceList.getRawStoredDevicesForUser(userId));
     }
     const channel = new ToDeviceChannel(this._baseApis, userId, devices);
     return this._requestVerificationWithChannel(
         userId,
-        methods,
         channel,
         this._toDeviceVerificationRequests,
     );
 };
 
 Crypto.prototype._requestVerificationWithChannel = async function(
-    userId, methods, channel, requestsMap,
+    userId, channel, requestsMap,
 ) {
-    let verificationMethods = this._verificationMethods;
-    if (methods) {
-        verificationMethods = methods.reduce((map, name) => {
-            const method = this._verificationMethods.get(name);
-            if (!method) {
-                throw new Error(`Verification method ${name} is not supported.`);
-            } else {
-                map.set(name, method);
-            }
-            return map;
-        }, new Map());
-    }
     let request = new VerificationRequest(
-        channel, verificationMethods, this._baseApis);
+        channel, this._verificationMethods, this._baseApis);
     await request.sendRequest();
     // don't replace the request created by a racing remote echo
     const racingRequest = requestsMap.getRequestByChannel(channel);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12319
It's easy for all the calls in react-sdk to `requestVerification(DM)` to have a different set of methods they pass along. There is also little value to it, as clients built on top of js-sdk can already select the subset of methods they can provide an UI for through the `verificationMethods` option when creating the client.

This is sort of a breaking change, as the extra argument consumers of the js-sdk might still pass will be ignored.