### PR TITLE
Properly support txnId

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2523,7 +2523,7 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
     const type = localEvent.getType();
     logger.log(`sendEvent of type ${type} in ${roomId} with txnId ${txnId}`);
 
-    localEvent._txnId = txnId;
+    localEvent.setTxnId(txnId);
     localEvent.setStatus(EventStatus.SENDING);
 
     // add this event immediately to the local store as 'sending'.
@@ -2691,7 +2691,11 @@ function _updatePendingEventStatus(room, event, newStatus) {
 }
 
 function _sendEventHttpRequest(client, event) {
-    const txnId = event._txnId ? event._txnId : client.makeTxnId();
+    let txnId = event.getTxnId();
+    if (!txnId) {
+        txnId = client.makeTxnId();
+        event.setTxnId(txnId);
+    }
 
     const pathParams = {
         $roomId: event.getRoomId(),

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -164,12 +164,16 @@ export const MatrixEvent = function(
      * so it can be easily accessed from the timeline.
      */
     this.verificationRequest = null;
+
+    /* The txnId with which this event was sent if it was during this session,
+       allows for a unique ID which does not change when the event comes back down sync.
+     */
+    this._txnId = null;
 };
 utils.inherits(MatrixEvent, EventEmitter);
 
 
 utils.extend(MatrixEvent.prototype, {
-
     /**
      * Get the event_id for this event.
      * @return {string} The event ID, e.g. <code>$143350589368169JsLZx:localhost
@@ -1084,6 +1088,14 @@ utils.extend(MatrixEvent.prototype, {
 
     setVerificationRequest: function(request) {
         this.verificationRequest = request;
+    },
+
+    setTxnId(txnId) {
+        this._txnId = txnId;
+    },
+
+    getTxnId() {
+        return this._txnId;
     },
 });
 


### PR DESCRIPTION
This allows the app to access an identifier on the event which does not change as the event gets sent, helps with Element accessibility (and less remounting)