### PR TITLE
Fix secret sharing names to match spec

### DIFF
--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -216,7 +216,7 @@ export class VerificationBase extends EventEmitter {
                         console.debug("VerificationBase.done: requesting secret",
                                       type, this.deviceId);
                         const { promise } =
-                            storage.request(`m.key.${type}`, [this.deviceId]);
+                            storage.request(`m.cross_signing.${type}`, [this.deviceId]);
                         const result = await promise;
                         const decoded = decodeBase64(result);
                         return Uint8Array.from(decoded);


### PR DESCRIPTION
When sharing keys, we should use `m.cross_signing` prefix.

Part of https://github.com/vector-im/riot-web/issues/12661
See also https://github.com/matrix-org/matrix-react-sdk/pull/4185