### PR TITLE
More VoIP connectivity fixes

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1525,9 +1525,6 @@ export class MatrixCall extends EventEmitter {
         }
     }
 
-    /*
-     * Transfers this call to another user
-     */
     async transfer(targetUserId: string, targetRoomId?: string) {
         // Fetch the target user's global profile info: their room avatar / displayname
         // could be different in whatever room we shae with them.

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1528,7 +1528,7 @@ export class MatrixCall extends EventEmitter {
     /*
      * Transfers this call to another user
      */
-    async transfer(targetUserId: string) {
+    async transfer(targetUserId: string, targetRoomId?: string) {
         // Fetch the target user's global profile info: their room avatar / displayname
         // could be different in whatever room we shae with them.
         const profileInfo = await this.client.getProfileInfo(targetUserId);
@@ -1545,14 +1545,9 @@ export class MatrixCall extends EventEmitter {
             create_call: replacementId,
         } as MCallReplacesEvent;
 
-        return this.sendVoipEvent(EventType.CallReplaces, body);
-    }
+        if (targetRoomId) body.target_room = targetRoomId;
 
-    /*
-     * Transfers this call to the target call, effectively 'joining' the
-     * two calls (so the remote parties on each call are connected together).
-     */
-    async transferToCall(transferTargetCall?: MatrixCall) {
+        return this.sendVoipEvent(EventType.CallReplaces, body);
     }
 
     private async terminate(hangupParty: CallParty, hangupReason: CallErrorCode, shouldEmit: boolean) {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -541,6 +541,7 @@ export class MatrixCall extends EventEmitter {
         this.chooseOpponent(event);
         try {
             await this.peerConn.setRemoteDescription(invite.offer);
+            await this.addBufferedIceCandidates();
         } catch (e) {
             logger.debug("Failed to set remote description", e);
             this.terminate(CallParty.Local, CallErrorCode.SetRemoteDescription, false);
@@ -985,7 +986,7 @@ export class MatrixCall extends EventEmitter {
     private gotLocalIceCandidate = (event: RTCPeerConnectionIceEvent) => {
         if (event.candidate) {
             logger.debug(
-                "Got local ICE " + event.candidate.sdpMid + " candidate: " +
+                "Call " + this.callId + " got local ICE " + event.candidate.sdpMid + " candidate: " +
                 event.candidate.candidate,
             );
 
@@ -1019,7 +1020,7 @@ export class MatrixCall extends EventEmitter {
         }
     };
 
-    onRemoteIceCandidatesReceived(ev: MatrixEvent) {
+    async onRemoteIceCandidatesReceived(ev: MatrixEvent) {
         if (this.callHasEnded()) {
             //debuglog("Ignoring remote ICE candidate because call has ended");
             return;
@@ -1051,7 +1052,7 @@ export class MatrixCall extends EventEmitter {
             return;
         }
 
-        this.addIceCandidates(cands);
+        await this.addIceCandidates(cands);
     }
 
     /**
@@ -1059,7 +1060,10 @@ export class MatrixCall extends EventEmitter {
      * @param {Object} msg
      */
     async onAnswerReceived(event: MatrixEvent) {
+        logger.debug(`Got answer for call ID ${this.callId} from party ID ${event.getContent().party_id}`);
+
         if (this.callHasEnded()) {
+            logger.debug(`Ignoring answer because call ID ${this.callId} has ended`);
             return;
         }
 
@@ -1072,6 +1076,7 @@ export class MatrixCall extends EventEmitter {
         }
 
         this.chooseOpponent(event);
+        await this.addBufferedIceCandidates();
 
         this.setState(CallState.Connecting);
 
@@ -1520,7 +1525,10 @@ export class MatrixCall extends EventEmitter {
         }
     }
 
-    async transfer(targetUserId: string, targetRoomId?: string) {
+    /*
+     * Transfers this call to another user
+     */
+    async transfer(targetUserId: string) {
         // Fetch the target user's global profile info: their room avatar / displayname
         // could be different in whatever room we shae with them.
         const profileInfo = await this.client.getProfileInfo(targetUserId);
@@ -1537,9 +1545,14 @@ export class MatrixCall extends EventEmitter {
             create_call: replacementId,
         } as MCallReplacesEvent;
 
-        if (targetRoomId) body.target_room = targetRoomId;
-
         return this.sendVoipEvent(EventType.CallReplaces, body);
+    }
+
+    /*
+     * Transfers this call to the target call, effectively 'joining' the
+     * two calls (so the remote parties on each call are connected together).
+     */
+    async transferToCall(transferTargetCall?: MatrixCall) {
     }
 
     private async terminate(hangupParty: CallParty, hangupReason: CallErrorCode, shouldEmit: boolean) {
@@ -1722,6 +1735,8 @@ export class MatrixCall extends EventEmitter {
         // I choo-choo-choose you
         const msg = ev.getContent();
 
+        logger.debug(`Choosing party ID ${msg.party_id} for call ID ${this.callId}`);
+
         this.opponentVersion = msg.version;
         if (this.opponentVersion === 0) {
             // set to null to indicate that we've chosen an opponent, but because
@@ -1735,30 +1750,32 @@ export class MatrixCall extends EventEmitter {
         }
         this.opponentCaps = msg.capabilities || {};
         this.opponentMember = ev.sender;
+    }
 
+    private async addBufferedIceCandidates() {
         const bufferedCands = this.remoteCandidateBuffer.get(this.opponentPartyId);
         if (bufferedCands) {
             logger.info(`Adding ${bufferedCands.length} buffered candidates for opponent ${this.opponentPartyId}`);
-            this.addIceCandidates(bufferedCands);
+            await this.addIceCandidates(bufferedCands);
         }
         this.remoteCandidateBuffer = null;
     }
 
-    private addIceCandidates(cands: RTCIceCandidate[]) {
+    private async addIceCandidates(cands: RTCIceCandidate[]) {
         for (const cand of cands) {
             if (
                 (cand.sdpMid === null || cand.sdpMid === undefined) &&
                 (cand.sdpMLineIndex === null || cand.sdpMLineIndex === undefined)
             ) {
                 logger.debug("Ignoring remote ICE candidate with no sdpMid or sdpMLineIndex");
-                return;
+                continue;
             }
-            logger.debug("Got remote ICE " + cand.sdpMid + " candidate: " + cand.candidate);
+            logger.debug("Call " + this.callId + " got remote ICE " + cand.sdpMid + " candidate: " + cand.candidate);
             try {
-                this.peerConn.addIceCandidate(cand);
+                await this.peerConn.addIceCandidate(cand);
             } catch (err) {
                 if (!this.ignoreOffer) {
-                    logger.info("Failed to add remore ICE candidate", err);
+                    logger.info("Failed to add remote ICE candidate", err);
                 }
             }
         }


### PR DESCRIPTION
 * Don't ignore other candidates when we see a null one (continue
   rather than return)
 * await on addICECandidate()
 * Don't add ice candidates until we've set a remote description
 * More & better logging