### PR TITLE
Apply hidden char check to rawDisplayName too

### DIFF
--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -131,7 +131,11 @@ export class RoomMember extends EventEmitter {
             this.disambiguate,
         );
 
-        this.rawDisplayName = event.getDirectionalContent().displayname || this.userId;
+        this.rawDisplayName = event.getDirectionalContent().displayname;
+        if (!this.rawDisplayName || !utils.removeHiddenChars(this.rawDisplayName)) {
+            this.rawDisplayName = this.userId;
+        }
+
         if (oldMembership !== this.membership) {
             this.updateModifiedTime();
             this.emit("RoomMember.membership", event, this, oldMembership);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -402,10 +402,11 @@ export function normalize(str: string): string {
 // various width spaces U+2000 - U+200D
 // LTR and RTL marks U+200E and U+200F
 // LTR/RTL and other directional formatting marks U+202A - U+202F
+// Arabic Letter RTL mark U+061C
 // Combining characters U+0300 - U+036F
 // Zero width no-break space (BOM) U+FEFF
 // eslint-disable-next-line no-misleading-character-class
-const removeHiddenCharsRegex = /[\u2000-\u200F\u202A-\u202F\u0300-\u036f\uFEFF\s]/g;
+const removeHiddenCharsRegex = /[\u2000-\u200F\u202A-\u202F\u0300-\u036F\uFEFF\u061C\s]/g;
 
 export function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
The work on improving disambiguation in Element-Web made it obvious that we were only applying it to `name` where we should be applying it to the raw variant too, to prevent users making invisible displaynames as we once did.

Also for good measure, bundle in yet another BiDi char into the regexp.