### PR TITLE
Fix release script to handle no signing ID

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -191,7 +191,10 @@ git commit package.json $pkglock -m "$tag"
 # figure out if we should be signing this release
 signing_id=
 if [ -f release_config.yaml ]; then
-    signing_id=`cat release_config.yaml | python -c "import yaml; import sys; print yaml.load(sys.stdin)['signing_id']"`
+    result=`cat release_config.yaml | python -c "import yaml; import sys; print yaml.load(sys.stdin)['signing_id']" 2> /dev/null || true`
+    if [ "$?" -eq 0 ]; then
+        signing_id=$result
+    fi
 fi
 
 


### PR DESCRIPTION
We now use the file for stuff other than just the signing ID, so
the file may be present but with no signing ID: handle this case.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->