### PR TITLE
Fix conditional on returning file tree spaces

### DIFF
--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -237,6 +237,7 @@ describe("MatrixClient", function() {
     it("should get (unstable) file trees with valid state", async () => {
         const roomId = "!room:example.org";
         const mockRoom = {
+            getMyMembership: () => "join",
             currentState: {
                 getStateEvents: (eventType, stateKey) => {
                     if (eventType === EventType.RoomCreate) {
@@ -296,6 +297,7 @@ describe("MatrixClient", function() {
     it("should not get (unstable) file trees with invalid create contents", async () => {
         const roomId = "!room:example.org";
         const mockRoom = {
+            getMyMembership: () => "join",
             currentState: {
                 getStateEvents: (eventType, stateKey) => {
                     if (eventType === EventType.RoomCreate) {
@@ -330,6 +332,7 @@ describe("MatrixClient", function() {
     it("should not get (unstable) file trees with invalid purpose/subtype contents", async () => {
         const roomId = "!room:example.org";
         const mockRoom = {
+            getMyMembership: () => "join",
             currentState: {
                 getStateEvents: (eventType, stateKey) => {
                     if (eventType === EventType.RoomCreate) {

--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -270,6 +270,29 @@ describe("MatrixClient", function() {
         expect(tree.room).toBe(mockRoom);
     });
 
+    it("should not get (unstable) file trees if not joined", async () => {
+        const roomId = "!room:example.org";
+        const mockRoom = {
+            getMyMembership: () => "leave", // "not join"
+        };
+        client.getRoom = (getRoomId) => {
+            expect(getRoomId).toEqual(roomId);
+            return mockRoom;
+        };
+        const tree = client.unstableGetFileTreeSpace(roomId);
+        expect(tree).toBeFalsy();
+    });
+
+    it("should not get (unstable) file trees for unknown rooms", async () => {
+        const roomId = "!room:example.org";
+        client.getRoom = (getRoomId) => {
+            expect(getRoomId).toEqual(roomId);
+            return null; // imply unknown
+        };
+        const tree = client.unstableGetFileTreeSpace(roomId);
+        expect(tree).toBeFalsy();
+    });
+
     it("should not get (unstable) file trees with invalid create contents", async () => {
         const roomId = "!room:example.org";
         const mockRoom = {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8060,7 +8060,7 @@ export class MatrixClient extends EventEmitter {
      */
     public unstableGetFileTreeSpace(roomId: string): MSC3089TreeSpace {
         const room = this.getRoom(roomId);
-        if (!room) return null;
+        if (room?.getMyMembership() !== 'join') return null;
 
         const createEvent = room.currentState.getStateEvents(EventType.RoomCreate, "");
         const purposeEvent = room.currentState.getStateEvents(


### PR DESCRIPTION
If a tree space was deleted then it'll still hold a Room object for us, which is not much help if we're effectively trying to get the joined trees.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix conditional on returning file tree spaces ([\#1841](https://github.com/matrix-org/matrix-js-sdk/pull/1841)).<!-- CHANGELOG_PREVIEW_END -->