### PR TITLE
Avoid deadlocks when ensuring Olm sessions for devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:minify-browser": "terser dist/browser-matrix.js --compress --mangle --source-map --output dist/browser-matrix.min.js",
     "gendoc": "jsdoc -c jsdoc.json -P package.json",
     "lint": "yarn lint:types && yarn lint:js",
-    "lint:js": "eslint --max-warnings 73 src spec",
+    "lint:js": "eslint --max-warnings 72 src spec",
     "lint:types": "tsc --noEmit",
     "test": "jest spec/ --coverage --testEnvironment node",
     "test:watch": "jest spec/ --coverage --testEnvironment node --watch"

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -331,10 +331,10 @@ export async function ensureOlmSessionsForDevices(
         failedServers.push(...Object.keys(res.failures));
     }
 
-    const otk_res = res.one_time_keys || {};
+    const otkResult = res.one_time_keys || {};
     const promises = [];
     for (const [userId, devices] of Object.entries(devicesByUser)) {
-        const userRes = otk_res[userId] || {};
+        const userRes = otkResult[userId] || {};
         for (let j = 0; j < devices.length; j++) {
             const deviceInfo = devices[j];
             const deviceId = deviceInfo.deviceId;

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -273,11 +273,9 @@ export async function ensureOlmSessionsForDevices(
             log.debug(`Got Olm session ${sessionId} ${forWhom}`);
             if (sessionId !== null && resolveSession[key]) {
                 // we found a session, but we had marked the session as
-                // in-progress, so unmark it and unblock anything that was
-                // waiting
-                delete olmDevice._sessionsInProgress[key];
+                // in-progress, so resolve it now, which will unmark it and
+                // unblock anything that was waiting
                 resolveSession[key]();
-                delete resolveSession[key];
             }
             if (sessionId === null || force) {
                 if (force) {

--- a/src/crypto/olmlib.js
+++ b/src/crypto/olmlib.js
@@ -295,9 +295,13 @@ export async function ensureOlmSessionsForDevices(
     // timeout on this request, let's first log whether that's the root
     // cause we're seeing in practice.
     // See also https://github.com/vector-im/element-web/issues/16194
-    const otkTimeoutLogger = setTimeout(() => {
-        log.error(`Homeserver never replied while claiming ${taskDetail}`);
-    }, otkTimeout);
+    let otkTimeoutLogger;
+    // XXX: Perhaps there should be a default timeout?
+    if (otkTimeout) {
+        otkTimeoutLogger = setTimeout(() => {
+            log.error(`Homeserver never replied while claiming ${taskDetail}`);
+        }, otkTimeout);
+    }
     try {
         log.debug(`Claiming ${taskDetail}`);
         res = await baseApis.claimOneTimeKeys(


### PR DESCRIPTION
This reworks tracking the Olm sessions a particular task is updating to avoid deadlocks. By ensuring we synchronously mark all sessions a task cares about as in progress from the start, we know that no other tasks will own updating a session in common, which avoids deadlocks across multiple tasks that might be working on a shared set of devices.

The potential for deadlocks first appeared with https://github.com/matrix-org/matrix-js-sdk/pull/857 (2 years ago), but I believe it would be unlikely for most users to trigger this deadlock during normal usage. The app would need to be sluggish enough to permit stacking up several messages in different rooms with devices in common, which is most likely only possible on larger accounts. In any case, with this change, this process should now avoid deadlocks in all cases.

Fixes https://github.com/vector-im/element-web/issues/16194