### PR TITLE
Fix verification request timeouts to match spec

### DIFF
--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -26,10 +26,10 @@ import {
 import {QRCodeData, SCAN_QR_CODE_METHOD} from "../QRCode";
 
 // How long after the event's timestamp that the request times out
-const TIMEOUT_FROM_EVENT_TS = 10 * 1000 * 60; // 10 minutes
+const TIMEOUT_FROM_EVENT_TS = 10 * 60 * 1000; // 10 minutes
 
 // How long after we receive the event that the request times out
-const TIMEOUT_FROM_EVENT_RECEIPT = 2 * 1000 * 60; // 2 minutes
+const TIMEOUT_FROM_EVENT_RECEIPT = 2 * 60 * 1000; // 2 minutes
 
 // to avoid almost expired verification notifications
 // from showing a notification and almost immediately

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -26,16 +26,16 @@ import {
 import {QRCodeData, SCAN_QR_CODE_METHOD} from "../QRCode";
 
 // How long after the event's timestamp that the request times out
-const TIMEOUT_FROM_EVENT_TS = 10 * 1000;//60 * 1000; //10m
+const TIMEOUT_FROM_EVENT_TS = 10 * 1000 * 60; // 10 minutes
 
 // How long after we receive the event that the request times out
-const TIMEOUT_FROM_EVENT_RECEIPT = 2 * 1000;//60 * 1000; //2m
+const TIMEOUT_FROM_EVENT_RECEIPT = 2 * 1000 * 60; // 2 minutes
 
 // to avoid almost expired verification notifications
 // from showing a notification and almost immediately
 // disappearing, also ignore verification requests that
 // are this amount of time away from expiring.
-const VERIFICATION_REQUEST_MARGIN = 3 * 1000; //3s
+const VERIFICATION_REQUEST_MARGIN = 3 * 1000; // 3 seconds
 
 
 export const EVENT_PREFIX = "m.key.verification.";
@@ -174,10 +174,16 @@ export class VerificationRequest extends EventEmitter {
     get timeout() {
         const requestEvent = this._getEventByEither(REQUEST_TYPE);
         if (requestEvent) {
-            const expiresAtByReceipt = this._requestReceivedAt + TIMEOUT_FROM_EVENT_RECEIPT;
-            const expiresAtByTs = this.channel.getTimestamp(requestEvent) + TIMEOUT_FROM_EVENT_TS;
+            let effectiveExpiresAt = this.channel.getTimestamp(requestEvent)
+                + TIMEOUT_FROM_EVENT_TS;
 
-            const effectiveExpiresAt = Math.min(expiresAtByReceipt, expiresAtByTs);
+            if (this._requestReceivedAt && !this.initiatedByMe &&
+                this.phase <= PHASE_REQUESTED
+            ) {
+                const expiresAtByReceipt = this._requestReceivedAt
+                    + TIMEOUT_FROM_EVENT_RECEIPT;
+                effectiveExpiresAt = Math.min(effectiveExpiresAt, expiresAtByReceipt);
+            }
 
             return Math.max(0, effectiveExpiresAt - Date.now());
         }
@@ -744,7 +750,7 @@ export class VerificationRequest extends EventEmitter {
 
     _setupTimeout(phase) {
         const shouldTimeout = !this._timeoutTimer && !this.observeOnly &&
-            phase === PHASE_REQUESTED && this.initiatedByMe;
+            phase === PHASE_REQUESTED;
 
         if (shouldTimeout) {
             this._timeoutTimer = setTimeout(this._cancelOnTimeout, this.timeout);
@@ -763,7 +769,17 @@ export class VerificationRequest extends EventEmitter {
 
     _cancelOnTimeout = () => {
         try {
-            this.cancel({reason: "Other party didn't accept in time", code: "m.timeout"});
+            if (this.initiatedByMe) {
+                this.cancel({
+                    reason: "Other party didn't accept in time",
+                    code: "m.timeout",
+                });
+            } else {
+                this.cancel({
+                    reason: "User didn't accept in time",
+                    code: "m.timeout",
+                });
+            }
         } catch (err) {
             logger.error("Error while cancelling verification request", err);
         }
@@ -800,7 +816,7 @@ export class VerificationRequest extends EventEmitter {
         if (!isLiveEvent) {
             this._observeOnly = true;
         }
-        if (this.timeout < TIMEOUT_FROM_EVENT_TS - VERIFICATION_REQUEST_MARGIN) {
+        if (this.timeout < VERIFICATION_REQUEST_MARGIN) {
             this._observeOnly = true;
         }
     }

--- a/src/crypto/verification/request/VerificationRequest.js
+++ b/src/crypto/verification/request/VerificationRequest.js
@@ -677,7 +677,7 @@ export class VerificationRequest extends EventEmitter {
 
         this._adjustObserveOnly(event, isLiveEvent);
 
-        if (!wasObserveOnly && !isRemoteEcho) {
+        if (!this.observeOnly && !isRemoteEcho) {
             if (await this._cancelOnError(type, event)) {
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12430

Implements https://matrix.org/docs/spec/client_server/latest#key-verification-framework
> The prompt for Bob to accept/reject Alice's request (or the unsupported method prompt) should be automatically dismissed 10 minutes after the timestamp field or 2 minutes after Bob's client receives the message, whichever comes first, if Bob does not interact with the prompt. The prompt should additionally be hidden if an appropriate m.key.verification.cancel
