### PR TITLE
Make selectDesktopCapturerSource param optional

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -372,7 +372,7 @@ export class MatrixCall extends EventEmitter {
     async placeScreenSharingCall(
         remoteVideoElement: HTMLVideoElement,
         localVideoElement: HTMLVideoElement,
-        selectDesktopCapturerSource: () => Promise<DesktopCapturerSource>,
+        selectDesktopCapturerSource?: () => Promise<DesktopCapturerSource>,
     ) {
         logger.debug("placeScreenSharingCall");
         this.checkForErrorListener();


### PR DESCRIPTION
Web apps shouldn't be forced to provide a callback since they don'ŧ need it