### PR TITLE
Fix compatibility with v0 calls

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1471,11 +1471,6 @@ export class MatrixCall extends EventEmitter {
     private async terminate(hangupParty: CallParty, hangupReason: CallErrorCode, shouldEmit: boolean) {
         if (this.callHasEnded()) return;
 
-        const stats = await this.peerConn.getStats();
-        for (const s of stats.keys()) {
-            console.log(stats.get(s));
-        }
-
         if (this.inviteTimeout) {
             clearTimeout(this.inviteTimeout);
             this.inviteTimeout = null;

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -990,7 +990,7 @@ export class MatrixCall extends EventEmitter {
             return;
         }
 
-        if (this.opponentPartyId !== undefined) {
+        if (this.opponentPartyId !== null) {
             logger.info(
                 `Ignoring answer from party ID ${event.getContent().party_id}: ` +
                 `we already have an answer/reject from ${this.opponentPartyId}`,


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/1567 introduced a
bug where we'd leave opponentPartyId undefined, but we compared it
to null later when testing for its presence.

Fixes https://github.com/vector-im/element-web/issues/16239