### PR TITLE
Use webpack worker-loader instead of homegrown hack

### DIFF
--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -37,15 +37,13 @@ export class RemoteIndexedDBStoreBackend implements IIndexeddbBackend {
      * Construct a new Indexed Database store backend. This requires a call to
      * <code>connect()</code> before this store can be used.
      * @constructor
-     * @param {string} workerScript URL to the worker script
+     * @param {Function} workerFactory Factory which produces a Worker
      * @param {string=} dbName Optional database name. The same name must be used
      * to open the same database.
-     * @param {Object} WorkerApi The web worker compatible interface object
      */
     constructor(
-        private readonly workerScript: string,
+        private readonly workerFactory: () => Worker,
         private readonly dbName: string,
-        private readonly WorkerApi: typeof Worker,
     ) {}
 
     /**
@@ -137,7 +135,7 @@ export class RemoteIndexedDBStoreBackend implements IIndexeddbBackend {
 
     private ensureStarted(): Promise<void> {
         if (this.startPromise === null) {
-            this.worker = new this.WorkerApi(this.workerScript);
+            this.worker = this.workerFactory();
             this.worker.onmessage = this.onWorkerMessage;
 
             // tell the worker the db name.

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -43,8 +43,7 @@ const WRITE_DELAY_MS = 1000 * 60 * 5; // once every 5 minutes
 interface IOpts extends IBaseOpts {
     indexedDB: IDBFactory;
     dbName?: string;
-    workerScript?: string;
-    workerApi?: typeof Worker;
+    workerFactory?: () => Worker;
 }
 
 export class IndexedDBStore extends MemoryStore {
@@ -111,16 +110,8 @@ export class IndexedDBStore extends MemoryStore {
             throw new Error('Missing required option: indexedDB');
         }
 
-        if (opts.workerScript) {
-            // try & find a webworker-compatible API
-            let workerApi = opts.workerApi;
-            if (!workerApi) {
-                // default to the global Worker object (which is where it in a browser)
-                workerApi = global.Worker;
-            }
-            this.backend = new RemoteIndexedDBStoreBackend(
-                opts.workerScript, opts.dbName, workerApi,
-            );
+        if (opts.workerFactory) {
+            this.backend = new RemoteIndexedDBStoreBackend(opts.workerFactory, opts.dbName);
         } else {
             this.backend = new LocalIndexedDBStoreBackend(opts.indexedDB, opts.dbName);
         }


### PR DESCRIPTION
# Requires a version bump

Switches to a more generic approach to passing a worker to the indexeddb remote backend by means of a factory