### PR TITLE
Store key backup key in cache as Uint8Array

### DIFF
--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -644,6 +644,11 @@ export function createCryptoStoreCacheCallbacks(store) {
             });
         },
         storeCrossSigningKeyCache: function(type, key) {
+            if (!(key instanceof Uint8Array)) {
+                throw new Error(
+                    `storeCrossSigningKeyCache expects Uint8Array, got ${key}`,
+                );
+            }
             return store.doTxn(
                 'readwrite',
                 [IndexedDBCryptoStore.STORE_ACCOUNT],

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -711,7 +711,8 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         const sessionBackupKey = await this.getSecret('m.megolm_backup.v1');
         if (sessionBackupKey) {
             logger.info("Got session backup key from secret storage: caching");
-            await this.storeSessionBackupPrivateKey(sessionBackupKey);
+            const decoded = olmlib.decodeBase64(sessionBackupKey);
+            await this.storeSessionBackupPrivateKey(decoded);
         }
     } finally {
         // Restore the original callbacks. NB. we must do this by manipulating

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -822,6 +822,9 @@ Crypto.prototype.getSessionBackupPrivateKey = async function() {
  * @returns {Promise} so you can catch failures
  */
 Crypto.prototype.storeSessionBackupPrivateKey = async function(key) {
+    if (!(key instanceof Uint8Array)) {
+        throw new Error(`storeSessionBackupPrivateKey expects Uint8Array, got ${key}`);
+    }
     return this._cryptoStore.doTxn(
         'readwrite',
         [IndexedDBCryptoStore.STORE_ACCOUNT],

--- a/src/crypto/recoverykey.js
+++ b/src/crypto/recoverykey.js
@@ -59,8 +59,8 @@ export function decodeRecoveryKey(recoverykey) {
         throw new Error("Incorrect length");
     }
 
-    return result.slice(
+    return Uint8Array.from(result.slice(
         OLM_RECOVERY_KEY_PREFIX.length,
         OLM_RECOVERY_KEY_PREFIX.length + global.Olm.PRIVATE_KEY_LENGTH,
-    );
+    ));
 }

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -221,8 +221,7 @@ export class VerificationBase extends EventEmitter {
                             `m.cross_signing.${type}`, [this.deviceId],
                         );
                         const result = await promise;
-                        const decoded = decodeBase64(result);
-                        return Uint8Array.from(decoded);
+                        return decodeBase64(result);
                     } },
                     original._cacheCallbacks,
                 );
@@ -252,9 +251,7 @@ export class VerificationBase extends EventEmitter {
                         logger.info("Got key backup key, decoding...");
                         const decodedKey = decodeBase64(base64Key);
                         logger.info("Decoded backup key, storing...");
-                        client._crypto.storeSessionBackupPrivateKey(
-                            Uint8Array.from(decodedKey),
-                        );
+                        client._crypto.storeSessionBackupPrivateKey(decodedKey);
                         logger.info("Backup key stored. Starting backup restore...");
                         const backupInfo = await client.getKeyBackupVersion();
                         // no need to await for this - just let it go in the bg

--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -221,7 +221,8 @@ export class VerificationBase extends EventEmitter {
                             `m.cross_signing.${type}`, [this.deviceId],
                         );
                         const result = await promise;
-                        return decodeBase64(result);
+                        const decoded = decodeBase64(result);
+                        return Uint8Array.from(decoded);
                     } },
                     original._cacheCallbacks,
                 );
@@ -251,7 +252,9 @@ export class VerificationBase extends EventEmitter {
                         logger.info("Got key backup key, decoding...");
                         const decodedKey = decodeBase64(base64Key);
                         logger.info("Decoded backup key, storing...");
-                        client._crypto.storeSessionBackupPrivateKey(decodedKey);
+                        client._crypto.storeSessionBackupPrivateKey(
+                            Uint8Array.from(decodedKey),
+                        );
                         logger.info("Backup key stored. Starting backup restore...");
                         const backupInfo = await client.getKeyBackupVersion();
                         // no need to await for this - just let it go in the bg


### PR DESCRIPTION
Bootstrap was incorrectly storing the key backup key as base64 encoded, when
instead it should be a Uint8Array.

Fixes https://github.com/vector-im/riot-web/issues/13057
