### PR TITLE
If a key upload fails, throw an error and emit an event

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -672,7 +672,8 @@ Crypto.prototype._afterCrossSigningLocalKeyChange = async function() {
         [this._userId]: {
             [this._deviceId]: signedDevice,
         },
-    }).then(({failures}) => {
+    }).then((response) => {
+        const { failures } = response || {};
         if (Object.keys(failures || []).length > 0) {
             this._baseApis.emit(
                 "crypto.keySignatureUploadFailure",
@@ -970,7 +971,8 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
     if (keysToUpload.length) {
         logger.info(`Starting background key sig upload for ${keysToUpload}`);
         this._baseApis.uploadKeySignatures({ [this._userId]: keySignatures })
-        .then(({failures}) => {
+        .then((response) => {
+            const { failures } = response || {};
             logger.info(`Finished background key sig upload for ${keysToUpload}`);
             if (Object.keys(failures || []).length > 0) {
                 this._baseApis.emit(
@@ -1624,11 +1626,12 @@ Crypto.prototype.setDeviceVerification = async function(
             const device = await this._crossSigningInfo.signUser(xsk);
             if (device) {
                 logger.info("Uploading signature for " + userId + "...");
-                const { failures } = await this._baseApis.uploadKeySignatures({
+                const response = await this._baseApis.uploadKeySignatures({
                     [userId]: {
                         [deviceId]: device,
                     },
                 });
+                const { failures } = response || {};
                 if (Object.keys(failures || []).length > 0) {
                     this._baseApis.emit(
                         "crypto.keySignatureUploadFailure",
@@ -1689,11 +1692,12 @@ Crypto.prototype.setDeviceVerification = async function(
         );
         if (device) {
             logger.info("Uploading signature for " + deviceId);
-            const { failures } = await this._baseApis.uploadKeySignatures({
+            const response = await this._baseApis.uploadKeySignatures({
                 [userId]: {
                     [deviceId]: device,
                 },
             });
+            const { failures } = response || {};
             if (Object.keys(failures || []).length > 0) {
                 throw new KeySignatureUploadError("Key upload failed", { failures });
             }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -670,7 +670,7 @@ Crypto.prototype._afterCrossSigningLocalKeyChange = async function() {
     logger.info(`Starting background key sig upload for ${this._deviceId}`);
 
     const upload = ({ shouldEmit }) => {
-        this._baseApis.uploadKeySignatures({
+        return this._baseApis.uploadKeySignatures({
             [this._userId]: {
                 [this._deviceId]: signedDevice,
             },
@@ -981,7 +981,7 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
     if (keysToUpload.length) {
         const upload = ({ shouldEmit }) => {
             logger.info(`Starting background key sig upload for ${keysToUpload}`);
-            this._baseApis.uploadKeySignatures({ [this._userId]: keySignatures })
+            return this._baseApis.uploadKeySignatures({ [this._userId]: keySignatures })
             .then((response) => {
                 const { failures } = response || {};
                 logger.info(`Finished background key sig upload for ${keysToUpload}`);

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -55,7 +55,7 @@ import {InRoomChannel, InRoomRequests} from "./verification/request/InRoomChanne
 import {ToDeviceChannel, ToDeviceRequests} from "./verification/request/ToDeviceChannel";
 import * as httpApi from "../http-api";
 import {IllegalMethod} from "./verification/IllegalMethod";
-import {KeyUploadError} from "../errors";
+import {KeySignatureUploadError} from "../errors";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 
@@ -675,11 +675,11 @@ Crypto.prototype._afterCrossSigningLocalKeyChange = async function() {
     }).then(({failures}) => {
         if (Object.keys(failures || []).length > 0) {
             this._baseApis.emit(
-                "crypto.keyUploadFailure",
+                "crypto.keySignatureUploadFailure",
                 failures,
-                "_afterCrossSigningLocalKeyChange"
+                "_afterCrossSigningLocalKeyChange",
             );
-            throw new KeyUploadError("Key upload failed", { failures });
+            throw new KeySignatureUploadError("Key upload failed", { failures });
         }
         logger.info(`Finished background key sig upload for ${this._deviceId}`);
     }).catch(e => {
@@ -974,11 +974,11 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
             logger.info(`Finished background key sig upload for ${keysToUpload}`);
             if (Object.keys(failures || []).length > 0) {
                 this._baseApis.emit(
-                    "crypto.keyUploadFailure",
+                    "crypto.keySignatureUploadFailure",
                     failures,
-                    "checkOwnCrossSigningTrust"
+                    "checkOwnCrossSigningTrust",
                 );
-                throw new KeyUploadError("Key upload failed", { failures });
+                throw new KeySignatureUploadError("Key upload failed", { failures });
             }
         }).catch(e => {
             logger.error(`Error during background key sig upload for ${keysToUpload}`, e);
@@ -1631,13 +1631,13 @@ Crypto.prototype.setDeviceVerification = async function(
                 });
                 if (Object.keys(failures || []).length > 0) {
                     this._baseApis.emit(
-                        "crypto.keyUploadFailure",
+                        "crypto.keySignatureUploadFailure",
                         failures,
-                        "setDeviceVerification"
+                        "setDeviceVerification",
                     );
                     /* Throwing here causes the process to be cancelled and the other
                      * user to be notified */
-                    throw new KeyUploadError("Key upload failed", { failures });
+                    throw new KeySignatureUploadError("Key upload failed", { failures });
                 }
 
                 // This will emit events when it comes back down the sync
@@ -1695,7 +1695,7 @@ Crypto.prototype.setDeviceVerification = async function(
                 },
             });
             if (Object.keys(failures || []).length > 0) {
-                throw new KeyUploadError("Key upload failed", { failures });
+                throw new KeySignatureUploadError("Key upload failed", { failures });
             }
             // XXX: we'll need to wait for the device list to be updated
         }

--- a/src/errors.js
+++ b/src/errors.js
@@ -45,7 +45,7 @@ InvalidCryptoStoreError.prototype = Object.create(Error.prototype, {
 });
 Reflect.setPrototypeOf(InvalidCryptoStoreError, Error);
 
-export class KeyUploadError extends Error {
+export class KeySignatureUploadError extends Error {
   constructor(message, value) {
     super(message);
     this.value = value;

--- a/src/errors.js
+++ b/src/errors.js
@@ -44,3 +44,10 @@ InvalidCryptoStoreError.prototype = Object.create(Error.prototype, {
   },
 });
 Reflect.setPrototypeOf(InvalidCryptoStoreError, Error);
+
+export class KeyUploadError extends Error {
+  constructor(message, value) {
+    super(message);
+    this.value = value;
+  }
+}


### PR DESCRIPTION
Relates to: https://github.com/vector-im/riot-web/issues/11574

I think the only user-visible change here is that when they fail to upload a key, a cancellation event now fires and so both sides see the change as cancelled. 

Inexplicably, the device that throws considers the other to be verified until it's refreshed.  I cannot track down why this is, and it looks like the way it's meant to work is that the key is uploaded and then retrieved in the next sync.

I think this task only half-completes the matter – the other is to surface it to the user.