### PR TITLE
Fix uploadContent not rejecting promise when http status code >= 400

### DIFF
--- a/src/http-api.js
+++ b/src/http-api.js
@@ -790,6 +790,8 @@ const requestCallback = function(
     userDefinedCallback = userDefinedCallback || function() {};
 
     return function(err, response, body) {
+        const httpStatus = response.status || response.statusCode; // XMLHttpRequest vs http.IncomingMessage
+
         if (err) {
             // the unit tests use matrix-mock-request, which throw the string "aborted" when aborting a request.
             // See https://github.com/matrix-org/matrix-mock-request/blob/3276d0263a561b5b8326b47bae720578a2c7473a/src/index.js#L48
@@ -803,7 +805,7 @@ const requestCallback = function(
         }
         if (!err) {
             try {
-                if (response.statusCode >= 400) {
+                if (httpStatus >= 400) {
                     err = parseErrorResponse(response, body);
                 } else if (bodyParser) {
                     body = bodyParser(body);
@@ -818,7 +820,7 @@ const requestCallback = function(
             userDefinedCallback(err);
         } else {
             const res = {
-                code: response.statusCode,
+                code: httpStatus,
 
                 // XXX: why do we bother with this? it doesn't work for
                 // XMLHttpRequest, so clearly we don't use it.
@@ -842,7 +844,7 @@ const requestCallback = function(
  * @returns {Error}
  */
 function parseErrorResponse(response, body) {
-    const httpStatus = response.statusCode;
+    const httpStatus = response.status || response.statusCode; // XMLHttpRequest vs http.IncomingMessage
     const contentType = getResponseContentType(response);
 
     let err;

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -790,8 +790,6 @@ const requestCallback = function(
     userDefinedCallback = userDefinedCallback || function() {};
 
     return function(err, response, body) {
-        const httpStatus = response.status || response.statusCode; // XMLHttpRequest vs http.IncomingMessage
-
         if (err) {
             // the unit tests use matrix-mock-request, which throw the string "aborted" when aborting a request.
             // See https://github.com/matrix-org/matrix-mock-request/blob/3276d0263a561b5b8326b47bae720578a2c7473a/src/index.js#L48
@@ -805,6 +803,7 @@ const requestCallback = function(
         }
         if (!err) {
             try {
+                const httpStatus = response.status || response.statusCode; // XMLHttpRequest vs http.IncomingMessage
                 if (httpStatus >= 400) {
                     err = parseErrorResponse(response, body);
                 } else if (bodyParser) {
@@ -820,7 +819,7 @@ const requestCallback = function(
             userDefinedCallback(err);
         } else {
             const res = {
-                code: httpStatus,
+                code: response.status || response.statusCode, // XMLHttpRequest vs http.IncomingMessage
 
                 // XXX: why do we bother with this? it doesn't work for
                 // XMLHttpRequest, so clearly we don't use it.


### PR DESCRIPTION
This was causing an `/upload` 500 ISE to resolve and thus send broken media events into rooms

![image](https://user-images.githubusercontent.com/2403652/118999566-489bf700-b982-11eb-8db4-7d07e47a981d.png)
