### PR TITLE
Remove `postinstall` script which also runs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Matrix Client-Server SDK for Javascript",
   "scripts": {
     "prepublishOnly": "yarn build",
-    "postinstall": "yarn build:dev",
     "start": "echo THIS IS FOR LEGACY PURPOSES ONLY. && babel src -w -s -d lib --verbose --extensions \".ts,.js\"",
     "dist": "echo 'This is for the release script so it can make assets (browser bundle).' && yarn build",
     "clean": "rimraf lib dist",


### PR DESCRIPTION
It seems I misunderstood the `postinstall` script and had thought it would only
run when installing the project root. Instead, it seems to run also as a
dependency as well.

This change should be fine for release, but it does mean when developing
the JS SDK, you'll need to manually build. CI pipelines may also need to be
changed to call an extra build step.
