### PR TITLE
Raise the last known account data / state event for an update

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5602,8 +5602,9 @@ MatrixClient.prototype.generateClientSecret = function() {
  * Fires whenever new user-scoped account_data is added.
  * @event module:client~MatrixClient#"accountData"
  * @param {MatrixEvent} event The event describing the account_data just added
+ * @param {MatrixEvent} event The previous account data, if known.
  * @example
- * matrixClient.on("accountData", function(event){
+ * matrixClient.on("accountData", function(event, oldEvent){
  *   myAccountData[event.type] = event.content;
  * });
  */

--- a/src/crypto/EncryptionSetup.js
+++ b/src/crypto/EncryptionSetup.js
@@ -259,13 +259,14 @@ class AccountDataClientAdapter extends EventEmitter {
      * @return {Promise}
      */
     setAccountData(type, content) {
+        const lastEvent = this._values.get(type);
         this._values.set(type, content);
         // ensure accountData is emitted on the next tick,
         // as SecretStorage listens for it while calling this method
         // and it seems to rely on this.
         return Promise.resolve().then(() => {
             const event = new MatrixEvent({type, content});
-            this.emit("accountData", event);
+            this.emit("accountData", event, lastEvent);
         });
     }
 }

--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -395,7 +395,7 @@ RoomState.prototype._setStateEvent = function(event) {
 RoomState.prototype._getStateEventMatching = function(event) {
     if (!this.events[event.getType()]) return null;
     return this.events[event.getType()][event.getStateKey()];
-}
+};
 
 RoomState.prototype._updateMember = function(member) {
     // this member may have a power level already, so set it.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1793,8 +1793,9 @@ Room.prototype.addAccountData = function(events) {
         if (event.getType() === "m.tag") {
             this.addTags(event);
         }
+        const lastEvent = this.accountData[event.getType()];
         this.accountData[event.getType()] = event;
-        this.emit("Room.accountData", event, this);
+        this.emit("Room.accountData", event, this, lastEvent);
     }
 };
 
@@ -1991,8 +1992,10 @@ function memberNamesToRoomName(names, count = (names.length + 1)) {
  * @event module:client~MatrixClient#"Room.accountData"
  * @param {event} event The account_data event
  * @param {Room} room The room whose account_data was updated.
+ * @param {MatrixEvent} prevEvent The event being replaced by
+ * the new account data, if known.
  * @example
- * matrixClient.on("Room.accountData", function(event, room){
+ * matrixClient.on("Room.accountData", function(event, room, oldEvent){
  *   if (event.getType() === "m.room.colorscheme") {
  *       applyColorScheme(event.getContents());
  *   }


### PR DESCRIPTION
This is to better support the react-sdk in trying to identify what actually changed in settings instead of re-firing everything. 

Overall this change differs from `prev_content` semantics as it's the last known *stored* event, not whatever the server thinks may or may not have changed.

For https://github.com/matrix-org/matrix-react-sdk/pull/4803