### PR TITLE
Use existing session id for fetching flows as to not get a new session

### DIFF
--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -148,8 +148,14 @@ InteractiveAuth.prototype = {
             // if we have no flows, try a request to acquire the flows
             if (!hasFlows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
-                // Do a fresh request as we're just acquiring flows.
-                this._doRequest(null).finally(() => {
+                // use the existing sessionid, if one is present.
+                let auth = null;
+                if (this._data.session) {
+                    auth = {
+                        session: this._data.session,
+                    };
+                }
+                this._doRequest(auth).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
                 });
             } else {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -148,14 +148,7 @@ InteractiveAuth.prototype = {
             // if we have no flows, try a request to acquire the flows
             if (!hasFlows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
-                // use the existing sessionid, if one is present.
-                let auth = null;
-                if (this._data.session) {
-                    auth = {
-                        session: this._data.session,
-                    };
-                }
-                this._doRequest(auth).finally(() => {
+                this._doRequest(this._data || null).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
                 });
             } else {

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -148,7 +148,14 @@ InteractiveAuth.prototype = {
             // if we have no flows, try a request to acquire the flows
             if (!hasFlows) {
                 if (this._busyChangedCallback) this._busyChangedCallback(true);
-                this._doRequest(this._data || null).finally(() => {
+                // use the existing sessionid, if one is present.
+                let auth = null;
+                if (this._data.session) {
+                    auth = {
+                        session: this._data.session,
+                    };
+                }
+                this._doRequest(auth).finally(() => {
                     if (this._busyChangedCallback) this._busyChangedCallback(false);
                 });
             } else {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/13990

Regression caused by https://github.com/matrix-org/matrix-js-sdk/commit/bebeec7d84295a994036502974e76f3327ef842f