### PR TITLE
Make auth argument in the register request compliant with r0.6.0

### DIFF
--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -97,7 +97,7 @@ describe("InteractiveAuth", function() {
         // first we expect a call to doRequest
         doRequest.mockImplementation(function(authData) {
             logger.log("request1", authData);
-            expect(authData).toEqual({});
+            expect(authData).toEqual(null); // first request should be null
             const err = new MatrixError({
                 session: "sessionId",
                 flows: [
@@ -156,7 +156,7 @@ describe("InteractiveAuth", function() {
 
         doRequest.mockImplementation(function(authData) {
             logger.log("request1", authData);
-            expect(authData).toEqual({});
+            expect(authData).toEqual(null); // first request should be null
             const err = new MatrixError({
                 session: "sessionId",
                 flows: [],

--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -97,7 +97,7 @@ describe("InteractiveAuth", function() {
         // first we expect a call to doRequest
         doRequest.mockImplementation(function(authData) {
             logger.log("request1", authData);
-            expect(authData).toEqual(null);
+            expect(authData).toEqual({});
             const err = new MatrixError({
                 session: "sessionId",
                 flows: [

--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -97,7 +97,7 @@ describe("InteractiveAuth", function() {
         // first we expect a call to doRequest
         doRequest.mockImplementation(function(authData) {
             logger.log("request1", authData);
-            expect(authData).toEqual({});
+            expect(authData).toEqual(null);
             const err = new MatrixError({
                 session: "sessionId",
                 flows: [

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -206,9 +206,6 @@ MatrixBaseApis.prototype.register = function(
         inhibitLogin = undefined;
     }
 
-    if (auth === undefined || auth === null) {
-        auth = {};
-    }
     if (sessionId) {
         auth.session = sessionId;
     }

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -145,7 +145,7 @@ InteractiveAuth.prototype = {
 
             // if we have no flows, try a request (we'll have
             // just a session ID in _data if resuming)
-            if (!this._data.flows) {
+            if (this._data  && !this._data.flows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
                 this._doRequest(this._data).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
@@ -162,12 +162,12 @@ InteractiveAuth.prototype = {
      * be resolved.
      */
     poll: async function() {
-        if (!this._data.session) return;
+        if (this._data && !this._data.session) return;
         // if we currently have a request in flight, there's no point making
         // another just to check what the status is
         if (this._submitPromise) return;
 
-        let authDict = {};
+        let authDict = null;
         if (this._currentStage == EMAIL_STAGE_TYPE) {
             // The email can be validated out-of-band, but we need to provide the
             // creds so the HS can go & check it.
@@ -321,7 +321,7 @@ InteractiveAuth.prototype = {
         } catch (error) {
             // sometimes UI auth errors don't come with flows
             const errorFlows = error.data ? error.data.flows : null;
-            const haveFlows = Boolean(this._data.flows) || Boolean(errorFlows);
+            const haveFlows = Boolean(this._data && this._data.flows) || Boolean(errorFlows);
             if (error.httpStatus !== 401 || !error.data || !haveFlows) {
                 // doesn't look like an interactive-auth failure.
                 if (!background) {
@@ -364,7 +364,7 @@ InteractiveAuth.prototype = {
                         this._inputs.emailAddress,
                         this._clientSecret,
                         1, // TODO: Multiple send attempts?
-                        this._data.session,
+                        this._data ? this._data.session : null,
                     );
                     this._emailSid = requestTokenResult.sid;
                     // NB. promise is not resolved here - at some point, doRequest
@@ -408,7 +408,7 @@ InteractiveAuth.prototype = {
             return;
         }
 
-        if (this._data.errcode || this._data.error) {
+        if (this._data && this._data.errcode || this._data.error) {
             this._stateUpdatedCallback(nextStage, {
                 errcode: this._data.errcode || "",
                 error: this._data.error || "",

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -104,7 +104,7 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  */
 export function InteractiveAuth(opts) {
     this._matrixClient = opts.matrixClient;
-    this._data = opts.authData || {};
+    this._data = opts.authData || null;
     this._requestCallback = opts.doRequest;
     this._busyChangedCallback = opts.busyChanged;
     // startAuthStage included for backwards compat

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -104,7 +104,7 @@ const MSISDN_STAGE_TYPE = "m.login.msisdn";
  */
 export function InteractiveAuth(opts) {
     this._matrixClient = opts.matrixClient;
-    this._data = opts.authData || null;
+    this._data = opts.authData || {};
     this._requestCallback = opts.doRequest;
     this._busyChangedCallback = opts.busyChanged;
     // startAuthStage included for backwards compat
@@ -316,6 +316,7 @@ InteractiveAuth.prototype = {
      */
     _doRequest: async function(auth, background) {
         try {
+            if (auth === {}) auth = null;
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);
         } catch (error) {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -316,7 +316,7 @@ InteractiveAuth.prototype = {
      */
     _doRequest: async function(auth, background) {
         try {
-            if (auth == {}) auth = null;
+            if (Object.keys(auth).length === 0 && auth.constructor === Object) auth = null;
             console.warn(auth);
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -143,11 +143,13 @@ InteractiveAuth.prototype = {
             this._resolveFunc = resolve;
             this._rejectFunc = reject;
 
-            // if we have no flows, try a request (we'll have
-            // just a session ID in _data if resuming)
-            if (this._data && !this._data.flows) {
+            const hasFlows = this._data && this._data.flows;
+
+            // if we have no flows, try a request to acquire the flows
+            if (!hasFlows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
-                this._doRequest(this._data).finally(() => {
+                // Do a fresh request as we're just acquiring flows.
+                this._doRequest(null).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
                 });
             } else {
@@ -264,8 +266,7 @@ InteractiveAuth.prototype = {
             }
         }
 
-        // use the sessionid from the last request.
-        // but keep the null in authData if this is the first stage.
+        // use the sessionid from the last request, if one is present.
         let auth;
         if (this._data.session) {
             auth = {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -162,14 +162,14 @@ InteractiveAuth.prototype = {
      * be resolved.
      */
     poll: async function() {
-        if (this._data && !this._data.session) return;
+        if (!this._data.session) return;
         // likewise don't poll if there is no auth session in progress
         if (!this._resolveFunc) return;
         // if we currently have a request in flight, there's no point making
         // another just to check what the status is
         if (this._submitPromise) return;
 
-        let authDict = null;
+        let authDict = {};
         if (this._currentStage == EMAIL_STAGE_TYPE) {
             // The email can be validated out-of-band, but we need to provide the
             // creds so the HS can go & check it.
@@ -320,7 +320,6 @@ InteractiveAuth.prototype = {
         try {
             if (Object.keys(auth).length === 0 &&
                 auth.constructor === Object) auth = null;
-            console.warn(auth);
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);
             this._resolveFunc = null;
@@ -328,8 +327,7 @@ InteractiveAuth.prototype = {
         } catch (error) {
             // sometimes UI auth errors don't come with flows
             const errorFlows = error.data ? error.data.flows : null;
-            const haveFlows = Boolean(this._data &&
-                this._data.flows) || Boolean(errorFlows);
+            const haveFlows = this._data.flows || Boolean(errorFlows);
             if (error.httpStatus !== 401 || !error.data || !haveFlows) {
                 // doesn't look like an interactive-auth failure.
                 if (!background) {
@@ -372,7 +370,7 @@ InteractiveAuth.prototype = {
                         this._inputs.emailAddress,
                         this._clientSecret,
                         1, // TODO: Multiple send attempts?
-                        this._data ? this._data.session : null,
+                        this._data.session,
                     );
                     this._emailSid = requestTokenResult.sid;
                     // NB. promise is not resolved here - at some point, doRequest

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -318,8 +318,6 @@ InteractiveAuth.prototype = {
      */
     _doRequest: async function(auth, background) {
         try {
-            if (Object.keys(auth).length === 0 &&
-                auth.constructor === Object) auth = null;
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);
             this._resolveFunc = null;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -316,7 +316,8 @@ InteractiveAuth.prototype = {
      */
     _doRequest: async function(auth, background) {
         try {
-            if (auth === {}) auth = null;
+            if (auth == {}) auth = null;
+            console.warn(auth);
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);
         } catch (error) {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -328,7 +328,8 @@ InteractiveAuth.prototype = {
         } catch (error) {
             // sometimes UI auth errors don't come with flows
             const errorFlows = error.data ? error.data.flows : null;
-            const haveFlows = Boolean(this._data && this._data.flows) || Boolean(errorFlows);
+            const haveFlows = Boolean(this._data &&
+                this._data.flows) || Boolean(errorFlows);
             if (error.httpStatus !== 401 || !error.data || !haveFlows) {
                 // doesn't look like an interactive-auth failure.
                 if (!background) {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -145,7 +145,7 @@ InteractiveAuth.prototype = {
 
             // if we have no flows, try a request (we'll have
             // just a session ID in _data if resuming)
-            if (this._data  && !this._data.flows) {
+            if (this._data && !this._data.flows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
                 this._doRequest(this._data).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
@@ -316,7 +316,8 @@ InteractiveAuth.prototype = {
      */
     _doRequest: async function(auth, background) {
         try {
-            if (Object.keys(auth).length === 0 && auth.constructor === Object) auth = null;
+            if (Object.keys(auth).length === 0 &&
+                auth.constructor === Object) auth = null;
             console.warn(auth);
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -265,10 +265,16 @@ InteractiveAuth.prototype = {
         }
 
         // use the sessionid from the last request.
-        const auth = {
-            session: this._data.session,
-        };
-        utils.extend(auth, authData);
+        // but keep the null in authData if this is the first stage.
+        let auth;
+        if (this._data.session) {
+            auth = {
+                session: this._data.session,
+            };
+            utils.extend(auth, authData);
+        } else {
+            auth = authData;
+        }
 
         try {
             // NB. the 'background' flag is deprecated by the busyChanged

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -373,6 +373,7 @@ export function extend() {
     const target = arguments[0] || {};
     for (let i = 1; i < arguments.length; i++) {
         const source = arguments[i];
+        if (!source) continue;
         for (const propName in source) { // eslint-disable-line guard-for-in
             target[propName] = source[propName];
         }


### PR DESCRIPTION
This fix has a companion PR over at react-sdk. https://github.com/matrix-org/matrix-react-sdk/pull/4347

This fix is tested with synapse and works fine on matrix.org!

This fix is required for https://git.koesters.xyz/timo/matrixserver which implements the r0.6.0 spec. In that spec version it says that auth shouldn't be `auth: {}` but rather not be present. This fix should fix this. I tested it both with synapse and the linked server to check that everything still works

Signed-off-by: Marcel Radzio<mtrnord1@gmail.com>