### PR TITLE
Fix timeline jumpiness by setting correct txnId

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -1098,7 +1098,6 @@ utils.extend(MatrixEvent.prototype, {
             origin_server_ts: this.getTs(),
             unsigned: this.getUnsigned(),
             room_id: this.getRoomId(),
-            txn_id: this.getTxnId(),
         };
 
         // if this is a redaction then attach the redacts key

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -168,7 +168,7 @@ export const MatrixEvent = function(
     /* The txnId with which this event was sent if it was during this session,
        allows for a unique ID which does not change when the event comes back down sync.
      */
-    this._txnId = null;
+    this._txnId = event.txn_id || null;
 
     /* Set an approximate timestamp for the event relative the local clock.
      * This will inherently be approximate because it doesn't take into account
@@ -1098,6 +1098,7 @@ utils.extend(MatrixEvent.prototype, {
             origin_server_ts: this.getTs(),
             unsigned: this.getUnsigned(),
             room_id: this.getRoomId(),
+            txn_id: this.getTxnId(),
         };
 
         // if this is a redaction then attach the redacts key

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -195,9 +195,10 @@ export function Room(roomId, client, myUserId, opts) {
         if (serializedPendingEventList) {
             JSON.parse(serializedPendingEventList)
                 .forEach(serializedEvent => {
+                    const txnId = client.makeTxnId();
                     const event = new MatrixEvent(serializedEvent);
                     event.setStatus(EventStatus.NOT_SENT);
-                    const txnId = client.makeTxnId();
+                    event.setTxnId(txnId);
                     this.addPendingEvent(event, txnId);
                 });
         }
@@ -1471,9 +1472,6 @@ Room.prototype.updatePendingEvent = function(event, newStatus, newEventId) {
         // timeline map.
         for (let i = 0; i < this._timelineSets.length; i++) {
             this._timelineSets[i].replaceEventId(oldEventId, newEventId);
-        }
-        if (this._opts.pendingEventOrdering === "detached") {
-            this.removePendingEvent(event.event.event_id);
         }
     } else if (newStatus == EventStatus.CANCELLED) {
         // remove it from the pending event list, or the timeline.

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1303,6 +1303,19 @@ Room.prototype.addPendingEvent = function(event, txnId) {
     this.emit("Room.localEchoUpdated", event, this, null, null);
 };
 
+/**
+ * Persists all pending events to local storage
+ *
+ * If the current room is encrypted only encrypted events will be persisted
+ * all messages that are not yet encrypted will be discarded
+ *
+ * This is because the flow of EVENT_STATUS transition is
+ * queued => sending => encrypting => sending => sent
+ *
+ * Steps 3 and 4 are skipped for unencrypted room.
+ * It is better to discard an unencrypted message rather than persisting
+ * it locally for everyone to read
+ */
 Room.prototype._savePendingEvents = function() {
     const pendingEvents = this._pendingEventList.map(event => {
         return {

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -195,11 +195,9 @@ export function Room(roomId, client, myUserId, opts) {
         if (serializedPendingEventList) {
             JSON.parse(serializedPendingEventList)
                 .forEach(serializedEvent => {
-                    const txnId = client.makeTxnId();
                     const event = new MatrixEvent(serializedEvent);
                     event.setStatus(EventStatus.NOT_SENT);
-                    event.setTxnId(txnId);
-                    this.addPendingEvent(event, txnId);
+                    this.addPendingEvent(event, event.getTxnId());
                 });
         }
     }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1311,10 +1311,9 @@ Room.prototype._savePendingEvents = function() {
         };
     }).filter(event => {
         // Filter out the unencrypted messages if the room is encrypted
-        const isEventEncrypted = event.getType !== "m.room.encrypted";
+        const isEventEncrypted = event.getType() === "m.room.encrypted";
         const isRoomEncrypted = this._client.isRoomEncrypted(this.roomId);
-
-        return !isRoomEncrypted || (isRoomEncrypted && isEventEncrypted);
+        return isEventEncrypted || !isRoomEncrypted;
     });
 
     const { store } = this._client._sessionStore;

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1324,7 +1324,7 @@ Room.prototype._savePendingEvents = function() {
         };
     }).filter(event => {
         // Filter out the unencrypted messages if the room is encrypted
-        const isEventEncrypted = event.getType() === "m.room.encrypted";
+        const isEventEncrypted = event.type === "m.room.encrypted";
         const isRoomEncrypted = this._client.isRoomEncrypted(this.roomId);
         return isEventEncrypted || !isRoomEncrypted;
     });

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -1317,26 +1317,28 @@ Room.prototype.addPendingEvent = function(event, txnId) {
  * it locally for everyone to read
  */
 Room.prototype._savePendingEvents = function() {
-    const pendingEvents = this._pendingEventList.map(event => {
-        return {
-            ...event.event,
-            txn_id: event.getTxnId(),
-        };
-    }).filter(event => {
-        // Filter out the unencrypted messages if the room is encrypted
-        const isEventEncrypted = event.type === "m.room.encrypted";
-        const isRoomEncrypted = this._client.isRoomEncrypted(this.roomId);
-        return isEventEncrypted || !isRoomEncrypted;
-    });
+    if (this._pendingEventList) {
+        const pendingEvents = this._pendingEventList.map(event => {
+            return {
+                ...event.event,
+                txn_id: event.getTxnId(),
+            };
+        }).filter(event => {
+            // Filter out the unencrypted messages if the room is encrypted
+            const isEventEncrypted = event.type === "m.room.encrypted";
+            const isRoomEncrypted = this._client.isRoomEncrypted(this.roomId);
+            return isEventEncrypted || !isRoomEncrypted;
+        });
 
-    const { store } = this._client._sessionStore;
-    if (this._pendingEventList.length > 0) {
-        store.setItem(
-            pendingEventsKey(this.roomId),
-            JSON.stringify(pendingEvents),
-        );
-    } else {
-        store.removeItem(pendingEventsKey(this.roomId));
+        const { store } = this._client._sessionStore;
+        if (this._pendingEventList.length > 0) {
+            store.setItem(
+                pendingEventsKey(this.roomId),
+                JSON.stringify(pendingEvents),
+            );
+        } else {
+            store.removeItem(pendingEventsKey(this.roomId));
+        }
     }
 };
 


### PR DESCRIPTION
Fixes vector-im/element-web#16914

Regression introduced by matrix-org/matrix-js-sdk#1655

I incorrectly tried to remove pending events in `updatePendingEvent` when this reconciliation is the responsability of that transaction ID. This PR sets that `txnId` attribute properly and remove the need to explicitely call `removePendingEvent` as the event is now going through the usual timeline flow

@t3chguy raised an [interesting comment](https://github.com/matrix-org/matrix-js-sdk/pull/1655#discussion_r611412326) in my previous pull request that is adressed here. The `txnId` is now persisted in storage and re-used at a later stage to ensure idempotency