### PR TITLE
Fix replying to key share requests

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -3430,7 +3430,7 @@ Crypto.prototype._processReceivedRoomKeyRequest = async function(req) {
         return;
     }
 
-    if (deviceId !== this._deviceId) {
+    if (deviceId === this._deviceId) {
         // We'll always get these because we send room key requests to
         // '*' (ie. 'all devices') which includes the sending device,
         // so ignore requests from ourself because apart from it being


### PR DESCRIPTION
This check was meant to filter out key sharing requests from ourselves. Accidentally, it filtered out sharing requests from anyone *but* ourselves.

Signed-off-by: Sorunome <mail@sorunome.de>