### PR TITLE
Fix `requestVerificationDM` with chronological `pendingEventOrdering`

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3201,6 +3201,10 @@ export class Crypto extends EventEmitter {
         createRequest: any, // TODO types
         isLiveEvent = true,
     ): Promise<void> {
+        // Wait for event to get its final ID with pendingEventOrdering: "chronological", since DM channels depend on it.
+        if (event.isSending()) {
+            await new Promise(resolve => event.once("Event.localEventIdReplaced", resolve));
+        }
         let request = requestsMap.getRequest(event);
         let isNewRequest = false;
         if (!request) {


### PR DESCRIPTION
Signed-off-by: Martin Giger <martin@humanoids.be>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->

This PR is the result of an issue I ran into while implementing user verification for Thunderbird. I'm not sure this is the correct way to handle the chronological timeline case, but it makes sure that the handler won't run with an unsent temporary event ID, and thus assuming the wrong transaction ID.

CC @uhoreg 