### PR TITLE
Emit event when a trusted self-key is stored

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2027,6 +2027,8 @@ Crypto.prototype.setDeviceVerification = async function(
 
         if (!this._crossSigningInfo.getId() && userId === this._crossSigningInfo.userId) {
             this._storeTrustedSelfKeys(xsk.keys);
+            // This will cause our own user trust to change, so emit the event
+            this.emit("userTrustStatusChanged", this._userId, this.checkUserTrust(userId));
         }
 
         // Now sign the master key with our user signing key (unless it's ourself)

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2028,7 +2028,9 @@ Crypto.prototype.setDeviceVerification = async function(
         if (!this._crossSigningInfo.getId() && userId === this._crossSigningInfo.userId) {
             this._storeTrustedSelfKeys(xsk.keys);
             // This will cause our own user trust to change, so emit the event
-            this.emit("userTrustStatusChanged", this._userId, this.checkUserTrust(userId));
+            this.emit(
+                "userTrustStatusChanged", this._userId, this.checkUserTrust(userId),
+            );
         }
 
         // Now sign the master key with our user signing key (unless it's ourself)


### PR DESCRIPTION
This will cause our own user trust status to change, so emit an
event to say so.