### PR TITLE
Fix ContentHelpers export

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -52,7 +52,7 @@ export * from "./store/session/webstorage";
 export * from "./crypto/store/memory-crypto-store";
 export * from "./crypto/store/indexeddb-crypto-store";
 export * from "./content-repo";
-export const ContentHelpers = import("./content-helpers");
+export * as ContentHelpers from "./content-helpers";
 export {
     createNewMatrixCall,
     setAudioOutput as setMatrixCallAudioOutput,


### PR DESCRIPTION
This was previously exporting a promise, since it called the import function manually but didn't await the result. However, since we have Babel we can just use the new export … as … from syntax instead.