### PR TITLE
Handle auth errors during cross-signing key upload

### DIFF
--- a/spec/unit/crypto/cross-signing.spec.js
+++ b/spec/unit/crypto/cross-signing.spec.js
@@ -21,6 +21,7 @@ import * as olmlib from "../../../src/crypto/olmlib";
 import {TestClient} from '../../TestClient';
 import {HttpResponse, setHttpResponses} from '../../test-utils';
 import {resetCrossSigningKeys, createSecretStorageKey} from "./crypto-utils";
+import { MatrixError } from '../../../src/http-api';
 
 async function makeTestClient(userInfo, options, keys) {
     if (!keys) keys = {};
@@ -75,6 +76,58 @@ describe("Cross Signing", function() {
             authUploadDeviceSigningKeys: async func => await func({}),
         });
         expect(alice.uploadDeviceSigningKeys).toHaveBeenCalled();
+    });
+
+    it("should abort bootstrap if device signing auth fails", async function() {
+        const alice = await makeTestClient(
+            {userId: "@alice:example.com", deviceId: "Osborne2"},
+        );
+        alice.uploadDeviceSigningKeys = async (auth, keys) => {
+            const errorResponse = {
+                session: "sessionId",
+                flows: [
+                    {
+                        stages: [
+                            "m.login.password",
+                        ],
+                    },
+                ],
+                params: {},
+            };
+
+            // If we're not just polling for flows, add on error rejecting the
+            // auth attempt.
+            if (auth) {
+                Object.assign(errorResponse, {
+                    completed: [],
+                    error: "Invalid password",
+                    errcode: "M_FORBIDDEN",
+                });
+            }
+
+            const error = new MatrixError(errorResponse);
+            error.httpStatus == 401;
+            throw error;
+        };
+        alice.uploadKeySignatures = async () => {};
+        alice.setAccountData = async () => {};
+        alice.getAccountDataFromServer = async () => { };
+        const authUploadDeviceSigningKeys = async func => await func({});
+
+        // Try bootstrap, expecting `authUploadDeviceSigningKeys` to pass
+        // through failure, stopping before actually applying changes.
+        let bootstrapDidThrow = false;
+        try {
+            await alice.bootstrapSecretStorage({
+                createSecretStorageKey,
+                authUploadDeviceSigningKeys,
+            });
+        } catch (e) {
+            if (e.errcode === "M_FORBIDDEN") {
+                bootstrapDidThrow = true;
+            }
+        }
+        expect(bootstrapDidThrow).toBeTruthy();
     });
 
     it("should upload a signature when a user is verified", async function() {

--- a/src/crypto/EncryptionSetup.js
+++ b/src/crypto/EncryptionSetup.js
@@ -171,12 +171,6 @@ export class EncryptionSetupOperation {
      */
     async apply(crypto) {
         const baseApis = crypto._baseApis;
-        // set account data
-        if (this._accountData) {
-            for (const [type, content] of this._accountData) {
-                await baseApis.setAccountData(type, content);
-            }
-        }
         // upload cross-signing keys
         if (this._crossSigningKeys) {
             const keys = {};
@@ -192,6 +186,12 @@ export class EncryptionSetupOperation {
 
             // pass the new keys to the main instance of our own CrossSigningInfo.
             crypto._crossSigningInfo.setKeys(this._crossSigningKeys.keys);
+        }
+        // set account data
+        if (this._accountData) {
+            for (const [type, content] of this._accountData) {
+                await baseApis.setAccountData(type, content);
+            }
         }
         // upload first cross-signing signatures with the new key
         // (e.g. signing our own device)

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -453,7 +453,8 @@ Crypto.prototype.isCrossSigningReady = async function() {
  * called to await an interactive auth flow when uploading device signing keys.
  * Args:
  *     {function} A function that makes the request requiring auth. Receives the
- *     auth data as an object. Can be called multiple times, first with an empty authDict, to obtain the flows.
+ *     auth data as an object. Can be called multiple times, first with an empty
+ *     authDict, to obtain the flows.
  * @param {function} [opts.createSecretStorageKey] Optional. Function
  * called to await a secret storage key creation flow.
  * Returns:
@@ -525,17 +526,9 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         // sign master key with device key
         await this._signObject(crossSigningInfo.keys.master);
 
-        await authUploadDeviceSigningKeys(authDict => {
-            if (authDict) {
-                builder.addCrossSigningKeys(authDict, crossSigningInfo.keys);
-                return Promise.resolve();
-            } else {
-                // This callback also gets called to obtain the IUA flows,
-                // so do a call to obtain those if we don't have the authDict yet
-                // We should get called again at a later point with the authDict.
-                return this._baseApis.uploadDeviceSigningKeys(null, {});
-            }
-        });
+        // Store auth flow helper function, as we need to call it when uploading
+        // to ensure we handle auth errors properly.
+        builder.addCrossSigningKeys(authUploadDeviceSigningKeys, crossSigningInfo.keys);
 
         // cross-sign own device
         const device = this._deviceList.getStoredDevice(this._userId, this._deviceId);


### PR DESCRIPTION
In order to handle auth errors (such as incorrect passwords), we need to ensure
we only try to upload cross-signing keys from within the auth flow helper
function.

This rearranges things to store that function in the builder to use it when the
actual upload happens.

Noticed while working on https://github.com/vector-im/element-web/issues/14954