### PR TITLE
Apply new Babel linting config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,9 @@ module.exports = {
     plugins: [
         "matrix-org",
     ],
-    extends: ["plugin:matrix-org/babel"],
+    extends: [
+        "plugin:matrix-org/babel",
+    ],
     env: {
         browser: true,
         node: true,
@@ -31,14 +33,26 @@ module.exports = {
         "no-console": "error",
     },
     overrides: [{
-        "files": ["src/**/*.ts"],
-        "extends": ["plugin:matrix-org/typescript"],
-        "rules": {
+        files: [
+            "**/*.ts",
+        ],
+        extends: [
+            "plugin:matrix-org/typescript",
+        ],
+        rules: {
+            // TypeScript has its own version of this
+            "@babel/no-invalid-this": "off",
+
             // We're okay being explicit at the moment
             "@typescript-eslint/no-empty-interface": "off",
-            // While we're converting to ts we make heavy use of this
+            // We disable this while we're transitioning
             "@typescript-eslint/no-explicit-any": "off",
+            // We'd rather not do this but we do
+            "@typescript-eslint/ban-ts-comment": "off",
+
             "quotes": "off",
+            // We use a `logger` intermediary module
+            "no-console": "error",
         },
     }],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
     plugins: [
         "matrix-org",
     ],
-    extends: ["plugin:matrix-org/javascript"],
+    extends: ["plugin:matrix-org/babel"],
     env: {
         browser: true,
         node: true,

--- a/spec/integ/matrix-client-crypto.spec.js
+++ b/spec/integ/matrix-client-crypto.spec.js
@@ -28,10 +28,10 @@ limitations under the License.
 // load olm before the sdk if possible
 import '../olm-loader';
 
-import {logger} from '../../src/logger';
+import { logger } from '../../src/logger';
 import * as testUtils from "../test-utils";
-import {TestClient} from "../TestClient";
-import {CRYPTO_ENABLED} from "../../src/client";
+import { TestClient } from "../TestClient";
+import { CRYPTO_ENABLED } from "../../src/client";
 
 let aliTestClient;
 const roomId = "!room:localhost";
@@ -75,7 +75,7 @@ function expectAliQueryKeys() {
         );
         const result = {};
         result[bobUserId] = bobKeys;
-        return {device_keys: result};
+        return { device_keys: result };
     });
     return aliTestClient.httpBackend.flush("/keys/query", 1);
 }
@@ -103,7 +103,7 @@ function expectBobQueryKeys() {
         );
         const result = {};
         result[aliUserId] = aliKeys;
-        return {device_keys: result};
+        return { device_keys: result };
     });
     return bobTestClient.httpBackend.flush("/keys/query", 1);
 }
@@ -132,7 +132,7 @@ function expectAliClaimKeys() {
             result[bobUserId] = {};
             result[bobUserId][bobDeviceId] = {};
             result[bobUserId][bobDeviceId][keyId] = keys[keyId];
-            return {one_time_keys: result};
+            return { one_time_keys: result };
         });
     }).then(() => {
         // it can take a while to process the key query, so give it some extra
@@ -143,7 +143,6 @@ function expectAliClaimKeys() {
         });
     });
 }
-
 
 function aliDownloadsKeys() {
     // can't query keys before bob has uploaded them
@@ -269,7 +268,7 @@ function expectBobSendMessageRequest() {
 
 function sendMessage(client) {
     return client.sendMessage(
-        roomId, {msgtype: "m.text", body: "Hello, World"},
+        roomId, { msgtype: "m.text", body: "Hello, World" },
     );
 }
 
@@ -357,7 +356,6 @@ function recvMessage(httpBackend, client, sender, message) {
     });
 }
 
-
 /**
  * Send an initial sync response to the client (which just includes the member
  * list for our test room).
@@ -394,7 +392,6 @@ function firstSync(testClient) {
     testClient.httpBackend.when("GET", "/sync").respond(200, syncData);
     return testClient.flushSync();
 }
-
 
 describe("MatrixClient crypto", function() {
     if (!CRYPTO_ENABLED) {
@@ -477,7 +474,7 @@ describe("MatrixClient crypto", function() {
         ).respond(200, function(path, content) {
             const result = {};
             result[bobUserId] = bobKeys;
-            return {device_keys: result};
+            return { device_keys: result };
         });
 
         return Promise.all([
@@ -519,7 +516,7 @@ describe("MatrixClient crypto", function() {
         ).respond(200, function(path, content) {
             const result = {};
             result[bobUserId] = bobKeys;
-            return {device_keys: result};
+            return { device_keys: result };
         });
 
         return Promise.all([
@@ -533,7 +530,6 @@ describe("MatrixClient crypto", function() {
         });
     });
 
-
     it("Bob starts his client and uploads device keys and one-time keys", function() {
         return Promise.resolve()
             .then(() => bobTestClient.start())
@@ -545,7 +541,7 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Ali sends a message", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -555,7 +551,7 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Bob receives a message", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -566,7 +562,7 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Bob receives a message with a bogus sender", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -620,7 +616,7 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Ali blocks Bob's device", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -640,7 +636,7 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Bob receives two pre-key messages", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -653,8 +649,8 @@ describe("MatrixClient crypto", function() {
     });
 
     it("Bob replies to the message", function() {
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
-        bobTestClient.expectKeyQuery({device_keys: {[bobUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
+        bobTestClient.expectKeyQuery({ device_keys: { [bobUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => bobTestClient.start())
@@ -672,7 +668,7 @@ describe("MatrixClient crypto", function() {
     it("Ali does a key query when encryption is enabled", function() {
         // enabling encryption in the room should make alice download devices
         // for both members.
-        aliTestClient.expectKeyQuery({device_keys: {[aliUserId]: {}}});
+        aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} } });
         return Promise.resolve()
             .then(() => aliTestClient.start())
             .then(() => firstSync(aliTestClient))

--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -72,7 +72,7 @@ describe("Relations", function() {
         }
     });
 
-    it("should emit created regardless of ordering", async function () {
+    it("should emit created regardless of ordering", async function() {
         const targetEvent = new MatrixEvent({
             "sender": "@bob:example.com",
             "type": "m.room.message",

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {TestClient} from '../../TestClient';
-import {MatrixCall, CallErrorCode, CallEvent} from '../../../src/webrtc/call';
+import { TestClient } from '../../TestClient';
+import { MatrixCall, CallErrorCode, CallEvent } from '../../../src/webrtc/call';
 
 const DUMMY_SDP = (
     "v=0\r\n" +

--- a/src/crypto/OutgoingRoomKeyRequestManager.js
+++ b/src/crypto/OutgoingRoomKeyRequestManager.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {logger} from '../logger';
+import { logger } from '../logger';
 
 /**
  * Internal module. Management of outgoing room key requests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as matrixcs from "./matrix";
 import * as utils from "./utils";
+import { logger } from './logger';
 import request from "request";
 
 matrixcs.request(request);
@@ -25,7 +26,7 @@ try {
     const crypto = require('crypto');
     utils.setCrypto(crypto);
 } catch (err) {
-    console.log('nodejs was compiled without crypto support');
+    logger.log('nodejs was compiled without crypto support');
 }
 
 export * from "./matrix";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -36,11 +36,11 @@ const DEFAULT_NAMESPACE = "matrix";
 // when logging so we always get the current value of console methods.
 log.methodFactory = function(methodName, logLevel, loggerName) {
     return function(...args) {
-        /* eslint-disable @babel/no-invalid-this */
+        /* eslint-disable @typescript-eslint/no-invalid-this */
         if (this.prefix) {
             args.unshift(this.prefix);
         }
-        /* eslint-enable @babel/no-invalid-this */
+        /* eslint-enable @typescript-eslint/no-invalid-this */
         const supportedByConsole = methodName === "error" ||
             methodName === "warn" ||
             methodName === "trace" ||

--- a/src/models/room.js
+++ b/src/models/room.js
@@ -20,17 +20,17 @@ limitations under the License.
  * @module models/room
  */
 
-import {EventEmitter} from "events";
-import {EventTimelineSet} from "./event-timeline-set";
-import {EventTimeline} from "./event-timeline";
-import {getHttpUriForMxc} from "../content-repo";
+import { EventEmitter } from "events";
+import { EventTimelineSet } from "./event-timeline-set";
+import { EventTimeline } from "./event-timeline";
+import { getHttpUriForMxc } from "../content-repo";
 import * as utils from "../utils";
-import {EventStatus, MatrixEvent} from "./event";
-import {RoomMember} from "./room-member";
-import {RoomSummary} from "./room-summary";
-import {logger} from '../logger';
-import {ReEmitter} from '../ReEmitter';
-import {EventType, RoomCreateTypeField, RoomType} from "../@types/event";
+import { EventStatus, MatrixEvent } from "./event";
+import { RoomMember } from "./room-member";
+import { RoomSummary } from "./room-summary";
+import { logger } from '../logger';
+import { ReEmitter } from '../ReEmitter';
+import { EventType, RoomCreateTypeField, RoomType } from "../@types/event";
 import { normalize } from "../utils";
 
 // These constants are used as sane defaults when the homeserver doesn't support
@@ -58,7 +58,6 @@ function synthesizeReceipt(userId, event, receiptType) {
     };
     return new MatrixEvent(fakeReceipt);
 }
-
 
 /**
  * Construct a new Room.
@@ -233,7 +232,6 @@ function pendingEventsKey(roomId) {
 }
 
 utils.inherits(Room, EventEmitter);
-
 
 /**
  * Bulk decrypt critical events in a room
@@ -495,7 +493,6 @@ Room.prototype.getLiveTimeline = function() {
     return this.getUnfilteredTimelineSet().getLiveTimeline();
 };
 
-
 /**
  * Get the timestamp of the last message in the room
  *
@@ -634,12 +631,11 @@ Room.prototype._loadMembersFromServer = async function() {
         at: lastSyncToken,
     });
     const path = utils.encodeUri("/rooms/$roomId/members?" + queryString,
-        {$roomId: this.roomId});
+        { $roomId: this.roomId });
     const http = this._client._http;
     const response = await http.authedRequest(undefined, "GET", path);
     return response.chunk;
 };
-
 
 Room.prototype._loadMembers = async function() {
     // were the members loaded from the server?
@@ -653,7 +649,7 @@ Room.prototype._loadMembers = async function() {
             `members from server for room ${this.roomId}`);
     }
     const memberEvents = rawMembersEvents.map(this._client.getEventMapper());
-    return {memberEvents, fromServer};
+    return { memberEvents, fromServer };
 };
 
 /**
@@ -1125,7 +1121,6 @@ Room.prototype.getInvitedAndJoinedMemberCount = function() {
     return calculateRoomName(this, userId, true);
  };
 
-
  /**
  * Check if the given user_id has the given membership state.
  * @param {string} userId The user ID to check.
@@ -1281,7 +1276,6 @@ Room.prototype._addLiveEvent = function(event, duplicateStrategy, fromCache) {
         // reset the lastActiveAgo and lastPresenceTs from the RoomState's user.
     }
 };
-
 
 /**
  * Add a pending outgoing event to this room.
@@ -1693,7 +1687,6 @@ Room.prototype.removeEvent = function(eventId) {
     return removedAny;
 };
 
-
 /**
  * Recalculate various aspects of the room, including the room name and
  * room summary. Call this any time the room's current state is modified.
@@ -1918,7 +1911,6 @@ Room.prototype._buildReceiptCache = function(receipts) {
     return receiptCacheByEventId;
 };
 
-
 /**
  * Add a temporary local-echo receipt to the room to reflect in the
  * client the fact that we've sent one.
@@ -1975,7 +1967,6 @@ Room.prototype.addAccountData = function(events) {
 Room.prototype.getAccountData = function(type) {
     return this.accountData[type];
 };
-
 
 /**
  * Returns whether the syncing user has permission to send a message in the room

--- a/src/models/search-result.js
+++ b/src/models/search-result.js
@@ -19,7 +19,7 @@ limitations under the License.
  * @module models/search-result
  */
 
-import {EventContext} from "./event-context";
+import { EventContext } from "./event-context";
 
 /**
  * Construct a new SearchResult

--- a/src/store/memory.js
+++ b/src/store/memory.js
@@ -22,7 +22,7 @@ limitations under the License.
  * @module store/memory
  */
 
-import {User} from "../models/user";
+import { User } from "../models/user";
 
 function isValidFilterId(filterId) {
     const isValidStr = typeof filterId === "string" &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,8 +2845,8 @@ eslint-config-google@^0.14.0:
   integrity sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==
 
 "eslint-plugin-matrix-org@github:matrix-org/eslint-plugin-matrix-org#main":
-  version "0.2.0"
-  resolved "https://codeload.github.com/matrix-org/eslint-plugin-matrix-org/tar.gz/0ae103fe9af97655be6039fc1e7ad6ea95da310b"
+  version "0.3.1"
+  resolved "https://codeload.github.com/matrix-org/eslint-plugin-matrix-org/tar.gz/b55649a0f48ee27155c1968ed5050b6ddc5afdbe"
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This applies the new Babel linting config layer from https://github.com/matrix-org/eslint-plugin-matrix-org/pull/7.

In addition, the local project TypeScript config is expanded to cover tests as well.

A few linting errors were revealed and fixed.