### PR TITLE
Remove export keyword from global.d.ts 

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -41,7 +41,7 @@ declare global {
         getUserMedia(constraints: MediaStreamConstraints | DesktopCapturerConstraints): Promise<MediaStream>;
     }
 
-    export interface DesktopCapturerConstraints {
+    interface DesktopCapturerConstraints {
         audio: boolean | {
             mandatory: {
                 chromeMediaSource: string;
@@ -56,7 +56,7 @@ declare global {
         };
     }
 
-    export interface DesktopCapturerSource {
+    interface DesktopCapturerSource {
         id: string;
         name: string;
         thumbnailURL: string;


### PR DESCRIPTION
As far as I can tell this shouldn't be here... I accidentally copied the `export` keyword along with the rest of the declarations when I wrote this