### PR TITLE
Support m.call.select_answer

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -46,6 +46,7 @@ export enum EventType {
     CallAnswer = "m.call.answer",
     CallHangup = "m.call.hangup",
     CallReject = "m.call.reject",
+    CallSelectAnswer = "m.call.select_answer",
     KeyVerificationRequest = "m.key.verification.request",
     KeyVerificationStart = "m.key.verification.start",
     KeyVerificationCancel = "m.key.verification.cancel",

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -213,7 +213,7 @@ export class CallEventHandler {
                     call.onAnsweredElsewhere(content);
                 }
             } else {
-                call.receivedAnswer(content);
+                call.onAnswerReceived(event);
             }
         } else if (event.getType() === EventType.CallCandidates) {
             if (event.getSender() === this.client.credentials.userId) {
@@ -251,6 +251,13 @@ export class CallEventHandler {
                     this.calls.delete(content.call_id);
                 }
             }
+        } else if (event.getType() === EventType.CallSelectAnswer) {
+            if (event.getContent().party_id === call.ourPartyId) {
+                // Ignore remote echo
+                return;
+            }
+
+            call.onSelectAnswerReceived(event);
         }
     }
 }


### PR DESCRIPTION
Only send one if the answer has a party_id set

Also change some event types to the enum and rename receivedAnswer
to be more consistent