### PR TITLE
Remove redundant key backup setup path

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -601,14 +601,6 @@ Crypto.prototype.bootstrapSecretStorage = async function({
             if (oldKeyInfo && oldKeyInfo.algorithm === SECRET_STORAGE_ALGORITHM_V1_AES) {
                 await ensureCanCheckPassphrase(oldKeyId, oldKeyInfo);
             }
-
-            if (setupNewKeyBackup) {
-                const info = await this._baseApis.prepareKeyBackupVersion(
-                    null /* random key */,
-                    { secureSecretStorage: true },
-                );
-                await this._baseApis.createKeyBackupVersion(info);
-            }
         } else if (!inStorage && keyBackupInfo) {
             // we have an existing backup, but no SSSS
 
@@ -758,6 +750,14 @@ Crypto.prototype.bootstrapSecretStorage = async function({
                     this._secretStorage,
                 );
             }
+        }
+
+        if (setupNewKeyBackup && !keyBackupInfo) {
+            const info = await this._baseApis.prepareKeyBackupVersion(
+                null /* random key */,
+                { secureSecretStorage: true },
+            );
+            await this._baseApis.createKeyBackupVersion(info);
         }
 
         // Call `getCrossSigningKey` for side effect of caching private keys for

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -760,14 +760,6 @@ Crypto.prototype.bootstrapSecretStorage = async function({
             }
         }
 
-        if (setupNewKeyBackup && !keyBackupInfo) {
-            const info = await this._baseApis.prepareKeyBackupVersion(
-                null /* random key */,
-                { secureSecretStorage: true },
-            );
-            await this._baseApis.createKeyBackupVersion(info);
-        }
-
         // Call `getCrossSigningKey` for side effect of caching private keys for
         // future gossiping to other devices if enabled via app level callbacks.
         if (this._crossSigningInfo._cacheCallbacks) {


### PR DESCRIPTION
Bootstrap was creating key backup versions twice due to some code duplication we missed in
previous refactorings.

Fixes https://github.com/vector-im/riot-web/issues/13423