### PR TITLE
Force `is_verified` for key backups to bool and fix computation

### DIFF
--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -380,6 +380,26 @@ export class DeviceList extends EventEmitter {
     }
 
     /**
+     * Get a user ID by one of their device's curve25519 identity key
+     *
+     * @param {string} algorithm  encryption algorithm
+     * @param {string} senderKey  curve25519 key to match
+     *
+     * @return {string} user ID
+     */
+    getUserByIdentityKey(algorithm, senderKey) {
+        if (
+            algorithm !== olmlib.OLM_ALGORITHM &&
+            algorithm !== olmlib.MEGOLM_ALGORITHM
+        ) {
+            // we only deal in olm keys
+            return null;
+        }
+
+        return this._userByIdentityKey[senderKey];
+    }
+
+    /**
      * Find a device by curve25519 identity key
      *
      * @param {string} algorithm  encryption algorithm
@@ -388,16 +408,8 @@ export class DeviceList extends EventEmitter {
      * @return {module:crypto/deviceinfo?}
      */
     getDeviceByIdentityKey(algorithm, senderKey) {
-        const userId = this._userByIdentityKey[senderKey];
+        const userId = this.getUserByIdentityKey(algorithm, senderKey);
         if (!userId) {
-            return null;
-        }
-
-        if (
-            algorithm !== olmlib.OLM_ALGORITHM &&
-            algorithm !== olmlib.MEGOLM_ALGORITHM
-        ) {
-            // we only deal in olm keys
             return null;
         }
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -842,7 +842,7 @@ Crypto.prototype.checkDeviceTrust = function(userId, deviceId) {
  * @returns {DeviceTrustLevel}
  */
 Crypto.prototype._checkDeviceInfoTrust = function(userId, device) {
-    const trustedLocally = device && device.isVerified();
+    const trustedLocally = !!(device && device.isVerified());
 
     const userCrossSigning = this._deviceList.getStoredCrossSigningForUser(userId);
     if (device && userCrossSigning) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2168,10 +2168,13 @@ Crypto.prototype._backupPendingKeys = async function(limit) {
         const forwardedCount =
               (sessionData.forwarding_curve25519_key_chain || []).length;
 
+        const userId = this._deviceList.getUserByIdentityKey(
+            olmlib.MEGOLM_ALGORITHM, session.senderKey,
+        );
         const device = this._deviceList.getDeviceByIdentityKey(
             olmlib.MEGOLM_ALGORITHM, session.senderKey,
         );
-        const verified = this._checkDeviceInfoTrust(this._userId, device).isVerified();
+        const verified = this._checkDeviceInfoTrust(userId, device).isVerified();
 
         data[roomId]['sessions'][session.sessionId] = {
             first_message_index: firstKnownIndex,


### PR DESCRIPTION
This both fixes the type to match what Synapse wants and uses the right user to compute trust.

Fixes https://github.com/vector-im/riot-web/issues/12693