### PR TITLE
Fix: don't do extra /filter request when enabling lazy loading of members

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -56,13 +56,6 @@ Filter.LAZY_LOADING_MESSAGES_FILTER = {
     lazy_load_members: true,
 };
 
-Filter.LAZY_LOADING_SYNC_FILTER = {
-    room: {
-        state: Filter.LAZY_LOADING_MESSAGES_FILTER,
-    },
-};
-
-
 /**
  * Get the ID of this filter on your homeserver (if known)
  * @return {?Number} The filter ID
@@ -96,6 +89,7 @@ Filter.prototype.setDefinition = function(definition) {
     //     "state": {
     //       "types": ["m.room.*"],
     //       "not_rooms": ["!726s6s6q:example.com"],
+    //       "lazy_load_members": true,
     //     },
     //     "timeline": {
     //       "limit": 10,
@@ -175,6 +169,10 @@ Filter.prototype.filterRoomTimeline = function(events) {
  */
 Filter.prototype.setTimelineLimit = function(limit) {
     setProp(this.definition, "room.timeline.limit", limit);
+};
+
+Filter.prototype.setLazyLoadMembers = function(enabled) {
+    setProp(this.definition, "room.state.lazy_load_members", !!enabled);
 };
 
 /**

--- a/src/sync.js
+++ b/src/sync.js
@@ -511,6 +511,12 @@ SyncApi.prototype.sync = function() {
         checkLazyLoadStatus(); // advance to the next stage
     }
 
+    function createDefaultFilter() {
+        const filter = new Filter(client.credentials.userId);
+        filter.setTimelineLimit(self.opts.initialSyncLimit);
+        return filter;
+    }
+
     const checkLazyLoadStatus = async () => {
         debuglog("Checking lazy load status...");
         if (this.opts.lazyLoadMembers && client.isGuest()) {
@@ -520,19 +526,11 @@ SyncApi.prototype.sync = function() {
             debuglog("Checking server lazy load support...");
             const supported = await client.doesServerSupportLazyLoading();
             if (supported) {
-                try {
-                    debuglog("Creating and storing lazy load sync filter...");
-                    this.opts.filter = await client.createFilter(
-                        Filter.LAZY_LOADING_SYNC_FILTER,
-                    );
-                    debuglog("Created and stored lazy load sync filter");
-                } catch (err) {
-                    logger.error(
-                        "Creating and storing lazy load sync filter failed",
-                        err,
-                    );
-                    throw err;
+                debuglog("Enabling lazy load on sync filter...");
+                if (!this.opts.filter) {
+                    this.opts.filter = createDefaultFilter();
                 }
+                this.opts.filter.setLazyLoadMembers(true);
             } else {
                 debuglog("LL: lazy loading requested but not supported " +
                     "by server, so disabling");
@@ -575,8 +573,7 @@ SyncApi.prototype.sync = function() {
         if (self.opts.filter) {
             filter = self.opts.filter;
         } else {
-            filter = new Filter(client.credentials.userId);
-            filter.setTimelineLimit(self.opts.initialSyncLimit);
+            filter = createDefaultFilter();
         }
 
         let filterId;

--- a/src/sync.js
+++ b/src/sync.js
@@ -511,7 +511,7 @@ SyncApi.prototype.sync = function() {
         checkLazyLoadStatus(); // advance to the next stage
     }
 
-    function createDefaultFilter() {
+    function buildDefaultFilter() {
         const filter = new Filter(client.credentials.userId);
         filter.setTimelineLimit(self.opts.initialSyncLimit);
         return filter;
@@ -528,7 +528,7 @@ SyncApi.prototype.sync = function() {
             if (supported) {
                 debuglog("Enabling lazy load on sync filter...");
                 if (!this.opts.filter) {
-                    this.opts.filter = createDefaultFilter();
+                    this.opts.filter = buildDefaultFilter();
                 }
                 this.opts.filter.setLazyLoadMembers(true);
             } else {
@@ -573,7 +573,7 @@ SyncApi.prototype.sync = function() {
         if (self.opts.filter) {
             filter = self.opts.filter;
         } else {
-            filter = createDefaultFilter();
+            filter = buildDefaultFilter();
         }
 
         let filterId;


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13280

This had the side-effect that `room.timeline.limit` on the filter wasn't being set when using lazy loading. So since the introduction of lazy loading, we've been working with the default which is 10 IIRC. This will restore it to 20 as set in `MatrixClientPeg`.