### PR TITLE
allow updating device keys

### DIFF
--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -936,13 +936,12 @@ async function _storeDeviceKeys(_olmDevice, userStore, deviceResult) {
         deviceStore = userStore[deviceId];
 
         if (deviceStore.getFingerprint() != signKey) {
-            // this should only happen if the list has been MITMed; we are
-            // best off sticking with the original keys.
-            //
-            // Should we warn the user about it somehow?
-            logger.warn("Ed25519 key for device " + userId + ":" +
-               deviceId + " has changed");
-            return false;
+            // this happens if the other device rotated their keys (if indexeddb got cleared)
+            // or the list has been MITMed; we are still storing the new key, as otherwise
+            // verification breaks as we never have an up to date device key. Storing the new key
+            // will make it be marked as untrusted.
+            // Depending on the paranoia setting, we might still encrypt for this device.
+            logger.warn(`Changing Ed25519 key for device ${userId}:${deviceId}`);
         }
     } else {
         userStore[deviceId] = deviceStore = new DeviceInfo(deviceId);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12226

Device keys can get rotated because idb got cleared out on low disk. So far, other riots wouldn't update the rotated keys in this case to prevent MITM. This prevents verification as the other clients are stuck with an old device key and the MAC fails.

This PR changes the above to accept the new device key. This should be fine because the device becomes unverified and depending on the paranoia settings we will or will not encrypt for that device after accepting the new key.

There does seem to be a bug verifying the rotated device afterwards though, see https://github.com/vector-im/riot-web/issues/12399