### PR TITLE
Fix call ID NaN

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -211,8 +211,8 @@ export class CallError extends Error {
     }
 }
 
-function genCallID() {
-    return Date.now() + randomString(16);
+function genCallID(): string {
+    return Date.now().toString() + randomString(16);
 }
 
 /**


### PR DESCRIPTION
We were seeing call IDs of NaN in the wild somehow... hopefully this
should make sure they're all actually strings.