### PR TITLE
Fix: ensureOlmSessionsForDevices parameter format

### DIFF
--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -629,9 +629,7 @@ MegolmEncryption.prototype.reshareKeyWithDevice = async function(
 
     await olmlib.ensureOlmSessionsForDevices(
         this._olmDevice, this._baseApis, {
-            [userId]: {
-                [device.deviceId]: device,
-            },
+            [userId]: [device],
         },
     );
 


### PR DESCRIPTION
`devicesByUser` parameter should probably be userId => array of devices

In [a rageshake from Nad](https://github.com/matrix-org/riot-web-rageshakes/issues/2403) (which I requested just because there were a lot of errors in his console while he was sharing his screen) I saw quite a few of these:
```
TypeError: devices is not iterable
    at Module.ensureOlmSessionsForDevices (webpack-internal:///74:197:30)
    at MegolmEncryption.reshareKeyWithDevice (webpack-internal:///91:573:76)
    at async Crypto._processReceivedRoomKeyRequest (webpack-internal:///85:2924:7)
    at async Promise.all (index 0)
    at async Crypto._processReceivedRoomKeyRequests (webpack-internal:///85:2885:5)
```
The `ensureOlmSessionsForDevices` implementation and other uses of it seem to assume that the devices come in an array, not in a id => device map.

I guess this might break key sharing in some circumstances, but not sure which problems this is causing (Nad didn't seem to have any obvious problems) but good to fix it.