### PR TITLE
Allow guests to fetch TURN servers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5130,9 +5130,6 @@ function checkTurnServers(client) {
     if (!client._supportsVoip) {
         return;
     }
-    if (client.isGuest()) {
-        return; // guests can't access TURN servers
-    }
 
     client.turnServer().then(function(res) {
         if (res.uris) {


### PR DESCRIPTION
Allows guests to use the servers endpoint to try and fetch TURN servers. The configuration at the server decides if they are allowed to do this and either return the TURN servers or an GUEST_ACCESS_FORBIDDEN error.

Fixes #1274