### PR TITLE
Reject attemptAuth promise if no auth flow found

### DIFF
--- a/spec/unit/interactive-auth.spec.js
+++ b/spec/unit/interactive-auth.spec.js
@@ -143,4 +143,33 @@ describe("InteractiveAuth", function() {
             expect(stateUpdated).toBeCalledTimes(1);
         });
     });
+
+    it("should start an auth stage and reject if no auth flow", function() {
+        const doRequest = jest.fn();
+        const stateUpdated = jest.fn();
+
+        const ia = new InteractiveAuth({
+            matrixClient: new FakeClient(),
+            doRequest: doRequest,
+            stateUpdated: stateUpdated,
+        });
+
+        doRequest.mockImplementation(function(authData) {
+            logger.log("request1", authData);
+            expect(authData).toEqual({});
+            const err = new MatrixError({
+                session: "sessionId",
+                flows: [],
+                params: {
+                    "logintype": { param: "aa" },
+                },
+            });
+            err.httpStatus = 401;
+            throw err;
+        });
+
+        return ia.attemptAuth().catch(function(error) {
+            expect(error.message).toBe('No appropriate authentication flow found');
+        });
+    });
 });

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -351,7 +351,13 @@ InteractiveAuth.prototype = {
                 error.data.session = this._data.session;
             }
             this._data = error.data;
-            this._startNextAuthStage();
+            try {
+                this._startNextAuthStage();
+            } catch (e) {
+                this._rejectFunc(e);
+                this._resolveFunc = null;
+                this._rejectFunc = null;
+            }
 
             if (
                 !this._emailSid &&


### PR DESCRIPTION
When there was no auth flow found, the attemptAuth promise didn't get rejected, which leads to the client not knowing that there was an error. This lead to issues like https://github.com/vector-im/riot-web/issues/13269, which should be fixed by this.

Due to my inexperience, I can't guarantee this won't break any flows in other clients though :/

Signed-off-by: Michael Kohler <me@michaelkohler.info>

Fixes https://github.com/vector-im/riot-web/issues/13269