### PR TITLE
Add some logging around sync for stuck message debugging

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -833,7 +833,8 @@ SyncApi.prototype._doSyncRequest = function(syncOptions, syncToken) {
         // is fixed
 
         try {
-            if (localStorage && !localStorage.getItem("mx_do_sync_logging")) {
+            if (typeof(localStorage) === 'object'
+                && !localStorage.getItem("mx_do_sync_logging")) {
                 return r;
             }
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -833,8 +833,7 @@ SyncApi.prototype._doSyncRequest = function(syncOptions, syncToken) {
         // is fixed
 
         try {
-            // Give a skip option for larger accounts which might burn CPU by logging
-            if (localStorage && localStorage.getItem("mx_skip_sync_logging")) {
+            if (localStorage && !localStorage.getItem("mx_do_sync_logging")) {
                 return r;
             }
 


### PR DESCRIPTION
For https://github.com/matrix-org/synapse/issues/7206

**Reviewer: if this looks okay, please merge it so the backend team can test with it ASAP.**

Intended to be removed (or possibly converted into a proper off-by-default setting) once the issue concludes.

There's a bunch of null checking through defaults here because this is a very critical part of the whole stack. We default to writing errors to the console, but do not break the app for failing to log info about the sync.

To enable, run `localStorage.setItem("mx_do_sync_logging", "true");` in the JS console