### PR TITLE
Include all TypeScript @types listed in project dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dev": "yarn clean && git rev-parse HEAD > git-revision.txt && yarn build:compile && yarn build:types",
     "build:types": "tsc --emitDeclarationOnly",
     "build:compile": "babel -d lib --verbose --extensions \".ts,.js\" src",
-    "build:compile-browser": "mkdirp dist && browserify -d src/browser-index.js -p [ tsify -p ./tsconfig.json ] -t [ babelify --sourceMaps=inline --presets [ @babel/preset-env @babel/preset-typescript ] ] | exorcist dist/browser-matrix.js.map > dist/browser-matrix.js",
+    "build:compile-browser": "mkdirp dist && browserify -d src/browser-index.js -p [ tsify -p ./tsconfig-build.json ] -t [ babelify --sourceMaps=inline --presets [ @babel/preset-env @babel/preset-typescript ] ] | exorcist dist/browser-matrix.js.map > dist/browser-matrix.js",
     "build:minify-browser": "terser dist/browser-matrix.js --compress --mangle --source-map --output dist/browser-matrix.min.js",
     "gendoc": "jsdoc -c jsdoc.json -P package.json",
     "lint": "yarn lint:types && yarn lint:js",

--- a/spec/unit/models/MSC3089Branch.spec.ts
+++ b/spec/unit/models/MSC3089Branch.spec.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { MatrixClient } from "../../../src";
 import { Room } from "../../../src/models/room";
-import { MatrixEvent } from "../../../src/models/event";
 import { UNSTABLE_MSC3089_BRANCH } from "../../../src/@types/event";
 import { EventTimelineSet } from "../../../src/models/event-timeline-set";
 import { EventTimeline } from "../../../src/models/event-timeline";
@@ -25,7 +24,7 @@ import { MSC3089Branch } from "../../../src/models/MSC3089Branch";
 describe("MSC3089Branch", () => {
     let client: MatrixClient;
     // @ts-ignore - TS doesn't know that this is a type
-    let indexEvent: MatrixEvent;
+    let indexEvent: any;
     let branch: MSC3089Branch;
 
     const branchRoomId = "!room:example.org";
@@ -47,10 +46,10 @@ describe("MSC3089Branch", () => {
                 }
             },
         };
-        indexEvent = {
+        indexEvent = ({
             getRoomId: () => branchRoomId,
             getStateKey: () => fileEventId,
-        };
+        });
         branch = new MSC3089Branch(client, indexEvent);
     });
 

--- a/spec/unit/models/MSC3089TreeSpace.spec.ts
+++ b/spec/unit/models/MSC3089TreeSpace.spec.ts
@@ -29,7 +29,7 @@ import { MatrixError } from "../../../src/http-api";
 
 describe("MSC3089TreeSpace", () => {
     let client: MatrixClient;
-    let room: Room;
+    let room: any;
     let tree: MSC3089TreeSpace;
     const roomId = "!tree:localhost";
     const targetUser = "@target:example.org";
@@ -170,7 +170,7 @@ describe("MSC3089TreeSpace", () => {
             expect(userIds).toMatchObject([target]);
             return Promise.resolve();
         });
-        client.invite = () => Promise.resolve(); // we're not testing this here - see other tests
+        client.invite = () => Promise.resolve({}); // we're not testing this here - see other tests
         client.sendSharedHistoryKeys = sendKeysFn;
 
         // Mock the history check as best as possible
@@ -198,7 +198,7 @@ describe("MSC3089TreeSpace", () => {
             expect(userIds).toMatchObject([target]);
             return Promise.resolve();
         });
-        client.invite = () => Promise.resolve(); // we're not testing this here - see other tests
+        client.invite = () => Promise.resolve({}); // we're not testing this here - see other tests
         client.sendSharedHistoryKeys = sendKeysFn;
 
         const historyVis = "joined"; // NOTE: Changed.
@@ -446,9 +446,9 @@ describe("MSC3089TreeSpace", () => {
         // Danger: these are partial implementations for testing purposes only
 
         // @ts-ignore - "MatrixEvent is a value but used as a type", which is true but not important
-        let childState: { [roomId: string]: MatrixEvent[] } = {};
+        let childState: { [roomId: string]: any[] } = {};
         // @ts-ignore - "MatrixEvent is a value but used as a type", which is true but not important
-        let parentState: MatrixEvent[] = [];
+        let parentState: any[] = [];
         let parentRoom: Room;
         let childTrees: MSC3089TreeSpace[];
         let rooms: { [roomId: string]: Room };

--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -16,11 +16,13 @@ limitations under the License.
 
 import { EventTimelineSet } from "../../src/models/event-timeline-set";
 import { MatrixEvent } from "../../src/models/event";
+import { Room } from "../../src/models/room";
 import { Relations } from "../../src/models/relations";
 
 describe("Relations", function() {
     it("should deduplicate annotations", function() {
-        const relations = new Relations("m.annotation", "m.reaction");
+        const room = new Room("room123", null, null);
+        const relations = new Relations("m.annotation", "m.reaction", room);
 
         // Create an instance of an annotation
         const eventData = {
@@ -95,10 +97,8 @@ describe("Relations", function() {
         });
 
         // Stub the room
-        const room = {
-            getPendingEvent() { return null; },
-            getUnfilteredTimelineSet() { return null; },
-        };
+
+        const room = new Room("room123", null, null);
 
         // Add the target event first, then the relation event
         {

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -204,9 +204,9 @@ export class RoomState extends EventEmitter {
      * @return {MatrixEvent[]|MatrixEvent} A list of events if state_key was
      * <code>undefined</code>, else a single event (or null if no match found).
      */
-    public getStateEvents(eventType: string): MatrixEvent[];
-    public getStateEvents(eventType: string, stateKey: string): MatrixEvent;
-    public getStateEvents(eventType: string, stateKey?: string) {
+    public getStateEvents(eventType: EventType | string): MatrixEvent[];
+    public getStateEvents(eventType: EventType | string, stateKey: string): MatrixEvent;
+    public getStateEvents(eventType: EventType | string, stateKey?: string) {
         if (!this.events.has(eventType)) {
             // no match
             return stateKey === undefined ? [] : null;

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./spec/**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,10 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "outDir": "./lib",
-    "declaration": true,
-    "types": [
-      "node"
-    ]
+    "declaration": true
   },
   "include": [
-    "./src/**/*.ts"
+    "./src/**/*.ts",
+    "./spec/**/*.ts",
   ]
 }


### PR DESCRIPTION
Fixes vector-im/element-web#17743

The package @types/jest was not discovered because if types is specified, only packages listed will be included in the global scope.