### PR TITLE
Reduce noise in tests

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1804,7 +1804,10 @@ export function createNewMatrixCall(client: any, roomId: string, options?: CallO
             window.RTCIceCandidate || navigator.mediaDevices,
         );
         if (!supported) {
-            logger.error("WebRTC is not supported in this browser / environment");
+            // Adds a lot of noise to test runs, so disable logging there.
+            if (process.env.NODE_ENV !== "test") {
+                logger.error("WebRTC is not supported in this browser / environment");
+            }
             return null;
         }
     } catch (e) {


### PR DESCRIPTION
This disables a common log message to cut down the test log size and make it easier to read messages specific to each test.