### PR TITLE
Add WebRTC DataChannels to MatrixCall

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -128,7 +128,9 @@ export enum CallEvent {
 
     AssertedIdentityChanged = 'asserted_identity_changed',
 
-    LengthChanged = 'length_changed'
+    LengthChanged = 'length_changed',
+
+    DataChannel = 'datachannel',
 }
 
 export enum CallErrorCode {
@@ -340,6 +342,18 @@ export class MatrixCall extends EventEmitter {
      */
     public async placeVideoCall(): Promise<void> {
         await this.placeCall(true, true);
+    }
+
+    /**
+     * Create a datachannel using this call's peer connection.
+     * @param label A human readable label for this datachannel
+     * @param options An object providing configuration options for the data channel.
+     */
+    public createDataChannel(label: string, options: RTCDataChannelInit) {
+        const dataChannel = this.peerConn.createDataChannel(label, options);
+        this.emit(CallEvent.DataChannel, dataChannel);
+        logger.debug("created data channel");
+        return dataChannel;
     }
 
     public getOpponentMember(): RoomMember {
@@ -1499,6 +1513,10 @@ export class MatrixCall extends EventEmitter {
         stream.addEventListener("removetrack", () => this.deleteFeedByStream(stream));
     };
 
+    private onDataChannel = (ev: RTCDataChannelEvent): void => {
+        this.emit(CallEvent.DataChannel, ev.channel);
+    };
+
     /**
      * This method removes all video/rtx codecs from screensharing video
      * transceivers. This is necessary since they can cause problems. Without
@@ -1864,6 +1882,7 @@ export class MatrixCall extends EventEmitter {
         pc.addEventListener('icegatheringstatechange', this.onIceGatheringStateChange);
         pc.addEventListener('track', this.onTrack);
         pc.addEventListener('negotiationneeded', this.onNegotiationNeeded);
+        pc.addEventListener('datachannel', this.onDataChannel);
 
         return pc;
     }


### PR DESCRIPTION
This PR adds WebRTC Datachannels to `MatrixCall`. Having the `datachannel` event emitted by the call lets you easily manage datachannels when the call is replaced.

Notes: Added `createDataChannel()` and `CallEvent.DataChannel` to `MatrixCall` for creating and listening for WebRTC datachannels.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Added `createDataChannel()` and `CallEvent.DataChannel` to `MatrixCall` for creating and listening for WebRTC datachannels. ([\#1929](https://github.com/matrix-org/matrix-js-sdk/pull/1929)). Contributed by [robertlong](https://github.com/robertlong).<!-- CHANGELOG_PREVIEW_END -->