### PR TITLE
Cache cross-signing private keys if needed on bootstrap

### DIFF
--- a/spec/unit/crypto/cross-signing.spec.js
+++ b/spec/unit/crypto/cross-signing.spec.js
@@ -193,7 +193,9 @@ describe("Cross Signing", function() {
         const keyChangePromise = new Promise((resolve, reject) => {
             alice.once("crossSigning.keysChanged", async (e) => {
                 resolve(e);
-                await alice.checkOwnCrossSigningTrust();
+                await alice.checkOwnCrossSigningTrust({
+                    allowPrivateKeyRequests: true,
+                });
             });
         });
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -568,7 +568,9 @@ Crypto.prototype.bootstrapCrossSigning = async function({
             "Cross-signing private keys not found locally, but they are available " +
             "in secret storage, reading storage and caching locally",
         );
-        await this.checkOwnCrossSigningTrust();
+        await this.checkOwnCrossSigningTrust({
+            allowPrivateKeyRequests: true,
+        });
     }
 
     // Assuming no app-supplied callback, default to storing new private keys in
@@ -1300,12 +1302,18 @@ Crypto.prototype._onDeviceListUserCrossSigningUpdated = async function(userId) {
  * Check the copy of our cross-signing key that we have in the device list and
  * see if we can get the private key. If so, mark it as trusted.
  */
-Crypto.prototype.checkOwnCrossSigningTrust = async function() {
+Crypto.prototype.checkOwnCrossSigningTrust = async function({
+    allowPrivateKeyRequests = false,
+} = {}) {
     const userId = this._userId;
 
     // Before proceeding, ensure our cross-signing public keys have been
     // downloaded via the device list.
     await this.downloadKeys([this._userId]);
+
+    // Also check which private keys are locally cached.
+    const crossSigningPrivateKeys =
+        await this._crossSigningInfo.getCrossSigningKeysFromCache();
 
     // If we see an update to our own master key, check it against the master
     // key we have and, if it matches, mark it as verified
@@ -1324,6 +1332,11 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
     const masterChanged = this._crossSigningInfo.getId() !== seenPubkey;
     if (masterChanged) {
         logger.info("Got new master public key", seenPubkey);
+    }
+    if (
+        allowPrivateKeyRequests &&
+        (masterChanged || !crossSigningPrivateKeys.has("master"))
+    ) {
         logger.info("Attempting to retrieve cross-signing master private key");
         let signing = null;
         try {
@@ -1352,6 +1365,11 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
 
     if (selfSigningChanged) {
         logger.info("Got new self-signing key", newCrossSigning.getId("self_signing"));
+    }
+    if (
+        allowPrivateKeyRequests &&
+        (selfSigningChanged || !crossSigningPrivateKeys.has("self_signing"))
+    ) {
         logger.info("Attempting to retrieve cross-signing self-signing private key");
         let signing = null;
         try {
@@ -1374,6 +1392,11 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
     }
     if (userSigningChanged) {
         logger.info("Got new user-signing key", newCrossSigning.getId("user_signing"));
+    }
+    if (
+        allowPrivateKeyRequests &&
+        (userSigningChanged || !crossSigningPrivateKeys.has("user_signing"))
+    ) {
         logger.info("Attempting to retrieve cross-signing user-signing private key");
         let signing = null;
         try {


### PR DESCRIPTION
This is a revised version of https://github.com/matrix-org/matrix-js-sdk/pull/1472 which was previously reverted for causing security prompts to appear on device list sync. In this version, we only allow private key requests (which are likely to trigger user dialogs) if we are coming from the bootstrap path.

This allows sessions that have already synced cross-signing public keys but never got the private keys for some reason to make forward progress when e.g. the user triggers bootstrap from security settings.