### PR TITLE
Make RoomState::hasSufficientPowerLevelFor public

### DIFF
--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -578,7 +578,7 @@ export class RoomState extends EventEmitter {
      * @param {number} powerLevel The power level of the member
      * @return {boolean} true if the given power level is sufficient
      */
-    private hasSufficientPowerLevelFor(action: string, powerLevel: number): boolean {
+    public hasSufficientPowerLevelFor(action: string, powerLevel: number): boolean {
         const powerLevelsEvent = this.getStateEvents(EventType.RoomPowerLevels, "");
 
         let powerLevels = {};


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->