### PR TITLE
Fix failure to lookup timeline in handleRemoteEcho

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -576,7 +576,7 @@ EventTimelineSet.prototype.addEventToTimeline = function(event, timeline,
 EventTimelineSet.prototype.handleRemoteEcho = function(localEvent, oldEventId,
                                                         newEventId) {
     // XXX: why don't we infer newEventId from localEvent?
-    const existingTimeline = this._eventIdToTimeline[oldEventId];
+    const existingTimeline = this._eventIdToTimeline[oldEventId] || this._eventIdToTimeline[newEventId];
     if (existingTimeline) {
         delete this._eventIdToTimeline[oldEventId];
         this._eventIdToTimeline[newEventId] = existingTimeline;


### PR DESCRIPTION
### Reproduction / Use case

I was trying to implement the "sending of voice message". I am:
* (creating a voice record)
* calling `room.addPendingEvent`, so a local message with the state being "sending" is shown to the user (UX: immediate feedback after stopping the recording). I create a dummy event with a txnId.
* uploading the voice record file
* sending an audio message using the txnId of the dummy event (and the content URL received from the upload)

### The issue

The problem was that once the audio message has been sent it would appear as a new message in chat, not updating the local echo (e.g. removing it).

### What I find out

The local echo event will be updated earlier when the message is being marked as "sent". The code `handleRemoteEcho` function was just looking up using the old event id (and handleRemoteEcho has been called with the old event id being the txnId, although the local event's id has already been updated).

With this fix, this doesn't happen. I can imagine that this might happens in other cases as well.
I am just surfacing the sdk's code, maybe this is just a workaround for a symptom, and did not fix the root cause? 

_Side note:_ There is a different issue that prevents the above-described flow/reproduction from working. The fix is in [this](https://github.com/matrix-org/matrix-js-sdk/pull/1668) PR.