### PR TITLE
QR code reciprocation

### DIFF
--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -236,21 +236,21 @@ export class QRCodeData {
     static _generateBuffer(qrData) {
         let buf = Buffer.alloc(0); // we'll concat our way through life
 
-        const appendByte = (b: number) => {
+        const appendByte = (b) => {
             const tmpBuf = Buffer.from([b]);
             buf = Buffer.concat([buf, tmpBuf]);
         };
-        const appendInt = (i: number) => {
+        const appendInt = (i) => {
             const tmpBuf = Buffer.alloc(2);
             tmpBuf.writeInt16BE(i, 0);
             buf = Buffer.concat([buf, tmpBuf]);
         };
-        const appendStr = (s: string, enc: string, withLengthPrefix = true) => {
+        const appendStr = (s, enc, withLengthPrefix = true) => {
             const tmpBuf = Buffer.from(s, enc);
             if (withLengthPrefix) appendInt(tmpBuf.byteLength);
             buf = Buffer.concat([buf, tmpBuf]);
         };
-        const appendEncBase64 = (b64: string) => {
+        const appendEncBase64 = (b64) => {
             const b = decodeBase64(b64);
             const tmpBuf = Buffer.from(b);
             buf = Buffer.concat([buf, tmpBuf]);

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -23,6 +23,7 @@ limitations under the License.
 import {VerificationBase as Base} from "./Base";
 import {
     newKeyMismatchError,
+    newUserCancelledError,
 } from './Error';
 import {encodeUnpaddedBase64, decodeBase64} from "../olmlib";
 
@@ -59,7 +60,7 @@ export class ReciprocateQRCode extends Base {
         await new Promise((resolve, reject) => {
             this.reciprocateQREvent = {
                 confirm: resolve,
-                cancel: reject, // which code should we cancel with here?
+                cancel: () => reject(newUserCancelledError()),
             };
             this.emit("show_reciprocate_qr", this.reciprocateQREvent);
         });

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -24,7 +24,7 @@ import {VerificationBase as Base} from "./Base";
 import {
     newKeyMismatchError,
 } from './Error';
-import olmlib from "../olmlib";
+import {encodeUnpaddedBase64, decodeBase64} from "../olmlib";
 
 export const SHOW_QR_CODE_METHOD = "m.qr_code.show.v1";
 export const SCAN_QR_CODE_METHOD = "m.qr_code.scan.v1";
@@ -148,7 +148,7 @@ export class QRCodeData {
     static _generateSharedSecret() {
         const secretBytes = new Uint8Array(11);
         global.crypto.getRandomValues(secretBytes);
-        this._sharedSecret = olmlib.encodeUnpaddedBase64(secretBytes);
+        this._sharedSecret = encodeUnpaddedBase64(secretBytes);
     }
 
     static _getOtherDeviceKey(request, client) {
@@ -230,7 +230,7 @@ export class QRCodeData {
             buf = Buffer.concat([buf, tmpBuf]);
         };
         const appendEncBase64 = (b64: string) => {
-            const b = olmlib.decodeBase64(b64);
+            const b = decodeBase64(b64);
             const tmpBuf = Buffer.from(b);
             buf = Buffer.concat([buf, tmpBuf]);
         };

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -49,6 +49,7 @@ export class ReciprocateQRCode extends Base {
                 "with this method yet.");
         }
 
+        // 1. check the secret
         if (this.startEvent.getContent()['secret'] !== this.request.encodedSharedSecret) {
             throw newKeyMismatchError();
         }
@@ -64,6 +65,13 @@ export class ReciprocateQRCode extends Base {
         const devices = (await this._baseApis.getStoredDevicesForUser(this.userId)) || [];
         const targetDevice = devices.find(d => {
             return d.deviceId === this.request.targetDevice.deviceId;
+        // 2. ask if other user shows shield as well
+        await new Promise((resolve, reject) => {
+            this.reciprocateQREvent = {
+                confirm: resolve,
+                cancel: reject, // which code should we cancel with here?
+            };
+            this.emit("show_reciprocate_qr", this.reciprocateQREvent);
         });
         if (!targetDevice) throw new Error("Device not found, somehow");
         keys[`ed25519:${targetDevice.deviceId}`] = targetDevice.getFingerprint();

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -23,7 +23,6 @@ limitations under the License.
 import {VerificationBase as Base} from "./Base";
 import {
     newKeyMismatchError,
-    newUserMismatchError,
 } from './Error';
 import {decodeBase64} from "../olmlib";
 
@@ -48,23 +47,6 @@ export class ReciprocateQRCode extends Base {
             // TODO: Support scanning QR codes
             throw new Error("It is not currently possible to start verification" +
                 "with this method yet.");
-        }
-
-        const targetUserId = this.startEvent.getSender();
-        if (!this.userId) {
-            console.log("Asking to confirm user ID");
-            this.userId = await new Promise((resolve, reject) => {
-                this.emit("confirm_user_id", {
-                    userId: targetUserId,
-                    confirm: resolve, // takes a userId
-                    cancel: () => reject(newUserMismatchError()),
-                });
-            });
-        } else if (targetUserId !== this.userId) {
-            throw newUserMismatchError({
-                expected: this.userId,
-                actual: targetUserId,
-            });
         }
 
         if (this.startEvent.getContent()['secret'] !== this.request.encodedSharedSecret) {

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -146,7 +146,7 @@ export class QRCodeData {
     }
 
     static _generateSharedSecret() {
-        const secretBytes = new Uint8Array(8);
+        const secretBytes = new Uint8Array(11);
         global.crypto.getRandomValues(secretBytes);
         this._sharedSecret = olmlib.encodeUnpaddedBase64(secretBytes);
     }

--- a/src/crypto/verification/QRCode.js
+++ b/src/crypto/verification/QRCode.js
@@ -64,6 +64,7 @@ export class ReciprocateQRCode extends Base {
             this.emit("show_reciprocate_qr", this.reciprocateQREvent);
         });
 
+        // 3. determine key to sign
         const keys = {};
         if (qrCodeData.mode === MODE_VERIFY_OTHER_USER) {
             // add master key to keys to be signed, only if we're not doing self-verification
@@ -76,7 +77,9 @@ export class ReciprocateQRCode extends Base {
             // TODO: not sure if MODE_VERIFY_SELF_UNTRUSTED makes sense to sign anything here?
         }
 
+        // 4. sign the key
         await this._verifyKeys(this.userId, keys, (keyId, device, keyInfo) => {
+            // make sure the device has the expected keys
             const targetKey = keys[keyId];
             if (!targetKey) throw newKeyMismatchError();
 
@@ -93,8 +96,6 @@ export class ReciprocateQRCode extends Base {
                     throw newKeyMismatchError();
                 }
             }
-
-            // Otherwise it is probably fine
         });
     }
 }

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -221,6 +221,7 @@ export class VerificationRequest extends EventEmitter {
      *  if the other party supports SCAN_QR, we should show a QR code in the UI, and vice versa.
      *  For methods that need to be supported by both ends, use the `methods` property.
      *  @param {string} method the method to check
+     *  @param {boolean} force to check even if the phase is not ready or started yet, internal usage
      *  @return {bool} whether or not the other party said the supported the method */
     otherPartySupportsMethod(method, force = false) {
         if (!force && !this.ready && !this.started) {

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -678,6 +678,12 @@ export class VerificationRequest extends EventEmitter {
             }
 
             if (newTransitions.length) {
+                // create QRCodeData if the other side can scan
+                // important this happens before emitting a phase change,
+                // so listeners can rely on it being there already
+                // We only do this for live events because it is important that
+                // we sign the keys that were in the QR code, and not the keys
+                // we happen to have at some later point in time.
                 if (isLiveEvent && newTransitions.some(t => t.phase === PHASE_READY)) {
                     const shouldGenerateQrCode =
                         this.otherPartySupportsMethod(SCAN_QR_CODE_METHOD, true);


### PR DESCRIPTION
This move the generation of the QR code from the react-sdk into the js-sdk. I did this to be able to keep the keys that are being verified attached on the verification request ([as we should not read the again from the store when signing](https://github.com/matrix-org/matrix-doc/pull/1544#discussion_r400787324)), and it also feels like a more natural place to put it.

The qr code data is now exposed on `VerificationRequest.qrCodeData` after moving into the ready phase if the other party can scan qr codes. `qrCodeData.buffer` is what needs to go into the QR code.