### PR TITLE
Support MSC3086 asserted identity

### DIFF
--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import {TestClient} from '../../TestClient';
-import {MatrixCall, CallErrorCode} from '../../../src/webrtc/call';
+import {MatrixCall, CallErrorCode, CallEvent} from '../../../src/webrtc/call';
 
 const DUMMY_SDP = (
     "v=0\r\n" +
@@ -272,6 +272,9 @@ describe('Call', function() {
             },
         });
 
+        const identChangedCallback = jest.fn();
+        call.on(CallEvent.AssertedIdentityChanged, identChangedCallback)
+
         await call.onAssertedIdentityReceived({
             getContent: () => {
                 return {
@@ -285,6 +288,8 @@ describe('Call', function() {
                 };
             },
         });
+
+        expect(identChangedCallback).toHaveBeenCalled();
 
         const ident = call.getRemoteAssertedIdentity();
         expect(ident.id).toEqual("@steve:example.com");

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -273,7 +273,7 @@ describe('Call', function() {
         });
 
         const identChangedCallback = jest.fn();
-        call.on(CallEvent.AssertedIdentityChanged, identChangedCallback)
+        call.on(CallEvent.AssertedIdentityChanged, identChangedCallback);
 
         await call.onAssertedIdentityReceived({
             getContent: () => {

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -53,6 +53,8 @@ export enum EventType {
     CallSelectAnswer = "m.call.select_answer",
     CallNegotiate = "m.call.negotiate",
     CallReplaces = "m.call.replaces",
+    CallAssertedIdentity = "m.call.asserted_identity",
+    CallAssertedIdentityPrefix = "org.matrix.call.asserted_identity",
     KeyVerificationRequest = "m.key.verification.request",
     KeyVerificationStart = "m.key.verification.start",
     KeyVerificationCancel = "m.key.verification.cancel",

--- a/src/client.js
+++ b/src/client.js
@@ -730,6 +730,17 @@ MatrixClient.prototype.setSupportsCallTransfer = function(supportsCallTransfer) 
 };
 
 /**
+ * Creates a new call.
+ * The place*Call methods on the returned call can be used to actually place a call
+ *
+ * @param {string} roomId The room the call is to be placed in.
+ * @return {MatrixCall} the call or null if the browser doesn't support calling.
+ */
+MatrixClient.prototype.createCall = function(roomId) {
+    return createNewMatrixCall(this, roomId);
+};
+
+/**
  * Get the current sync state.
  * @return {?string} the sync state, which may be null.
  * @see module:client~MatrixClient#event:"sync"

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1217,7 +1217,7 @@ export class MatrixCall extends EventEmitter {
 
         this.remoteAssertedIdentity = {
             id: event.getContent().asserted_identity.id,
-            displayName: event.getContent().asserted_identity.displayName,
+            displayName: event.getContent().asserted_identity.display_name,
         };
         this.emit(CallEvent.AssertedIdentityChanged);
     }

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1936,6 +1936,9 @@ export function setAudioInput(deviceId: string) { audioInput = deviceId; }
 export function setVideoInput(deviceId: string) { videoInput = deviceId; }
 
 /**
+ * DEPRECATED
+ * Use client.createCall()
+ *
  * Create a new Matrix call for the browser.
  * @param {MatrixClient} client The client instance to use.
  * @param {string} roomId The room the call is in.

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -276,7 +276,8 @@ export class CallEventHandler {
 
             call.onNegotiateReceived(event);
         } else if (
-            event.getType() === EventType.CallAssertedIdentity || event.getType() === EventType.CallAssertedIdentityPrefix
+            event.getType() === EventType.CallAssertedIdentity ||
+            event.getType() === EventType.CallAssertedIdentityPrefix
         ) {
             if (!call) return;
 

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -87,7 +87,11 @@ export class CallEventHandler {
 
     private onEvent = (event: MatrixEvent) => {
         // any call events or ones that might be once they're decrypted
-        if (event.getType().indexOf("m.call.") === 0 || event.isBeingDecrypted()) {
+        if (
+            event.getType().indexOf("m.call.") === 0 ||
+            event.getType().indexOf("org.matrix.call.") === 0
+            || event.isBeingDecrypted()
+        ) {
             // queue up for processing once all events from this sync have been
             // processed (see above).
             this.callEventBuffer.push(event);
@@ -271,6 +275,17 @@ export class CallEventHandler {
             }
 
             call.onNegotiateReceived(event);
+        } else if (
+            event.getType() === EventType.CallAssertedIdentity || event.getType() === EventType.CallAssertedIdentityPrefix
+        ) {
+            if (!call) return;
+
+            if (event.getContent().party_id === call.ourPartyId) {
+                // Ignore remote echo (not that we send asserted identity, but still...)
+                return;
+            }
+
+            call.onAssertedIdentityReceived(event);
         }
     }
 }


### PR DESCRIPTION
Adds support for receiving MSC3086 Asserted Identity events & emitting event from the call object.

Also moves the method for creating new calls to the client so it can be stubbed out when testing applications using the js-sdk (the client was passed in before so I'm not sure what the benefit was of it being separate).