### PR TITLE
Remove specbuild from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ lib-cov
 out
 /dist
 /lib
-/specbuild
 
 # version file and tarball created by `npm pack` / `yarn pack`
 /git-revision.txt


### PR DESCRIPTION
It's no longer a thing