### PR TITLE
Properly dispose of CallFeeds

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -558,6 +558,10 @@ export class MatrixCall extends EventEmitter {
     }
 
     private deleteAllFeeds(): void {
+        for (const feed of this.feeds) {
+            feed.dispose();
+        }
+
         this.feeds = [];
         this.emit(CallEvent.FeedsChanged, this.feeds);
     }
@@ -571,6 +575,7 @@ export class MatrixCall extends EventEmitter {
             return;
         }
 
+        feed.dispose();
         this.feeds.splice(this.feeds.indexOf(feed), 1);
         this.emit(CallEvent.FeedsChanged, this.feeds);
     }

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -36,6 +36,7 @@ export class CallFeed extends EventEmitter {
     private frequencyBinCount: Float32Array;
     private speakingThreshold = SPEAKING_THRESHOLD;
     private speaking = false;
+    private volumeLooperTimeout: number;
 
     constructor(
         public stream: MediaStream,
@@ -166,7 +167,7 @@ export class CallFeed extends EventEmitter {
     private volumeLooper(): void {
         if (!this.analyser) return;
 
-        setTimeout(() => {
+        this.volumeLooperTimeout = setTimeout(() => {
             if (!this.measuringVolumeActivity) return;
 
             this.analyser.getFloatFrequencyData(this.frequencyBinCount);
@@ -187,5 +188,9 @@ export class CallFeed extends EventEmitter {
 
             this.volumeLooper();
         }, POLLING_INTERVAL);
+    }
+
+    public dispose(): void {
+        clearTimeout(this.volumeLooperTimeout);
     }
 }


### PR DESCRIPTION
A `setTimeout` loop was recently added to the `CallFeed` class to poll volume levels. When we remove call feeds we never clean it up. This PR properly disposes of call feeds by immediately calling `clearTimeout` when they are removed.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->