### PR TITLE
Add a method for legacy single device verification, returning a verification request

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1135,6 +1135,7 @@ wrapCryptoFuncs(MatrixClient, [
     "checkDeviceTrust",
     "checkOwnCrossSigningTrust",
     "checkCrossSigningPrivateKey",
+    "legacyDeviceVerification",
 ]);
 
 /**


### PR DESCRIPTION
...rather than a verifier

Related to https://github.com/vector-im/riot-web/issues/12636

we need this method and can't use `beginKeyVerification` because react-sdk needs a request object to show in EncryptionPanel, and can't work with just a verifier anymore.