### PR TITLE
Attempt to fix megolm key not being in SSSS

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -974,10 +974,9 @@ export class Crypto extends EventEmitter {
                 const backupKey = await this.getSessionBackupPrivateKey() || await getKeyBackupPassphrase();
                 if (!backupKey) {
                     // This will require user intervention to recover from since we don't have the key
-                    // backup key anywhere. It's possible that this is a legacy setup where the SSSS
-                    // master key is the same as the key backup key, but we can't assume that it is:
-                    // we'd have to at least check it against the backup. Alternatively, the user could
-                    // just set up a new key backup and the key for the new backup will be stored.
+                    // backup key anywhere. The user should probably just set up a new key backup and
+                    // the key for the new backup will be stored. If we hit this scenario in the wild
+                    // with any frequency, we should do more than just log an error.
                     logger.error("Key backup is enabled but couldn't get key backup key!");
                     return;
                 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -951,22 +951,39 @@ export class Crypto extends EventEmitter {
             builder.addSessionBackup(data);
         }
 
-        // Cache the session backup key
-        const sessionBackupKey = await secretStorage.get('m.megolm_backup.v1');
-        if (sessionBackupKey) {
-            logger.info("Got session backup key from secret storage: caching");
-            // fix up the backup key if it's in the wrong format, and replace
-            // in secret storage
-            const fixedBackupKey = fixBackupKey(sessionBackupKey);
-            if (fixedBackupKey) {
-                await secretStorage.store("m.megolm_backup.v1",
-                    fixedBackupKey, [newKeyId || oldKeyId],
-                );
+        if (this.backupManager.getKeyBackupEnabled()) {
+            // Cache the session backup key
+            const sessionBackupKey = await secretStorage.get('m.megolm_backup.v1');
+            if (sessionBackupKey) {
+                logger.info("Got session backup key from secret storage: caching");
+                // fix up the backup key if it's in the wrong format, and replace
+                // in secret storage
+                const fixedBackupKey = fixBackupKey(sessionBackupKey);
+                if (fixedBackupKey) {
+                    await secretStorage.store("m.megolm_backup.v1",
+                        fixedBackupKey, [newKeyId || oldKeyId],
+                    );
+                }
+                const decodedBackupKey = new Uint8Array(olmlib.decodeBase64(
+                    fixedBackupKey || sessionBackupKey,
+                ));
+                await builder.addSessionBackupPrivateKeyToCache(decodedBackupKey);
+            } else {
+                // key backup is enabled but we don't have a session backup key in SSSS: see if we have one in
+                // the cache or the user can provide one, and if so, write it to SSSS
+                const backupKey = await this.getSessionBackupPrivateKey() || await getKeyBackupPassphrase();
+                if (!backupKey) {
+                    // This will require user intervention to recover from since we don't have the key
+                    // backup key anywhere. It's possible that this is a legacy setup where the SSSS
+                    // master key is the same as the key backup key, but we can't assume that it is:
+                    // we'd have to at least check it against the backup. Alternatively, the user could
+                    // just set up a new key backup and the key for the new backup will be stored.
+                    logger.error("Key backup is enabled but couldn't get key backup key!");
+                    return;
+                }
+                logger.info("Got session backup key from cache/user that wasn't in SSSS: saving to SSSS");
+                await secretStorage.store("m.megolm_backup.v1", olmlib.encodeBase64(backupKey));
             }
-            const decodedBackupKey = new Uint8Array(olmlib.decodeBase64(
-                fixedBackupKey || sessionBackupKey,
-            ));
-            await builder.addSessionBackupPrivateKeyToCache(decodedBackupKey);
         }
 
         const operation = builder.buildOperation();


### PR DESCRIPTION
If the account has both a key backup and SSSS enabled but the key
backup key isn't stored in SSSS, try to save it there by getting
it from either the cache or the user (if perhaps it's the same as
their security passphrase but lost a passthrough entry).

Fixes https://github.com/vector-im/element-web/issues/17886

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.rst#sign-off -->
