### PR TITLE
Receive private key for caching from the app layer

### DIFF
--- a/spec/unit/crypto/secrets.spec.js
+++ b/spec/unit/crypto/secrets.spec.js
@@ -347,7 +347,11 @@ describe("Secrets", function() {
 
         // Set up cross-signing keys from scratch with specific storage key
         await bob.bootstrapSecretStorage({
-            createSecretStorageKey: async () => ({ pubkey: storagePublicKey }),
+            createSecretStorageKey: async () => ({
+                // `pubkey` not used anymore with symmetric 4S
+                keyInfo: { pubkey: storagePublicKey },
+                privateKey: storagePrivateKey,
+            }),
         });
 
         // Clear local cross-signing keys and read from secret storage

--- a/src/client.js
+++ b/src/client.js
@@ -1179,7 +1179,9 @@ MatrixClient.prototype.checkEventSenderTrust = async function(event) {
  * @param {string} password Passphrase string that can be entered by the user
  *     when restoring the backup as an alternative to entering the recovery key.
  *     Optional.
- * @returns {Promise<String>} The user-facing recovery key string.
+ * @returns {Promise<Object>} Object with public key metadata, encoded private
+ *     recovery key which should be disposed of after displaying to the user,
+ *     and raw private key to avoid round tripping if needed.
  */
 
 /**
@@ -1563,7 +1565,7 @@ MatrixClient.prototype.prepareKeyBackupVersion = async function(
         throw new Error("End-to-end encryption disabled");
     }
 
-    const [keyInfo, encodedPrivateKey, privateKey] =
+    const { keyInfo, encodedPrivateKey, privateKey } =
         await this.createRecoveryKeyFromPassphrase(password);
 
     if (secureSecretStorage) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -368,7 +368,7 @@ Crypto.prototype.setCryptoTrustCrossSignedDevices = function(val) {
  * @param {string} password Passphrase string that can be entered by the user
  *     when restoring the backup as an alternative to entering the recovery key.
  *     Optional.
- * @returns {Promise<Array>} Array with public key metadata, encoded private
+ * @returns {Promise<Object>} Object with public key metadata, encoded private
  *     recovery key which should be disposed of after displaying to the user,
  *     and raw private key to avoid round tripping if needed.
  */
@@ -389,7 +389,7 @@ Crypto.prototype.createRecoveryKeyFromPassphrase = async function(password) {
         }
         const privateKey = decryption.get_private_key();
         const encodedPrivateKey = encodeRecoveryKey(privateKey);
-        return [keyInfo, encodedPrivateKey, privateKey];
+        return { keyInfo, encodedPrivateKey, privateKey };
     } finally {
         if (decryption) decryption.free();
     }
@@ -439,6 +439,10 @@ Crypto.prototype.isCrossSigningReady = async function() {
  *     auth data as an object.
  * @param {function} [opts.createSecretStorageKey] Optional. Function
  * called to await a secret storage key creation flow.
+ * Returns:
+ *     {Promise<Object>} Object with public key metadata, encoded private
+ *     recovery key which should be disposed of after displaying to the user,
+ *     and raw private key to avoid round tripping if needed.
  * @param {object} [opts.keyBackupInfo] The current key backup object. If passed,
  * the passphrase and recovery key from this backup will be used.
  * @param {bool} [opts.setupNewKeyBackup] If true, a new key backup version will be
@@ -454,7 +458,7 @@ Crypto.prototype.isCrossSigningReady = async function() {
  */
 Crypto.prototype.bootstrapSecretStorage = async function({
     authUploadDeviceSigningKeys,
-    createSecretStorageKey = async () => { },
+    createSecretStorageKey = async () => ({ }),
     keyBackupInfo,
     setupNewKeyBackup,
     setupNewSecretStorage,
@@ -637,13 +641,13 @@ Crypto.prototype.bootstrapSecretStorage = async function({
             } else {
                 if (!newKeyId) {
                     logger.log("Secret storage default key not found, creating new key");
-                    const [keyOptions, , key] = await createSecretStorageKey();
+                    const { keyInfo, privateKey } = await createSecretStorageKey();
                     newKeyId = await this.addSecretStorageKey(
                         SECRET_STORAGE_ALGORITHM_V1_AES,
-                        keyOptions,
+                        keyInfo,
                     );
                     await this.setDefaultSecretStorageKeyId(newKeyId);
-                    ssssKeys[newKeyId] = key;
+                    ssssKeys[newKeyId] = privateKey;
                 }
                 if (await this.isSecretStored("m.megolm_backup.v1")) {
                     // we created a new SSSS, and we previously encrypted the

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -637,12 +637,13 @@ Crypto.prototype.bootstrapSecretStorage = async function({
             } else {
                 if (!newKeyId) {
                     logger.log("Secret storage default key not found, creating new key");
-                    const keyOptions = await createSecretStorageKey();
+                    const [keyOptions, , key] = await createSecretStorageKey();
                     newKeyId = await this.addSecretStorageKey(
                         SECRET_STORAGE_ALGORITHM_V1_AES,
                         keyOptions,
                     );
                     await this.setDefaultSecretStorageKeyId(newKeyId);
+                    ssssKeys[newKeyId] = key;
                 }
                 if (await this.isSecretStored("m.megolm_backup.v1")) {
                     // we created a new SSSS, and we previously encrypted the

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -608,7 +608,7 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     newKeyId = await this.addSecretStorageKey(
                         SECRET_STORAGE_ALGORITHM_V1_AES, opts,
                     );
-                    this.setDefaultSecretStorageKeyId(newKeyId);
+                    await this.setDefaultSecretStorageKeyId(newKeyId);
                     // use the backup key as the new ssss key
                     ssssKeys[newKeyId] = backupKey;
                 }
@@ -690,7 +690,7 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         const sessionBackupKey = await this.getSecret('m.megolm_backup.v1');
         if (sessionBackupKey) {
             logger.info("Got session backup key from secret storage: caching");
-            this.storeSessionBackupPrivateKey(sessionBackupKey);
+            await this.storeSessionBackupPrivateKey(sessionBackupKey);
         }
 
         if (setupNewKeyBackup && !keyBackupInfo) {


### PR DESCRIPTION
This passes through the new secret storage key as well as the key info so that
bootstrap can use it immediately without triggering an immediate prompt.

Part of https://github.com/vector-im/riot-web/issues/12867
Used by https://github.com/matrix-org/matrix-react-sdk/pull/4308