### PR TITLE
Handle missing cross-signing keys gracefully

### DIFF
--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -202,6 +202,9 @@ export class CrossSigningInfo extends EventEmitter {
      */
     static async getFromSecretStorage(type, secretStorage) {
         const encodedKey = await secretStorage.get(`m.cross_signing.${type}`);
+        if (!encodedKey) {
+            return null;
+        }
         return decodeBase64(encodedKey);
     }
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -2122,9 +2122,18 @@ Crypto.prototype.setDeviceVerification = async function(
     // do cross-signing
     if (verified && userId === this._userId) {
         logger.info("Own device " + deviceId + " marked verified: signing");
-        const device = await this._crossSigningInfo.signDevice(
-            userId, DeviceInfo.fromStorage(dev, deviceId),
-        );
+
+        // Signing only needed if other device not already signed
+        let device;
+        const deviceTrust = this.checkDeviceTrust(userId, deviceId);
+        if (deviceTrust.isCrossSigningVerified()) {
+            logger.log(`Own device ${deviceId} already cross-signing verified`);
+        } else {
+            device = await this._crossSigningInfo.signDevice(
+                userId, DeviceInfo.fromStorage(dev, deviceId),
+            );
+        }
+
         if (device) {
             const upload = async ({shouldEmit}) => {
                 logger.info("Uploading signature for " + deviceId);


### PR DESCRIPTION
This improves several error paths when cross-signing keys aren't available, such as when verifying a new device.

Part of https://github.com/vector-im/element-web/issues/14970