### PR TITLE
Emit relations created when target event added later

### DIFF
--- a/src/models/event-timeline-set.js
+++ b/src/models/event-timeline-set.js
@@ -740,16 +740,11 @@ EventTimelineSet.prototype.setRelationsTarget = function(event) {
     if (!relationsForEvent) {
         return;
     }
-    // don't need it for non m.replace relations for now
-    const relationsWithRelType = relationsForEvent["m.replace"];
-    if (!relationsWithRelType) {
-        return;
-    }
-    // only doing replacements for messages for now (e.g. edits)
-    const relationsWithEventType = relationsWithRelType["m.room.message"];
 
-    if (relationsWithEventType) {
-        relationsWithEventType.setTargetEvent(event);
+    for (const relationsWithRelType of Object.values(relationsForEvent)) {
+        for (const relationsWithEventType of Object.values(relationsWithRelType)) {
+            relationsWithEventType.setTargetEvent(event);
+        }
     }
 };
 
@@ -797,7 +792,6 @@ EventTimelineSet.prototype.aggregateRelations = function(event) {
     }
     let relationsWithEventType = relationsWithRelType[eventType];
 
-    let isNewRelations = false;
     let relatesToEvent;
     if (!relationsWithEventType) {
         relationsWithEventType = relationsWithRelType[eventType] = new Relations(
@@ -805,7 +799,6 @@ EventTimelineSet.prototype.aggregateRelations = function(event) {
             eventType,
             this.room,
         );
-        isNewRelations = true;
         relatesToEvent = this.findEventById(relatesToEventId) || this.room.getPendingEvent(relatesToEventId);
         if (relatesToEvent) {
             relationsWithEventType.setTargetEvent(relatesToEvent);
@@ -813,11 +806,6 @@ EventTimelineSet.prototype.aggregateRelations = function(event) {
     }
 
     relationsWithEventType.addEvent(event);
-
-    // only emit once event has been added to relations
-    if (isNewRelations && relatesToEvent) {
-        relatesToEvent.emit("Event.relationsCreated", relationType, eventType);
-    }
 };
 
 /**


### PR DESCRIPTION
This changes the "relations created" event to ensure it is properly emitted even if the target event is added to the timeline after the relation event. There was perhaps always a risk of this happening in the past, but is seems more likely to bite now with delayed decryption.

Part of https://github.com/vector-im/element-web/issues/17461
Related to https://github.com/matrix-org/matrix-react-sdk/pull/6106