### PR TITLE
If there are extraParams set, ensure that queryParams is defined

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -651,12 +651,10 @@ MatrixHttpApi.prototype = {
 
         const self = this;
         if (this.opts.extraParams) {
-            for (const key in this.opts.extraParams) {
-                if (!this.opts.extraParams.hasOwnProperty(key)) {
-                    continue;
-                }
-                queryParams[key] = this.opts.extraParams[key];
-            }
+            queryParams = {
+              ...queryParams,
+              ...this.opts.extraParams,
+            };
         }
 
         const headers = utils.extend({}, opts.headers || {});


### PR DESCRIPTION
Fixes #1476 