### PR TITLE
Add separate reason code for transferred calls

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -192,7 +192,12 @@ export enum CallErrorCode {
     /**
      * The remote party is busy
      */
-    UserBusy = 'user_busy'
+    UserBusy = 'user_busy',
+
+    /**
+     * We transferred the call off to somewhere else
+     */
+    Transfered = 'transferred',
 }
 
 enum ConstraintsType {
@@ -1428,7 +1433,7 @@ export class MatrixCall extends EventEmitter {
 
         await this.sendVoipEvent(EventType.CallReplaces, body);
 
-        await this.terminate(CallParty.Local, CallErrorCode.Replaced, true);
+        await this.terminate(CallParty.Local, CallErrorCode.Transfered, true);
     }
 
     /*
@@ -1468,7 +1473,7 @@ export class MatrixCall extends EventEmitter {
         await this.sendVoipEvent(EventType.CallReplaces, bodyToTransferee);
 
         await this.terminate(CallParty.Local, CallErrorCode.Replaced, true);
-        await transferTargetCall.terminate(CallParty.Local, CallErrorCode.Replaced, true);
+        await transferTargetCall.terminate(CallParty.Local, CallErrorCode.Transfered, true);
     }
 
     private async terminate(hangupParty: CallParty, hangupReason: CallErrorCode, shouldEmit: boolean) {


### PR DESCRIPTION
'Replaced' is special cased so the media isn't torn down, but we
were passing Replaced for calls we transferred off elsewhere which
meant we never closed the media capture. Calls transferred elsewhere
aren't really replaced: they may as well have their own code.