### PR TITLE
Remove Element-specifc screen-sharing code out of the js-sdk 

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -33,12 +33,7 @@ declare global {
     }
 
     interface Window {
-        electron?: Electron;
         webkitAudioContext: typeof AudioContext;
-    }
-
-    interface Electron {
-        getDesktopCapturerSources(options: GetSourcesOptions): Promise<Array<DesktopCapturerSource>>;
     }
 
     interface Crypto {
@@ -71,15 +66,6 @@ declare global {
         id: string;
         name: string;
         thumbnailURL: string;
-    }
-
-    interface GetSourcesOptions {
-        types: Array<string>;
-        thumbnailSize?: {
-            height: number;
-            width: number;
-        };
-        fetchWindowIcons?: boolean;
     }
 
     interface HTMLAudioElement {

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -62,12 +62,6 @@ declare global {
         };
     }
 
-    interface DesktopCapturerSource {
-        id: string;
-        name: string;
-        thumbnailURL: string;
-    }
-
     interface HTMLAudioElement {
         // sinkId & setSinkId are experimental and typescript doesn't know about them
         sinkId: string;

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -226,21 +226,6 @@ const FALLBACK_ICE_SERVER = 'stun:turn.matrix.org';
 /** The length of time a call can be ringing for. */
 const CALL_TIMEOUT_MS = 60000;
 
-/** Retrieves sources from desktopCapturer */
-export function getDesktopCapturerSources(): Promise<Array<DesktopCapturerSource>> {
-    const options: GetSourcesOptions = {
-        thumbnailSize: {
-            height: 176,
-            width: 312,
-        },
-        types: [
-            "screen",
-            "window",
-        ],
-    };
-    return window.electron.getDesktopCapturerSources(options);
-}
-
 export class CallError extends Error {
     code: string;
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -84,6 +84,12 @@ interface AssertedIdentity {
     displayName: string;
 }
 
+export interface DesktopCapturerSource {
+    id: string;
+    name: string;
+    thumbnailURL: string;
+}
+
 export enum CallState {
     Fledgling = 'fledgling',
     InviteSent = 'invite_sent',


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/1645
**Requires https://github.com/matrix-org/matrix-react-sdk/pull/6727**
Type: task

<hr>

Notes: This changes the `selectDesktopCapturerSource` callback in `setScreensharingEnabled()` to a `string` parameter `desktopCapturerSourceId`. This way you can handle choosing a source more easily on your side and just pass the id of the chosen source. This also removes the `getDesktopCapturerSources()` method which was Element specific and shouldn't have been in the `js-sdk` in the first place.

<hr>

This fixes some of my awful 8 months old code.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->