### PR TITLE
Give `CallFeed` the capability to emit on volume changes

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -34,6 +34,7 @@ declare global {
 
     interface Window {
         electron?: Electron;
+        webkitAudioContext: typeof AudioContext;
     }
 
     interface Electron {

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -121,16 +121,28 @@ export class CallFeed extends EventEmitter {
         }
     }
 
+    /**
+     * Set feed's internal audio mute state
+     * @param muted is the feed's audio muted?
+     */
     public setAudioMuted(muted: boolean): void {
         this.audioMuted = muted;
         this.emit(CallFeedEvent.MuteStateChanged, this.audioMuted, this.videoMuted);
     }
 
+    /**
+     * Set feed's internal video mute state
+     * @param muted is the feed's video muted?
+     */
     public setVideoMuted(muted: boolean): void {
         this.videoMuted = muted;
         this.emit(CallFeedEvent.MuteStateChanged, this.audioMuted, this.videoMuted);
     }
 
+    /**
+     * Starts emitting volume_changed events where the emitter value is in decibels
+     * @param enabled emit volume changes
+     */
     public measureVolumeActivity(enabled: boolean): void {
         if (enabled) {
             if (!this.audioContext || !this.analyser || !this.frequencyBinCount || !this.hasAudioTrack) return;

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -110,7 +110,7 @@ export class CallFeed extends EventEmitter {
      * This method should be only used by MatrixCall.
      * @param newStream new stream with which to replace the current one
      */
-    public setNewStream(newStream: MediaStream) {
+    public setNewStream(newStream: MediaStream): void {
         this.stream = newStream;
         this.emit(CallFeedEvent.NewStream, this.stream);
 
@@ -131,7 +131,7 @@ export class CallFeed extends EventEmitter {
         this.emit(CallFeedEvent.MuteStateChanged, this.audioMuted, this.videoMuted);
     }
 
-    public measureVolumeActivity(enabled: boolean) {
+    public measureVolumeActivity(enabled: boolean): void {
         if (enabled) {
             if (!this.audioContext || !this.analyser || !this.frequencyBinCount || !this.hasAudioTrack) return;
 


### PR DESCRIPTION
Type: enhancement 
For https://github.com/matrix-org/matrix-react-sdk/pull/6639

<hr>

To be transparent, I have no idea what I am doing but it seems to work :sweat_smile: 

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Give `CallFeed` the capability to emit on volume changes ([\#1865](https://github.com/matrix-org/matrix-js-sdk/pull/1865)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).<!-- CHANGELOG_PREVIEW_END -->