### PR TITLE
Send .done event for to_device verification

### DIFF
--- a/src/crypto/verification/request/InRoomChannel.js
+++ b/src/crypto/verification/request/InRoomChannel.js
@@ -44,11 +44,6 @@ export class InRoomChannel {
         this._requestEventId = null;
     }
 
-    /** Whether this channel needs m.key.verification.done messages to be sent after a successful verification */
-    get needsDoneMessage() {
-        return true;
-    }
-
     get receiveStartFromOtherDevices() {
         return true;
     }

--- a/src/crypto/verification/request/ToDeviceChannel.js
+++ b/src/crypto/verification/request/ToDeviceChannel.js
@@ -61,10 +61,6 @@ export class ToDeviceChannel {
         return this._deviceId;
     }
 
-    get needsDoneMessage() {
-        return false;
-    }
-
     static getEventType(event) {
         return event.getType();
     }

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -819,7 +819,6 @@ export class VerificationRequest extends EventEmitter {
     }
 
     onVerifierFinished() {
-        // verification in DM requires a done message
         this.channel.send("m.key.verification.done", {});
         this._verifierHasFinished = true;
         // move to .done phase

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -819,11 +819,10 @@ export class VerificationRequest extends EventEmitter {
     }
 
     onVerifierFinished() {
-        if (this.channel.needsDoneMessage) {
-            // verification in DM requires a done message
-            this.channel.send("m.key.verification.done", {});
-        }
+        // verification in DM requires a done message
+        this.channel.send("m.key.verification.done", {});
         this._verifierHasFinished = true;
+        // move to .done phase
         const newTransitions = this._applyPhaseTransitions();
         if (newTransitions.length) {
             this._setPhase(newTransitions[newTransitions.length - 1].phase);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12733

We'll include .done events in the spec for to_device verification so later on we can signal with this event to the other party that we've successfully uploaded our cross-signing signature and are ready to respond to key gossiping requests.

For now, we're just sending the .done events and not delaying them until the signature upload completes, to be spec compliant when launching.