### PR TITLE
Fix sending when pending event exists

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2857,7 +2857,9 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
         try {
             room.addPendingEvent(localEvent, txnId);
         } catch (e) {
-            logger.warn(`_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`); 
+            logger.warn(
+                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`
+            );
         }
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -2854,7 +2854,11 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
 
     // add this event immediately to the local store as 'sending'.
     if (room) {
-        room.addPendingEvent(localEvent, txnId);
+        try {
+            room.addPendingEvent(localEvent, txnId);
+        } catch (e) {
+            logger.warn(`_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`); 
+        }
     }
 
     // addPendingEvent can change the state to NOT_SENT if it believes

--- a/src/client.js
+++ b/src/client.js
@@ -2858,7 +2858,7 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
             room.addPendingEvent(localEvent, txnId);
         } catch (e) {
             logger.warn(
-                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`
+                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`,
             );
         }
     }


### PR DESCRIPTION
### Reproduction / Use case

I was trying to implement the "sending of voice message". I am:

* (creating a voice record)
* calling room.addPendingEvent, so a local message with the state being "sending" is shown to the user (UX: immediate feedback after stopping the recording). I create a dummy event with a txnId.
* uploading the voice record file
* sending an audio message using the txnId of the dummy event (and the content URL received from the upload)

### The issue

When sending the audio message event with the same txnId of the event we added earlier as pending the sending of the whole event will fail, as (the changed code line) will throw that the event already exists. It's fine that it exists and it should proceed.

_Side note:_ There is a different issue that prevents the above-described flow/reproduction from working. The fix is in [this](https://github.com/matrix-org/matrix-js-sdk/pull/1667) PR.

Signed-off-by: Hanno Gödecke <hgoedecke@cuvent.com>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->