### PR TITLE
Guard against confused server retry times

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -164,7 +164,7 @@ MatrixScheduler.RETRY_BACKOFF_RATELIMIT = function(event, attempts, err) {
 
     if (err.name === "M_LIMIT_EXCEEDED") {
         const waitTime = err.data.retry_after_ms;
-        if (waitTime) {
+        if (waitTime > 0) {
             return waitTime;
         }
     }


### PR DESCRIPTION
If a server happens to give a negative retry time, this would be passed to
`setTimeout`, and browsers interpret negative values as `0`, meaning "as soon as
possible", so we then start looping infinitely with no delay.