### PR TITLE
Add test coverage collection script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:js": "eslint --max-warnings 72 src spec",
     "lint:types": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "yarn test --coverage"
   },
   "repository": {
     "type": "git",
@@ -100,6 +101,12 @@
     "testEnvironment": "node",
     "testMatch": [
       "<rootDir>/spec/**/*.spec.{js,ts}"
+    ],
+    "collectCoverageFrom": [
+      "<rootDir>/src/**/*.{js,ts}"
+    ],
+    "coverageReporters": [
+      "text"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint:js": "eslint --max-warnings 72 src spec",
     "lint:types": "tsc --noEmit",
-    "test": "jest spec/ --coverage --testEnvironment node",
-    "test:watch": "jest spec/ --coverage --testEnvironment node --watch"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",
@@ -97,6 +97,9 @@
     "typescript": "^4.1.3"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testMatch": [
+      "<rootDir>/spec/**/*.spec.{js,ts}"
+    ]
   }
 }


### PR DESCRIPTION
This makes it clear to how collect basic test coverage when desired.

See also https://github.com/matrix-org/matrix-react-sdk/pull/5937