### PR TITLE
Expose getPresence endpoint

### DIFF
--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -521,4 +521,19 @@ describe("MatrixClient", function() {
         xit("should be able to peek into a room using peekInRoom", function(done) {
         });
     });
+
+    describe("getPresence", function() {
+        it("should send a presence HTTP GET", function() {
+            httpLookups = [{
+                method: "GET",
+                path: `/presence/${encodeURIComponent(userId)}/status`,
+                data: {
+                    "presence": "unavailable",
+                    "last_active_ago": 420845,
+                },
+            }];
+            client.getPresence(userId);
+            expect(httpLookups.length).toEqual(0);
+        });
+    });
 });

--- a/src/client.js
+++ b/src/client.js
@@ -3841,6 +3841,19 @@ MatrixClient.prototype.setPresence = function(opts, callback) {
     );
 };
 
+/**
+ * @param {string} userId The user to get presence for
+ * @param {module:client.callback} callback Optional.
+ * @return {Promise} Resolves: The presence state for this user.
+ * @return {module:http-api.MatrixError} Rejects: with an error response.
+ */
+MatrixClient.prototype.getPresence = function(userId, callback) {
+    const path = utils.encodeUri("/presence/$userId/status", {
+        $userId: userId,
+    });
+
+    return this._http.authedRequest(callback, "GET", path, undefined, undefined);
+};
 
 /**
  * Retrieve older messages from the given room and put them in the timeline.


### PR DESCRIPTION
Expose the `getPresence` endpoint in the client server API through `MatrixClient`:
https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status

Currently only the `setPresence` endpoint is exposed.

Signed-off-by: tzyl <tim95@hotmail.co.uk>