### PR TITLE
Add a flag for whether cross signing signatures are trusted

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -760,7 +760,6 @@ MatrixClient.prototype.isCryptoEnabled = function() {
     return this._crypto !== null;
 };
 
-
 /**
  * Get the Ed25519 key for this device
  *
@@ -1152,6 +1151,8 @@ wrapCryptoFuncs(MatrixClient, [
     "legacyDeviceVerification",
     "prepareToEncrypt",
     "isCrossSigningReady",
+    "getCryptoTrustCrossSignedDevices",
+    "setCryptoTrustCrossSignedDevices",
 ]);
 
 /**

--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -460,17 +460,18 @@ export class CrossSigningInfo extends EventEmitter {
      * @param {CrossSigningInfo} userCrossSigning Cross signing info for user
      * @param {module:crypto/deviceinfo} device The device to check
      * @param {bool} localTrust Whether the device is trusted locally
+     * @param {bool} trustCrossSignedDevices Whether we trust cross signed devices
      *
      * @returns {DeviceTrustLevel}
      */
-    checkDeviceTrust(userCrossSigning, device, localTrust) {
+    checkDeviceTrust(userCrossSigning, device, localTrust, trustCrossSignedDevices) {
         const userTrust = this.checkUserTrust(userCrossSigning);
 
         const userSSK = userCrossSigning.keys.self_signing;
         if (!userSSK) {
             // if the user has no self-signing key then we cannot make any
             // trust assertions about this device from cross-signing
-            return new DeviceTrustLevel(false, false, localTrust);
+            return new DeviceTrustLevel(false, false, localTrust, trustCrossSignedDevices);
         }
 
         const deviceObj = deviceToObject(device, userCrossSigning.userId);
@@ -482,9 +483,9 @@ export class CrossSigningInfo extends EventEmitter {
                 deviceObj, publicKeyFromKeyInfo(userSSK), userCrossSigning.userId,
             );
             // ...then we trust this device as much as far as we trust the user
-            return DeviceTrustLevel.fromUserTrustLevel(userTrust, localTrust);
+            return DeviceTrustLevel.fromUserTrustLevel(userTrust, localTrust, trustCrossSignedDevices);
         } catch (e) {
-            return new DeviceTrustLevel(false, false, localTrust);
+            return new DeviceTrustLevel(false, false, localTrust, trustCrossSignedDevices);
         }
     }
 
@@ -547,17 +548,19 @@ export class UserTrustLevel {
  * Represents the ways in which we trust a device
  */
 export class DeviceTrustLevel {
-    constructor(crossSigningVerified, tofu, localVerified) {
+    constructor(crossSigningVerified, tofu, localVerified, trustCrossSignedDevices) {
         this._crossSigningVerified = crossSigningVerified;
         this._tofu = tofu;
         this._localVerified = localVerified;
+        this._trustCrossSignedDevices = trustCrossSignedDevices;
     }
 
-    static fromUserTrustLevel(userTrustLevel, localVerified) {
+    static fromUserTrustLevel(userTrustLevel, localVerified, trustCrossSignedDevices) {
         return new DeviceTrustLevel(
             userTrustLevel._crossSigningVerified,
             userTrustLevel._tofu,
             localVerified,
+            trustCrossSignedDevices,
         );
     }
 
@@ -565,7 +568,9 @@ export class DeviceTrustLevel {
      * @returns {bool} true if this device is verified via any means
      */
     isVerified() {
-        return this.isCrossSigningVerified() || this.isLocallyVerified();
+        return this.isLocallyVerified() || (
+            this._trustCrossSignedDevices && this.isCrossSigningVerified()
+        );
     }
 
     /**

--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -471,7 +471,9 @@ export class CrossSigningInfo extends EventEmitter {
         if (!userSSK) {
             // if the user has no self-signing key then we cannot make any
             // trust assertions about this device from cross-signing
-            return new DeviceTrustLevel(false, false, localTrust, trustCrossSignedDevices);
+            return new DeviceTrustLevel(
+                false, false, localTrust, trustCrossSignedDevices,
+            );
         }
 
         const deviceObj = deviceToObject(device, userCrossSigning.userId);
@@ -483,9 +485,13 @@ export class CrossSigningInfo extends EventEmitter {
                 deviceObj, publicKeyFromKeyInfo(userSSK), userCrossSigning.userId,
             );
             // ...then we trust this device as much as far as we trust the user
-            return DeviceTrustLevel.fromUserTrustLevel(userTrust, localTrust, trustCrossSignedDevices);
+            return DeviceTrustLevel.fromUserTrustLevel(
+                userTrust, localTrust, trustCrossSignedDevices,
+            );
         } catch (e) {
-            return new DeviceTrustLevel(false, false, localTrust, trustCrossSignedDevices);
+            return new DeviceTrustLevel(
+                false, false, localTrust, trustCrossSignedDevices,
+            );
         }
     }
 

--- a/src/crypto/DeviceList.js
+++ b/src/crypto/DeviceList.js
@@ -318,6 +318,15 @@ export class DeviceList extends EventEmitter {
     }
 
     /**
+     * Returns a list of all user IDs the DeviceList knows about
+     *
+     * @return {array} All known user IDs
+     */
+    getKnownUserIds() {
+        return Object.keys(this._devices);
+    }
+
+    /**
      * Get the stored device keys for a user id
      *
      * @param {string} userId the user to list keys for.

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1078,8 +1078,11 @@ Crypto.prototype._checkDeviceInfoTrust = function(userId, device) {
 
     const userCrossSigning = this._deviceList.getStoredCrossSigningForUser(userId);
     if (device && userCrossSigning) {
+        // The _trustCrossSignedDevices only affects trust of other people's cross-signing
+        // signatures
+        const trustCrossSigning =  this._trustCrossSignedDevices || userId === this._userId;
         return this._crossSigningInfo.checkDeviceTrust(
-            userCrossSigning, device, trustedLocally, this._trustCrossSignedDevices,
+            userCrossSigning, device, trustedLocally, trustCrossSigning,
         );
     } else {
         return new DeviceTrustLevel(false, false, trustedLocally);

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -348,7 +348,10 @@ Crypto.prototype.setCryptoTrustCrossSignedDevices = function(val) {
         const devices = this._deviceList.getRawStoredDevicesForUser(userId);
         for (const deviceId of Object.keys(devices)) {
             const deviceTrust = this.checkDeviceTrust(userId, deviceId);
-            if (!deviceTrust.isLocallyVerified() && deviceTrust.isCrossSigningVerified()) {
+            if (
+                !deviceTrust.isLocallyVerified() &&
+                deviceTrust.isCrossSigningVerified()
+            ) {
                 const deviceObj = this._deviceList.getStoredDevice(userId, deviceId);
                 this.emit("deviceVerificationChanged", userId, deviceId, deviceObj);
             }

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -348,6 +348,9 @@ Crypto.prototype.setCryptoTrustCrossSignedDevices = function(val) {
         const devices = this._deviceList.getRawStoredDevicesForUser(userId);
         for (const deviceId of Object.keys(devices)) {
             const deviceTrust = this.checkDeviceTrust(userId, deviceId);
+            // If the device is locally verified then isVerified() is always true,
+            // so this will only have caused the value to change if the device is
+            // cross-signing verified but not locally verified
             if (
                 !deviceTrust.isLocallyVerified() &&
                 deviceTrust.isCrossSigningVerified()

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1080,9 +1080,9 @@ Crypto.prototype._checkDeviceInfoTrust = function(userId, device) {
     if (device && userCrossSigning) {
         // The _trustCrossSignedDevices only affects trust of other people's cross-signing
         // signatures
-        const trustCrossSigning =  this._trustCrossSignedDevices || userId === this._userId;
+        const trustCrossSig = this._trustCrossSignedDevices || userId === this._userId;
         return this._crossSigningInfo.checkDeviceTrust(
-            userCrossSigning, device, trustedLocally, trustCrossSigning,
+            userCrossSigning, device, trustedLocally, trustCrossSig,
         );
     } else {
         return new DeviceTrustLevel(false, false, trustedLocally);


### PR DESCRIPTION
<del>TODO: Double check things are using the appropriate `isVerified / isCrossSigningVerified` for what they actually care about as this will only apply for things that check `isVerified()`.</del>