### PR TITLE
Fix: more informative error message when we cant find a key to decrypt with

### DIFF
--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -363,6 +363,11 @@ export class SecretStorage extends EventEmitter {
             }
         }
 
+        if (Object.keys(keys) === 0) {
+            throw new Error(`Could not decrypt ${name} because none of ` +
+                `the keys it is encrypted with are for a supported algorithm`);
+        }
+
         let keyId;
         let decryption;
         try {

--- a/src/crypto/SecretStorage.js
+++ b/src/crypto/SecretStorage.js
@@ -363,7 +363,7 @@ export class SecretStorage extends EventEmitter {
             }
         }
 
-        if (Object.keys(keys) === 0) {
+        if (Object.keys(keys).length === 0) {
             throw new Error(`Could not decrypt ${name} because none of ` +
                 `the keys it is encrypted with are for a supported algorithm`);
         }


### PR DESCRIPTION
Should give a more informative error message when something like https://github.com/vector-im/riot-web/issues/13105 happens.