### PR TITLE
Fix broken /messages filtering due to internal field changes in FilterComponent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4427,7 +4427,7 @@ export class MatrixClient extends EventEmitter {
             // XXX: it's horrific that /messages' filter parameter doesn't match
             // /sync's one - see https://matrix.org/jira/browse/SPEC-451
             filter = filter || {};
-            Object.assign(filter, timelineFilter.getRoomTimelineFilterComponent());
+            Object.assign(filter, timelineFilter.getRoomTimelineFilterComponent()?.toJSON());
         }
         if (filter) {
             params.filter = JSON.stringify(filter);

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -25,7 +25,7 @@ import { MatrixEvent } from "./models/event";
  * wildcard pattern.
  * @param {String} actualValue  The value to be compared
  * @param {String} filterValue  The filter pattern to be compared
- * @return {bool} true if the actualValue matches the filterValue
+ * @return {boolean} true if the actualValue matches the filterValue
  */
 function matchesWildcard(actualValue: string, filterValue: string): boolean {
     if (filterValue.endsWith("*")) {
@@ -66,15 +66,30 @@ export class FilterComponent {
     /**
      * Checks with the filter component matches the given event
      * @param {MatrixEvent} event event to be checked against the filter
-     * @return {bool} true if the event matches the filter
+     * @return {boolean} true if the event matches the filter
      */
-    check(event: MatrixEvent): boolean {
+    public check(event: MatrixEvent): boolean {
         return this.checkFields(
             event.getRoomId(),
             event.getSender(),
             event.getType(),
             event.getContent() ? event.getContent().url !== undefined : false,
         );
+    }
+
+    /**
+     * Converts the filter component into the form expected over the wire
+     */
+    public toJSON(): object {
+        return {
+            types: this.filterJson.types || null,
+            not_types: this.filterJson.not_types || [],
+            rooms: this.filterJson.rooms || null,
+            not_rooms: this.filterJson.not_rooms || [],
+            senders: this.filterJson.senders || null,
+            not_senders: this.filterJson.not_senders || [],
+            contains_url: this.filterJson.contains_url || null,
+        };
     }
 
     /**
@@ -123,7 +138,7 @@ export class FilterComponent {
 
     /**
      * Filters a list of events down to those which match this filter component
-     * @param {MatrixEvent[]} events  Events to be checked againt the filter component
+     * @param {MatrixEvent[]} events  Events to be checked against the filter component
      * @return {MatrixEvent[]} events which matched the filter component
      */
     filter(events: MatrixEvent[]): MatrixEvent[] {
@@ -132,7 +147,7 @@ export class FilterComponent {
 
     /**
      * Returns the limit field for a given filter component, providing a default of
-     * 10 if none is otherwise specified.  Cargo-culted from Synapse.
+     * 10 if none is otherwise specified. Cargo-culted from Synapse.
      * @return {Number} the limit for this filter component.
      */
     limit(): number {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -168,9 +168,7 @@ export class Filter {
         }
 
         this.roomFilter = new FilterComponent(roomFilterFields);
-        this.roomTimelineFilter = new FilterComponent(
-            roomFilterJson ? (roomFilterJson.timeline || {}) : {},
-        );
+        this.roomTimelineFilter = new FilterComponent(roomFilterJson?.timeline || {});
 
         // don't bother porting this from synapse yet:
         // this._room_state_filter =


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/17753#event-4952613253

Also no longer sends `filter_json` redundantly, this halves the size of the filter GET field being sent, yay?