### PR TITLE
Add types for the MatrixClient register method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6109,7 +6109,7 @@ export class MatrixClient extends EventEmitter {
         password: string,
         sessionId: string | null,
         auth: { session?: string, type: string },
-        bindThreepids?: boolean | null | { email?: boolean | boolean, msisdn?: boolean },
+        bindThreepids?: boolean | null | { email?: boolean, msisdn?: boolean },
         guestAccessToken?: string,
         inhibitLogin?: boolean,
         callback?: Callback,

--- a/src/client.ts
+++ b/src/client.ts
@@ -6107,17 +6107,17 @@ export class MatrixClient extends EventEmitter {
     public register(
         username: string,
         password: string,
-        sessionId: string,
-        auth: any,
-        bindThreepids: any,
-        guestAccessToken: string,
-        inhibitLogin: boolean,
+        sessionId: string | null,
+        auth: { session?: string, type: string },
+        bindThreepids?: boolean | null | { email?: boolean | boolean, msisdn?: boolean },
+        guestAccessToken?: string,
+        inhibitLogin?: boolean,
         callback?: Callback,
     ): Promise<any> { // TODO: Types (many)
         // backwards compat
         if (bindThreepids === true) {
             bindThreepids = { email: true };
-        } else if (bindThreepids === null || bindThreepids === undefined) {
+        } else if (bindThreepids === null || bindThreepids === undefined || bindThreepids === false) {
             bindThreepids = {};
         }
         if (typeof inhibitLogin === 'function') {


### PR DESCRIPTION
Added types for the `MatrixClient` `register()` method. Typescript projects importing matrix-js-sdk that don't set all of the fields don't pass type checking.

If there's a better place for the types to be converted to type or interface definitions, let me know. I could just put them at the top of `client.ts` if that works?


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->