### PR TITLE
Add method to check whether client .well-known has been fetched

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4817,11 +4817,18 @@ MatrixClient.prototype._fetchClientWellKnown = async function() {
         logger.error("Failed to get client well-known", err);
         this._clientWellKnown = undefined;
         this.emit("WellKnown.error", err);
+    } finally {
+        this.emit("WellKnown.attempted");
+        this._clientWellKnownFetchAttempted = true;
     }
 };
 
 MatrixClient.prototype.getClientWellKnown = function() {
     return this._clientWellKnown;
+};
+
+MatrixClient.prototype.haveAttemptedFetchingClientWellKnown = function() {
+    return this._clientWellKnownFetchAttempted;
 };
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -5704,6 +5704,13 @@ MatrixClient.prototype.generateClientSecret = function() {
  * @param {string} data.request_id The ID of the original request.
  */
 
+/**
+ * Fires when the client .well-known info is fetched.
+ *
+ * @event module:client~MatrixClient#"WellKnown.client"
+ * @param {object} data The JSON object returned by the server
+ */
+
 // EventEmitter JSDocs
 
 /**


### PR DESCRIPTION
This allows clearly detecting whether we have _ever_ fetched .well-known at all.
Without this, it's hard to be sure whether the value is `undefined` because the
fetch has not been attempted yet or because an error occurred.

Part of https://github.com/vector-im/element-web/issues/14954
Used by https://github.com/matrix-org/matrix-react-sdk/pull/5130