### PR TITLE
Make an accurate version of 'age' for events

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -169,6 +169,14 @@ export const MatrixEvent = function(
        allows for a unique ID which does not change when the event comes back down sync.
      */
     this._txnId = null;
+
+    /* Set an approximate timestamp for the event relative the local clock.
+     * This will inherently be approximate because it doesn't take into account
+     * the time between the server putting the 'age' field on the event as it sent
+     * it to us and the time we're now constructing this event, but that's better
+     * than assuming the local clock is in sync with the origin HS's clock.
+     */
+    this._localTimestamp = Date.now() - this.getAge();
 };
 utils.inherits(MatrixEvent, EventEmitter);
 
@@ -311,11 +319,12 @@ utils.extend(MatrixEvent.prototype, {
 
     /**
      * Get the age of the event when this function was called.
-     * Relies on the local clock being in sync with the clock of the original homeserver.
+     * This is the 'age' field adjusted according to how long this client has
+     * had the event.
      * @return {Number} The age of this event in milliseconds.
      */
     getLocalAge: function() {
-        return Date.now() - this.getTs();
+        return Date.now() - this._localTimestamp;
     },
 
     /**

--- a/src/store/indexeddb-local-backend.js
+++ b/src/store/indexeddb-local-backend.js
@@ -226,7 +226,7 @@ LocalIndexedDBStoreBackend.prototype = {
                 account_data: {
                     events: accountData,
                 },
-            });
+            }, true);
         });
     },
 
@@ -416,7 +416,7 @@ LocalIndexedDBStoreBackend.prototype = {
     },
 
     syncToDatabase: function(userTuples) {
-        const syncData = this._syncAccumulator.getJSON();
+        const syncData = this._syncAccumulator.getJSON(true);
 
         return Promise.all([
             this._persistUserPresenceEvents(userTuples),

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -500,6 +500,14 @@ export class SyncAccumulator {
 
                 let transformedEvent;
                 if (!forDatabase && msgData.event._localTs) {
+                    // This means we have to copy each event so we can fix it up to
+                    // set a correct 'age' parameter whilst keeping the local timestamp
+                    // on our stored event. If this turns out to be a bottleneck, it could
+                    // be optimised either by doing this in the main process after the data
+                    // has been structured-cloned to go between the worker & main process,
+                    // or special-casing data from saved syncs to read the local timstamp
+                    // directly rather than turning it into age to then immediately be
+                    // transformed back again into a local timestamp.
                     transformedEvent = Object.assign({}, msgData.event);
                     transformedEvent.unsigned = transformedEvent.unsigned || {};
                     transformedEvent.unsigned.age = Date.now() - msgData.event._localTs;

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -340,14 +340,13 @@ export class SyncAccumulator {
                 // corresponds to the first event in the timeline
                 let transformedEvent;
                 if (!fromDatabase) {
-                    console.log("transforming event");
                     transformedEvent = Object.assign({}, e);
                     const age = e.unsigned ? e.unsigned.age : e.age;
                     transformedEvent._localTs = Date.now() - age;
                 } else {
                     transformedEvent = e;
                 }
-                
+
                 currentData._timeline.push({
                     event: transformedEvent,
                     token: index === 0 ? data.timeline.prev_batch : null,

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -342,7 +342,7 @@ export class SyncAccumulator {
                 if (!fromDatabase) {
                     transformedEvent = Object.assign({}, e);
                     const age = e.unsigned ? e.unsigned.age : e.age;
-                    transformedEvent._localTs = Date.now() - age;
+                    if (age !== undefined) transformedEvent._localTs = Date.now() - age;
                 } else {
                     transformedEvent = e;
                 }

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -341,6 +341,9 @@ export class SyncAccumulator {
                 let transformedEvent;
                 if (!fromDatabase) {
                     transformedEvent = Object.assign({}, e);
+                    if (transformedEvent.unsigned !== undefined) {
+                        transformedEvent.unsigned = Object.assign({}, transformedEvent.unsigned);
+                    }
                     const age = e.unsigned ? e.unsigned.age : e.age;
                     if (age !== undefined) transformedEvent._localTs = Date.now() - age;
                 } else {
@@ -509,6 +512,10 @@ export class SyncAccumulator {
                     // directly rather than turning it into age to then immediately be
                     // transformed back again into a local timestamp.
                     transformedEvent = Object.assign({}, msgData.event);
+                    if (transformedEvent.unsigned !== undefined) {
+                        transformedEvent.unsigned = Object.assign({}, transformedEvent.unsigned);
+                    }
+                    delete transformedEvent._localTs;
                     transformedEvent.unsigned = transformedEvent.unsigned || {};
                     transformedEvent.unsigned.age = Date.now() - msgData.event._localTs;
                 } else {

--- a/src/sync-accumulator.js
+++ b/src/sync-accumulator.js
@@ -87,8 +87,8 @@ export class SyncAccumulator {
         };
     }
 
-    accumulate(syncResponse) {
-        this._accumulateRooms(syncResponse);
+    accumulate(syncResponse, fromDatabase) {
+        this._accumulateRooms(syncResponse, fromDatabase);
         this._accumulateGroups(syncResponse);
         this._accumulateAccountData(syncResponse);
         this.nextBatch = syncResponse.next_batch;
@@ -107,35 +107,36 @@ export class SyncAccumulator {
     /**
      * Accumulate incremental /sync room data.
      * @param {Object} syncResponse the complete /sync JSON
+     * @param {boolean} fromDatabase True if the sync response is one saved to the database
      */
-    _accumulateRooms(syncResponse) {
+    _accumulateRooms(syncResponse, fromDatabase) {
         if (!syncResponse.rooms) {
             return;
         }
         if (syncResponse.rooms.invite) {
             Object.keys(syncResponse.rooms.invite).forEach((roomId) => {
                 this._accumulateRoom(
-                    roomId, "invite", syncResponse.rooms.invite[roomId],
+                    roomId, "invite", syncResponse.rooms.invite[roomId], fromDatabase,
                 );
             });
         }
         if (syncResponse.rooms.join) {
             Object.keys(syncResponse.rooms.join).forEach((roomId) => {
                 this._accumulateRoom(
-                    roomId, "join", syncResponse.rooms.join[roomId],
+                    roomId, "join", syncResponse.rooms.join[roomId], fromDatabase,
                 );
             });
         }
         if (syncResponse.rooms.leave) {
             Object.keys(syncResponse.rooms.leave).forEach((roomId) => {
                 this._accumulateRoom(
-                    roomId, "leave", syncResponse.rooms.leave[roomId],
+                    roomId, "leave", syncResponse.rooms.leave[roomId], fromDatabase,
                 );
             });
         }
     }
 
-    _accumulateRoom(roomId, category, data) {
+    _accumulateRoom(roomId, category, data, fromDatabase) {
         // Valid /sync state transitions
         //       +--------+ <======+            1: Accept an invite
         //   +== | INVITE |        | (5)        2: Leave a room
@@ -159,7 +160,7 @@ export class SyncAccumulator {
                     delete this.inviteRooms[roomId];
                 }
                 // (3)
-                this._accumulateJoinState(roomId, data);
+                this._accumulateJoinState(roomId, data, fromDatabase);
                 break;
             case "leave":
                 if (this.inviteRooms[roomId]) { // (4)
@@ -203,7 +204,7 @@ export class SyncAccumulator {
     }
 
     // Accumulate timeline and state events in a room.
-    _accumulateJoinState(roomId, data) {
+    _accumulateJoinState(roomId, data, fromDatabase) {
         // We expect this function to be called a lot (every /sync) so we want
         // this to be fast. /sync stores events in an array but we often want
         // to clobber based on type/state_key. Rather than convert arrays to
@@ -337,8 +338,18 @@ export class SyncAccumulator {
                 setState(currentData._currentState, e);
                 // append the event to the timeline. The back-pagination token
                 // corresponds to the first event in the timeline
+                let transformedEvent;
+                if (!fromDatabase) {
+                    console.log("transforming event");
+                    transformedEvent = Object.assign({}, e);
+                    const age = e.unsigned ? e.unsigned.age : e.age;
+                    transformedEvent._localTs = Date.now() - age;
+                } else {
+                    transformedEvent = e;
+                }
+                
                 currentData._timeline.push({
-                    event: e,
+                    event: transformedEvent,
                     token: index === 0 ? data.timeline.prev_batch : null,
                 });
             });
@@ -405,6 +416,7 @@ export class SyncAccumulator {
      * represents all room data that should be stored. This should be paired
      * with the sync token which represents the most recent /sync response
      * provided to accumulate().
+     * @param {boolean} forDatabase True to generate a sync to be saved to storage
      * @return {Object} An object with a "nextBatch", "roomsData" and "accountData"
      * keys.
      * The "nextBatch" key is a string which represents at what point in the
@@ -414,7 +426,7 @@ export class SyncAccumulator {
      * /sync response from the 'rooms' key onwards. The "accountData" key is
      * a list of raw events which represent global account data.
      */
-    getJSON() {
+    getJSON(forDatabase) {
         const data = {
             join: {},
             invite: {},
@@ -486,7 +498,16 @@ export class SyncAccumulator {
                     }
                     roomJson.timeline.prev_batch = msgData.token;
                 }
-                roomJson.timeline.events.push(msgData.event);
+
+                let transformedEvent;
+                if (!forDatabase && msgData.event._localTs) {
+                    transformedEvent = Object.assign({}, msgData.event);
+                    transformedEvent.unsigned = transformedEvent.unsigned || {};
+                    transformedEvent.unsigned.age = Date.now() - msgData.event._localTs;
+                } else {
+                    transformedEvent = msgData.event;
+                }
+                roomJson.timeline.events.push(transformedEvent);
             });
 
             // Add state data: roll back current state to the start of timeline,


### PR DESCRIPTION
We've always had 'age' in events but it's never really been an
accurate representation of the event's age because we never did
anything with it. This transforms it into a local clock timestamp
when the event arives and when it comes out of the sync store, and
changes getLocalAge() to use it.

react-sdk doesn't appear to use getLocalAge() but any 3rd party apps
that do may notice a slight change in bahaviour.