### PR TITLE
Fix re-emit of Event.replaced to be on client and not room

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5475,9 +5475,8 @@ function _PojoToMatrixEventMapper(client, options) {
             }
             event.attemptDecryption(client._crypto);
         }
-        const room = client.getRoom(event.getRoomId());
-        if (room && !preventReEmit) {
-            room.reEmitter.reEmit(event, ["Event.replaced"]);
+        if (!preventReEmit) {
+            client.reEmitter.reEmit(event, ["Event.replaced"]);
         }
         return event;
     }

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -904,6 +904,8 @@ utils.extend(MatrixEvent.prototype, {
     /**
      * Set an event that replaces the content of this event, through an m.replace relation.
      *
+     * @fires module:models/event.MatrixEvent#"Event.replaced"
+     *
      * @param {MatrixEvent?} newEvent the event with the replacing content, if any.
      */
     makeReplaced(newEvent) {


### PR DESCRIPTION
The one listener in react-sdk listens on the MatrixClient and it never gets re-emitted there.
It isn't very useful on Room as during app-launch we do not have the Room available to bind the re-emmission