### PR TITLE
SSSSCryptoCallbacks.getSecretStorageKey return Promise<null> if no key was found

### DIFF
--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -356,7 +356,7 @@ class SSSSCryptoCallbacks {
     public async getSecretStorageKey(
         { keys }: { keys: Record<string, ISecretStorageKeyInfo> },
         name: string,
-    ): Promise<[string, Uint8Array]> {
+    ): Promise<[string, Uint8Array]|void> {
         for (const keyId of Object.keys(keys)) {
             const privateKey = this.privateKeys.get(keyId);
             if (privateKey) {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -356,7 +356,7 @@ class SSSSCryptoCallbacks {
     public async getSecretStorageKey(
         { keys }: { keys: Record<string, ISecretStorageKeyInfo> },
         name: string,
-    ): Promise<[string, Uint8Array]|void> {
+    ): Promise<[string, Uint8Array]|null> {
         for (const keyId of Object.keys(keys)) {
             const privateKey = this.privateKeys.get(keyId);
             if (privateKey) {
@@ -374,6 +374,7 @@ class SSSSCryptoCallbacks {
             }
             return result;
         }
+        return null;
     }
 
     public addPrivateKey(keyId: string, keyInfo: ISecretStorageKeyInfo, privKey: Uint8Array): void {


### PR DESCRIPTION
Fixes #1848

If no result is found, the function may reach the last line without `return` ever being called.

Note: SSSSCryptoCallbacks.getSecretStorageKey now returns Promise<null> instead of Promise<void>, if no key was found.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->