### PR TITLE
Don't fail if the requested audio output isn't available

### DIFF
--- a/src/webrtc/call.js
+++ b/src/webrtc/call.js
@@ -1129,7 +1129,11 @@ const _tryPlayRemoteAudioStream = async function(self) {
         const player = self.getRemoteAudioElement();
 
         // if audioOutput is non-default:
-        if (audioOutput) await player.setSinkId(audioOutput);
+        try {
+            if (audioOutput) await player.setSinkId(audioOutput);
+        } catch (e) {
+            logger.warn("Couldn't set requested audio output device: using default", e);
+        }
 
         player.autoplay = true;
         self.assignElement(player, self.remoteAStream, "remoteAudio");


### PR DESCRIPTION
This thorws an exception if the requested device isn't available,
in which case we should catch it  & carry on with the default device.

Fixes https://github.com/vector-im/element-web/issues/15019