### PR TITLE
Disable pending events for threads temporarily

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8494,7 +8494,7 @@ export class MatrixClient extends EventEmitter {
      * @experimental
      */
     public supportsExperimentalThreads(): boolean {
-        return this.clientOpts.experimentalThreadSupport;
+        return this.clientOpts?.experimentalThreadSupport || false;
     }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -8489,6 +8489,13 @@ export class MatrixClient extends EventEmitter {
             publicise: isPublic,
         });
     }
+
+    /**
+     * @experimental
+     */
+    public supportsExperimentalThreads(): boolean {
+        return this.clientOpts.experimentalThreadSupport;
+    }
 }
 
 /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1417,7 +1417,7 @@ export class Room extends EventEmitter {
         // TODO: Enable "pending events" for threads
         // There's a fair few things to update to make them work with Threads
         // Will get back to it when the plan is to build a more polished UI ready for production
-        if (this.client.supportsExperimentalThreads() && event.replyInThread) {
+        if (this.client?.supportsExperimentalThreads() && event.replyInThread) {
             return;
         }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1582,17 +1582,15 @@ export class Room extends EventEmitter {
         // any, which is good, because we don't want to try decoding it again).
         localEvent.handleRemoteEcho(remoteEvent.event);
 
-        // Disables remote echo for threaded events as it would never
-        // work given the "pending events" are disabled for threads at the moment
-        const thread = this.findThreadByEventId(localEvent.getId());
-        if (!thread) {
-            for (let i = 0; i < this.timelineSets.length; i++) {
-                const timelineSet = this.timelineSets[i];
+        for (let i = 0; i < this.timelineSets.length; i++) {
+            const timelineSet = this.timelineSets[i];
 
-                // if it's already in the timeline, update the timeline map. If it's not, add it.
-                timelineSet.handleRemoteEcho(localEvent, oldEventId, newEventId);
-            }
+            // if it's already in the timeline, update the timeline map. If it's not, add it.
+            timelineSet.handleRemoteEcho(localEvent, oldEventId, newEventId);
         }
+
+        this.emit("Room.localEchoUpdated", localEvent, this,
+            oldEventId, oldStatus);
     }
 
     public findThreadByEventId(eventId: string): Thread {


### PR DESCRIPTION
Pre-requisite for vector-im/element-web#18947

- Make timelineSet public readonly
- Add helper to check threads support
- Disable pending events for threads



<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->