### PR TITLE
Fix: error during tests

### DIFF
--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -502,10 +502,12 @@ export class AutoDiscovery {
             request(
                 { method: "GET", uri: url, timeout: 5000 },
                 (err, response, body) => {
-                    if (err || response.statusCode < 200 || response.statusCode >= 300) {
+                    if (err || response &&
+                        (response.statusCode < 200 || response.statusCode >= 300)
+                    ) {
                         let action = "FAIL_PROMPT";
                         let reason = (err ? err.message : null) || "General failure";
-                        if (response.statusCode === 404) {
+                        if (response && response.statusCode === 404) {
                             action = "IGNORE";
                             reason = AutoDiscovery.ERROR_MISSING_WELLKNOWN;
                         }


### PR DESCRIPTION
Add null check for when there is no response. Seems like the tests were intermittently failing [here](https://buildkite.com/matrix-dot-org/matrix-react-sdk/builds/4676#c8bf091a-096c-4f11-901a-83072cb80c47/302-2039) (assuming because there was on network?).