### PR TITLE
SSSSCryptoCallbacks.getSecretStorageKey: Test if delegateCryptoCallbacks has getSecretStorageKey

### DIFF
--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -365,7 +365,7 @@ class SSSSCryptoCallbacks {
         }
         // if we don't have the key cached yet, ask
         // for it to the general crypto callbacks and cache it
-        if (this.delegateCryptoCallbacks?.getSecretStorageKey) {
+        if (this?.delegateCryptoCallbacks?.getSecretStorageKey) {
             const result = await this.delegateCryptoCallbacks.
                 getSecretStorageKey({ keys }, name);
             if (result) {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -365,7 +365,7 @@ class SSSSCryptoCallbacks {
         }
         // if we don't have the key cached yet, ask
         // for it to the general crypto callbacks and cache it
-        if (this.delegateCryptoCallbacks) {
+        if (this.delegateCryptoCallbacks && this.delegateCryptoCallbacks.getSecretStorageKey) {
             const result = await this.delegateCryptoCallbacks.
                 getSecretStorageKey({ keys }, name);
             if (result) {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -365,7 +365,7 @@ class SSSSCryptoCallbacks {
         }
         // if we don't have the key cached yet, ask
         // for it to the general crypto callbacks and cache it
-        if (this.delegateCryptoCallbacks && this.delegateCryptoCallbacks.getSecretStorageKey) {
+        if (this.delegateCryptoCallbacks?.getSecretStorageKey) {
             const result = await this.delegateCryptoCallbacks.
                 getSecretStorageKey({ keys }, name);
             if (result) {


### PR DESCRIPTION
Fixes #1845 

Notes: Fix a JavaScript error on matrixClient.bootstrapSecretStorage() if matrixClient.cryptoCallbacks.getSecretStorageKey is not defined.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->