### PR TITLE
Exclude opt-in Element performance metrics from encryption

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2756,11 +2756,21 @@ export class Crypto extends EventEmitter {
             delete content['m.relates_to'];
         }
 
+        // Treat element's performance metrics the same as `m.relates_to` (when present)
+        const elementPerfMetrics = content['io.element.performance_metrics'];
+        if (elementPerfMetrics) {
+            content = Object.assign({}, content);
+            delete content['io.element.performance_metrics'];
+        }
+
         const encryptedContent = await alg.encryptMessage(
             room, event.getType(), content);
 
         if (mRelatesTo) {
             encryptedContent['m.relates_to'] = mRelatesTo;
+        }
+        if (elementPerfMetrics) {
+            encryptedContent['io.element.performance_metrics'] = elementPerfMetrics;
         }
 
         event.makeEncrypted(


### PR DESCRIPTION
This is needed for the system which is meant to be monitoring this metadata. See https://github.com/matrix-org/matrix-react-sdk/pull/6766

***Required by https://github.com/matrix-org/matrix-react-sdk/pull/6766***

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Exclude opt-in Element performance metrics from encryption ([\#1897](https://github.com/matrix-org/matrix-js-sdk/pull/1897)).<!-- CHANGELOG_PREVIEW_END -->