### PR TITLE
Fix Electron type merging

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -27,9 +27,11 @@ declare global {
     }
 
     interface Window {
-        electron?: {
-            getDesktopCapturerSources(options: GetSourcesOptions): Promise<Array<DesktopCapturerSource>>;
-        }
+        electron?: Electron;
+    }
+
+    interface Electron {
+        getDesktopCapturerSources(options: GetSourcesOptions): Promise<Array<DesktopCapturerSource>>;
     }
 
     interface MediaDevices {


### PR DESCRIPTION
This changes to an interface for Electron types so that other layers can merge
in further APIs as needed.

Related to https://github.com/vector-im/element-web/pull/16405