### PR TITLE
Add ability to check symmetric SSSS key before we try to use it

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1307,6 +1307,7 @@ wrapCryptoFuncs(MatrixClient, [
     "requestSecret",
     "getDefaultSecretStorageKeyId",
     "setDefaultSecretStorageKeyId",
+    "checkSecretStorageKey",
     "checkSecretStoragePrivateKey",
 ]);
 

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -27,6 +27,8 @@ export const SECRET_STORAGE_ALGORITHM_V1_AES
 export const SECRET_STORAGE_ALGORITHM_V1_CURVE25519
     = "m.secret_storage.v1.curve25519-aes-sha2";
 
+const ZERO_STR = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
 /**
  * Implements Secure Secret Storage and Sharing (MSC1946)
  * @module crypto/SecretStorage
@@ -92,13 +94,13 @@ export class SecretStorage extends EventEmitter {
         switch (algorithm) {
         case SECRET_STORAGE_ALGORITHM_V1_AES:
         {
-            const decryption = new global.Olm.PkDecryption();
-            try {
-                if (opts.passphrase) {
-                    keyData.passphrase = opts.passphrase;
-                }
-            } finally {
-                decryption.free();
+            if (opts.passphrase) {
+                keyData.passphrase = opts.passphrase;
+            }
+            if (opts.key) {
+                const {iv, mac} = await encryptAES(ZERO_STR, opts.key, "");
+                keyData.iv = iv;
+                keyData.mac = mac;
             }
             break;
         }
@@ -191,6 +193,43 @@ export class SecretStorage extends EventEmitter {
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Check whether a key matches what we expect based on the key info
+     *
+     * @param {Uint8Array} key the key to check
+     * @param {object} info the key info
+     *
+     * @return {boolean} whether or not the key matches
+     */
+    async checkKey(key, info) {
+        switch (info.algorithm) {
+        case SECRET_STORAGE_ALGORITHM_V1_AES:
+            if (info.mac) {
+                const {mac} = await encryptAES(ZERO_STR, key, "", info.iv);
+                return info.mac === mac;
+            } else {
+                // if we have no information, we have to assume the key is right
+                return true;
+            }
+        case SECRET_STORAGE_ALGORITHM_V1_CURVE25519:
+        {
+            let decryption = null;
+            try {
+                decryption = new global.Olm.PkDecryption();
+                const gotPubkey = decryption.init_with_private_key(key);
+                // make sure it agrees with the given pubkey
+                return gotPubkey === info.pubkey;
+            } catch (e) {
+                return false;
+            } finally {
+                if (decryption) decryption.free();
+            }
+        }
+        default:
+            throw new Error("Unknown algorithm");
         }
     }
 

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -207,6 +207,7 @@ export class SecretStorage extends EventEmitter {
     async checkKey(key, info) {
         switch (info.algorithm) {
         case SECRET_STORAGE_ALGORITHM_V1_AES:
+        {
             if (info.mac) {
                 const {mac} = await encryptAES(ZERO_STR, key, "", info.iv);
                 return info.mac === mac;
@@ -214,6 +215,7 @@ export class SecretStorage extends EventEmitter {
                 // if we have no information, we have to assume the key is right
                 return true;
             }
+        }
         case SECRET_STORAGE_ALGORITHM_V1_CURVE25519:
         {
             let decryption = null;

--- a/src/crypto/aes.js
+++ b/src/crypto/aes.js
@@ -29,14 +29,20 @@ const zerosalt = new Uint8Array(8);
  * @param {string} data the plaintext to encrypt
  * @param {Uint8Array} key the encryption key to use
  * @param {string} name the name of the secret
+ * @param {string} ivStr the initialization vector to use
  */
-async function encryptNode(data, key, name) {
+async function encryptNode(data, key, name, ivStr) {
     const crypto = getCrypto();
     if (!crypto) {
         throw new Error("No usable crypto implementation");
     }
 
-    const iv = crypto.randomBytes(16);
+    let iv;
+    if (ivStr) {
+        iv = decodeBase64(ivStr);
+    } else {
+        iv = crypto.randomBytes(16);
+    }
 
     // clear bit 63 of the IV to stop us hitting the 64-bit counter boundary
     // (which would mean we wouldn't be able to decrypt on Android). The loss

--- a/src/crypto/aes.js
+++ b/src/crypto/aes.js
@@ -112,10 +112,16 @@ function deriveKeysNode(key, name) {
  * @param {string} data the plaintext to encrypt
  * @param {Uint8Array} key the encryption key to use
  * @param {string} name the name of the secret
+ * @param {string} ivStr the initialization vector to use
  */
-async function encryptBrowser(data, key, name) {
-    const iv = new Uint8Array(16);
-    window.crypto.getRandomValues(iv);
+async function encryptBrowser(data, key, name, ivStr) {
+    let iv;
+    if (ivStr) {
+        iv = decodeBase64(ivStr);
+    } else {
+        iv = new Uint8Array(16);
+        window.crypto.getRandomValues(iv);
+    }
 
     // clear bit 63 of the IV to stop us hitting the 64-bit counter boundary
     // (which would mean we wouldn't be able to decrypt on Android). The loss

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -387,7 +387,7 @@ Crypto.prototype.createRecoveryKeyFromPassphrase = async function(password) {
         } else {
             keyInfo.pubkey = decryption.generate_key();
         }
-        const privateKey = keyInfo.key = decryption.get_private_key();
+        const privateKey = decryption.get_private_key();
         const encodedPrivateKey = encodeRecoveryKey(privateKey);
         return { keyInfo, encodedPrivateKey, privateKey };
     } finally {
@@ -647,6 +647,7 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                 if (!newKeyId) {
                     logger.log("Secret storage default key not found, creating new key");
                     const { keyInfo, privateKey } = await createSecretStorageKey();
+                    keyInfo.key = privateKey;
                     newKeyId = await this.addSecretStorageKey(
                         SECRET_STORAGE_ALGORITHM_V1_AES,
                         keyInfo,

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -647,7 +647,9 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                 if (!newKeyId) {
                     logger.log("Secret storage default key not found, creating new key");
                     const { keyInfo, privateKey } = await createSecretStorageKey();
-                    keyInfo.key = privateKey;
+                    if (keyInfo && privateKey) {
+                        keyInfo.key = privateKey;
+                    }
                     newKeyId = await this.addSecretStorageKey(
                         SECRET_STORAGE_ALGORITHM_V1_AES,
                         keyInfo,


### PR DESCRIPTION
fixes (partially) https://github.com/vector-im/riot-web/issues/12897 (along with https://github.com/matrix-org/matrix-react-sdk/pull/4309)

Only remaining question is if we need to migrate users who already have an existing Symmetric SSSS.