### PR TITLE
Revert "Migrate errors to TypeScript"

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 // can't just do InvalidStoreError extends Error
 // because of http://babeljs.io/docs/usage/caveats/#classes
-export function InvalidStoreError(reason: string, value: boolean): void {
+export function InvalidStoreError(reason, value) {
     const message = `Store is invalid because ${reason}, ` +
         `please stop the client, delete all data and start the client again`;
     const instance = Reflect.construct(Error, [message]);
@@ -13,16 +13,16 @@ export function InvalidStoreError(reason: string, value: boolean): void {
 InvalidStoreError.TOGGLED_LAZY_LOADING = "TOGGLED_LAZY_LOADING";
 
 InvalidStoreError.prototype = Object.create(Error.prototype, {
-    constructor: {
-        value: Error,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-    },
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
 });
 Reflect.setPrototypeOf(InvalidStoreError, Error);
 
-export function InvalidCryptoStoreError(reason: string): void {
+export function InvalidCryptoStoreError(reason) {
     const message = `Crypto store is invalid because ${reason}, ` +
         `please stop the client, delete all data and start the client again`;
     const instance = Reflect.construct(Error, [message]);
@@ -35,17 +35,18 @@ export function InvalidCryptoStoreError(reason: string): void {
 InvalidCryptoStoreError.TOO_NEW = "TOO_NEW";
 
 InvalidCryptoStoreError.prototype = Object.create(Error.prototype, {
-    constructor: {
-        value: Error,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-    },
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
 });
 Reflect.setPrototypeOf(InvalidCryptoStoreError, Error);
 
 export class KeySignatureUploadError extends Error {
-    constructor(message: string, public value: { failures: any }) { // TODO: types
-        super(message);
-    }
+  constructor(message, value) {
+    super(message);
+    this.value = value;
+  }
 }


### PR DESCRIPTION
Reverts part of https://github.com/matrix-org/matrix-js-sdk/pull/1907

We need to migrate these errors to Typescript by converting them to actual typescript types; until then Typescript doesn't consider them types so the previous migration is causing the following error in matrix-react-sdk

```
src/Lifecycle.ts:241:44 - error TS2709: Cannot use namespace 'InvalidStoreError' as a type.

241 export function handleInvalidStoreError(e: InvalidStoreError): Promise<void> {
```

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->