### PR TITLE
Fix relations getRelationsForEvent create relation

### DIFF
--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -18,25 +18,39 @@ import { EventTimelineSet } from "../../src/models/event-timeline-set";
 import { MatrixEvent } from "../../src/models/event";
 import { Relations } from "../../src/models/relations";
 
+// Helper
+function createRelationEvent() {
+    return new MatrixEvent({
+        "sender": "@bob:example.com",
+        "type": "m.reaction",
+        "event_id": "$cZ1biX33ENJqIm00ks0W_hgiO_6CHrsAc3ZQrnLeNTw",
+        "room_id": "!pzVjCQSoQPpXQeHpmK:example.com",
+        "content": {
+            "m.relates_to": {
+                "event_id": "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
+                "key": "👍️",
+                "rel_type": "m.annotation",
+            },
+        },
+    });
+}
+
+function createTargetEvent() {
+    return new MatrixEvent({
+        "sender": "@bob:example.com",
+        "type": "m.room.message",
+        "event_id": "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
+        "room_id": "!pzVjCQSoQPpXQeHpmK:example.com",
+        "content": {},
+    });
+}
+
 describe("Relations", function() {
     it("should deduplicate annotations", function() {
         const relations = new Relations("m.annotation", "m.reaction");
 
         // Create an instance of an annotation
-        const eventData = {
-            "sender": "@bob:example.com",
-            "type": "m.reaction",
-            "event_id": "$cZ1biX33ENJqIm00ks0W_hgiO_6CHrsAc3ZQrnLeNTw",
-            "room_id": "!pzVjCQSoQPpXQeHpmK:example.com",
-            "content": {
-                "m.relates_to": {
-                    "event_id": "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
-                    "key": "👍️",
-                    "rel_type": "m.annotation",
-                },
-            },
-        };
-        const eventA = new MatrixEvent(eventData);
+        const eventA = createRelationEvent();
 
         // Add the event once and check results
         {
@@ -59,7 +73,7 @@ describe("Relations", function() {
         }
 
         // Create a fresh object with the same event content
-        const eventB = new MatrixEvent(eventData);
+        const eventB = createRelationEvent();
 
         // Add the event again and expect the same
         {
@@ -73,26 +87,8 @@ describe("Relations", function() {
     });
 
     it("should emit created regardless of ordering", async function() {
-        const targetEvent = new MatrixEvent({
-            "sender": "@bob:example.com",
-            "type": "m.room.message",
-            "event_id": "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
-            "room_id": "!pzVjCQSoQPpXQeHpmK:example.com",
-            "content": {},
-        });
-        const relationEvent = new MatrixEvent({
-            "sender": "@bob:example.com",
-            "type": "m.reaction",
-            "event_id": "$cZ1biX33ENJqIm00ks0W_hgiO_6CHrsAc3ZQrnLeNTw",
-            "room_id": "!pzVjCQSoQPpXQeHpmK:example.com",
-            "content": {
-                "m.relates_to": {
-                    "event_id": "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
-                    "key": "👍️",
-                    "rel_type": "m.annotation",
-                },
-            },
-        });
+        const targetEvent = createTargetEvent();
+        const relationEvent = createRelationEvent();
 
         // Stub the room
         const room = {
@@ -130,4 +126,45 @@ describe("Relations", function() {
             await relationsCreated;
         }
     });
+
+    it("should return relations object with no relations set when getRelationsForEvent", async function() {
+        const targetEvent = createTargetEvent();
+        // Stub the room
+        const room = {
+            getPendingEvent() { return null; },
+            getUnfilteredTimelineSet() { return null; },
+        };
+
+        // Add the target event to a timeline set
+        const timelineSet = new EventTimelineSet(room, {
+            unstableClientRelationAggregation: true,
+        });
+        timelineSet.addLiveEvent(targetEvent);
+
+        // Get a relation for the event
+        const eventRelations = timelineSet.getRelationsForEvent(targetEvent.getId(), "m.annotation", "m.reaction");
+
+        // The relation exists
+        expect(eventRelations).not.toBeUndefined();
+        expect(eventRelations.getRelations()).toEqual([]);
+
+        // When getting the relation again, we get the same reference
+        const eventRelations2 = timelineSet.getRelationsForEvent(targetEvent.getId(), "m.annotation", "m.reaction");
+        expect(eventRelations).toBe(eventRelations2);
+
+        // Add a relation event to the timeline
+        const relationsCreated = new Promise(resolve => {
+            targetEvent.once("Event.relationsCreated", resolve);
+        });
+
+        const relationEvent = createRelationEvent();
+        timelineSet.addLiveEvent(relationEvent);
+        await relationsCreated;
+
+        // Getting the relation again, i˙ts still the same:
+        const eventRelations3 = timelineSet.getRelationsForEvent(targetEvent.getId(), "m.annotation", "m.reaction");
+        expect(eventRelations2).toBe(eventRelations3);
+        // a new relation event exists:
+        expect(eventRelations3.getRelations()).toHaveLength(1);
+    })
 });

--- a/src/client.js
+++ b/src/client.js
@@ -2857,7 +2857,9 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
         try {
             room.addPendingEvent(localEvent, txnId);
         } catch (e) {
-            logger.warn(`_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`); 
+            logger.warn(
+                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`
+            );
         }
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -2854,7 +2854,11 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
 
     // add this event immediately to the local store as 'sending'.
     if (room) {
-        room.addPendingEvent(localEvent, txnId);
+        try {
+            room.addPendingEvent(localEvent, txnId);
+        } catch (e) {
+            logger.warn(`_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`); 
+        }
     }
 
     // addPendingEvent can change the state to NOT_SENT if it believes

--- a/src/client.js
+++ b/src/client.js
@@ -2858,7 +2858,7 @@ MatrixClient.prototype._sendCompleteEvent = function(roomId, eventObject, txnId,
             room.addPendingEvent(localEvent, txnId);
         } catch (e) {
             logger.warn(
-                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`
+                `_sendCompleteEvent adding pending event failed because of: ${e ? e.message : "unknown reason"}`,
             );
         }
     }


### PR DESCRIPTION
### The problem

Currently, when calling `getRelationsForEvent` on a timeline set it will return undefined when no relation event exists.
In our app, we have the following logic:

*Message component:*

```jsx
const Message = (props) => {
  ...
  useEffect(() => {
    const client = RNMWrapper.getClient();
    const relation = client
      .getRoom(matrixEvent.getRoomId())
      ?.getLiveTimeline()
      .getTimelineSet()
      .getRelationsForEvent(matrixEvent.getId(), "m.moment.seen", "m.reaction");
    relation?.addListener("Relations.add", (e) => {
      // process newly added relation on message
    });
  }, [matrixEvent]);
```

When a relation is added for `matrixEvent` we won't know it, as `relation` is `undefined`.

### The change

I implemented (and wrote tests) that when `getRelationsForEvent` a new relation will be created if none exists. I think this behaviour is fine, because we can then do `relation.getRelations()` which will return an empty array, which is more descriptive than just returning undefined.

However, I am not sure whether this change would be breaking?

Happy to discuss this change with you ✌️ 