### PR TITLE
Typescriptify thread events a bit

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -33,7 +33,7 @@ import {
 import { Crypto } from "../crypto";
 import { deepSortedObjectEntries } from "../utils";
 import { RoomMember } from "./room-member";
-import { Thread } from "./thread";
+import { Thread, THREAD_EVENTS } from "./thread";
 import { IActionsObject } from '../pushprocessor';
 import { ReEmitter } from '../ReEmitter';
 
@@ -1321,7 +1321,7 @@ export class MatrixEvent extends EventEmitter {
      */
     public setThread(thread: Thread): void {
         this.thread = thread;
-        this.reEmitter.reEmit(thread, ["Thread.ready", "Thread.update"]);
+        this.reEmitter.reEmit(thread, [THREAD_EVENTS.ready, THREAD_EVENTS.update]);
     }
 
     /**

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -33,7 +33,7 @@ import {
 import { Crypto } from "../crypto";
 import { deepSortedObjectEntries } from "../utils";
 import { RoomMember } from "./room-member";
-import { Thread, THREAD_EVENTS } from "./thread";
+import { Thread, ThreadEvents } from "./thread";
 import { IActionsObject } from '../pushprocessor';
 import { ReEmitter } from '../ReEmitter';
 
@@ -1321,7 +1321,7 @@ export class MatrixEvent extends EventEmitter {
      */
     public setThread(thread: Thread): void {
         this.thread = thread;
-        this.reEmitter.reEmit(thread, [THREAD_EVENTS.ready, THREAD_EVENTS.update]);
+        this.reEmitter.reEmit(thread, [ThreadEvents.Ready, ThreadEvents.Update]);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -35,7 +35,7 @@ import { IRoomVersionsCapability, MatrixClient, PendingEventOrdering, RoomVersio
 import { JoinRule, ResizeMethod } from "../@types/partials";
 import { Filter } from "../filter";
 import { RoomState } from "./room-state";
-import { Thread, THREAD_EVENTS } from "./thread";
+import { Thread, ThreadEvents } from "./thread";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -1074,9 +1074,9 @@ export class Room extends EventEmitter {
     public addThread(thread: Thread): Set<Thread> {
         this.threads.add(thread);
         if (!thread.ready) {
-            thread.once(THREAD_EVENTS.ready, this.dedupeThreads);
-            this.emit(THREAD_EVENTS.update, thread);
-            this.reEmitter.reEmit(thread, [THREAD_EVENTS.update, THREAD_EVENTS.ready]);
+            thread.once(ThreadEvents.Ready, this.dedupeThreads);
+            this.emit(ThreadEvents.Update, thread);
+            this.reEmitter.reEmit(thread, [ThreadEvents.Update, ThreadEvents.Ready]);
         }
         return this.threads;
     }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -35,7 +35,7 @@ import { IRoomVersionsCapability, MatrixClient, PendingEventOrdering, RoomVersio
 import { JoinRule, ResizeMethod } from "../@types/partials";
 import { Filter } from "../filter";
 import { RoomState } from "./room-state";
-import { Thread } from "./thread";
+import { Thread, THREAD_EVENTS } from "./thread";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -1074,9 +1074,9 @@ export class Room extends EventEmitter {
     public addThread(thread: Thread): Set<Thread> {
         this.threads.add(thread);
         if (!thread.ready) {
-            thread.once("Thread.ready", this.dedupeThreads);
-            this.emit("Thread.update", thread);
-            this.reEmitter.reEmit(thread, ["Thread.update", "Thread.ready"]);
+            thread.once(THREAD_EVENTS.ready, this.dedupeThreads);
+            this.emit(THREAD_EVENTS.update, thread);
+            this.reEmitter.reEmit(thread, [THREAD_EVENTS.update, THREAD_EVENTS.ready]);
         }
         return this.threads;
     }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -20,9 +20,9 @@ import { MatrixEvent } from "./event";
 import { EventTimelineSet } from './event-timeline-set';
 import { Room } from './room';
 
-export enum THREAD_EVENTS {
-    ready = "Thread.ready",
-    update = "Thread.update"
+export enum ThreadEvents {
+    Ready = "Thread.ready",
+    Update = "Thread.update"
 }
 
 /**
@@ -78,7 +78,7 @@ export class Thread extends EventEmitter {
         if (this.ready) {
             this.client.decryptEventIfNeeded(event, {});
         }
-        this.emit(THREAD_EVENTS.ready, this);
+        this.emit(ThreadEvents.Ready, this);
     }
 
     /**
@@ -101,7 +101,7 @@ export class Thread extends EventEmitter {
                 await this.fetchReplyChain();
             } else {
                 await this.decryptEvents();
-                this.emit(THREAD_EVENTS.ready, this);
+                this.emit(ThreadEvents.Ready, this);
             }
         }
     }
@@ -199,23 +199,23 @@ export class Thread extends EventEmitter {
         return this.timelineSet.findEventById(eventId) instanceof MatrixEvent;
     }
 
-    public on(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+    public on(event: ThreadEvents, listener: (...args: any[]) => void): this {
         super.on(event, listener);
         return this;
     }
-    public once(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+    public once(event: ThreadEvents, listener: (...args: any[]) => void): this {
         super.once(event, listener);
         return this;
     }
-    public off(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+    public off(event: ThreadEvents, listener: (...args: any[]) => void): this {
         super.off(event, listener);
         return this;
     }
-    public addListener(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+    public addListener(event: ThreadEvents, listener: (...args: any[]) => void): this {
         super.addListener(event, listener);
         return this;
     }
-    public removeListener(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+    public removeListener(event: ThreadEvents, listener: (...args: any[]) => void): this {
         super.removeListener(event, listener);
         return this;
     }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -20,6 +20,11 @@ import { MatrixEvent } from "./event";
 import { EventTimelineSet } from './event-timeline-set';
 import { Room } from './room';
 
+export enum THREAD_EVENTS {
+    ready = "Thread.ready",
+    update = "Thread.update"
+}
+
 /**
  * @experimental
  */
@@ -73,7 +78,7 @@ export class Thread extends EventEmitter {
         if (this.ready) {
             this.client.decryptEventIfNeeded(event, {});
         }
-        this.emit("Thread.update", this);
+        this.emit(THREAD_EVENTS.ready, this);
     }
 
     /**
@@ -96,7 +101,7 @@ export class Thread extends EventEmitter {
                 await this.fetchReplyChain();
             } else {
                 await this.decryptEvents();
-                this.emit("Thread.ready", this);
+                this.emit(THREAD_EVENTS.ready, this);
             }
         }
     }
@@ -192,5 +197,26 @@ export class Thread extends EventEmitter {
 
     public has(eventId: string): boolean {
         return this.timelineSet.findEventById(eventId) instanceof MatrixEvent;
+    }
+
+    public on(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+        super.on(event, listener);
+        return this;
+    }
+    public once(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+        super.once(event, listener);
+        return this;
+    }
+    public off(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+        super.off(event, listener);
+        return this;
+    }
+    public addListener(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+        super.addListener(event, listener);
+        return this;
+    }
+    public removeListener(event: THREAD_EVENTS, listener: (...args: any[]) => void): this {
+        super.removeListener(event, listener);
+        return this;
     }
 }


### PR DESCRIPTION
Move stringly typed events to enum, so it's harder to make a development mistake

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->