### PR TITLE
Fix verification request cancellation

### DIFF
--- a/src/crypto/verification/request/ToDeviceChannel.js
+++ b/src/crypto/verification/request/ToDeviceChannel.js
@@ -248,7 +248,7 @@ export class ToDeviceChannel {
      */
     async sendCompleted(type, content) {
         let result;
-        if (type === REQUEST_TYPE || type === CANCEL_TYPE && !this.__deviceId) {
+        if (type === REQUEST_TYPE || (type === CANCEL_TYPE && !this.__deviceId)) {
             result = await this._sendToDevices(type, content, this._devices);
         } else {
             result = await this._sendToDevices(type, content, [this._deviceId]);


### PR DESCRIPTION
If you started trying to verify against your other devices and
then cancelled the dialog, the device destination in the cancellation
to-device message would be 'null', so the cancellation wouldn't go
anywhere.

If we haven't yet picked a specific device to talk to, send the
cancellation to all devices (like we did the request).

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix verification request cancellation ([\#1871](https://github.com/matrix-org/matrix-js-sdk/pull/1871)).<!-- CHANGELOG_PREVIEW_END -->