### PR TITLE
Cache user and self signing keys during bootstrap

### DIFF
--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -526,6 +526,7 @@ export class SecretStorage extends EventEmitter {
                 device_trust: this._baseApis.checkDeviceTrust(sender, deviceId),
             });
             if (secret) {
+                logger.info(`Preparing ${content.name} secret for ${deviceId}`)
                 const payload = {
                     type: "m.secret.send",
                     content: {
@@ -562,7 +563,10 @@ export class SecretStorage extends EventEmitter {
                     },
                 };
 
+                logger.info(`Sending ${content.name} secret for ${deviceId}`)
                 this._baseApis.sendToDevice("m.room.encrypted", contentMap);
+            } else {
+                logger.info(`Request denied for ${content.name} secret for ${deviceId}`)
             }
         }
     }

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -527,7 +527,7 @@ export class SecretStorage extends EventEmitter {
                 device_trust: this._baseApis.checkDeviceTrust(sender, deviceId),
             });
             if (secret) {
-                logger.info(`Preparing ${content.name} secret for ${deviceId}`)
+                logger.info(`Preparing ${content.name} secret for ${deviceId}`);
                 const payload = {
                     type: "m.secret.send",
                     content: {
@@ -564,10 +564,10 @@ export class SecretStorage extends EventEmitter {
                     },
                 };
 
-                logger.info(`Sending ${content.name} secret for ${deviceId}`)
+                logger.info(`Sending ${content.name} secret for ${deviceId}`);
                 this._baseApis.sendToDevice("m.room.encrypted", contentMap);
             } else {
-                logger.info(`Request denied for ${content.name} secret for ${deviceId}`)
+                logger.info(`Request denied for ${content.name} secret for ${deviceId}`);
             }
         }
     }

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -473,6 +473,7 @@ export class SecretStorage extends EventEmitter {
         for (const device of devices) {
             toDevice[device] = requestData;
         }
+        logger.info(`Request secret ${name} from ${devices}, id ${requestId}`);
         this._baseApis.sendToDevice("m.secret.request", {
             [this._baseApis.getUserId()]: toDevice,
         });
@@ -578,7 +579,7 @@ export class SecretStorage extends EventEmitter {
             return;
         }
         const content = event.getContent();
-        logger.log("got secret share for request ", content.request_id);
+        logger.log("got secret share for request", content.request_id);
         const requestControl = this._requests[content.request_id];
         if (requestControl) {
             // make sure that the device that sent it is one of the devices that

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -632,13 +632,14 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     this._secretStorage,
                 );
             }
-            // Call `getCrossSigningKey` for side effect of caching if enabled
-            // via app level callbacks.
-            if (this._crossSigningInfo._cacheCallbacks) {
-                for (const type of ["self_signing", "user_signing"]) {
-                    logger.log(`Cache ${type} cross-signing private key locally`);
-                    await this._crossSigningInfo.getCrossSigningKey(type);
-                }
+        }
+
+        // Call `getCrossSigningKey` for side effect of caching private keys for
+        // future gossiping to other devices if enabled via app level callbacks.
+        if (this._crossSigningInfo._cacheCallbacks) {
+            for (const type of ["self_signing", "user_signing"]) {
+                logger.log(`Cache ${type} cross-signing private key locally`);
+                await this._crossSigningInfo.getCrossSigningKey(type);
             }
         }
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -632,6 +632,14 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     this._secretStorage,
                 );
             }
+            // Call `getCrossSigningKey` for side effect of caching if enabled
+            // via app level callbacks.
+            if (this._crossSigningInfo._cacheCallbacks) {
+                for (const type of ["self_signing", "user_signing"]) {
+                    logger.log(`Cache ${type} cross-signing private key locally`);
+                    await this._crossSigningInfo.getCrossSigningKey(type);
+                }
+            }
         }
 
         if (setupNewKeyBackup && !keyBackupInfo) {


### PR DESCRIPTION
This series of changes causes us to cache the both the USK and SSK whenever we go through the bootstrap path. It also improves logging for secret sharing.

Fixes https://github.com/vector-im/riot-web/issues/12604