### PR TITLE
[Breaking] Change hasPendingEvent to return false if pending ordering !detached

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -358,16 +358,14 @@ Room.prototype.getPendingEvents = function() {
 
 /**
  * Check whether the pending event list contains a given event by ID.
+ * If pending event ordering is not "detached" then this returns false.
  *
  * @param {string} eventId The event ID to check for.
  * @return {boolean}
- * @throws If <code>opts.pendingEventOrdering</code> was not 'detached'
  */
 Room.prototype.hasPendingEvent = function(eventId) {
     if (this._opts.pendingEventOrdering !== "detached") {
-        throw new Error(
-            "Cannot call hasPendingEvent with pendingEventOrdering == " +
-                this._opts.pendingEventOrdering);
+        return false;
     }
 
     return this._pendingEventList.some(event => event.getId() === eventId);


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/1504

It is called in 3 places which assumed it would not throw, IMO its a little bit strict for it to throw.