### PR TITLE
Handle undefined peerconn

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -521,6 +521,10 @@ export class MatrixCall extends EventEmitter {
     }
 
     private async collectCallStats(): Promise<any[]> {
+        // This happens when the call fails before it starts.
+        // For example when we fail to get capture sources
+        if (!this.peerConn) return;
+
         const statsReport = await this.peerConn.getStats();
         const stats = [];
         for (const item of statsReport) {


### PR DESCRIPTION
Accompanied by [#5632](https://github.com/matrix-org/matrix-react-sdk/pull/5632)

Hopefully explained by the comment

Without this, a call could fail without the `CallView` disappearing from the room