### PR TITLE
Ask general crypto callbacks for 4S privkey if operation adapter doesn't have it yet

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -483,7 +483,11 @@ Crypto.prototype.bootstrapSecretStorage = async function({
     getKeyBackupPassphrase,
 } = {}) {
     logger.log("Bootstrapping Secure Secret Storage");
-    const builder = new EncryptionSetupBuilder(this._baseApis.store.accountData);
+    const delegateCryptoCallbacks = this._baseApis._cryptoCallbacks;
+    const builder = new EncryptionSetupBuilder(
+        this._baseApis.store.accountData,
+        delegateCryptoCallbacks,
+    );
     const secretStorage = new SecretStorage(
         builder.accountDataClientAdapter,
         builder.ssssCryptoCallbacks);


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/14113

If 4S already exists during bootstrapping, the adapter crypto callbacks won't have the privkey yet, and 4S operations start failing. To fix, delegate to the general crypto callbacks.