### PR TITLE
Remove catch handlers in private key retrieval

### DIFF
--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1326,14 +1326,15 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
         logger.info("Got new master public key", seenPubkey);
         logger.info("Attempting to retrieve cross-signing master private key");
         let signing = null;
+        // It's important for control flow that we leave any errors alone for
+        // higher levels to handle so that e.g. cancelling access properly
+        // aborts any larger operation as well.
         try {
             const ret = await this._crossSigningInfo.getCrossSigningKey(
                 'master', seenPubkey,
             );
             signing = ret[1];
             logger.info("Got cross-signing master private key");
-        } catch (e) {
-            logger.error("Cross-signing master private key not available", e);
         } finally {
             if (signing) signing.free();
         }
@@ -1360,8 +1361,6 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
             );
             signing = ret[1];
             logger.info("Got cross-signing self-signing private key");
-        } catch (e) {
-            logger.error("Cross-signing self-signing private key not available", e);
         } finally {
             if (signing) signing.free();
         }
@@ -1382,8 +1381,6 @@ Crypto.prototype.checkOwnCrossSigningTrust = async function() {
             );
             signing = ret[1];
             logger.info("Got cross-signing user-signing private key");
-        } catch (e) {
-            logger.error("Cross-signing user-signing private key not available", e);
         } finally {
             if (signing) signing.free();
         }


### PR DESCRIPTION
This removes some catch blocks originally added by https://github.com/matrix-org/matrix-js-sdk/pull/1472 so that higher level operations can handle them as needed.

Part of https://github.com/vector-im/element-web/issues/15584
Needed for https://github.com/matrix-org/matrix-react-sdk/pull/5812