### PR TITLE
Fix: spontanous verification request cancellation under some circumstances

### DIFF
--- a/src/crypto/verification/request/InRoomChannel.js
+++ b/src/crypto/verification/request/InRoomChannel.js
@@ -178,6 +178,11 @@ export class InRoomChannel {
      * @returns {Promise} a promise that resolves when any requests as an anwser to the passed-in event are sent.
      */
     async handleEvent(event, request, isLiveEvent) {
+        // prevent processing the same event multiple times, as under
+        // some circumstances Room.timeline can get emitted twice for the same event
+        if (request.hasEventId(event.getId())) {
+            return;
+        }
         const type = InRoomChannel.getEventType(event);
         // do validations that need state (roomId, userId),
         // ignore if invalid

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -612,6 +612,20 @@ export class VerificationRequest extends EventEmitter {
         return newRaceIdentifier < oldRaceIdentifier;
     }
 
+    hasEventId(eventId) {
+        for (const event of this._eventsByUs.values()) {
+            if (event.getId() === eventId) {
+                return true;
+            }
+        }
+        for (const event of this._eventsByThem.values()) {
+            if (event.getId() === eventId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Changes the state of the request and verifier in response to a key verification event.
      * @param {string} type the "symbolic" event type, as returned by the `getEventType` function on the channel.


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12950

The `Room.timeline` event was being emitted twice, once when [adding the event to the notification timeline](https://github.com/matrix-org/matrix-js-sdk/blob/62bd41d/src/sync.js#L1340) and once [when adding live events](https://github.com/matrix-org/matrix-js-sdk/blob/62bd41d/src/sync.js#L1629).

Easiest solution was to have a look at the events already part of the request and see if the event_id is already in there.