### PR TITLE
Handle race between sending and await next event from other party

### DIFF
--- a/src/crypto/verification/Base.js
+++ b/src/crypto/verification/Base.js
@@ -122,6 +122,11 @@ export class VerificationBase extends EventEmitter {
         if (this._done) {
             return Promise.reject(new Error("Verification is already done"));
         }
+        const existingEvent = this.request.getEventFromOtherParty(type);
+        if (existingEvent) {
+            return Promise.resolve(existingEvent);
+        }
+
         this._expectedEvent = type;
         return new Promise((resolve, reject) => {
             this._resolveEvent = resolve;

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -877,4 +877,8 @@ export class VerificationRequest extends EventEmitter {
             this._setPhase(newTransitions[newTransitions.length - 1].phase);
         }
     }
+
+    getEventFromOtherParty(type) {
+        return this._eventsByThem.get(type);
+    }
 }


### PR DESCRIPTION
This came up during the last cross-signing smoke test, where the verification just stalls with a spinner because the .key event of the other party was ignored while still sending the .accept event.

Fix this by looking in the received events Map in the verification request first.