### PR TITLE
Update on Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,8 @@ you can pass the result of the promise into it with something like:
   matrixClient.someMethod(arg1, arg2).nodeify(callback);
 ```
 
-The main thing to note is that it is an error to discard the result of a
-promise-returning function, as that will cause exceptions to go unobserved. If
-you have nothing better to do with the result, just call ``.done()`` on it. See
-http://documentup.com/kriskowal/q/#the-end for more information.
+The main thing to note is that it is problematic to discard the result of a
+promise-returning function, as that will cause exceptions to go unobserved.
 
 Methods which return a promise show this in their documentation.
 


### PR DESCRIPTION
It seems that with ES6 Promises being apparently used, the reference to `done()` is outdated (ES6 Promises [do not implement `done`](https://stackoverflow.com/questions/26667598/will-javascript-es6-promise-support-done-api)).

Also clarifies that it is "problematic" to discard the results of promises rather than it being an "error" .