### PR TITLE
Await key cache check to avoid prompts

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -763,12 +763,16 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         // be trusted via cross-signing.
         if (
             this._crossSigningInfo.getId() &&
-            this._crossSigningInfo.isStoredInKeyCache("master")
+            await this._crossSigningInfo.isStoredInKeyCache("master")
         ) {
-            logger.log("Adding cross-signing signature to key backup");
-            await this._crossSigningInfo.signObject(
-                keyBackupInfo.auth_data, "master",
-            );
+            try {
+                logger.log("Adding cross-signing signature to key backup");
+                await this._crossSigningInfo.signObject(
+                    keyBackupInfo.auth_data, "master",
+                );
+            } catch (e) {
+                logger.error("Signing key backup with cross-signing keys failed", e);
+            }
         } else {
             logger.warn(
                 "Cross-signing keys not available, skipping signature on key backup",
@@ -826,11 +830,17 @@ Crypto.prototype.bootstrapSecretStorage = async function({
 
         if (
             this._crossSigningInfo.getId() &&
-            this._crossSigningInfo.isStoredInKeyCache("master")
+            await this._crossSigningInfo.isStoredInKeyCache("master")
         ) {
-            // sign with cross-sign master key
-            logger.log("Adding cross-signing signature to key backup");
-            await this._crossSigningInfo.signObject(data.auth_data, "master");
+            try {
+                // sign with cross-sign master key
+                logger.log("Adding cross-signing signature to key backup");
+                await this._crossSigningInfo.signObject(data.auth_data, "master");
+            } catch (e) {
+                // This step is not critical (just helpful), so we catch here
+                // and continue if it fails.
+                logger.error("Signing key backup with cross-signing keys failed", e);
+            }
         } else {
             logger.warn(
                 "Cross-signing keys not available, skipping signature on key backup",

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -695,6 +695,26 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         }
     };
 
+    const signKeyBackupWithCrossSigning = async (keyBackupAuthData) => {
+        if (
+            this._crossSigningInfo.getId() &&
+            await this._crossSigningInfo.isStoredInKeyCache("master")
+        ) {
+            try {
+                logger.log("Adding cross-signing signature to key backup");
+                await this._crossSigningInfo.signObject(keyBackupAuthData, "master");
+            } catch (e) {
+                // This step is not critical (just helpful), so we catch here
+                // and continue if it fails.
+                logger.error("Signing key backup with cross-signing keys failed", e);
+            }
+        } else {
+            logger.warn(
+                "Cross-signing keys not available, skipping signature on key backup",
+            );
+        }
+    };
+
     const oldSSSSKey = await this.getSecretStorageKey();
     const [oldKeyId, oldKeyInfo] = oldSSSSKey || [null, null];
     const storageExists = (
@@ -761,23 +781,7 @@ Crypto.prototype.bootstrapSecretStorage = async function({
         // The backup is trusted because the user provided the private key.
         // Sign the backup with the cross-signing key so the key backup can
         // be trusted via cross-signing.
-        if (
-            this._crossSigningInfo.getId() &&
-            await this._crossSigningInfo.isStoredInKeyCache("master")
-        ) {
-            try {
-                logger.log("Adding cross-signing signature to key backup");
-                await this._crossSigningInfo.signObject(
-                    keyBackupInfo.auth_data, "master",
-                );
-            } catch (e) {
-                logger.error("Signing key backup with cross-signing keys failed", e);
-            }
-        } else {
-            logger.warn(
-                "Cross-signing keys not available, skipping signature on key backup",
-            );
-        }
+        await signKeyBackupWithCrossSigning(keyBackupInfo.auth_data);
 
         builder.addSessionBackup(keyBackupInfo);
     } else {
@@ -828,24 +832,8 @@ Crypto.prototype.bootstrapSecretStorage = async function({
             auth_data: info.auth_data,
         };
 
-        if (
-            this._crossSigningInfo.getId() &&
-            await this._crossSigningInfo.isStoredInKeyCache("master")
-        ) {
-            try {
-                // sign with cross-sign master key
-                logger.log("Adding cross-signing signature to key backup");
-                await this._crossSigningInfo.signObject(data.auth_data, "master");
-            } catch (e) {
-                // This step is not critical (just helpful), so we catch here
-                // and continue if it fails.
-                logger.error("Signing key backup with cross-signing keys failed", e);
-            }
-        } else {
-            logger.warn(
-                "Cross-signing keys not available, skipping signature on key backup",
-            );
-        }
+        // Sign with cross-signing master key
+        await signKeyBackupWithCrossSigning(data.auth_data);
 
         // sign with the device fingerprint
         await this._signObject(data.auth_data);


### PR DESCRIPTION
`isStoredInKeyCache` is async, so we need to await the result to know whether to
proceed. In addition, this wraps the block in a try / catch, since signing the
key backup is an optional step.

**Reviewer:** Maybe review commit by commit for easier reading

Fixes https://github.com/vector-im/element-web/issues/15530