### PR TITLE
Revert 1579 (Fix extra negotiate message in Firefox)

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1106,21 +1106,8 @@ export class MatrixCall extends EventEmitter {
             await this.peerConn.setRemoteDescription(description);
 
             if (description.type === 'offer') {
-                // First we sent the direction of the tranciever to what we'd like it to be,
-                // irresepective of whether the other side has us on hold - so just whether we
-                // want the call to be on hold or not. This is necessary because in a few lines,
-                // we'll adjust the direction and unless we do this too, we'll never come off hold.
-                for (const tranceiver of this.peerConn.getTransceivers()) {
-                    tranceiver.direction = this.isRemoteOnHold() ? 'inactive' : 'sendrecv';
-                }
                 const localDescription = await this.peerConn.createAnswer();
                 await this.peerConn.setLocalDescription(localDescription);
-                // Now we've got our answer, set the direction to the outcome of the negotiation.
-                // We need to do this otherwise Firefox will notice that the direction is not the
-                // currentDirection and try to negotiate itself off hold again.
-                for (const tranceiver of this.peerConn.getTransceivers()) {
-                    tranceiver.direction = tranceiver.currentDirection;
-                }
 
                 this.sendVoipEvent(EventType.CallNegotiate, {
                     description: this.peerConn.localDescription,


### PR DESCRIPTION
This is causing all sorts of problems, like
https://github.com/vector-im/element-web/issues/17450
and also issues where we fail to respond to negotiates because
we can't adjust a direction of a stopped transceiver. Until
s/inactive/sendonly/ let's live with the minor firefox bug rather
than all this brokenness.

Reverts https://github.com/matrix-org/matrix-js-sdk/pull/1579
Fixes https://github.com/vector-im/element-web/issues/17450