### PR TITLE
Make delegateCryptoCallbacks an optional parameter of EncryptionSetupBuilder and SSSSCryptoCallbacks

### DIFF
--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -351,7 +351,7 @@ class CrossSigningCallbacks implements ICryptoCallbacks, ICacheCallbacks {
 class SSSSCryptoCallbacks {
     private readonly privateKeys = new Map<string, Uint8Array>();
 
-    constructor(private readonly delegateCryptoCallbacks: ICryptoCallbacks) {}
+    constructor(private readonly delegateCryptoCallbacks?: ICryptoCallbacks) {}
 
     public async getSecretStorageKey(
         { keys }: { keys: Record<string, ISecretStorageKeyInfo> },

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -59,7 +59,7 @@ export class EncryptionSetupBuilder {
      * @param {Object.<String, MatrixEvent>} accountData pre-existing account data, will only be read, not written.
      * @param {CryptoCallbacks} delegateCryptoCallbacks crypto callbacks to delegate to if the key isn't in cache yet
      */
-    constructor(accountData: Record<string, MatrixEvent>, delegateCryptoCallbacks: ICryptoCallbacks) {
+    constructor(accountData: Record<string, MatrixEvent>, delegateCryptoCallbacks?: ICryptoCallbacks) {
         this.accountDataClientAdapter = new AccountDataClientAdapter(accountData);
         this.crossSigningCallbacks = new CrossSigningCallbacks();
         this.ssssCryptoCallbacks = new SSSSCryptoCallbacks(delegateCryptoCallbacks);


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/blob/a69d9a9f20b680e3710e0f43cca68a2ce31ba030/src/client.ts#L315

`cryptoCallbacks` may be undefined but the constructor of `EncryptionSetupBuilder` requires it to be defined.

https://github.com/matrix-org/matrix-js-sdk/blob/a69d9a9f20b680e3710e0f43cca68a2ce31ba030/src/crypto/index.ts#L616-L620

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->