### PR TITLE
Fix calling removeEventListener if it does not exist

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -704,7 +704,7 @@ export class SyncApi {
      */
     public stop(): void {
         debuglog("SyncApi.stop");
-        if (global.window) {
+        if (global.window && global.window.removeEventListener) {
             global.window.removeEventListener("online", this.onOnline, false);
         }
         this.running = false;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -704,6 +704,10 @@ export class SyncApi {
      */
     public stop(): void {
         debuglog("SyncApi.stop");
+        // It is necessary to check for the existance of
+        // global.window AND global.window.removeEventListener.
+        // Some platforms (e.g. React Native) register global.window,
+        // but do not have global.window.removeEventListener.
         if (global.window && global.window.removeEventListener) {
             global.window.removeEventListener("online", this.onOnline, false);
         }


### PR DESCRIPTION
Some platforms (e.g. React Native) register global.window, but do not have global.window.removeEventListener. In this case, this function should not be called.

This has already been fixed for addEventListener (https://github.com/matrix-org/matrix-js-sdk/pull/1661), however not yet for removeEventListener.

Signed-off-by: Jan Pawellek jpawellek@churchtools.de


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->