### PR TITLE
Switch callEventHandler from listening on `event` to `Room.timeline`

### DIFF
--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -47,12 +47,12 @@ export class CallEventHandler {
 
     public start() {
         this.client.on("sync", this.evaluateEventBuffer);
-        this.client.on("event", this.onEvent);
+        this.client.on("Room.timeline", this.onRoomTimeline);
     }
 
     public stop() {
         this.client.removeListener("sync", this.evaluateEventBuffer);
-        this.client.removeListener("event", this.onEvent);
+        this.client.removeListener("Room.timeline", this.onRoomTimeline);
     }
 
     private evaluateEventBuffer = async () => {
@@ -89,7 +89,7 @@ export class CallEventHandler {
         }
     };
 
-    private onEvent = (event: MatrixEvent) => {
+    private onRoomTimeline = (event: MatrixEvent) => {
         this.client.decryptEventIfNeeded(event);
         // any call events or ones that might be once they're decrypted
         if (this.eventIsACall(event) || event.isBeingDecrypted()) {


### PR DESCRIPTION
so that it doesn't end up processing ephemerals, account data, remote echoes, etc etc

This was causing remote-echoes to be pointlessly decrypted