### PR TITLE
Fix: prevent error being thrown during sync in some cases

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -407,9 +407,9 @@ export function MatrixClient(opts) {
                     break;
                 }
 
-                highlightCount += this.getPushActionsForEvent(
-                    event,
-                ).tweaks.highlight ? 1 : 0;
+                const pushActions = this.getPushActionsForEvent(event);
+                highlightCount += pushActions.tweaks &&
+                    pushActions.tweaks.highlight ? 1 : 0;
             }
 
             // Note: we don't need to handle 'total' notifications because the counts


### PR DESCRIPTION
`tweaks` isn't guaranteed to be on the push actions, see for example `pushprocessor.js:352`. Might be related to https://github.com/vector-im/riot-web/issues/12677 (and good to fix anyway) as the logs contained this:
```
2020-03-11T00:20:33.614Z E Caught /sync error TypeError: Cannot read property 'highlight' of undefined
    at MatrixClient.eval (webpack-internal:///40:412:68)
    at MatrixClient.emit (webpack-internal:///38:157:7)
    at ReEmitter._handleEvent (webpack-internal:///66:33:17)
    at ReEmitter.forSource (webpack-internal:///66:41:24)
    at Room.emit (webpack-internal:///38:152:5)
    at Room.addReceipt (webpack-internal:///57:1708:8)
    at Room.addEphemeralEvents (webpack-internal:///57:1508:12)
    at eval (webpack-internal:///56:1253:10)
    at Module.promiseMapSeries (webpack-internal:///33:894:11)
    at async SyncApi._processSyncResponse (webpack-internal:///56:1165:3)
```