### PR TITLE
Add state event check

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -626,7 +626,7 @@ utils.extend(MatrixEvent.prototype, {
      * @return {boolean} True if this event is encrypted.
      */
     isEncrypted: function() {
-        return this.event.type === "m.room.encrypted";
+        return !this.isState() && this.event.type === "m.room.encrypted";
     },
 
     /**


### PR DESCRIPTION
State events are never encrypted, so we can ignore them here.