### PR TITLE
Fix isVerified returning false

### DIFF
--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -574,9 +574,9 @@ export class DeviceTrustLevel {
      * @returns {bool} true if this device is verified via any means
      */
     isVerified() {
-        return this.isLocallyVerified() || (
+        return Boolean(this.isLocallyVerified() || (
             this._trustCrossSignedDevices && this.isCrossSigningVerified()
-        );
+        ));
     }
 
     /**

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1097,7 +1097,7 @@ Crypto.prototype._checkDeviceInfoTrust = function(userId, device) {
             userCrossSigning, device, trustedLocally, trustCrossSig,
         );
     } else {
-        return new DeviceTrustLevel(false, false, trustedLocally);
+        return new DeviceTrustLevel(false, false, trustedLocally, false);
     }
 };
 


### PR DESCRIPTION
which would cause key backups uploads to be missing is_verified
because it was set to `undefined` which would cause the backup to
fail

Fixes https://github.com/vector-im/riot-web/issues/12901