### PR TITLE
Fix calling addEventListener if it does not exist

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -476,7 +476,7 @@ SyncApi.prototype.sync = function() {
 
     this._running = true;
 
-    if (global.window) {
+    if (global.window && global.window.addEventListener) {
         this._onOnlineBound = this._onOnline.bind(this);
         global.window.addEventListener("online", this._onOnlineBound, false);
     }


### PR DESCRIPTION
Some platforms (e.g. React Native) register global.window, but do not have global.window.addEventListener. In this case, this function should not be called.

Signed-off-by: Jan Pawellek <jpawellek@churchtools.de>