### PR TITLE
Don't log error when environment does not support WebRTC

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1569,7 +1569,7 @@ export function setVideoInput(deviceId: string) { videoInput = deviceId; }
 export function createNewMatrixCall(client: any, roomId: string, options?: CallOpts) {
     // typeof prevents Node from erroring on an undefined reference
     if (typeof(window) === 'undefined' || typeof(document) === 'undefined') {
-        logger.error("No window or document object: WebRTC is not supported in this environement");
+        logger.info("No window or document object: WebRTC is not supported in this environment");
         return null;
     }
 


### PR DESCRIPTION
This function is *always* called when a MatrixClient is created, e.g. in
an appservice. If the environment does not support WebRTC, this is not
necessarily an error; it is expected in many situations.
