### PR TITLE
Always publish to `next` tag

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -294,14 +294,15 @@ fi
 rm "${release_text}"
 rm "${latest_changes}"
 
-npm_publish_flags=''
-if [ $prerelease -eq 1 ]; then
-    # Tag prereleases as `next` so the last stable release remains the default
-    npm_publish_flags='--tag next'
-fi
 # Login and publish continues to use `npm`, as it seems to have more clearly
 # defined options and semantics than `yarn` for writing to the registry.
-npm publish $npm_publish_flags
+# Tag both releases and prereleases as `next` so the last stable release remains
+# the default.
+npm publish --tag next
+if [ $prerelease -eq 0 ]; then
+    # For a release, also publish to the default `latest` tag.
+    npm publish
+fi
 
 if [ -z "$skip_jsdoc" ]; then
     echo "generating jsdocs"


### PR DESCRIPTION
This ensures that anyone who wants the latest version (pre-release or final
release) can always use the `next` tag.

**Note:** Targetting the release branch.