### PR TITLE
Filter out edits from other senders in history

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5413,6 +5413,9 @@ async function(roomId, eventId, relationType, eventType, opts = {}) {
         }));
         events = events.filter(e => e.getType() === eventType);
     }
+    if (originalEvent && relationType === "m.replace") {
+        events = events.filter(e => e.getSender() === originalEvent.getSender());
+    }
     return {
         originalEvent,
         events,


### PR DESCRIPTION
We currently don't support edits from other senders, but the server may not
filter them, so we filter them here on the client.