### PR TITLE
Use an unstable prefix for MSC2885: Hidden read receipts  

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3650,7 +3650,7 @@ export class MatrixClient extends EventEmitter {
         }
 
         const addlContent = {
-            "m.hidden": Boolean(opts.hidden),
+            "org.matrix.msc2885.hidden": Boolean(opts.hidden),
         };
 
         return this.sendReceipt(event, "m.read", addlContent, callback);
@@ -6429,7 +6429,7 @@ export class MatrixClient extends EventEmitter {
         const content = {
             "m.fully_read": rmEventId,
             "m.read": rrEventId,
-            "m.hidden": Boolean(opts ? opts.hidden : false),
+            "org.matrix.msc2885.hidden": Boolean(opts ? opts.hidden : false),
         };
 
         return this.http.authedRequest(

--- a/src/client.ts
+++ b/src/client.ts
@@ -6429,7 +6429,7 @@ export class MatrixClient extends EventEmitter {
         const content = {
             "m.fully_read": rmEventId,
             "m.read": rrEventId,
-            "org.matrix.msc2885.hidden": Boolean(opts ? opts.hidden : false),
+            "org.matrix.msc2285.hidden": Boolean(opts ? opts.hidden : false),
         };
 
         return this.http.authedRequest(

--- a/src/client.ts
+++ b/src/client.ts
@@ -3650,7 +3650,7 @@ export class MatrixClient extends EventEmitter {
         }
 
         const addlContent = {
-            "org.matrix.msc2885.hidden": Boolean(opts.hidden),
+            "org.matrix.msc2285.hidden": Boolean(opts.hidden),
         };
 
         return this.sendReceipt(event, "m.read", addlContent, callback);


### PR DESCRIPTION
We should be using an unstable prefix as per [`a4e5b45` (#2285)](https://github.com/matrix-org/matrix-doc/pull/2285/commits/a4e5b45204b243b6b23226a0fcf5cf8a9b10cdc0)