### PR TITLE
Serialise Olm prekey decryptions

### DIFF
--- a/src/crypto/OlmDevice.js
+++ b/src/crypto/OlmDevice.js
@@ -105,6 +105,9 @@ export function OlmDevice(cryptoStore) {
     // Keep track of sessions that we're starting, so that we don't start
     // multiple sessions for the same device at the same time.
     this._sessionsInProgress = {};
+
+    // Used by olm to serialise prekey message decryptions
+    this._olmPrekeyPromise = Promise.resolve();
 }
 
 /**

--- a/src/crypto/algorithms/olm.js
+++ b/src/crypto/algorithms/olm.js
@@ -272,10 +272,12 @@ OlmDecryption.prototype._decryptMessage = async function(
         // not a prekey message: we can safely just try & decrypt it
         return this._reallyDecryptMessage(theirDeviceIdentityKey, message);
     } else {
-        this._olmDevice._olmPrekeyPromise = this._olmDevice._olmPrekeyPromise.then(() => {
+        const myPromise = this._olmDevice._olmPrekeyPromise.then(() => {
             return this._reallyDecryptMessage(theirDeviceIdentityKey, message);
         });
-        return await this._olmDevice._olmPrekeyPromise;
+        // we want the error, but don't propagate it to the next decryption
+        this._olmDevice._olmPrekeyPromise = myPromise.catch(() => {});
+        return await myPromise;
     }
 };
 

--- a/src/crypto/algorithms/olm.js
+++ b/src/crypto/algorithms/olm.js
@@ -265,6 +265,23 @@ OlmDecryption.prototype.decryptEvent = async function(event) {
 OlmDecryption.prototype._decryptMessage = async function(
     theirDeviceIdentityKey, message,
 ) {
+    // This is a wrapper that serialises decryptions of prekey messages, because
+    // otherwise we race between deciding we have no active sessions for the message
+    // and creating a new one, which we can only do once because it removes the OTK.
+    if (message.type !== 0) {
+        // not a prekey message: we can safely just try & decrypt it
+        return this._reallyDecryptMessage(theirDeviceIdentityKey, message);
+    } else {
+        this._olmDevice._olmPrekeyPromise = this._olmDevice._olmPrekeyPromise.then(() => {
+            return this._reallyDecryptMessage(theirDeviceIdentityKey, message);
+        });
+        return await this._olmDevice._olmPrekeyPromise;
+    }
+};
+
+OlmDecryption.prototype._reallyDecryptMessage = async function(
+    theirDeviceIdentityKey, message,
+) {
     const sessionIds = await this._olmDevice.getSessionIdsForDevice(
         theirDeviceIdentityKey,
     );


### PR DESCRIPTION
If they overlap, they can both try to create new sessions, but this
removes the OTK so it will only work once.

Fixes https://github.com/vector-im/riot-web/issues/13229