### PR TITLE
Avoid creating two devices on registration

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -163,6 +163,8 @@ InteractiveAuth.prototype = {
      */
     poll: async function() {
         if (!this._data.session) return;
+        // likewise don't poll if there is no auth session in progress
+        if (!this._resolveFunc) return;
         // if we currently have a request in flight, there's no point making
         // another just to check what the status is
         if (this._submitPromise) return;
@@ -318,6 +320,8 @@ InteractiveAuth.prototype = {
         try {
             const result = await this._requestCallback(auth, background);
             this._resolveFunc(result);
+            this._resolveFunc = null;
+            this._rejectFunc = null;
         } catch (error) {
             // sometimes UI auth errors don't come with flows
             const errorFlows = error.data ? error.data.flows : null;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -383,7 +383,7 @@ InteractiveAuth.prototype = {
                     // (or not being registered, depending on what we're trying
                     // to do) or it could be a network failure. Either way, pass
                     // the failure up as the user can't complete auth if we can't
-                    // send the email, foe whatever reason.
+                    // send the email, for whatever reason.
                     this._rejectFunc(e);
                     this._resolveFunc = null;
                     this._rejectFunc = null;

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -385,6 +385,8 @@ InteractiveAuth.prototype = {
                     // the failure up as the user can't complete auth if we can't
                     // send the email, foe whatever reason.
                     this._rejectFunc(e);
+                    this._resolveFunc = null;
+                    this._rejectFunc = null;
                 } finally {
                     this._requestingEmailToken = false;
                 }


### PR DESCRIPTION
Ignore poll requests after a UIA session has finished. Sometimes
the app calls poll() even after the registration has succeeded
which causes the API call to happen again which, in the case of
registration, creates a phantom device.

Fixes https://github.com/vector-im/riot-web/issues/13040