### PR TITLE
Fix temporary call messages being handled without call 

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1286,7 +1286,7 @@ export class MatrixCall extends EventEmitter {
         // https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation
         const offerCollision = (
             (description.type === 'offer') &&
-            (this.makingOffer || this.peerConn.signalingState != 'stable')
+            (this.makingOffer || this.peerConn.signalingState !== 'stable')
         );
 
         this.ignoreOffer = !polite && offerCollision;
@@ -1934,6 +1934,10 @@ export class MatrixCall extends EventEmitter {
                 }
             }
         }
+    }
+
+    get hasPeerConnection() {
+        return Boolean(this.peerConn);
     }
 }
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1936,7 +1936,7 @@ export class MatrixCall extends EventEmitter {
         }
     }
 
-    get hasPeerConnection() {
+    public get hasPeerConnection() {
         return Boolean(this.peerConn);
     }
 }

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -261,7 +261,7 @@ export class CallEventHandler {
         }
 
         // The following events need a call and a peer connection
-        if (!call && !call.hasPeerConnection) {
+        if (!call || !call.hasPeerConnection) {
             logger.warn('Discarding an event, we don't have a call/peerConn', type);
             return;
         }

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -220,6 +220,7 @@ export class CallEventHandler {
             } else {
                 this.client.emit("Call.incoming", call);
             }
+            return;
         } else if (type === EventType.CallCandidates) {
             if (weSentTheEvent) return;
 
@@ -232,6 +233,7 @@ export class CallEventHandler {
             } else {
                 call.onRemoteIceCandidatesReceived(event);
             }
+            return;
         } else if ([EventType.CallHangup, EventType.CallReject].includes(type)) {
             // Note that we also observe our own hangups here so we can see
             // if we've already rejected a call that would otherwise be valid
@@ -255,10 +257,14 @@ export class CallEventHandler {
                     this.calls.delete(content.call_id);
                 }
             }
+            return;
         }
 
-        // The following events need a call
-        if (!call) return;
+        // The following events need a call and a peer connection
+        if (!call && !call.hasPeerConnection) {
+            logger.warn('Discarding an event', type);
+            return;
+        }
         // Ignore remote echo
         if (event.getContent().party_id === call.ourPartyId) return;
 

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -262,7 +262,7 @@ export class CallEventHandler {
 
         // The following events need a call and a peer connection
         if (!call || !call.hasPeerConnection) {
-            logger.warn('Discarding an event, we don't have a call/peerConn', type);
+            logger.warn("Discarding an event, we don't have a call/peerConn", type);
             return;
         }
         // Ignore remote echo

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -262,7 +262,7 @@ export class CallEventHandler {
 
         // The following events need a call and a peer connection
         if (!call && !call.hasPeerConnection) {
-            logger.warn('Discarding an event', type);
+            logger.warn('Discarding an event, we don't have a call/peerConn', type);
             return;
         }
         // Ignore remote echo


### PR DESCRIPTION
In cases where a rogue client, or just a simple bug, sends a temporary call message, like CallNegotiate the messages should just be discarded if there's no actual p2p connection created.