### PR TITLE
Add option to allow users of pantialaimon to use the SDK

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -182,6 +182,10 @@ function keyFromRecoverySession(session, decryptionKey) {
  * Optional. Whether to allow a fallback ICE server should be used for negotiating a
  * WebRTC connection if the homeserver doesn't provide any servers. Defaults to false.
  *
+ * @param {boolean} [opts.usingE2EProxy]
+ * Optional. Whether to allow sending messages to encrypted rooms when encryption
+ * hasn't been enabled. This is useful if you are using a E2E proxy. Defaults to false.
+ *
  * @param {object} opts.cryptoCallbacks Optional. Callbacks for crypto and cross-signing.
  *     The cross-signing API is currently UNSTABLE and may change without notice.
  *
@@ -265,6 +269,8 @@ export function MatrixClient(opts) {
     this.olmVersion = null; // Populated after initCrypto is done
 
     this.reEmitter = new ReEmitter(this);
+
+    this.usingE2EProxy = opts.usingE2EProxy;
 
     this.store = opts.store || new StubStore();
 
@@ -2746,6 +2752,13 @@ function _encryptEventIfNeeded(client, event, room) {
 
     if (!client.isRoomEncrypted(event.getRoomId())) {
         // looks like this room isn't encrypted.
+        return null;
+    }
+
+    if (!client._crypto && client.usingE2EProxy) {
+        // The client has opted to allow sending messages to encrypted
+        // rooms even if the room is encrypted, and we haven't setup
+        // crypto. This is useful for users of matrix-org/pantalaimon
         return null;
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -184,7 +184,7 @@ function keyFromRecoverySession(session, decryptionKey) {
  *
  * @param {boolean} [opts.usingExternalCrypto]
  * Optional. Whether to allow sending messages to encrypted rooms when encryption
- * is not available internally within this SDK. This is useful if you are using an external 
+ * is not available internally within this SDK. This is useful if you are using an external
  * E2E proxy, for example. Defaults to false.
  *
  * @param {object} opts.cryptoCallbacks Optional. Callbacks for crypto and cross-signing.
@@ -271,7 +271,7 @@ export function MatrixClient(opts) {
 
     this.reEmitter = new ReEmitter(this);
 
-    this.usingE2EProxy = opts.usingE2EProxy;
+    this.usingExternalCrypto = opts.usingExternalCrypto;
 
     this.store = opts.store || new StubStore();
 
@@ -2756,7 +2756,7 @@ function _encryptEventIfNeeded(client, event, room) {
         return null;
     }
 
-    if (!client._crypto && client.usingE2EProxy) {
+    if (!client._crypto && client.usingExternalCrypto) {
         // The client has opted to allow sending messages to encrypted
         // rooms even if the room is encrypted, and we haven't setup
         // crypto. This is useful for users of matrix-org/pantalaimon

--- a/src/client.js
+++ b/src/client.js
@@ -182,9 +182,10 @@ function keyFromRecoverySession(session, decryptionKey) {
  * Optional. Whether to allow a fallback ICE server should be used for negotiating a
  * WebRTC connection if the homeserver doesn't provide any servers. Defaults to false.
  *
- * @param {boolean} [opts.usingE2EProxy]
+ * @param {boolean} [opts.usingExternalCrypto]
  * Optional. Whether to allow sending messages to encrypted rooms when encryption
- * hasn't been enabled. This is useful if you are using a E2E proxy. Defaults to false.
+ * is not available internally within this SDK. This is useful if you are using an external 
+ * E2E proxy, for example. Defaults to false.
  *
  * @param {object} opts.cryptoCallbacks Optional. Callbacks for crypto and cross-signing.
  *     The cross-signing API is currently UNSTABLE and may change without notice.


### PR DESCRIPTION
matrix-js-sdk will block attempts to send events to encrypted rooms by default if you've not enabled the crypto parts of the library. There are special reasons for which I need to use Pantalaimon as a proxy for some bridge work, so I need the SDK to not block attempts in this case, as the upstream library will take care of it.

I'd like to propose this flag to let developers opt to ignore such warnings. I also couldn't really decide upon a flag name, so suggestions welcome!