### PR TITLE
Add reply events rendering hint

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -168,6 +168,11 @@ export const UNSTABLE_ELEMENT_FUNCTIONAL_USERS = new UnstableValue(
     "io.element.functional_members",
     "io.element.functional_members");
 
+export const UNSTABLE_ELEMENT_REPLY_IN_THREAD = new UnstableValue(
+    "m.in_thread",
+    "io.element.in_thread",
+);
+
 export interface IEncryptedFile {
     url: string;
     mimetype?: string;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -24,7 +24,12 @@ import { EventEmitter } from 'events';
 
 import { logger } from '../logger';
 import { VerificationRequest } from "../crypto/verification/request/VerificationRequest";
-import { EventType, MsgType, RelationType } from "../@types/event";
+import {
+    EventType,
+    MsgType,
+    RelationType,
+    UNSTABLE_ELEMENT_REPLY_IN_THREAD,
+} from "../@types/event";
 import { Crypto } from "../crypto";
 import { deepSortedObjectEntries } from "../utils";
 import { RoomMember } from "./room-member";
@@ -399,6 +404,17 @@ export class MatrixEvent extends EventEmitter {
     public get replyEventId(): string {
         const relations = this.getWireContent()["m.relates_to"];
         return relations?.["m.in_reply_to"]?.["event_id"];
+    }
+
+    /**
+     * @experimental
+     * Determines whether a reply should be rendered in a thread
+     * or in the main room timeline
+     */
+    public get replyInThread(): boolean {
+        const relations = this.getWireContent()["m.relates_to"];
+        return this.replyEventId
+            && relations[UNSTABLE_ELEMENT_REPLY_IN_THREAD.name];
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -315,7 +315,7 @@ export class SyncApi {
     public partitionThreadedEvents(events: MatrixEvent[]): [MatrixEvent[], MatrixEvent[]] {
         if (this.opts.experimentalThreadSupport) {
             return events.reduce((memo, event: MatrixEvent) => {
-                memo[event.replyEventId ? 1 : 0].push(event);
+                memo[event.replyInThread ? 1 : 0].push(event);
                 return memo;
             }, [[], []]);
         } else {


### PR DESCRIPTION
As part of  vector-im/element-web#18717

Adds an unstable hint for clients to know whether to render an event in the room timeline or in a thread

There are currently no MSC associated with that unstable "io.element.in_thread" property as I am only experimenting before settling on a specific approach

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->