### PR TITLE
Fix the types in shipped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib dist",
     "build": "yarn build:dev && yarn build:compile-browser && yarn build:minify-browser",
     "build:dev": "yarn clean && git rev-parse HEAD > git-revision.txt && yarn build:compile && yarn build:types",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc -p tsconfig-build.json --emitDeclarationOnly",
     "build:compile": "babel -d lib --verbose --extensions \".ts,.js\" src",
     "build:compile-browser": "mkdirp dist && browserify -d src/browser-index.js -p [ tsify -p ./tsconfig-build.json ] -t [ babelify --sourceMaps=inline --presets [ @babel/preset-env @babel/preset-typescript ] ] | exorcist dist/browser-matrix.js.map > dist/browser-matrix.js",
     "build:minify-browser": "terser dist/browser-matrix.js --compress --mangle --source-map --output dist/browser-matrix.min.js",

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,5 +1,13 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true,
+    "noEmit": false,
+    "emitDecoratorMetadata": true,
+    "target": "es2016",
+    "outDir": "./lib",
+    "rootDir": "src"
+  },
   "exclude": [
     "./spec/**/*.ts"
   ]

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -4,7 +4,6 @@
     "sourceMap": true,
     "noEmit": false,
     "emitDecoratorMetadata": true,
-    "target": "es2016",
     "outDir": "./lib",
     "rootDir": "src"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,11 @@
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2016",
     "noImplicitAny": false,
-    "sourceMap": true,
-    "outDir": "./lib",
+    "noEmit": true,
     "declaration": true
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2016",
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "module": "commonjs",


### PR DESCRIPTION
1829 added the spec files to 'src', presumably because they just
were't type checked otherwise, but this chaqnged the implicit rootDir
so the lib directory we shipped has types in src/ and spec/ which
meant lib/index.d.ts was at lib/src/index.d.ts.

Specify the rootDir on the build tsconfig to put it back in the
right place, and also try to make the base tsconfig never emit
to avoid it ever generating .d.ts files in silly places. Move all
the options related to emitting to -build since they aren't relevant
in the main one.

Is this a sensible way to do this? It doesn't feel terribly elegant.

Fixes https://github.com/vector-im/element-web/issues/18503
Regressed in https://github.com/matrix-org/matrix-js-sdk/pull/1829

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix the types in shipped package ([\#1842](https://github.com/matrix-org/matrix-js-sdk/pull/1842)). Fixes vector-im/element-web#18503.<!-- CHANGELOG_PREVIEW_END -->