### PR TITLE
Prevent attempts to send olm messages to ourselves

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -3492,6 +3492,19 @@ Crypto.prototype._processReceivedRoomKeyRequest = async function(req) {
         return;
     }
 
+    if (deviceId !== this._deviceId) {
+        // We'll always get these because we send room key requests to
+        // '*' (ie. 'all devices') which includes the sending device,
+        // so ignore requests from ourself because apart from it being
+        // very silly, it won't work because an Olm session cannot send
+        // messages to itself.
+        // The log here is probably superfluous since we know this will
+        // always happen, but let's log anyway for now just in case it
+        // causes issues.
+        logger.log("Ignoring room key request from ourselves");
+        return;
+    }
+
     // todo: should we queue up requests we don't yet have keys for,
     // in case they turn up later?
 

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -215,7 +215,7 @@ export async function ensureOlmSessionsForDevices(
                 // they get a message and see that the 'other side' has started a
                 // new chain when this side has an active sender chain.
                 // If you see this message being logged in the wild, we should find
-                // the thing that it trying to send Olm messages to itself and fix it.
+                // the thing that is trying to send Olm messages to itself and fix it.
                 logger.info("Attempted to start session with ourself! Ignoring");
                 // We must fill in the section in the return value though, as callers
                 // expect it to be there.

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -207,6 +207,25 @@ export async function ensureOlmSessionsForDevices(
         for (const deviceInfo of devices) {
             const deviceId = deviceInfo.deviceId;
             const key = deviceInfo.getIdentityKey();
+
+            if (key === olmDevice.deviceCurve25519Key) {
+                // We should never be trying to start a session with ourself.
+                // Apart from talking to yourself being the first sign of madness,
+                // olm sessions can't do this because they get confused when
+                // they get a message and see that the 'other side' has started a
+                // new chain when this side has an active sender chain.
+                // If you see this message being logged in the wild, we should find
+                // the thing that it trying to send Olm messages to itself and fix it.
+                logger.info("Attempted to start session with ourself! Ignoring");
+                // We must fill in the section in the return value though, as callers
+                // expect it to be there.
+                result[userId][deviceId] = {
+                    device: deviceInfo,
+                    sessionId: null,
+                };
+                continue;
+            }
+
             if (!olmDevice._sessionsInProgress[key]) {
                 // pre-emptively mark the session as in-progress to avoid race
                 // conditions.  If we find that we already have a session, then
@@ -282,6 +301,14 @@ export async function ensureOlmSessionsForDevices(
             const deviceInfo = devices[j];
             const deviceId = deviceInfo.deviceId;
             const key = deviceInfo.getIdentityKey();
+
+            if (key === olmDevice.deviceCurve25519Key) {
+                // We've already logged about this above. Skip here too
+                // otherwise we'll log saying there are no one-time keys
+                // which will be confusing.
+                continue;
+            }
+
             if (result[userId][deviceId].sessionId && !force) {
                 // we already have a result for this device
                 continue;


### PR DESCRIPTION
The cause of this I've seen is us sending keyshare reqiests when
we didn't have keys but them arriving when we do, and us replying to
ourseles with keys, so exclude that explicity.

Also catch this lower down to catch any other code paths that
mistaklenly try this. Hopefully the comment explains enough as to why
it won't work.