### PR TITLE
Prioritise and reduce the amount of events decrypted on application startup

### DIFF
--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -699,7 +699,7 @@ describe("megolm", function() {
 
                 // the crypto stuff can take a while, so give the requests a whole second.
                 aliceTestClient.httpBackend.flushAllExpected({
-                    timeout: 10000,
+                    timeout: 1000,
                 }),
             ]);
         }).then(function() {

--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -484,8 +484,9 @@ describe("megolm", function() {
             return aliceTestClient.flushSync().then(() => {
                 return aliceTestClient.flushSync();
             });
-        }).then(function() {
+        }).then(async function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
+            await room.decryptCriticalEvents();
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
         });
@@ -698,7 +699,7 @@ describe("megolm", function() {
 
                 // the crypto stuff can take a while, so give the requests a whole second.
                 aliceTestClient.httpBackend.flushAllExpected({
-                    timeout: 1000,
+                    timeout: 10000,
                 }),
             ]);
         }).then(function() {
@@ -933,8 +934,9 @@ describe("megolm", function() {
 
             aliceTestClient.httpBackend.when("GET", "/sync").respond(200, syncResponse);
             return aliceTestClient.flushSync();
-        }).then(function() {
+        }).then(async function() {
             const room = aliceTestClient.client.getRoom(ROOM_ID);
+            await room.decryptCriticalEvents();
             const event = room.getLiveTimeline().getEvents()[0];
             expect(event.getContent().body).toEqual('42');
 

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -212,6 +212,9 @@ MockStorageApi.prototype = {
  * @returns {Promise} promise which resolves (to `event`) when the event has been decrypted
  */
 export function awaitDecryption(event) {
+    // An event is not always decrypted ahead of time
+    // getClearContent is a good signal to know whether an event has been decrypted
+    // already
     if (event.getClearContent() !== null) {
         return event;
     } else {

--- a/spec/test-utils.js
+++ b/spec/test-utils.js
@@ -212,18 +212,18 @@ MockStorageApi.prototype = {
  * @returns {Promise} promise which resolves (to `event`) when the event has been decrypted
  */
 export function awaitDecryption(event) {
-    if (!event.isBeingDecrypted()) {
-        return Promise.resolve(event);
-    }
+    if (event.getClearContent() !== null) {
+        return event;
+    } else {
+        logger.log(`${Date.now()} event ${event.getId()} is being decrypted; waiting`);
 
-    logger.log(`${Date.now()} event ${event.getId()} is being decrypted; waiting`);
-
-    return new Promise((resolve, reject) => {
-        event.once('Event.decrypted', (ev) => {
-            logger.log(`${Date.now()} event ${event.getId()} now decrypted`);
-            resolve(ev);
+        return new Promise((resolve, reject) => {
+            event.once('Event.decrypted', (ev) => {
+                logger.log(`${Date.now()} event ${event.getId()} now decrypted`);
+                resolve(ev);
+            });
         });
-    });
+    }
 }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -5556,7 +5556,7 @@ function _resolve(callback, resolve, res) {
 
 function _PojoToMatrixEventMapper(client, options = {}) {
     const preventReEmit = Boolean(options.preventReEmit);
-    const decrypt = options.decrypt === true;
+    const decrypt = options.decrypt !== false;
     function mapper(plainOldJsObject) {
         const event = new MatrixEvent(plainOldJsObject);
         if (event.isEncrypted()) {

--- a/src/client.js
+++ b/src/client.js
@@ -5554,8 +5554,9 @@ function _resolve(callback, resolve, res) {
     resolve(res);
 }
 
-function _PojoToMatrixEventMapper(client, options) {
-    const preventReEmit = Boolean(options && options.preventReEmit);
+function _PojoToMatrixEventMapper(client, options = {}) {
+    const preventReEmit = Boolean(options.preventReEmit);
+    const decrypt = options.decrypt === true;
     function mapper(plainOldJsObject) {
         const event = new MatrixEvent(plainOldJsObject);
         if (event.isEncrypted()) {
@@ -5564,7 +5565,9 @@ function _PojoToMatrixEventMapper(client, options) {
                     "Event.decrypted",
                 ]);
             }
-            event.attemptDecryption(client._crypto);
+            if (decrypt) {
+                event.attemptDecryption(client._crypto);
+            }
         }
         if (!preventReEmit) {
             client.reEmitter.reEmit(event, ["Event.replaced"]);
@@ -5577,6 +5580,7 @@ function _PojoToMatrixEventMapper(client, options) {
 /**
  * @param {object} [options]
  * @param {bool} options.preventReEmit don't reemit events emitted on an event mapped by this mapper on the client
+ * @param {bool} options.decrypt decrypt event proactively
  * @return {Function}
  */
 MatrixClient.prototype.getEventMapper = function(options = undefined) {

--- a/src/crypto/algorithms/megolm.js
+++ b/src/crypto/algorithms/megolm.js
@@ -1692,7 +1692,7 @@ MegolmDecryption.prototype._retryDecryption = async function(senderKey, sessionI
 
     await Promise.all([...pending].map(async (ev) => {
         try {
-            await ev.attemptDecryption(this._crypto, true);
+            await ev.attemptDecryption(this._crypto, { isRetry: true });
         } catch (e) {
             // don't die if something goes wrong
         }

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -399,6 +399,12 @@ utils.extend(MatrixEvent.prototype, {
             this._clearEvent.content.msgtype === "m.bad.encrypted";
     },
 
+    shouldAttemptDecryption: function() {
+        return this.isEncrypted()
+            && !this.isBeingDecrypted()
+            && this.getClearContent() === null
+    },
+
     /**
      * Start the process of trying to decrypt this event.
      *

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -413,12 +413,13 @@ utils.extend(MatrixEvent.prototype, {
      * @internal
      *
      * @param {module:crypto} crypto crypto module
-     * @param {bool} isRetry True if this is a retry (enables more logging)
+     * @param {bool} options.isRetry True if this is a retry (enables more logging)
+     * @param {bool} options.emit Emits "event.decrypted" if set to true
      *
      * @returns {Promise} promise which resolves (to undefined) when the decryption
      * attempt is completed.
      */
-    attemptDecryption: async function(crypto, isRetry) {
+    attemptDecryption: async function(crypto, options = {}) {
         // start with a couple of sanity checks.
         if (!this.isEncrypted()) {
             throw new Error("Attempt to decrypt event which isn't encrypted");
@@ -448,7 +449,7 @@ utils.extend(MatrixEvent.prototype, {
             return this._decryptionPromise;
         }
 
-        this._decryptionPromise = this._decryptionLoop(crypto, isRetry);
+        this._decryptionPromise = this._decryptionLoop(crypto, options);
         return this._decryptionPromise;
     },
 
@@ -493,7 +494,7 @@ utils.extend(MatrixEvent.prototype, {
         return recipients;
     },
 
-    _decryptionLoop: async function(crypto, isRetry) {
+    _decryptionLoop: async function(crypto, options = {}) {
         // make sure that this method never runs completely synchronously.
         // (doing so would mean that we would clear _decryptionPromise *before*
         // it is set in attemptDecryption - and hence end up with a stuck
@@ -510,7 +511,7 @@ utils.extend(MatrixEvent.prototype, {
                     res = this._badEncryptedMessage("Encryption not enabled");
                 } else {
                     res = await crypto.decryptEvent(this);
-                    if (isRetry) {
+                    if (options.isRetry === true) {
                         logger.info(`Decrypted event on retry (id=${this.getId()})`);
                     }
                 }
@@ -518,7 +519,7 @@ utils.extend(MatrixEvent.prototype, {
                 if (e.name !== "DecryptionError") {
                     // not a decryption error: log the whole exception as an error
                     // (and don't bother with a retry)
-                    const re = isRetry ? 're' : '';
+                    const re = options.isRetry ? 're' : '';
                     logger.error(
                         `Error ${re}decrypting event ` +
                         `(id=${this.getId()}): ${e.stack || e}`,
@@ -584,7 +585,9 @@ utils.extend(MatrixEvent.prototype, {
             // pick up the wrong contents.
             this.setPushActions(null);
 
-            this.emit("Event.decrypted", this, err);
+            if (options.emit !== false) {
+                this.emit("Event.decrypted", this, err);
+            }
 
             return;
         }

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -421,6 +421,15 @@ utils.extend(MatrixEvent.prototype, {
      * attempt is completed.
      */
     attemptDecryption: async function(crypto, options = {}) {
+
+        // For backwards compatibility purposes
+        // The function signature used to be attemptDecryption(crypto, isRetry)
+        if (typeof options === "boolean") {
+            options = {
+                isRetry: options
+            };
+        }
+
         // start with a couple of sanity checks.
         if (!this.isEncrypted()) {
             throw new Error("Attempt to decrypt event which isn't encrypted");

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -421,12 +421,11 @@ utils.extend(MatrixEvent.prototype, {
      * attempt is completed.
      */
     attemptDecryption: async function(crypto, options = {}) {
-
         // For backwards compatibility purposes
         // The function signature used to be attemptDecryption(crypto, isRetry)
         if (typeof options === "boolean") {
             options = {
-                isRetry: options
+                isRetry: options,
             };
         }
 

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -402,7 +402,7 @@ utils.extend(MatrixEvent.prototype, {
     shouldAttemptDecryption: function() {
         return this.isEncrypted()
             && !this.isBeingDecrypted()
-            && this.getClearContent() === null
+            && this.getClearContent() === null;
     },
 
     /**
@@ -413,6 +413,7 @@ utils.extend(MatrixEvent.prototype, {
      * @internal
      *
      * @param {module:crypto} crypto crypto module
+     * @param {object} options
      * @param {bool} options.isRetry True if this is a retry (enables more logging)
      * @param {bool} options.emit Emits "event.decrypted" if set to true
      *

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -228,6 +228,12 @@ function pendingEventsKey(roomId) {
 
 utils.inherits(Room, EventEmitter);
 
+function shouldAttemptDecryption(event) {
+    return event.isEncrypted()
+        && !event.isBeingDecrypted()
+        && event.getClearContent() === null
+}
+
 Room.prototype.decryptCriticalEvents = function() {
     const readReceiptEventId = this.getEventReadUpTo(this._client.getUserId(), true);
     const events = this.getLiveTimeline().getEvents();
@@ -237,7 +243,7 @@ Room.prototype.decryptCriticalEvents = function() {
 
     const decryptionPromises = events
         .slice(readReceiptTimelineIndex)
-        .filter(event => event.isEncrypted() && !event.isBeingDecrypted())
+        .filter(event => shouldAttemptDecryption(event))
         .reverse()
         .map(event => event.attemptDecryption(this._client._crypto, true));
 
@@ -249,7 +255,7 @@ Room.prototype.decryptAllEvents = function() {
         .getUnfilteredTimelineSet()
         .getLiveTimeline()
         .getEvents()
-        .filter(event => event.isEncrypted() && !event.isBeingDecrypted())
+        .filter(event => shouldAttemptDecryption(event))
         .reverse()
         .map(event => event.attemptDecryption(this._client._crypto, true));
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -228,6 +228,20 @@ function pendingEventsKey(roomId) {
 
 utils.inherits(Room, EventEmitter);
 
+Room.prototype.lazyDecryptEvents = async function() {
+    return Promise.allSettled(this
+        .getUnfilteredTimelineSet()
+        .getTimelines()
+        .reduce((decryptionPromises, timeline) => {
+            return decryptionPromises.concat(
+                timeline
+                    .getEvents()
+                    .filter(event => event.isEncrypted() && !event.isBeingDecrypted())
+                    .map(event => event.attemptDecryption(this._client._crypto, true))
+            );
+        }, []));
+}
+
 /**
  * Gets the version of the room
  * @returns {string} The version of the room, or null if it could not be determined

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -244,7 +244,7 @@ Room.prototype.decryptCriticalEvents = function() {
     const readReceiptEventId = this.getEventReadUpTo(this._client.getUserId(), true);
     const events = this.getLiveTimeline().getEvents();
     const readReceiptTimelineIndex = events.findIndex(matrixEvent => {
-        return matrixEvent.event.event_id === readReceiptEventId
+        return matrixEvent.event.event_id === readReceiptEventId;
     });
 
     const decryptionPromises = events
@@ -254,7 +254,7 @@ Room.prototype.decryptCriticalEvents = function() {
         .map(event => event.attemptDecryption(this._client._crypto, { isRetry: true }));
 
     return Promise.allSettled(decryptionPromises);
-}
+};
 
 /**
  * Bulk decrypt events in a room
@@ -271,7 +271,7 @@ Room.prototype.decryptAllEvents = function() {
         .map(event => event.attemptDecryption(this._client._crypto, { isRetry: true }));
 
     return Promise.allSettled(decryptionPromises);
-}
+};
 
 /**
  * Gets the version of the room

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -228,12 +228,6 @@ function pendingEventsKey(roomId) {
 
 utils.inherits(Room, EventEmitter);
 
-function shouldAttemptDecryption(event) {
-    return event.isEncrypted()
-        && !event.isBeingDecrypted()
-        && event.getClearContent() === null
-}
-
 Room.prototype.decryptCriticalEvents = function() {
     const readReceiptEventId = this.getEventReadUpTo(this._client.getUserId(), true);
     const events = this.getLiveTimeline().getEvents();
@@ -243,7 +237,7 @@ Room.prototype.decryptCriticalEvents = function() {
 
     const decryptionPromises = events
         .slice(readReceiptTimelineIndex)
-        .filter(event => shouldAttemptDecryption(event))
+        .filter(event => event.shouldAttemptDecryption())
         .reverse()
         .map(event => event.attemptDecryption(this._client._crypto, true));
 
@@ -255,7 +249,7 @@ Room.prototype.decryptAllEvents = function() {
         .getUnfilteredTimelineSet()
         .getLiveTimeline()
         .getEvents()
-        .filter(event => shouldAttemptDecryption(event))
+        .filter(event => event.shouldAttemptDecryption())
         .reverse()
         .map(event => event.attemptDecryption(this._client._crypto, true));
 

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -233,10 +233,10 @@ utils.inherits(Room, EventEmitter);
  * Bulk decrypt critical events in a room
  *
  * Critical events represents the minimal set of events to decrypt
- * for the UI to function properly
+ * for a typical UI to function properly
  *
- * - Last event of every room (to generate message preview)
- * - All events are the read receipt (to calculate an accurate notification count)
+ * - Last event of every room (to generate likely message preview)
+ * - All events up to the read receipt (to calculate an accurate notification count)
  *
  * @returns {Promise} Signals when all events have been decrypted
  */

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -239,7 +239,7 @@ Room.prototype.decryptCriticalEvents = function() {
         .slice(readReceiptTimelineIndex)
         .filter(event => event.shouldAttemptDecryption())
         .reverse()
-        .map(event => event.attemptDecryption(this._client._crypto, true));
+        .map(event => event.attemptDecryption(this._client._crypto, { isRetry: true }));
 
     return Promise.allSettled(decryptionPromises);
 }
@@ -251,7 +251,7 @@ Room.prototype.decryptAllEvents = function() {
         .getEvents()
         .filter(event => event.shouldAttemptDecryption())
         .reverse()
-        .map(event => event.attemptDecryption(this._client._crypto, true));
+        .map(event => event.attemptDecryption(this._client._crypto, { isRetry: true }));
 
     return Promise.allSettled(decryptionPromises);
 }

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -228,6 +228,18 @@ function pendingEventsKey(roomId) {
 
 utils.inherits(Room, EventEmitter);
 
+
+/**
+ * Bulk decrypt critical events in a room
+ *
+ * Critical events represents the minimal set of events to decrypt
+ * for the UI to function properly
+ *
+ * - Last event of every room (to generate message preview)
+ * - All events are the read receipt (to calculate an accurate notification count)
+ *
+ * @returns {Promise} Signals when all events have been decrypted
+ */
 Room.prototype.decryptCriticalEvents = function() {
     const readReceiptEventId = this.getEventReadUpTo(this._client.getUserId(), true);
     const events = this.getLiveTimeline().getEvents();
@@ -244,6 +256,11 @@ Room.prototype.decryptCriticalEvents = function() {
     return Promise.allSettled(decryptionPromises);
 }
 
+/**
+ * Bulk decrypt events in a room
+ *
+ * @returns {Promise} Signals when all events have been decrypted
+ */
 Room.prototype.decryptAllEvents = function() {
     const decryptionPromises = this
         .getUnfilteredTimelineSet()

--- a/src/sync.js
+++ b/src/sync.js
@@ -942,7 +942,7 @@ SyncApi.prototype._onSyncError = function(err, syncOptions) {
  * @param {Object} data The response from /sync
  */
 SyncApi.prototype._processSyncResponse = async function(
-    syncEventData, data
+    syncEventData, data,
 ) {
     const client = this.client;
     const self = this;
@@ -1525,6 +1525,7 @@ SyncApi.prototype._mapSyncResponseToRoomArray = function(obj) {
 /**
  * @param {Object} obj
  * @param {Room} room
+ * @param {bool} decrypt
  * @return {MatrixEvent[]}
  */
 SyncApi.prototype._mapSyncEventsFormat = function(obj, room, decrypt = true) {

--- a/src/sync.js
+++ b/src/sync.js
@@ -707,12 +707,12 @@ SyncApi.prototype._syncFromCache = async function(savedSync) {
         const breadcrumbsRooms = breadcrumbs?.getContent().recent_rooms || [];
 
         this.client.getRooms().forEach(room => {
-            const readReceipt = room.getAccountData("m.fully_read");
+            const readReceiptEventId = room.getEventReadUpTo(this.client.getUserId(), true);
 
             const events = room.getLiveTimeline().getEvents();
             const isInBreadcrumb = breadcrumbsRooms.includes(room.roomId);
             const readReceiptTimelineIndex = events.findIndex(matrixEvent => {
-                return matrixEvent.event.event_id === readReceipt?.getContent().event_id
+                return matrixEvent.event.event_id === readReceiptEventId
             });
             const decryptFromIndex = isInBreadcrumb
                 ? 0

--- a/src/sync.js
+++ b/src/sync.js
@@ -1158,6 +1158,10 @@ SyncApi.prototype._processSyncResponse = async function(
     await utils.promiseMapSeries(joinRooms, async function(joinObj) {
         const room = joinObj.room;
         const stateEvents = self._mapSyncEventsFormat(joinObj.state, room);
+        // Prevent events from being decrypted ahead of time
+        // this helps large account to speed up faster
+        // room::decryptCriticalEvent is in charge of decrypting all the events
+        // required for a client to function properly
         const timelineEvents = self._mapSyncEventsFormat(joinObj.timeline, room, false);
         const ephemeralEvents = self._mapSyncEventsFormat(joinObj.ephemeral);
         const accountDataEvents = self._mapSyncEventsFormat(joinObj.account_data);

--- a/src/sync.js
+++ b/src/sync.js
@@ -1547,6 +1547,7 @@ SyncApi.prototype._mapSyncEventsFormat = function(obj, room, decrypt = true) {
         return [];
     }
     const mapper = this.client.getEventMapper();
+    const mapper = this.client.getEventMapper({ decrypt });
     return obj.events.map(function(e) {
         if (room) {
             e.room_id = room.roomId;


### PR DESCRIPTION
Related to vector-im/element-web#13266
To review alongside matrix-org/matrix-react-sdk#5980

When loading element, it will either read from cache the entire `/sync` blob that has been persisted or will query that information from Synapse.
The idea is to implement a priority queue that will cap the maximum of events that will be decrypted on application startup. Everything else will be lazily decrypted when a user views a room

At the moment, from clicking on a tile to having all messages displayed on screen it takes roughly a second. With lazy decryption it will approximately take 2 seconds but the most recent messages will start to appear on screen from the first second.

# Critical events

This pull request brings the concept of critical events. These are the events that a client requires to have decrypted to ensure it can run and provide all the required features to the user

At the moment a critical event is an event that falls under the following category
* Last event of a room (to ensure previews are working)
* All events that occured after the read marker (to ensure correct-ness in notification count)

Let me know if you can think about anything else that would benefit from being decrypted ahead of time

In addition to that, I am using breadcrumb rooms to detect which rooms a user might be likely to interact with again in the future and proactively decrypt the live timeline. 
This could be scrapped if we wanted to further improve app start performance at the cost of a few layout shift as highlighted in [this video](https://github.com/matrix-org/matrix-js-sdk/pull/1684#issuecomment-833583200)

# Benchmark

| # of e2ee rooms  | load time (before) | load time (after) | % difference | 
| ---------------- | ------------------ | ----------------- | ------------ |
| 250 | 4mn50 | 31s | **89%** |
| 43 | 37s | 12s | **67%** |

These recordings are taken on an existing session by looking at the time between a hard refresh until the console stops spamming "decrypted events" messages by the thousands.

Please share with me your recording and I will add them to the table above, the code is [up and running on a netlify preview](https://deploy-preview-5980--matrix-react-sdk.netlify.app/)
If you want to know the number of encrypted rooms in your account you can run the following snippet in your terminal

```javascript
Object.values(mxMatrixClientPeg.get().store.rooms).filter(room => {
  return room._client.isRoomEncrypted(room.roomId)
}).length;
```