### PR TITLE
Fixed the media fail error on caller's side

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -396,7 +396,6 @@ export class MatrixCall extends EventEmitter {
 
             logger.debug("Got screen stream, requesting audio stream...");
             const audioConstraints = getUserMediaContraints(ConstraintsType.Audio);
-            this.type = CallType.Video;
             this.placeCallWithConstraints(audioConstraints);
         } catch (err) {
             this.emit(CallEvent.Error,
@@ -406,7 +405,7 @@ export class MatrixCall extends EventEmitter {
                 ),
             );
         }
-        
+        this.type = CallType.Video;
     }
 
     public getOpponentMember() {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -337,8 +337,9 @@ export class MatrixCall extends EventEmitter {
         logger.debug("placeVoiceCall");
         this.checkForErrorListener();
         const constraints = getUserMediaContraints(ConstraintsType.Audio);
-        await this.placeCallWithConstraints(constraints);
         this.type = CallType.Voice;
+        await this.placeCallWithConstraints(constraints);
+        
     }
 
     /**
@@ -355,8 +356,9 @@ export class MatrixCall extends EventEmitter {
         this.localVideoElement = localVideoElement;
         this.remoteVideoElement = remoteVideoElement;
         const constraints = getUserMediaContraints(ConstraintsType.Video);
-        await this.placeCallWithConstraints(constraints);
         this.type = CallType.Video;
+        await this.placeCallWithConstraints(constraints);
+        
     }
 
     /**
@@ -394,6 +396,7 @@ export class MatrixCall extends EventEmitter {
 
             logger.debug("Got screen stream, requesting audio stream...");
             const audioConstraints = getUserMediaContraints(ConstraintsType.Audio);
+            this.type = CallType.Video;
             this.placeCallWithConstraints(audioConstraints);
         } catch (err) {
             this.emit(CallEvent.Error,
@@ -403,7 +406,7 @@ export class MatrixCall extends EventEmitter {
                 ),
             );
         }
-        this.type = CallType.Video;
+        
     }
 
     public getOpponentMember() {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -339,7 +339,6 @@ export class MatrixCall extends EventEmitter {
         const constraints = getUserMediaContraints(ConstraintsType.Audio);
         this.type = CallType.Voice;
         await this.placeCallWithConstraints(constraints);
-        
     }
 
     /**
@@ -358,7 +357,6 @@ export class MatrixCall extends EventEmitter {
         const constraints = getUserMediaContraints(ConstraintsType.Video);
         this.type = CallType.Video;
         await this.placeCallWithConstraints(constraints);
-        
     }
 
     /**


### PR DESCRIPTION
Fixes vector-im/element-web/issues/16747

Switched `CallType` before async function calls  in `/src/webrtc/call.ts` that were causing the `showMediaCaptureError` in `matrix-react-sdk/src/CallHandler.tsx` to skip all the conditions and hence causing a generic error.

Signed-off-by: Ayush Pratap Singh ayushpratap16@gmail.com