### PR TITLE
Change call event handlers to adapt to undecrypted events

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -356,7 +356,13 @@ export function MatrixClient(opts) {
         // Start listening for calls after the initial sync is done
         // We do not need to backfill the call event buffer
         // with encrypted events that might never get decrypted
-        this.once("sync", () => this._callEventHandler.start());
+        function startCallEventHandler() {
+            if (this.isInitialSyncComplete()) {
+                this._callEventHandler.start();
+                this.off("sync", startCallEventHandler);
+            }
+        }
+        this.on("sync", startCallEventHandler);
     } else {
         this._callEventHandler = null;
     }

--- a/src/client.js
+++ b/src/client.js
@@ -353,6 +353,10 @@ export function MatrixClient(opts) {
     if (call) {
         this._callEventHandler = new CallEventHandler(this);
         this._supportsVoip = true;
+        // Start listening for calls after the initial sync is done
+        // We do not need to backfill the call event buffer
+        // with encrypted events that might never get decrypted
+        this.once("sync", () => this._callEventHandler.start());
     } else {
         this._callEventHandler = null;
     }

--- a/src/client.js
+++ b/src/client.js
@@ -356,13 +356,7 @@ export function MatrixClient(opts) {
         // Start listening for calls after the initial sync is done
         // We do not need to backfill the call event buffer
         // with encrypted events that might never get decrypted
-        function startCallEventHandler() {
-            if (this.isInitialSyncComplete()) {
-                this._callEventHandler.start();
-                this.off("sync", startCallEventHandler);
-            }
-        }
-        this.on("sync", startCallEventHandler);
+        this.on("sync", this._startCallEventHandler);
     } else {
         this._callEventHandler = null;
     }
@@ -4995,6 +4989,13 @@ MatrixClient.prototype.getOpenIdToken = function() {
 
 // VoIP operations
 // ===============
+
+MatrixClient.prototype._startCallEventHandler = function() {
+    if (this.isInitialSyncComplete()) {
+        this._callEventHandler.start();
+        this.off("sync", this._startCallEventHandler);
+    }
+};
 
 /**
  * @param {module:client.callback} callback Optional.

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -43,6 +43,9 @@ export class CallEventHandler {
         // after loading and after we've been offline for a bit.
         this.callEventBuffer = [];
         this.candidateEventsByCall = new Map<string, Array<MatrixEvent>>();
+    }
+
+    public start() {
         this.client.on("sync", this.evaluateEventBuffer);
         this.client.on("event", this.onEvent);
     }
@@ -85,36 +88,15 @@ export class CallEventHandler {
         }
     }
 
-    private onEvent = (event: MatrixEvent) => {
-        // any call events or ones that might be once they're decrypted
+    private onEvent = async (event: MatrixEvent) => {
+        await this.client.decryptEventIfNeeded(event);
         if (
             event.getType().indexOf("m.call.") === 0 ||
             event.getType().indexOf("org.matrix.call.") === 0
-            || event.isBeingDecrypted()
         ) {
             // queue up for processing once all events from this sync have been
             // processed (see above).
             this.callEventBuffer.push(event);
-        }
-
-        if (event.isBeingDecrypted() || event.isDecryptionFailure()) {
-            // add an event listener for once the event is decrypted.
-            event.once("Event.decrypted", () => {
-                if (event.getType().indexOf("m.call.") === -1) return;
-
-                if (this.callEventBuffer.includes(event)) {
-                    // we were waiting for that event to decrypt, so recheck the buffer
-                    this.evaluateEventBuffer();
-                } else {
-                    // This one wasn't buffered so just run the event handler for it
-                    // straight away
-                    try {
-                        this.handleCallEvent(event);
-                    } catch (e) {
-                        logger.error("Caught exception handling call event", e);
-                    }
-                }
-            });
         }
     }
 


### PR DESCRIPTION
Fixes vector-im/element-web#17393
Regressed by matrix-org/matrix-js-sdk#1684


The call event handler was expecting all messages to be decrypted or in the process of being decrypted and would not process any call events until everything has been processed.

The fix is to ignore all historical data by setting the listeners only after initial client sync