### PR TITLE
Only log once if a Room lacks an m.room.create event

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -216,6 +216,10 @@ export function Room(roomId, client, myUserId, opts) {
     } else {
         this._membersPromise = null;
     }
+
+    // flags to stop logspam about missing m.room.create events
+    this.getTypeWarning = false;
+    this.getVersionWarning = false;
 }
 
 /**
@@ -280,7 +284,10 @@ Room.prototype.decryptAllEvents = function() {
 Room.prototype.getVersion = function() {
     const createEvent = this.currentState.getStateEvents("m.room.create", "");
     if (!createEvent) {
-        logger.warn("[getVersion] Room " + this.roomId + " does not have an m.room.create event");
+        if (!this.getVersionWarning) {
+            logger.warn("[getVersion] Room " + this.roomId + " does not have an m.room.create event");
+            this.getVersionWarning = true;
+        }
         return '1';
     }
     const ver = createEvent.getContent()['room_version'];
@@ -2008,7 +2015,10 @@ Room.prototype.getJoinRule = function() {
 Room.prototype.getType = function() {
     const createEvent = this.currentState.getStateEvents("m.room.create", "");
     if (!createEvent) {
-        logger.warn("[getType] Room " + this.roomId + " does not have an m.room.create event");
+        if (!this.getTypeWarning) {
+            logger.warn("[getType] Room " + this.roomId + " does not have an m.room.create event");
+            this.getTypeWarning = true;
+        }
         return undefined;
     }
     return createEvent.getContent()[RoomCreateTypeField];


### PR DESCRIPTION
Currently my account is logging ~20,000 warnings a minute about getType() being called
on invites which have no m.room.create events, which crashes my inspector and makes
my console unusable.  We still want the logline though, as it helps diagnose
space invite problems.  So instead, log this only once.  (Untested).