### PR TITLE
Fix sender of local echo events in unsigned redactions

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2459,6 +2459,7 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
     const localEvent = new MatrixEvent(Object.assign(eventObject, {
         event_id: "~" + roomId + ":" + txnId,
         user_id: this.credentials.userId,
+        sender: this.credentials.userId,
         room_id: roomId,
         origin_server_ts: new Date().getTime(),
     }));


### PR DESCRIPTION
local echo events were only given the sender in v1 form, which is fine when using the `getSender` event abstraction but when we're looking at the `unsigned.redacted_because` lets ensure both v2 and v1 forms are there for consistency.

Part of https://github.com/matrix-org/matrix-react-sdk/pull/4484