### PR TITLE
Discard fallback body for HTML messages, and generate a spoiler-free plaintext representation to use locally in the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "bs58": "^4.0.1",
     "content-type": "^1.0.4",
     "loglevel": "^1.7.1",
+    "parse5": "^6.0.1",
     "qs": "^6.9.6",
     "request": "^2.88.2",
     "unhomoglyph": "^1.0.6"
@@ -73,6 +74,7 @@
     "@babel/register": "^7.12.10",
     "@types/jest": "^26.0.20",
     "@types/node": "12",
+    "@types/parse5": "^6.0.0",
     "@types/request": "^2.48.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -159,6 +159,9 @@ export function mkMembership(opts) {
  * @param {string} opts.room The room ID for the event.
  * @param {string} opts.user The user ID for the event.
  * @param {string} opts.msg Optional. The content.body for the event.
+ * @param {string} opts.html Optional. If provided, will add
+ * content.format as "org.matrix.custom.html" and set
+ * content.formatted_body to this value.
  * @param {boolean} opts.event True to make a MatrixEvent.
  * @return {Object|MatrixEvent} The event
  */
@@ -174,6 +177,10 @@ export function mkMessage(opts) {
         msgtype: "m.text",
         body: opts.msg,
     };
+    if (opts.html) {
+        opts.content.format = "org.matrix.custom.html";
+        opts.content.formatted_body = opts.html;
+    }
     return mkEvent(opts);
 }
 

--- a/spec/unit/event.spec.js
+++ b/spec/unit/event.spec.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import {logger} from "../../src/logger";
 import {MatrixEvent} from "../../src/models/event";
+import {mkMessage} from "../test-utils";
 
 describe("MatrixEvent", () => {
     describe(".attemptDecryption", () => {
@@ -71,6 +72,29 @@ describe("MatrixEvent", () => {
                 // make sure the second attemptDecryption resolves
                 return prom2;
             });
+        });
+    });
+
+    describe(".getContent", () => {
+        it('should provide the plain-text body for plain text messages', () => {
+            const event = mkMessage({
+                room: "!foo:bar",
+                user: "@baz:bar",
+                msg: "a plain text message",
+                event: true,
+            });
+            expect(event.getContent().body).toEqual("a plain text message");
+        });
+
+        it("will replace the fallback body for HTML messages", function() {
+            const event = mkMessage({
+                room: "!foo:bar",
+                user: "@baz:bar",
+                msg: "at the end of the movie, [Spoiler](it turns out it was all a dream)",
+                html: "at the end of the movie, <span data-mx-spoiler>it turns out it was all a dream</span>",
+                event: true,
+            });
+            expect(event.getContent().body).toEqual("at the end of the movie, ███████████████████████████████");
         });
     });
 });

--- a/spec/unit/utils.spec.js
+++ b/spec/unit/utils.spec.js
@@ -308,4 +308,38 @@ describe("utils", function() {
             expect(promiseCount).toEqual(2);
         });
     });
+
+    describe("htmlToText", function() {
+        it("should redact spoilers", function() {
+            expect(utils.htmlToText(
+                "<p>Spoiler alert: <span data-mx-spoiler>The person reading this is cute</span></p>",
+            )).toEqual("Spoiler alert: ███████████████████████████████");
+        });
+
+        it("should preserve spans that aren't spoilers", function() {
+            expect(utils.htmlToText(
+                `<p>Check out these <span data-mx-color="red">awesome colors!</span></p>`,
+            )).toEqual("Check out these awesome colors!");
+        });
+
+        it("should preserve <del> tags", function() {
+            expect(utils.htmlToText(
+                "<p>This food tastes <del>awful</del> delicious!</p>",
+            )).toEqual("This food tastes <del>awful</del> delicious!");
+        });
+
+        it("should space out block elements", function() {
+            expect(utils.htmlToText(
+                "<p>Here's a paragraph.</p><p>Here's another paragraph.</p>",
+            )).toEqual("Here's a paragraph. Here's another paragraph.");
+        });
+
+        it("should handle empty strings", function() {
+            expect(utils.htmlToText("")).toEqual("");
+        });
+
+        it("should handle strings with no tags", function() {
+            expect(utils.htmlToText("This is a test")).toEqual("This is a test");
+        });
+    });
 });

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -254,7 +254,14 @@ utils.extend(MatrixEvent.prototype, {
         if (this._localRedactionEvent) {
             return {};
         }
-        return this._clearEvent.content || this.event.content || {};
+        const content = this._clearEvent.content || this.event.content || {};
+        const format = content.format || "";
+        // MSC3124: discard original fallback body of HTML messages
+        // and replace it with a spoiler-free version derived from the formatted_body
+        if (format === "org.matrix.custom.html") {
+            content.body = utils.htmlToText(content.formatted_body || "");
+        }
+        return content;
     },
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/parse5@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.0.tgz#38590dc2c3cf5717154064e3ee9b6947ee21b299"
+  integrity sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA==
+
 "@types/prettier@^2.0.0":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
@@ -5276,6 +5281,11 @@ parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 pascalcase@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This fixes vector-im/element-web#12034 , I'm unclear on how to reproduce vector-im/element-web#14447 but I'm fairly sure this will fix that issue as well.

I've deliberately done the HTML-to-text conversion in a very fast-and-loose way, since the text version is only needed in a few limited contexts and doesn't need to do much more than give a general gist of the message content. If you'd rather retain a bit more formatting information, perhaps in a markdown-like syntax, I can adjust things.