### PR TITLE
Support m.call.reject

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -45,6 +45,7 @@ export enum EventType {
     CallCandidates = "m.call.candidates",
     CallAnswer = "m.call.answer",
     CallHangup = "m.call.hangup",
+    CallReject = "m.call.reject",
     KeyVerificationRequest = "m.key.verification.request",
     KeyVerificationStart = "m.key.verification.start",
     KeyVerificationCancel = "m.key.verification.cancel",

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -232,7 +232,7 @@ export class CallEventHandler {
                     call.gotRemoteIceCandidate(cand);
                 }
             }
-        } else if (event.getType() === EventType.CallHangup) {
+        } else if ([EventType.CallHangup, EventType.CallReject].includes(event.getType())) {
             // Note that we also observe our own hangups here so we can see
             // if we've already rejected a call that would otherwise be valid
             if (!call) {
@@ -247,7 +247,11 @@ export class CallEventHandler {
                 }
             } else {
                 if (call.state !== CallState.Ended) {
-                    call.onHangupReceived(content);
+                    if (event.getType() === EventType.CallHangup) {
+                        call.onHangupReceived(content);
+                    } else {
+                        call.onRejectReceived(content);
+                    }
                     this.calls.delete(content.call_id);
                 }
             }


### PR DESCRIPTION
Start the migration to v1 VoIP by supporting m.call.reject, which
we'll send if the caller says they're v1. Our version stays as v0
for now, until we speak the rest of v1.

Honour the default reaosn in a hangup being user_hangup.