### PR TITLE
Cancel call if no source was selected

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -377,6 +377,8 @@ export class MatrixCall extends EventEmitter {
             logger.debug("Electron getDesktopCapturerSources() is available...");
             try {
                 const selectedSource = await selectDesktopCapturerSource();
+                // If no source was selected cancel call
+                if (!selectedSource) return;
                 const getUserMediaOptions: MediaStreamConstraints | DesktopCapturerConstraints = {
                     audio: false,
                     video: {


### PR DESCRIPTION
This avoids an error which would otherwise appear if no desktop capturer source was selected