### PR TITLE
Add VS Code to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ out
 # version file and tarball created by `npm pack` / `yarn pack`
 /git-revision.txt
 /matrix-js-sdk-*.tgz
+
+.vscode
+.vscode/


### PR DESCRIPTION
We ignore both the directory and file since a symlink acts as a file and you might want to symlink a global config directory for all Element related projects