### PR TITLE
Repair secret storage reset, cache keys when missing

### DIFF
--- a/src/crypto/CrossSigning.js
+++ b/src/crypto/CrossSigning.js
@@ -235,6 +235,9 @@ export class CrossSigningInfo extends EventEmitter {
         if (!cacheCallbacks) return keys;
         for (const type of ["master", "self_signing", "user_signing"]) {
             const privKey = await cacheCallbacks.getCrossSigningKeyCache(type);
+            if (!privKey) {
+                continue;
+            }
             keys.set(type, privKey);
         }
         return keys;

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1296,13 +1296,12 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
                 'master', seenPubkey,
             );
             signing = ret[1];
-            if (!signing) {
-                throw new Error("Cross-signing master private key not available");
-            }
+            logger.info("Got cross-signing master private key");
+        } catch (e) {
+            logger.error("Cross-signing master private key not available", e);
         } finally {
             if (signing) signing.free();
         }
-        logger.info("Got cross-signing master private key");
     }
 
     const oldSelfSigningId = this._crossSigningInfo.getId("self_signing");
@@ -1328,6 +1327,8 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
             );
             signing = ret[1];
             logger.info("Got cross-signing self-signing private key");
+        } catch (e) {
+            logger.error("Cross-signing self-signing private key not available", e);
         } finally {
             if (signing) signing.free();
         }
@@ -1350,6 +1351,8 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
             );
             signing = ret[1];
             logger.info("Got cross-signing user-signing private key");
+        } catch (e) {
+            logger.error("Cross-signing user-signing private key not available", e);
         } finally {
             if (signing) signing.free();
         }


### PR DESCRIPTION
This includes changes to avoid an error when resetting if secret storage if you only have some but not all cross-signing keys. It also changes the path for caching from secret storage so it will try to cache private keys whenever they are missing as well as on private key change.

Fixes https://github.com/vector-im/element-web/issues/15230