### PR TITLE
Persist unsent messages for subsequent sessions

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -3,6 +3,7 @@ import {EventStatus, MatrixEvent} from "../../src/models/event";
 import {EventTimeline} from "../../src/models/event-timeline";
 import {RoomState} from "../../src/models/room-state";
 import {Room} from "../../src/models/room";
+import {TestClient} from "../TestClient";
 
 describe("Room", function() {
     const roomId = "!foo:bar";
@@ -1176,7 +1177,10 @@ describe("Room", function() {
     describe("addPendingEvent", function() {
         it("should add pending events to the pendingEventList if " +
                       "pendingEventOrdering == 'detached'", function() {
-            const room = new Room(roomId, null, userA, {
+            const client = (new TestClient(
+                "@alice:example.com", "alicedevice",
+            )).client;
+            const room = new Room(roomId, client, userA, {
                 pendingEventOrdering: "detached",
             });
             const eventA = utils.mkMessage({
@@ -1226,7 +1230,10 @@ describe("Room", function() {
 
     describe("updatePendingEvent", function() {
         it("should remove cancelled events from the pending list", function() {
-            const room = new Room(roomId, null, userA, {
+            const client = (new TestClient(
+                "@alice:example.com", "alicedevice",
+            )).client;
+            const room = new Room(roomId, client, userA, {
                 pendingEventOrdering: "detached",
             });
             const eventA = utils.mkMessage({

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -193,13 +193,12 @@ export function Room(roomId, client, myUserId, opts) {
         this._pendingEventList = [];
         const serializedPendingEventList = client._sessionStore.store.getItem(pendingEventsKey(this.roomId));
         if (serializedPendingEventList) {
-            const self = this;
             JSON.parse(serializedPendingEventList)
                 .forEach(serializedEvent => {
                     const event = new MatrixEvent(serializedEvent);
                     event.setStatus(EventStatus.NOT_SENT);
                     const txnId = client.makeTxnId();
-                    self.addPendingEvent(event, txnId);
+                    this.addPendingEvent(event, txnId);
                 });
         }
     }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -123,6 +123,8 @@ export function Room(roomId, client, myUserId, opts) {
     opts = opts || {};
     opts.pendingEventOrdering = opts.pendingEventOrdering || "chronological";
 
+    this._client = client;
+
     // In some cases, we add listeners for every displayed Matrix event, so it's
     // common to have quite a few more than the default limit.
     this.setMaxListeners(100);
@@ -208,7 +210,6 @@ export function Room(roomId, client, myUserId, opts) {
     this._summaryHeroes = null;
     // awaited by getEncryptionTargetMembers while room members are loading
 
-    this._client = client;
     if (!this._opts.lazyLoadMembers) {
         this._membersPromise = Promise.resolve();
     } else {
@@ -1472,7 +1473,9 @@ Room.prototype.updatePendingEvent = function(event, newStatus, newEventId) {
         for (let i = 0; i < this._timelineSets.length; i++) {
             this._timelineSets[i].replaceEventId(oldEventId, newEventId);
         }
-        this.removePendingEvent(event.event.event_id);
+        if (this._opts.pendingEventOrdering === "detached") {
+            this.removePendingEvent(event.event.event_id);
+        }
     } else if (newStatus == EventStatus.CANCELLED) {
         // remove it from the pending event list, or the timeline.
         if (this._pendingEventList) {


### PR DESCRIPTION
Fixes vector-im/element-web#7177

This pull requests hooks into the `Room#_pendingEventList` flow to store a serialised version of an unsent `MatrixEvent`.

The storage key is: `mx_pending_events_${roomId}`

Upon instanciation the `Room` model will query the storage and populate `_pendingEventList` if required. Element then picks up the unsent messages and display the `RoomStatusBar` and a user can decide whether to send or cancel the queued messages