### PR TITLE
Standardise spelling and casing of homeserver, identity server, and integration manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1735,13 +1735,13 @@ Changes in [2.4.0-rc.1](https://github.com/matrix-org/matrix-js-sdk/releases/tag
    [\#1021](https://github.com/matrix-org/matrix-js-sdk/pull/1021)
  * Add getIdServer() & doesServerRequireIdServerParam()
    [\#1018](https://github.com/matrix-org/matrix-js-sdk/pull/1018)
- * Make requestToken endpoints work without an identity server
+ * Make requestToken endpoints work without ID Server
    [\#1019](https://github.com/matrix-org/matrix-js-sdk/pull/1019)
  * Fix setIdentityServer
    [\#1016](https://github.com/matrix-org/matrix-js-sdk/pull/1016)
  * Change ICE fallback server and make fallback opt-in
    [\#1015](https://github.com/matrix-org/matrix-js-sdk/pull/1015)
- * Throw an exception if trying to do an identity server request with no identity server
+ * Throw an exception if trying to do an ID server request with no ID server
    [\#1014](https://github.com/matrix-org/matrix-js-sdk/pull/1014)
  * Add setIdentityServerUrl
    [\#1013](https://github.com/matrix-org/matrix-js-sdk/pull/1013)
@@ -1749,7 +1749,7 @@ Changes in [2.4.0-rc.1](https://github.com/matrix-org/matrix-js-sdk/releases/tag
    [\#1011](https://github.com/matrix-org/matrix-js-sdk/pull/1011)
  * Fix POST body for v2 IS requests
    [\#1010](https://github.com/matrix-org/matrix-js-sdk/pull/1010)
- * Add API for bulk lookup on the identity server
+ * Add API for bulk lookup on the Identity Server
    [\#1009](https://github.com/matrix-org/matrix-js-sdk/pull/1009)
  * Remove deprecated authedRequestWithPrefix and requestWithPrefix
    [\#1000](https://github.com/matrix-org/matrix-js-sdk/pull/1000)
@@ -3767,7 +3767,7 @@ Other improvements:
    [\#109](https://github.com/matrix-org/matrix-js-sdk/pull/109)
  * Refactor transmitted-messages code
    [\#110](https://github.com/matrix-org/matrix-js-sdk/pull/110)
- * Add a method to the js sdk to look up 3pids on the identity server.
+ * Add a method to the js sdk to look up 3pids on the ID server.
    [\#113](https://github.com/matrix-org/matrix-js-sdk/pull/113)
  * Support for cancelling pending events
    [\#112](https://github.com/matrix-org/matrix-js-sdk/pull/112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1749,7 +1749,7 @@ Changes in [2.4.0-rc.1](https://github.com/matrix-org/matrix-js-sdk/releases/tag
    [\#1011](https://github.com/matrix-org/matrix-js-sdk/pull/1011)
  * Fix POST body for v2 IS requests
    [\#1010](https://github.com/matrix-org/matrix-js-sdk/pull/1010)
- * Add API for bulk lookup on the Identity Server
+ * Add API for bulk lookup on the identity server
    [\#1009](https://github.com/matrix-org/matrix-js-sdk/pull/1009)
  * Remove deprecated authedRequestWithPrefix and requestWithPrefix
    [\#1000](https://github.com/matrix-org/matrix-js-sdk/pull/1000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1735,13 +1735,13 @@ Changes in [2.4.0-rc.1](https://github.com/matrix-org/matrix-js-sdk/releases/tag
    [\#1021](https://github.com/matrix-org/matrix-js-sdk/pull/1021)
  * Add getIdServer() & doesServerRequireIdServerParam()
    [\#1018](https://github.com/matrix-org/matrix-js-sdk/pull/1018)
- * Make requestToken endpoints work without ID Server
+ * Make requestToken endpoints work without an identity server
    [\#1019](https://github.com/matrix-org/matrix-js-sdk/pull/1019)
  * Fix setIdentityServer
    [\#1016](https://github.com/matrix-org/matrix-js-sdk/pull/1016)
  * Change ICE fallback server and make fallback opt-in
    [\#1015](https://github.com/matrix-org/matrix-js-sdk/pull/1015)
- * Throw an exception if trying to do an ID server request with no ID server
+ * Throw an exception if trying to do an identity server request with no identity server
    [\#1014](https://github.com/matrix-org/matrix-js-sdk/pull/1014)
  * Add setIdentityServerUrl
    [\#1013](https://github.com/matrix-org/matrix-js-sdk/pull/1013)
@@ -3767,7 +3767,7 @@ Other improvements:
    [\#109](https://github.com/matrix-org/matrix-js-sdk/pull/109)
  * Refactor transmitted-messages code
    [\#110](https://github.com/matrix-org/matrix-js-sdk/pull/110)
- * Add a method to the js sdk to look up 3pids on the ID server.
+ * Add a method to the js sdk to look up 3pids on the identity server.
    [\#113](https://github.com/matrix-org/matrix-js-sdk/pull/113)
  * Support for cancelling pending events
    [\#112](https://github.com/matrix-org/matrix-js-sdk/pull/112)

--- a/src/client.ts
+++ b/src/client.ts
@@ -4806,7 +4806,7 @@ export class MatrixClient extends EventEmitter {
     /**
      * Requests a text message verification token for the purposes of adding a
      * third party identifier to an account.
-     * This API proxies the Identity Server /validate/email/requestToken API,
+     * This API proxies the identity server /validate/email/requestToken API,
      * adding specific behaviour for the addition of phone numbers to an
      * account, as requestAdd3pidEmailToken.
      *
@@ -4839,7 +4839,7 @@ export class MatrixClient extends EventEmitter {
     /**
      * Requests an email verification token for the purposes of resetting
      * the password on an account.
-     * This API proxies the Identity Server /validate/email/requestToken API,
+     * This API proxies the identity server /validate/email/requestToken API,
      * adding specific behaviour for the password resetting. Specifically,
      * if no account with the given email address exists, it may either
      * return M_THREEPID_NOT_FOUND or send an email
@@ -4875,7 +4875,7 @@ export class MatrixClient extends EventEmitter {
     /**
      * Requests a text message verification token for the purposes of resetting
      * the password on an account.
-     * This API proxies the Identity Server /validate/email/requestToken API,
+     * This API proxies the identity server /validate/email/requestToken API,
      * adding specific behaviour for the password resetting, as requestPasswordEmailToken.
      *
      * @param {string} phoneCountry As requestRegisterMsisdnToken
@@ -5819,9 +5819,9 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Get the Identity Server URL of this client
+     * Get the identity server URL of this client
      * @param {boolean} stripProto whether or not to strip the protocol from the URL
-     * @return {string} Identity Server URL of this client
+     * @return {string} Identity server URL of this client
      */
     public getIdentityServerUrl(stripProto = false): string {
         if (stripProto && (this.idBaseUrl.startsWith("http://") ||
@@ -5832,8 +5832,8 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Set the Identity Server URL of this client
-     * @param {string} url New Identity Server URL
+     * Set the identity server URL of this client
+     * @param {string} url New identity server URL
      */
     public setIdentityServerUrl(url: string) {
         this.idBaseUrl = utils.ensureNoTrailingSlash(url);
@@ -7260,7 +7260,7 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Register with an Identity Server using the OpenID token from the user's
+     * Register with an identity server using the OpenID token from the user's
      * Homeserver, which can be retrieved via
      * {@link module:client~MatrixClient#getOpenIdToken}.
      *
@@ -7274,7 +7274,7 @@ export class MatrixClient extends EventEmitter {
      */
     public registerWithIdentityServer(hsOpenIdToken: any): Promise<any> { // TODO: Types
         if (!this.idBaseUrl) {
-            throw new Error("No Identity Server base URL set");
+            throw new Error("No identity server base URL set");
         }
 
         const uri = this.idBaseUrl + PREFIX_IDENTITY_V2 + "/account/register";
@@ -7549,7 +7549,7 @@ export class MatrixClient extends EventEmitter {
 
     /**
      * Looks up the public Matrix ID mapping for a given 3rd party
-     * identifier from the Identity Server
+     * identifier from the identity server
      *
      * @param {string} medium The medium of the threepid, eg. 'email'
      * @param {string} address The textual address of the threepid
@@ -7634,7 +7634,7 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Get account info from the Identity Server. This is useful as a neutral check
+     * Get account info from the identity server. This is useful as a neutral check
      * to verify that other APIs are likely to approve access by testing that the
      * token is valid, terms have been agreed, etc.
      *

--- a/src/client.ts
+++ b/src/client.ts
@@ -4778,7 +4778,7 @@ export class MatrixClient extends EventEmitter {
      * If an account with the given email address already exists and is
      * associated with an account other than the one the user is authed as,
      * it will either send an email to the address informing them of this
-     * or return M_THREEPID_IN_USE (which one is up to the Home Server).
+     * or return M_THREEPID_IN_USE (which one is up to the homeserver).
      *
      * @param {string} email As requestEmailToken
      * @param {string} clientSecret As requestEmailToken
@@ -4843,7 +4843,7 @@ export class MatrixClient extends EventEmitter {
      * adding specific behaviour for the password resetting. Specifically,
      * if no account with the given email address exists, it may either
      * return M_THREEPID_NOT_FOUND or send an email
-     * to the address informing them of this (which one is up to the Home Server).
+     * to the address informing them of this (which one is up to the homeserver).
      *
      * requestEmailToken calls the equivalent API directly on the ID server,
      * therefore bypassing the password reset specific logic.
@@ -5316,7 +5316,7 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Gets a bearer token from the Home Server that the user can
+     * Gets a bearer token from the homeserver that the user can
      * present to a third party in order to prove their ownership
      * of the Matrix account they are logged into.
      * @return {Promise} Resolves: Token object
@@ -5349,7 +5349,7 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Get the TURN servers for this home server.
+     * Get the TURN servers for this homeserver.
      * @return {Array<Object>} The servers or an empty list.
      */
     public getTurnServers(): any[] { // TODO: Types
@@ -6668,7 +6668,7 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
-     * Upload a file to the media repository on the home server.
+     * Upload a file to the media repository on the homeserver.
      *
      * @param {object} file The object to upload. On a browser, something that
      *   can be sent to XMLHttpRequest.send (typically a File).  Under node.js,

--- a/src/client.ts
+++ b/src/client.ts
@@ -4845,7 +4845,7 @@ export class MatrixClient extends EventEmitter {
      * return M_THREEPID_NOT_FOUND or send an email
      * to the address informing them of this (which one is up to the homeserver).
      *
-     * requestEmailToken calls the equivalent API directly on the ID server,
+     * requestEmailToken calls the equivalent API directly on the identity server,
      * therefore bypassing the password reset specific logic.
      *
      * @param {string} email As requestEmailToken
@@ -4920,7 +4920,7 @@ export class MatrixClient extends EventEmitter {
         if (!await this.doesServerSupportSeparateAddAndBind() && this.idBaseUrl) {
             const idServerUrl = url.parse(this.idBaseUrl);
             if (!idServerUrl.host) {
-                throw new Error("Invalid ID server URL: " + this.idBaseUrl);
+                throw new Error("Invalid identity server URL: " + this.idBaseUrl);
             }
             postParams.id_server = idServerUrl.host;
 
@@ -5884,7 +5884,7 @@ export class MatrixClient extends EventEmitter {
      * @param {string} sessionId
      * @param {Object} auth
      * @param {Object} bindThreepids Set key 'email' to true to bind any email
-     *     threepid uses during registration in the ID server. Set 'msisdn' to
+     *     threepid uses during registration in the identity server. Set 'msisdn' to
      *     true to bind msisdn.
      * @param {string} guestAccessToken
      * @param {string} inhibitLogin
@@ -7383,7 +7383,7 @@ export class MatrixClient extends EventEmitter {
      * Submits a MSISDN token to the identity server
      *
      * This is used when submitting the code sent by SMS to a phone number.
-     * The ID server has an equivalent API for email but the js-sdk does
+     * The identity server has an equivalent API for email but the js-sdk does
      * not expose this, since email is normally validated by the user clicking
      * a link rather than entering a code.
      *
@@ -7396,7 +7396,7 @@ export class MatrixClient extends EventEmitter {
      *
      * @return {Promise} Resolves: Object, currently with no parameters.
      * @return {module:http-api.MatrixError} Rejects: with an error response.
-     * @throws Error if No ID server is set
+     * @throws Error if No identity server is set
      */
     public async submitMsisdnToken(
         sid: string,

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -393,7 +393,7 @@ MatrixHttpApi.prototype = {
         accessToken,
     ) {
         if (!this.opts.idBaseUrl) {
-            throw new Error("No Identity Server base URL set");
+            throw new Error("No identity server base URL set");
         }
 
         const fullUri = this.opts.idBaseUrl + prefix + path;

--- a/src/http-api.js
+++ b/src/http-api.js
@@ -121,7 +121,7 @@ MatrixHttpApi.prototype = {
     },
 
     /**
-     * Upload content to the Home Server
+     * Upload content to the homeserver
      *
      * @param {object} file The object to upload. On a browser, something that
      *   can be sent to XMLHttpRequest.send (typically a File).  Under node.js,

--- a/src/interactive-auth.js
+++ b/src/interactive-auth.js
@@ -217,7 +217,7 @@ InteractiveAuth.prototype = {
 
     /**
      * get the client secret used for validation sessions
-     * with the ID server.
+     * with the identity server.
      *
      * @return {string} client secret
      */

--- a/src/service-types.ts
+++ b/src/service-types.ts
@@ -16,5 +16,5 @@ limitations under the License.
 
 export enum SERVICE_TYPES {
     IS = 'SERVICE_TYPE_IS', // An Identity Service
-    IM = 'SERVICE_TYPE_IM', // An Integration Manager
+    IM = 'SERVICE_TYPE_IM', // An integration manager
 }

--- a/src/service-types.ts
+++ b/src/service-types.ts
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 export enum SERVICE_TYPES {
-    IS = 'SERVICE_TYPE_IS', // An Identity Service
+    IS = 'SERVICE_TYPE_IS', // An identity server
     IM = 'SERVICE_TYPE_IM', // An integration manager
 }


### PR DESCRIPTION
This PR standardises the spelling and casing of the following terms, across the codebase, as per vector-im/element-web/issues/10569:

- homeserver
- identity server
- integration manager

While the issue mentions only user-visible text, this PR changes all instances of the terms, regardless of whether they're user-visible or not. I think there's value in standardising these terms even in non-user-visible text, so I went ahead and applied the changes to all text.

For reference, here's the script I used to find candidates for replacement:
https://gist.github.com/psrpinto/b3787bae212d5d99649b517e2efd4dce