### PR TITLE
For self-verifications, also request keys from the other device

### DIFF
--- a/spec/unit/crypto/verification/secret_request.spec.js
+++ b/spec/unit/crypto/verification/secret_request.spec.js
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {VerificationBase} from '../../../../src/crypto/verification/Base';
+import {CrossSigningInfo} from '../../../../src/crypto/CrossSigning';
+import {encodeBase64} from "../../../../src/crypto/olmlib";
+import {setupWebcrypto, teardownWebcrypto} from './util';
+
+jest.useFakeTimers();
+
+// Private key for tests only
+const testKey = new Uint8Array([
+    0xda, 0x5a, 0x27, 0x60, 0xe3, 0x3a, 0xc5, 0x82,
+    0x9d, 0x12, 0xc3, 0xbe, 0xe8, 0xaa, 0xc2, 0xef,
+    0xae, 0xb1, 0x05, 0xc1, 0xe7, 0x62, 0x78, 0xa6,
+    0xd7, 0x1f, 0xf8, 0x2c, 0x51, 0x85, 0xf0, 0x1d,
+]);
+const testKeyPub = "nqOvzeuGWT/sRx3h7+MHoInYj3Uk2LD/unI9kDYcHwk";
+
+describe("self-verifications", () => {
+    beforeAll(function() {
+        setupWebcrypto();
+        return global.Olm.init();
+    });
+
+    afterAll(() => {
+        teardownWebcrypto();
+    });
+
+    it("triggers a request for key sharing upon completion", async () => {
+        const userId = "@test:localhost";
+
+        const cacheCallbacks = {
+            getCrossSigningKeyCache: jest.fn().mockReturnValue(null),
+            storeCrossSigningKeyCache: jest.fn(),
+        };
+
+        const _crossSigningInfo = new CrossSigningInfo(
+            userId,
+            {},
+            cacheCallbacks,
+        );
+        _crossSigningInfo.keys = {
+            self_signing: { keys: { X: testKeyPub } },
+            user_signing: { keys: { X: testKeyPub } },
+        };
+
+        const _secretStorage = {
+            request: jest.fn().mockReturnValue({
+                promise: Promise.resolve(encodeBase64(testKey)),
+            }),
+        };
+
+        const client = {
+            _crypto: {
+                _crossSigningInfo,
+                _secretStorage,
+            },
+            getUserId: () => userId,
+        };
+
+        const request = {
+            onVerifierFinished: () => undefined,
+        };
+
+        const verification = new VerificationBase(
+            undefined, // channel
+            client, // baseApis
+            userId,
+            "ABC", // deviceId
+            undefined, // startEvent
+            request,
+        );
+        verification._resolve = () => undefined;
+
+        const result = await verification.done();
+
+        /* We should request, and store, two keys */
+        expect(cacheCallbacks.storeCrossSigningKeyCache.mock.calls.length).toBe(2);
+        expect(_secretStorage.request.mock.calls.length).toBe(2);
+
+        expect(cacheCallbacks.storeCrossSigningKeyCache.mock.calls[0][1])
+          .toEqual(testKey);
+        expect(cacheCallbacks.storeCrossSigningKeyCache.mock.calls[1][1])
+          .toEqual(testKey);
+
+        expect(result).toBeInstanceOf(Array);
+        expect(result[0][0]).toBe(testKeyPub);
+        expect(result[1][0]).toBe(testKeyPub);
+    });
+});

--- a/src/client.js
+++ b/src/client.js
@@ -5181,6 +5181,15 @@ MatrixClient.prototype.getEventMapper = function() {
     return _PojoToMatrixEventMapper(this);
 };
 
+/**
+ * The app may wish to see if we have a key cached without
+ * triggering a user interaction.
+ * @return {object}
+ */
+MatrixClient.prototype.getCrossSigningCacheCallbacks = function() {
+    return this._crypto && this._crypto._crossSigningInfo.getCacheCallbacks();
+};
+
 // Identity Server Operations
 // ==========================
 

--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -473,6 +473,13 @@ export class CrossSigningInfo extends EventEmitter {
             return new DeviceTrustLevel(false, false, localTrust);
         }
     }
+
+    /**
+     * @returns {object} Cache callbacks
+     */
+    getCacheCallbacks() {
+        return this._cacheCallbacks;
+    }
 }
 
 function deviceToObject(device, userId) {

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -24,6 +24,8 @@ import {EventEmitter} from 'events';
 import {logger} from '../../logger';
 import {DeviceInfo} from '../deviceinfo';
 import {newTimeoutError} from "./Error";
+import {CrossSigningInfo} from "../CrossSigning";
+import {decodeBase64} from "../olmlib";
 
 const timeoutException = new Error("Verification timed out");
 
@@ -75,6 +77,8 @@ export class VerificationBase extends EventEmitter {
         this._promise = null;
         this._transactionTimeoutTimer = null;
     }
+
+    static keyRequestTimeoutMs = 1000 * 60;
 
     get initiatedByMe() {
         // if there is no start event yet,
@@ -188,6 +192,63 @@ export class VerificationBase extends EventEmitter {
         if (!this._done) {
             this.request.onVerifierFinished();
             this._resolve();
+
+            //#region Cross-signing keys request
+            // If this is a self-verification, ask the other party for keys
+            if (this._baseApis.getUserId() !== this.userId) {
+                return;
+            }
+            console.log("VerificationBase.done: Self-verification done; requesting keys");
+            /* This happens asynchronously, and we're not concerned about
+             * waiting for it.  We return here in order to test. */
+            return new Promise((resolve, reject) => {
+                const client = this._baseApis;
+                const original = client._crypto._crossSigningInfo;
+                const storage = client._crypto._secretStorage;
+
+                /* We already have all of the infrastructure we need to validate and
+                 * cache cross-signing keys, so instead of replicating that, here we
+                 * set up callbacks that request them from the other device and call
+                 * CrossSigningInfo.getCrossSigningKey() to validate/cache */
+                const crossSigning = new CrossSigningInfo(
+                    original.userId,
+                    { getCrossSigningKey: async (type) => {
+                        console.debug("VerificationBase.done: requesting secret",
+                                      type, this.deviceId);
+                        const { promise } =
+                            storage.request(`m.key.${type}`, [this.deviceId]);
+                        const result = await promise;
+                        const decoded = decodeBase64(result);
+                        return Uint8Array.from(decoded);
+                    } },
+                    original._cacheCallbacks,
+                );
+                crossSigning.keys = original.keys;
+
+                // XXX: get all keys out if we get one key out
+                // XXX: https://github.com/vector-im/riot-web/issues/12604
+                // XXX: then change here to reject on the timeout
+                /* Requests can be ignored, so don't wait around forever */
+                const timeout = new Promise((resolve, reject) => {
+                    setTimeout(
+                        resolve,
+                        VerificationBase.keyRequestTimeoutMs,
+                        new Error("Timeout"),
+                    );
+                });
+
+                /* We call getCrossSigningKey() for its side-effects */
+                return Promise.race([
+                    Promise.all([
+                        crossSigning.getCrossSigningKey("self_signing"),
+                        crossSigning.getCrossSigningKey("user_signing"),
+                    ]),
+                    timeout,
+                ]).then(resolve, reject);
+            }).catch((e) => {
+                console.warn("VerificationBase: failure while requesting keys:", e);
+            });
+            //#endregion
         }
     }
 

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -226,8 +226,8 @@ export class VerificationBase extends EventEmitter {
                 crossSigning.keys = original.keys;
 
                 // XXX: get all keys out if we get one key out
-                // XXX: https://github.com/vector-im/riot-web/issues/12604
-                // XXX: then change here to reject on the timeout
+                // https://github.com/vector-im/riot-web/issues/12604
+                // then change here to reject on the timeout
                 /* Requests can be ignored, so don't wait around forever */
                 const timeout = new Promise((resolve, reject) => {
                     setTimeout(


### PR DESCRIPTION
Fixes: https://github.com/vector-im/riot-web/issues/12302

To view the cache:
```
let { getCrossSigningKeyCache } = mxMatrixClientPeg.get()._crypto._crossSigningInfo._cacheCallbacks;
getCrossSigningKeyCache && await Promise.all([getCrossSigningKeyCache("self_signing"), getCrossSigningKeyCache("user_signing")])
```
<img width="1792" alt="Screenshot 2020-03-04 at 14 58 01" src="https://user-images.githubusercontent.com/3935731/75892323-0643d400-5e29-11ea-8241-1fc9bdb1e056.png">
<img width="1792" alt="Screenshot 2020-03-04 at 14 58 07" src="https://user-images.githubusercontent.com/3935731/75892336-0ba11e80-5e29-11ea-9635-d40343c0256e.png">
