### PR TITLE
docs: registerGuest()

### DIFF
--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -246,16 +246,30 @@ MatrixBaseApis.prototype.register = function(
 
 /**
  * Register a guest account.
+ * This method returns the auth info needed to create a new authenticated client,
+ * Remember to call `setGuest(true)` on the (guest-)authenticated client, e.g:
+ * ```javascript
+ * const tmpClient = await sdk.createClient(MATRIX_INSTANCE);
+ * const { user_id, device_id, access_token } = tmpClient.registerGuest();
+ * const client = createClient({
+ *   baseUrl: MATRIX_INSTANCE,
+ *   accessToken: access_token,
+ *   userId: user_id,
+ *   deviceId: device_id,
+ * })
+ * client.setGuest(true);
+ * ```
+ *
  * @param {Object=} opts Registration options
  * @param {Object} opts.body JSON HTTP body to provide.
  * @param {module:client.callback} callback Optional.
- * @return {Promise} Resolves: TODO
+ * @return {Promise} Resolves: JSON object that contains:
+ *                   { user_id, device_id, access_token, home_server }
  * @return {module:http-api.MatrixError} Rejects: with an error response.
  */
 MatrixBaseApis.prototype.registerGuest = function(opts, callback) {
     opts = opts || {};
     opts.body = opts.body || {};
-    this.setGuest(true);
     return this.registerRequest(opts.body, "guest", callback);
 };
 

--- a/src/base-apis.js
+++ b/src/base-apis.js
@@ -255,6 +255,7 @@ MatrixBaseApis.prototype.register = function(
 MatrixBaseApis.prototype.registerGuest = function(opts, callback) {
     opts = opts || {};
     opts.body = opts.body || {};
+    this.setGuest(true);
     return this.registerRequest(opts.body, "guest", callback);
 };
 


### PR DESCRIPTION
Otherwise the client will have the default `_guest = false` and it will try to pushrules when doing the initial sync which will fail

This will set `client._guest = true` on the client even if it fails to register as a guest.
I could wrap the callback in some fancy logic (help needed)... buuut I guess people shouldn't rely on `.registerGuest()` failing and not having side-effects

Signed-off-by: Nicolai Søborg <matrix@xn--sb-lka.org>