### PR TITLE
Fix race on automatic backup restore

### DIFF
--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -807,7 +807,7 @@ export function requestKeysDuringVerification(
                 logger.info("Got key backup key, decoding...");
                 const decodedKey = decodeBase64(base64Key);
                 logger.info("Decoded backup key, storing...");
-                client.crypto.storeSessionBackupPrivateKey(
+                await client.crypto.storeSessionBackupPrivateKey(
                     Uint8Array.from(decodedKey),
                 );
                 logger.info("Backup key stored. Starting backup restore...");


### PR DESCRIPTION
We forgot to await the saving of the backup key, so there was a race
where it would fail to get the backup key because it hadn't been saved
yet, so the backup wouldn't be restored automatically.

Fixes https://github.com/vector-im/element-web/issues/17781

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix race on automatic backup restore ([\#1936](https://github.com/matrix-org/matrix-js-sdk/pull/1936)). Fixes vector-im/element-web#17781.<!-- CHANGELOG_PREVIEW_END -->