### PR TITLE
Fix regression in key backup request params

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2143,11 +2143,12 @@ Crypto.prototype._backupPendingKeys = async function(limit) {
         const device = this._deviceList.getDeviceByIdentityKey(
             olmlib.MEGOLM_ALGORITHM, session.senderKey,
         );
+        const verified = this._checkDeviceInfoTrust(this._userId, device).isVerified();
 
         data[roomId]['sessions'][session.sessionId] = {
             first_message_index: firstKnownIndex,
             forwarded_count: forwardedCount,
-            is_verified: this._checkDeviceInfoTrust(this._userId, device),
+            is_verified: verified,
             session_data: encrypted,
         };
     }


### PR DESCRIPTION
This converts the cross-signing trust to a boolean as required by the
homeserver.

Regressed by https://github.com/vector-im/riot-web/issues/12599
Fixes https://github.com/vector-im/riot-web/issues/12618