### PR TITLE
Fix sync with misconfigured push rules

### DIFF
--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -267,7 +267,7 @@ export function PushProcessor(client) {
         if (cond.value) {
             return cond.value === val;
         }
-        
+
         if (typeof cond.pattern !== 'string') {
             return false;
         }

--- a/src/pushprocessor.js
+++ b/src/pushprocessor.js
@@ -267,6 +267,10 @@ export function PushProcessor(client) {
         if (cond.value) {
             return cond.value === val;
         }
+        
+        if (typeof cond.pattern !== 'string') {
+            return false;
+        }
 
         let regex;
 


### PR DESCRIPTION
### The issue

A user had some misconfigured push rules, where `pattern` was not set. This lead to the following error during sync:
```
ERROR  Caught /sync error TypeError: Cannot read property 'replace' of undefined
    at escapeRegExp
    at globToRegexp
    at createCachedRegex
    at eventFulfillsEventMatchCondition
    at eventFulfillsCondition
    at anonymous
    at matchingRuleFromKindSet
    at matchingRuleForEventWithRulesets
    at pushActionsForEventAndRulesets
```

the push rule looks like this:

```json
{"actions": ["notify", {"set_tweak": "highlight", "value": false}], "conditions": [{"key": "type", "kind": "event_match"}], "rule_id": "undefined"} env: {"content": {"join_rule": "invite"}, "event_id": undefined, "origin_server_ts": undefined, "room_id": "!yPQVkxldbDQFVCFqcY:redacted.com", "sender": "@e0c1e219-0cd0-48fb-8044-d91167025fa3:redacted.com", "type": "m.room.join_rules", "unsigned": {}}
```

This fix solves this issue and the processing of the rules can continue (otherwise it looks like it stops when the error happens)

Signed-off-by: Hanno Gödecke hgoedecke@cuvent.com