### PR TITLE
Friendlier room names when calculating from members

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -696,7 +696,7 @@ describe("Room", function() {
                 });
 
                 room.recalculate();
-                expect(room.name).toEqual(`${userB} and 2 others`);
+                expect(room.name).toEqual(`${userB}, ${userC} and ${userD}`);
             });
 
             it("missing hero member state reverts to mxid", function() {
@@ -722,7 +722,8 @@ describe("Room", function() {
             });
 
             it("uses counts from summary", function() {
-                const name = "Mr B";
+                const firstName = "Bean";
+                const name = `${firstName} Mr`;
                 addMember(userB, "join", {name});
                 room.setSummary({
                     "m.heroes": [userB],
@@ -730,19 +731,21 @@ describe("Room", function() {
                     "m.invited_member_count": 50,
                 });
                 room.recalculate();
-                expect(room.name).toEqual(`${name} and 98 others`);
+                expect(room.name).toEqual(`${firstName} and 98 others`);
             });
 
             it("relies on heroes in case of absent counts", function() {
-                const nameB = "Mr Bean";
-                const nameC = "Mel C";
+                const firstNameB = "Bean";
+                const nameB = `${firstNameB} Mr`;
+                const firstNameC = "Mel";
+                const nameC = `${firstNameC} C`;
                 addMember(userB, "join", {name: nameB});
                 addMember(userC, "join", {name: nameC});
                 room.setSummary({
                     "m.heroes": [userB, userC],
                 });
                 room.recalculate();
-                expect(room.name).toEqual(`${nameB} and ${nameC}`);
+                expect(room.name).toEqual(`${firstNameB} and ${firstNameC}`);
             });
 
             it("uses only heroes", function() {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1926,6 +1926,16 @@ function calculateRoomName(room, userId, ignoreRoomNameEvent) {
     }
 }
 
+/**
+ * Simplifies a full name to a single word.
+ *
+ * @param {string} name The full name of a room member
+ * @return {string} A single word of the name
+ */
+function shortName(name) {
+    return name.split(" ")[0];
+}
+
 function memberNamesToRoomName(names, count = (names.length + 1)) {
     const countWithoutMe = count - 1;
     if (!names.length) {
@@ -1933,13 +1943,24 @@ function memberNamesToRoomName(names, count = (names.length + 1)) {
     } else if (names.length === 1 && countWithoutMe <= 1) {
         return names[0];
     } else if (names.length === 2 && countWithoutMe <= 2) {
-        return `${names[0]} and ${names[1]}`;
-    } else {
-        const plural = countWithoutMe > 1;
+        return `${shortName(names[0])} and ${shortName(names[1])}`;
+    } else if (names.length === 3 && countWithoutMe <= 3) {
+        return `${shortName(names[0])}, ${shortName(names[1])} and ${shortName(names[2])}`;
+    } else if (names.length >= 2) {
+        const restCount = countWithoutMe - 2;
+        const plural = restCount > 0;
         if (plural) {
-            return `${names[0]} and ${countWithoutMe} others`;
+            return `${shortName(names[0])}, ${shortName(names[1])} and ${restCount} others`;
         } else {
-            return `${names[0]} and 1 other`;
+            return `${shortName(names[0])}, ${shortName(names[1])} and 1 other`;
+        }
+    } else { // Implicit name.length === 1
+        const restCount = countWithoutMe - 1;
+        const plural = restCount > 0;
+        if (plural) {
+            return `${shortName(names[0])} and ${restCount} others`;
+        } else {
+            return `${shortName(names[0])} and 1 other`;
         }
     }
 }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1866,8 +1866,7 @@ function calculateRoomName(room, userId, ignoreRoomNameEvent) {
 
     const joinedMemberCount = room.currentState.getJoinedMemberCount();
     const invitedMemberCount = room.currentState.getInvitedMemberCount();
-    // -1 because these numbers include the syncing user
-    const inviteJoinCount = joinedMemberCount + invitedMemberCount - 1;
+    const inviteJoinCount = joinedMemberCount + invitedMemberCount;
 
     // get members that are NOT ourselves and are actually in the room.
     let otherNames = null;
@@ -1890,7 +1889,7 @@ function calculateRoomName(room, userId, ignoreRoomNameEvent) {
         otherNames = otherMembers.map((m) => m.name);
     }
 
-    if (inviteJoinCount) {
+    if (inviteJoinCount > 1) {
         return memberNamesToRoomName(otherNames, inviteJoinCount);
     }
 
@@ -1948,7 +1947,7 @@ function memberNamesToRoomName(names, count = (names.length + 1)) {
         return `${shortName(names[0])}, ${shortName(names[1])} and ${shortName(names[2])}`;
     } else if (names.length >= 2) {
         const restCount = countWithoutMe - 2;
-        const plural = restCount > 0;
+        const plural = restCount > 1;
         if (plural) {
             return `${shortName(names[0])}, ${shortName(names[1])} and ${restCount} others`;
         } else {
@@ -1956,7 +1955,7 @@ function memberNamesToRoomName(names, count = (names.length + 1)) {
         }
     } else { // Implicit name.length === 1
         const restCount = countWithoutMe - 1;
-        const plural = restCount > 0;
+        const plural = restCount > 1;
         if (plural) {
             return `${shortName(names[0])} and ${restCount} others`;
         } else {


### PR DESCRIPTION
This is my first PR, and an attempt to solve vector-im/element-web#15022.
The implementation is driven by my own motivation for quickly being able to recognize my own rooms (bridged from Facebook Messenger). The style is inspired by Messenger and the issue mentioned above.

I know room naming is specified the client-server spec section [13.2.2.5 Calculating the display name for a room](https://matrix.org/docs/spec/client_server/r0.6.1#calculating-the-display-name-for-a-room), and I don't believe this PR breaks that spec, although "calculate display names [...] and concatenating them" might be interpreted in several ways. I am of course open to changing my implementation should someone have better ideas, though.

## In action
Here are some screenshots from Element.
*Before*
![Skjermdump fra 2021-02-14 13-13-55](https://user-images.githubusercontent.com/817001/107876603-3f087c00-6ec7-11eb-9d00-9674048f005a.png)
*After*
![Skjermdump fra 2021-02-14 13-17-31](https://user-images.githubusercontent.com/817001/107876617-4760b700-6ec7-11eb-81e2-ffff163152d7.png)


## Possible caveats
- Not all names are delimited by spaces, or are reasonable distinct in their first "word"
- The first "word" of names might be long, so the total length of the room name is longer than ideal for an UI. This problem also exists in the existing implementation

## Commit message
The following changes are made to the room name calculation from
list of members:
 1. Only show the first word of each member name (before first space)
 3. Show up to three members listed explicitly
 2. Show two names before appending "and n others"

The possible forms are now:
 * Empty room
 * Paul Brown
   - When there is only one member except you
 * Paul and John
   - When there are two members except you
 * Paul, John and Will
   - When there are three members except you
 * Paul, John and 3 others
   - When there are more than three members except you
   - Or, only two members have actually joined the room
 * Paul, John and 1 other
   - When the third member except you has not yet joined the room
 * Paul and n other(s)
   - When only one member except you has actually joined the room

Signed-off-by: Tobias Laundal <tobias@laundal.no>