### PR TITLE
Lower max-warnings to 81

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:minify-browser": "terser dist/browser-matrix.js --compress --mangle --source-map --output dist/browser-matrix.min.js",
     "gendoc": "jsdoc -c jsdoc.json -P package.json",
     "lint": "yarn lint:types && yarn lint:ts && yarn lint:js",
-    "lint:js": "eslint --max-warnings 93 src spec",
+    "lint:js": "eslint --max-warnings 81 src spec",
     "lint:types": "tsc --noEmit",
     "lint:ts": "tslint --project ./tsconfig.json -t stylish",
     "test": "jest spec/ --coverage --testEnvironment node",


### PR DESCRIPTION
We apparently fixed 11 warnings at some point. Let's keep it that way.