### PR TITLE
Restrict event emit for room members that had power levels changed

### DIFF
--- a/src/models/room-state.js
+++ b/src/models/room-state.js
@@ -351,8 +351,14 @@ RoomState.prototype.setStateEvents = function(stateEvents) {
         } else if (event.getType() === "m.room.power_levels") {
             const members = utils.values(self.members);
             utils.forEach(members, function(member) {
+                // We only propagate `RoomState.members` event if the
+                // power levels has been changed
+                // large room suffer from large re-rendering especially when not needed
+                const oldLastModified = member.getLastModifiedTime();
                 member.setPowerLevelEvent(event);
-                self.emit("RoomState.members", event, self, member);
+                if (oldLastModified !== member.getLastModifiedTime()) {
+                    self.emit("RoomState.members", event, self, member);
+                }
             });
 
             // assume all our sentinels are now out-of-date


### PR DESCRIPTION
Fixes vector-im/element-web#16967

The `RoomState.members` event was propagated for every single room member even though their power level was not impacted.

This was tested on a room on a local synapse instance with 2000 members
The frame takes **90% less time** to process you can see in the two recording screenshots below

# 🐌 Before

![Screen Shot 2021-04-20 at 11 26 27](https://user-images.githubusercontent.com/769871/115381539-91b62b00-a1cb-11eb-836f-7598603aeab3.png)

# 🐎 After

![Screen Shot 2021-04-20 at 11 25 41](https://user-images.githubusercontent.com/769871/115381534-9084fe00-a1cb-11eb-936a-378de613710e.png)
