### PR TITLE
Cache normalized room name

### DIFF
--- a/src/models/room.js
+++ b/src/models/room.js
@@ -31,6 +31,7 @@ import {RoomSummary} from "./room-summary";
 import {logger} from '../logger';
 import {ReEmitter} from '../ReEmitter';
 import {EventType, RoomCreateTypeField, RoomType} from "../@types/event";
+import { normalize } from "../utils";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -102,6 +103,7 @@ function synthesizeReceipt(userId, event, receiptType) {
  *
  * @prop {string} roomId The ID of this room.
  * @prop {string} name The human-readable display name for this room.
+ * @prop {string} normalizedName The unhomoglyphed name for this room.
  * @prop {Array<MatrixEvent>} timeline The live event timeline for this room,
  * with the oldest event at index 0. Present for backwards compatibility -
  * prefer getLiveTimeline().getEvents().
@@ -1720,6 +1722,7 @@ Room.prototype.recalculate = function() {
 
     const oldName = this.name;
     this.name = calculateRoomName(this, this.myUserId);
+    this.normalizedName = normalize(this.name);
     this.summary = new RoomSummary(this.roomId, {
         title: this.name,
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,7 +347,7 @@ export function removeHiddenChars(str: string): string {
 }
 
 export function normalize(str: string): string {
-    // Note: we have to match the filter with the removeHiddenChars() room name because the
+    // Note: we have to match the filter with the removeHiddenChars() because the
     // function strips spaces and other characters (M becomes RN for example, in lowercase).
     return removeHiddenChars(str.toLowerCase())
         // Strip all punctuation

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -346,6 +346,16 @@ export function removeHiddenChars(str: string): string {
     return "";
 }
 
+export function normalize(str: string): string {
+    // Note: we have to match the filter with the removeHiddenChars() room name because the
+    // function strips spaces and other characters (M becomes RN for example, in lowercase).
+    return removeHiddenChars(str.toLowerCase())
+        // Strip all punctuation
+        .replace(/[\\'!"#$%&()*+,\-./:;<=>?@[\]^_`{|}~\u2000-\u206f\u2e00-\u2e7f]/g, "")
+        // We also doubly convert to lowercase to work around oddities of the library.
+        .toLowerCase();
+}
+
 // Regex matching bunch of unicode control characters and otherwise misleading/invisible characters.
 // Includes:
 // various width spaces U+2000 - U+200D


### PR DESCRIPTION
Fixes vector-im/element-web#17370

Approximatly divides the function execution time by three. Here is the difference of the two call stacks

# Before 🐌 

![Screen Shot 2021-05-20 at 10 42 26](https://user-images.githubusercontent.com/769871/118957807-bb907800-b958-11eb-99d0-d90cf7123224.png)

# After 🐎 

![Screen Shot 2021-05-20 at 10 26 33](https://user-images.githubusercontent.com/769871/118957803-baf7e180-b958-11eb-82b1-98714b789f81.png)
