### PR TITLE
Make screen sharing works on Chrome using getDisplayMedia()

### DIFF
--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -171,7 +171,6 @@ MatrixCall.prototype.placeScreenSharingCall =
     this.localVideoElement = localVideoElement;
     this.remoteVideoElement = remoteVideoElement;
     const self = this;
-
     try {
         self.screenSharingStream = await this.webRtc.getDisplayMedia({'audio': false});
         debuglog("Got screen stream, requesting audio stream...");

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -1344,8 +1344,13 @@ export function createNewMatrixCall(client, roomId, options) {
         };
     }
 
-    webRtc.getDisplayMedia = w.navigator.mediaDevices.getDisplayMedia.bind(
-        w.navigator.mediaDevices);
+    const getDisplayMedia = (
+        w.navigator.mediaDevices && w.navigator.mediaDevices.getDisplayMedia ||
+        w.navigator.getDisplayMedia
+    );
+    if (getDisplayMedia) {
+        webRtc.getDisplayMedia = getDisplayMedia.bind(w.navigator.mediaDevices);
+    }
 
     // Firefox throws on so little as accessing the RTCPeerConnection when operating in
     // a secure mode. There's some information at https://bugzilla.mozilla.org/show_bug.cgi?id=1542616

--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -165,29 +165,27 @@ MatrixCall.prototype.placeVideoCall = function(remoteVideoElement, localVideoEle
  * @throws If you have not specified a listener for 'error' events.
  */
 MatrixCall.prototype.placeScreenSharingCall =
-    function(remoteVideoElement, localVideoElement) {
+    async function(remoteVideoElement, localVideoElement) {
     debuglog("placeScreenSharingCall");
     checkForErrorListener(this);
-    const screenConstraints = _getScreenSharingConstraints(this);
-    if (!screenConstraints) {
-        return;
-    }
     this.localVideoElement = localVideoElement;
     this.remoteVideoElement = remoteVideoElement;
     const self = this;
-    this.webRtc.getUserMedia(screenConstraints, function(stream) {
-        self.screenSharingStream = stream;
+
+    try {
+        self.screenSharingStream = await this.webRtc.getDisplayMedia({'audio': false});
         debuglog("Got screen stream, requesting audio stream...");
         const audioConstraints = _getUserMediaVideoContraints('voice');
         _placeCallWithConstraints(self, audioConstraints);
-    }, function(err) {
+    } catch(err) {
         self.emit("error",
             callError(
                 MatrixCall.ERR_NO_USER_MEDIA,
                 "Failed to get screen-sharing stream: " + err,
             ),
         );
-    });
+    }
+
     this.type = 'video';
     _tryPlayRemoteStream(this);
 };
@@ -1231,31 +1229,6 @@ const _createPeerConnection = function(self) {
     return pc;
 };
 
-const _getScreenSharingConstraints = function(call) {
-    const screen = global.screen;
-    if (!screen) {
-        call.emit("error", callError(
-            MatrixCall.ERR_NO_USER_MEDIA,
-            "Couldn't determine screen sharing constaints.",
-        ));
-        return;
-    }
-
-    return {
-        video: {
-            mediaSource: 'screen',
-            mandatory: {
-                chromeMediaSource: "screen",
-                chromeMediaSourceId: "" + Date.now(),
-                maxWidth: screen.width,
-                maxHeight: screen.height,
-                minFrameRate: 1,
-                maxFrameRate: 10,
-            },
-        },
-    };
-};
-
 const _getUserMediaVideoContraints = function(callType) {
     const isWebkit = !!global.window.navigator.webkitGetUserMedia;
 
@@ -1370,6 +1343,9 @@ export function createNewMatrixCall(client, roomId, options) {
             return getUserMedia.apply(w.navigator, arguments);
         };
     }
+
+    webRtc.getDisplayMedia = w.navigator.mediaDevices.getDisplayMedia.bind(
+        w.navigator.mediaDevices);
 
     // Firefox throws on so little as accessing the RTCPeerConnection when operating in
     // a secure mode. There's some information at https://bugzilla.mozilla.org/show_bug.cgi?id=1542616


### PR DESCRIPTION
Screen sharing has never been working on recent versions of Chrome (fixes https://github.com/vector-im/riot-web/issues/6181).

This PR intends to use the new API getDisplayMedia() to make it works on all recent browsers : https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia

Signed-off-by: Maxime Jattiot <mjattiot@opensense.fr>