### PR TITLE
Revert "Remove RTX codec hack "

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1068,6 +1068,7 @@ export class MatrixCall extends EventEmitter {
 
         let myAnswer;
         try {
+            this.getRidOfRTXCodecs();
             myAnswer = await this.peerConn.createAnswer();
         } catch (err) {
             logger.debug("Failed to create answer: ", err);
@@ -1284,6 +1285,7 @@ export class MatrixCall extends EventEmitter {
             await this.peerConn.setRemoteDescription(description);
 
             if (description.type === 'offer') {
+                this.getRidOfRTXCodecs();
                 const localDescription = await this.peerConn.createAnswer();
                 await this.peerConn.setLocalDescription(localDescription);
 
@@ -1497,6 +1499,47 @@ export class MatrixCall extends EventEmitter {
         stream.addEventListener("removetrack", () => this.deleteFeedByStream(stream));
     };
 
+    /**
+     * This method removes all video/rtx codecs from screensharing video
+     * transceivers. This is necessary since they can cause problems. Without
+     * this the following steps should produce an error:
+     *   Chromium calls Firefox
+     *   Firefox answers
+     *   Firefox starts screen-sharing
+     *   Chromium starts screen-sharing
+     *   Call crashes for Chromium with:
+     *       [96685:23:0518/162603.933321:ERROR:webrtc_video_engine.cc(3296)] RTX codec (PT=97) mapped to PT=96 which is not in the codec list.
+     *       [96685:23:0518/162603.933377:ERROR:webrtc_video_engine.cc(1171)] GetChangedRecvParameters called without any video codecs.
+     *       [96685:23:0518/162603.933430:ERROR:sdp_offer_answer.cc(4302)] Failed to set local video description recv parameters for m-section with mid='2'. (INVALID_PARAMETER)
+     */
+    private getRidOfRTXCodecs(): void {
+        // RTCRtpReceiver.getCapabilities and RTCRtpSender.getCapabilities don't seem to be supported on FF
+        if (!RTCRtpReceiver.getCapabilities || !RTCRtpSender.getCapabilities) return;
+
+        const recvCodecs = RTCRtpReceiver.getCapabilities("video").codecs;
+        const sendCodecs = RTCRtpSender.getCapabilities("video").codecs;
+        const codecs = [...sendCodecs, ...recvCodecs];
+
+        for (const codec of codecs) {
+            if (codec.mimeType === "video/rtx") {
+                const rtxCodecIndex = codecs.indexOf(codec);
+                codecs.splice(rtxCodecIndex, 1);
+            }
+        }
+
+        for (const trans of this.peerConn.getTransceivers()) {
+            if (
+                this.screensharingSenders.includes(trans.sender) &&
+                    (
+                        trans.sender.track?.kind === "video" ||
+                        trans.receiver.track?.kind === "video"
+                    )
+            ) {
+                trans.setCodecPreferences(codecs);
+            }
+        }
+    }
+
     private onNegotiationNeeded = async (): Promise<void> => {
         logger.info("Negotiation is needed!");
 
@@ -1507,6 +1550,7 @@ export class MatrixCall extends EventEmitter {
 
         this.makingOffer = true;
         try {
+            this.getRidOfRTXCodecs();
             const myOffer = await this.peerConn.createOffer();
             await this.gotLocalOffer(myOffer);
         } catch (e) {


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#1923
Due to https://github.com/matrix-org/matrix-js-sdk/issues/1921#issuecomment-920109928

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->