### PR TITLE
Add missing options in ICreateClientOpts

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -120,6 +120,12 @@ interface ICreateClientOpts {
     cryptoStore?: CryptoStore;
     scheduler?: MatrixScheduler;
     request?: Request;
+    userId?: string;
+    accessToken?: string;
+    identityServer?: any;
+    localTimeoutMs?: number;
+    useAuthorizationHeader?: boolean;
+    queryParams?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
This makes the examples in the README actually compile.