### PR TITLE
Support party_id

### DIFF
--- a/spec/TestClient.js
+++ b/spec/TestClient.js
@@ -69,6 +69,9 @@ export function TestClient(
 
     this.deviceKeys = null;
     this.oneTimeKeys = {};
+    this._callEventHandler = {
+        calls: new Map(),
+    };
 }
 
 TestClient.prototype.toString = function() {
@@ -229,4 +232,8 @@ TestClient.prototype.flushSync = function() {
     ]).then(() => {
         logger.log(`${this}: flushSync completed`);
     });
+};
+
+TestClient.prototype.isFallbackICEServerAllowed = function() {
+    return true;
 };

--- a/spec/unit/webrtc/call.spec.js
+++ b/spec/unit/webrtc/call.spec.js
@@ -1,0 +1,169 @@
+/*
+Copyright 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {TestClient} from '../../TestClient';
+import {MatrixCall} from '../../../src/webrtc/call';
+
+const DUMMY_SDP = (
+    "v=0\r\n" +
+    "o=- 5022425983810148698 2 IN IP4 127.0.0.1\r\n" +
+    "s=-\r\nt=0 0\r\na=group:BUNDLE 0\r\n" + 
+    "a=msid-semantic: WMS h3wAi7s8QpiQMH14WG3BnDbmlOqo9I5ezGZA\r\n" +
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\n" +
+    "c=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:hLDR\r\n" +
+    "a=ice-pwd:bMGD9aOldHWiI+6nAq/IIlRw\r\n" +
+    "a=ice-options:trickle\r\n" +
+    "a=fingerprint:sha-256 E4:94:84:F9:4A:98:8A:56:F5:5F:FD:AF:72:B9:32:89:49:5C:4B:9A:4A:15:8E:41:8A:F3:69:E4:39:52:DC:D6\r\n" +
+    "a=setup:active\r\n" +
+    "a=mid:0\r\n" +
+    "a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n" +
+    "a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n" +
+    "a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n" +
+    "a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r\n" +
+    "a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\n" +
+    "a=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\n" +
+    "a=sendrecv\r\n" +
+    "a=msid:h3wAi7s8QpiQMH14WG3BnDbmlOqo9I5ezGZA 4357098f-3795-4131-bff4-9ba9c0348c49\r\n" +
+    "a=rtcp-mux\r\n" +
+    "a=rtpmap:111 opus/48000/2\r\n" +
+    "a=rtcp-fb:111 transport-cc\r\n" +
+    "a=fmtp:111 minptime=10;useinbandfec=1\r\n" +
+    "a=rtpmap:103 ISAC/16000\r\n" +
+    "a=rtpmap:104 ISAC/32000\r\n" +
+    "a=rtpmap:9 G722/8000\r\n" +
+    "a=rtpmap:0 PCMU/8000\r\n" +
+    "a=rtpmap:8 PCMA/8000\r\n" +
+    "a=rtpmap:106 CN/32000\r\n" +
+    "a=rtpmap:105 CN/16000\r\n" +
+    "a=rtpmap:13 CN/8000\r\n" +
+    "a=rtpmap:110 telephone-event/48000\r\n" +
+    "a=rtpmap:112 telephone-event/32000\r\n" +
+    "a=rtpmap:113 telephone-event/16000\r\n" +
+    "a=rtpmap:126 telephone-event/8000\r\n" +
+    "a=ssrc:3619738545 cname:2RWtmqhXLdoF4sOi\r\n"
+);
+
+class MockRTCPeerConnection {
+    constructor() {
+        this.localDescription = {
+            sdp: DUMMY_SDP,
+            type: '',
+        }
+    }
+
+    addEventListener() {}
+    createOffer() {
+        return Promise.resolve({});
+    }
+    setRemoteDescription() {
+        return Promise.resolve();
+    }
+    setLocalDescription() {
+        return Promise.resolve();
+    }
+}
+
+describe('Call', function() {
+    let client;
+    let call;
+    let prevNavigator;
+    let prevDocument;
+    let prevWindow;
+
+    beforeEach(function() {
+        prevNavigator = global.navigator;
+        prevDocument = global.document;
+        prevWindow = global.window;
+
+        global.navigator = {
+            mediaDevices: {
+                getUserMedia: () => {
+                    return {
+                        getTracks: () => [],
+                        getAudioTracks: () => [],
+                        getVideoTracks: () => [],
+                    };
+                }
+            }
+        };
+
+        global.window = {
+            RTCPeerConnection: MockRTCPeerConnection,
+            RTCSessionDescription: {},
+            RTCIceCandidate: {},
+            getUserMedia: {},
+        };
+        global.document = {};
+
+        client = new TestClient();
+        call = new MatrixCall({
+            client: client.client,
+            roomId: '!foo:bar',
+        });
+        // call checks one of these is wired up
+        call.on('error', () => {});
+    });
+
+    afterEach(function() {
+        client.stop();
+        global.navigator = prevNavigator;
+        global.window = prevWindow;
+        global.document = prevDocument;
+    });
+
+    it('should ignore candidate events from non-matching party ID', async function() {
+        await call.placeVoiceCall();
+        await call.receivedAnswer({
+            version: 0,
+            call_id: call.callId,
+            party_id: 'the_correct_party_id',
+            answer: {
+                sdp: DUMMY_SDP,
+            }
+        });
+
+        call.peerConn.addIceCandidate = jest.fn();
+        call.onRemoteIceCandidatesReceived({
+            getContent: () => { return {
+                version: 0,
+                call_id: call.callId,
+                party_id: 'the_correct_party_id',
+                candidates: [
+                    {
+                        candidate: '',
+                        sdpMid: '',
+                    }
+                ]
+            }},
+        });
+        expect(call.peerConn.addIceCandidate.mock.calls.length).toBe(1);
+
+        call.onRemoteIceCandidatesReceived({
+            getContent: () => { return {
+                version: 0,
+                call_id: call.callId,
+                party_id: 'some_other_party_id',
+                candidates: [
+                    {
+                        candidate: '',
+                        sdpMid: '',
+                    }
+                ]
+            }},
+        });
+        expect(call.peerConn.addIceCandidate.mock.calls.length).toBe(1);
+    });
+});

--- a/spec/unit/webrtc/call.spec.js
+++ b/spec/unit/webrtc/call.spec.js
@@ -20,13 +20,14 @@ import {MatrixCall} from '../../../src/webrtc/call';
 const DUMMY_SDP = (
     "v=0\r\n" +
     "o=- 5022425983810148698 2 IN IP4 127.0.0.1\r\n" +
-    "s=-\r\nt=0 0\r\na=group:BUNDLE 0\r\n" + 
+    "s=-\r\nt=0 0\r\na=group:BUNDLE 0\r\n" +
     "a=msid-semantic: WMS h3wAi7s8QpiQMH14WG3BnDbmlOqo9I5ezGZA\r\n" +
     "m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\n" +
     "c=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:hLDR\r\n" +
     "a=ice-pwd:bMGD9aOldHWiI+6nAq/IIlRw\r\n" +
     "a=ice-options:trickle\r\n" +
-    "a=fingerprint:sha-256 E4:94:84:F9:4A:98:8A:56:F5:5F:FD:AF:72:B9:32:89:49:5C:4B:9A:4A:15:8E:41:8A:F3:69:E4:39:52:DC:D6\r\n" +
+    "a=fingerprint:sha-256 E4:94:84:F9:4A:98:8A:56:F5:5F:FD:AF:72:B9:32:89:49:5C:4B:9A:" +
+        "4A:15:8E:41:8A:F3:69:E4:39:52:DC:D6\r\n" +
     "a=setup:active\r\n" +
     "a=mid:0\r\n" +
     "a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n" +
@@ -61,7 +62,7 @@ class MockRTCPeerConnection {
         this.localDescription = {
             sdp: DUMMY_SDP,
             type: '',
-        }
+        };
     }
 
     addEventListener() {}
@@ -96,8 +97,8 @@ describe('Call', function() {
                         getAudioTracks: () => [],
                         getVideoTracks: () => [],
                     };
-                }
-            }
+                },
+            },
         };
 
         global.window = {
@@ -132,37 +133,41 @@ describe('Call', function() {
             party_id: 'the_correct_party_id',
             answer: {
                 sdp: DUMMY_SDP,
-            }
+            },
         });
 
         call.peerConn.addIceCandidate = jest.fn();
         call.onRemoteIceCandidatesReceived({
-            getContent: () => { return {
-                version: 0,
-                call_id: call.callId,
-                party_id: 'the_correct_party_id',
-                candidates: [
-                    {
-                        candidate: '',
-                        sdpMid: '',
-                    }
-                ]
-            }},
+            getContent: () => {
+                return {
+                    version: 0,
+                    call_id: call.callId,
+                    party_id: 'the_correct_party_id',
+                    candidates: [
+                        {
+                            candidate: '',
+                            sdpMid: '',
+                        },
+                    ],
+                };
+            },
         });
         expect(call.peerConn.addIceCandidate.mock.calls.length).toBe(1);
 
         call.onRemoteIceCandidatesReceived({
-            getContent: () => { return {
-                version: 0,
-                call_id: call.callId,
-                party_id: 'some_other_party_id',
-                candidates: [
-                    {
-                        candidate: '',
-                        sdpMid: '',
-                    }
-                ]
-            }},
+            getContent: () => {
+                return {
+                    version: 0,
+                    call_id: call.callId,
+                    party_id: 'some_other_party_id',
+                    candidates: [
+                        {
+                            candidate: '',
+                            sdpMid: '',
+                        },
+                    ],
+                };
+            },
         });
         expect(call.peerConn.addIceCandidate.mock.calls.length).toBe(1);
     });

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -45,6 +45,7 @@ export enum EventType {
     CallCandidates = "m.call.candidates",
     CallAnswer = "m.call.answer",
     CallHangup = "m.call.hangup",
+    CallReject = "m.call.reject",
     KeyVerificationRequest = "m.key.verification.request",
     KeyVerificationStart = "m.key.verification.start",
     KeyVerificationCancel = "m.key.verification.cancel",

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1061,7 +1061,9 @@ export class MatrixCall extends EventEmitter {
     onHangupReceived = (msg) => {
         logger.debug("Hangup received");
 
-        if (!this.partyIdMatches(msg)) {
+        // party ID must match (our chosen partner hanging up the call) or be undefined (we haven't chosen
+        // a partner yet but we're treating the hangup as a reject as per VoIP v0)
+        if (!this.partyIdMatches(msg) && this.opponentPartyId !== undefined) {
             logger.info(`Ignoring message from party ID ${msg.party_id}: our partner is ${this.opponentPartyId}`);
             return;
         }

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -232,7 +232,7 @@ export class CallEventHandler {
                     call.gotRemoteIceCandidate(cand);
                 }
             }
-        } else if (event.getType() === EventType.CallHangup) {
+        } else if ([EventType.CallHangup, EventType.CallReject].includes(event.getType())) {
             // Note that we also observe our own hangups here so we can see
             // if we've already rejected a call that would otherwise be valid
             if (!call) {
@@ -247,7 +247,11 @@ export class CallEventHandler {
                 }
             } else {
                 if (call.state !== CallState.Ended) {
-                    call.onHangupReceived(content);
+                    if (event.getType() === EventType.CallHangup) {
+                        call.onHangupReceived(content);
+                    } else {
+                        call.onRejectReceived(content);
+                    }
                     this.calls.delete(content.call_id);
                 }
             }


### PR DESCRIPTION
Send party_id on events and check the party_id of incoming events matches

Includes a basic test to assert that it actually does: we should
build out a decent test suite for calls as there's a lot of edge-case
functionality that can break and slip through the cracks (eg. glare).
This is a start (although it would be nice if we could write the tests
in TypeScript).

Fixes #1511
Based on: https://github.com/matrix-org/matrix-js-sdk/pull/1510 (https://github.com/matrix-org/matrix-js-sdk/compare/pull/1510/head...pull/1512/head)