### PR TITLE
Share room state events with thread's timelines

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1,5 +1,5 @@
 import * as utils from "../test-utils";
-import { EventStatus, MatrixEvent } from "../../src";
+import { DuplicateStrategy, EventStatus, MatrixEvent } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
 import { RoomState } from "../../src";
 import { Room } from "../../src";
@@ -113,7 +113,7 @@ describe("Room", function() {
             dupe.event.event_id = events[0].getId();
             room.addLiveEvents(events);
             expect(room.timeline[0]).toEqual(events[0]);
-            room.addLiveEvents([dupe], "replace");
+            room.addLiveEvents([dupe], DuplicateStrategy.Replace);
             expect(room.timeline[0]).toEqual(dupe);
         });
 

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -27,6 +27,7 @@ import { Relations } from './relations';
 import { Room } from "./room";
 import { Filter } from "../filter";
 import { EventType, RelationType } from "../@types/event";
+import { RoomState } from "./room-state";
 
 // var DEBUG = false;
 const DEBUG = true;
@@ -43,6 +44,11 @@ interface IOpts {
     timelineSupport?: boolean;
     filter?: Filter;
     unstableClientRelationAggregation?: boolean;
+}
+
+export enum DuplicateStrategy {
+    Ignore = "ignore",
+    Replace = "replace",
 }
 
 export class EventTimelineSet extends EventEmitter {
@@ -509,8 +515,14 @@ export class EventTimelineSet extends EventEmitter {
      * @param {MatrixEvent} event Event to be added
      * @param {string?} duplicateStrategy 'ignore' or 'replace'
      * @param {boolean} fromCache whether the sync response came from cache
+     * @param {boolean} fromCache whether the sync response came from cache
      */
-    public addLiveEvent(event: MatrixEvent, duplicateStrategy?: "ignore" | "replace", fromCache = false): void {
+    public addLiveEvent(
+        event: MatrixEvent,
+        duplicateStrategy: DuplicateStrategy = DuplicateStrategy.Ignore,
+        fromCache = false,
+        roomState?: RoomState,
+    ): void {
         if (this.filter) {
             const events = this.filter.filterRoomTimeline([event]);
             if (!events.length) {
@@ -527,9 +539,12 @@ export class EventTimelineSet extends EventEmitter {
                 for (let j = 0; j < tlEvents.length; j++) {
                     if (tlEvents[j].getId() === event.getId()) {
                         // still need to set the right metadata on this event
+                        if (!roomState) {
+                            timeline.getState(EventTimeline.FORWARDS);
+                        }
                         EventTimeline.setEventMetadata(
                             event,
-                            timeline.getState(EventTimeline.FORWARDS),
+                            roomState,
                             false,
                         );
                         tlEvents[j] = event;
@@ -545,7 +560,7 @@ export class EventTimelineSet extends EventEmitter {
             return;
         }
 
-        this.addEventToTimeline(event, this.liveTimeline, false, fromCache);
+        this.addEventToTimeline(event, this.liveTimeline, false, fromCache, roomState);
     }
 
     /**
@@ -566,9 +581,10 @@ export class EventTimelineSet extends EventEmitter {
         timeline: EventTimeline,
         toStartOfTimeline: boolean,
         fromCache = false,
+        roomState?: RoomState,
     ) {
         const eventId = event.getId();
-        timeline.addEvent(event, toStartOfTimeline);
+        timeline.addEvent(event, toStartOfTimeline, roomState);
         this._eventIdToTimeline[eventId] = timeline;
 
         this.setRelationsTarget(event);

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -515,7 +515,7 @@ export class EventTimelineSet extends EventEmitter {
      * @param {MatrixEvent} event Event to be added
      * @param {string?} duplicateStrategy 'ignore' or 'replace'
      * @param {boolean} fromCache whether the sync response came from cache
-     * @param {boolean} fromCache whether the sync response came from cache
+     * @param roomState the state events to reconcile metadata from
      */
     public addLiveEvent(
         event: MatrixEvent,

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -532,7 +532,7 @@ export class EventTimelineSet extends EventEmitter {
 
         const timeline = this._eventIdToTimeline[event.getId()];
         if (timeline) {
-            if (duplicateStrategy === "replace") {
+            if (duplicateStrategy === DuplicateStrategy.Replace) {
                 debuglog("EventTimelineSet.addLiveEvent: replacing duplicate event " +
                     event.getId());
                 const tlEvents = timeline.getEvents();
@@ -540,7 +540,7 @@ export class EventTimelineSet extends EventEmitter {
                     if (tlEvents[j].getId() === event.getId()) {
                         // still need to set the right metadata on this event
                         if (!roomState) {
-                            timeline.getState(EventTimeline.FORWARDS);
+                            roomState = timeline.getState(EventTimeline.FORWARDS);
                         }
                         EventTimeline.setEventMetadata(
                             event,

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -347,8 +347,11 @@ export class EventTimeline {
      * @param {MatrixEvent} event   new event
      * @param {boolean}  atStart     true to insert new event at the start
      */
-    public addEvent(event: MatrixEvent, atStart: boolean): void {
-        const stateContext = atStart ? this.startState : this.endState;
+    public addEvent(event: MatrixEvent, atStart: boolean, stateContext?: RoomState): void {
+        if (!stateContext) {
+            stateContext = atStart ? this.startState : this.endState;
+        }
+
         const timelineSet = this.getTimelineSet();
 
         if (timelineSet.room) {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { EventEmitter } from "events";
 
-import { EventTimelineSet } from "./event-timeline-set";
+import { EventTimelineSet, DuplicateStrategy } from "./event-timeline-set";
 import { EventTimeline } from "./event-timeline";
 import { getHttpUriForMxc } from "../content-repo";
 import * as utils from "../utils";
@@ -1327,7 +1327,7 @@ export class Room extends EventEmitter {
      * @fires module:client~MatrixClient#event:"Room.timeline"
      * @private
      */
-    private addLiveEvent(event: MatrixEvent, duplicateStrategy?: "ignore" | "replace", fromCache = false): void {
+    private addLiveEvent(event: MatrixEvent, duplicateStrategy?: DuplicateStrategy, fromCache = false): void {
         if (event.isRedaction()) {
             const redactId = event.event.redacts;
 
@@ -1713,7 +1713,7 @@ export class Room extends EventEmitter {
      * @param {boolean} fromCache whether the sync response came from cache
      * @throws If <code>duplicateStrategy</code> is not falsey, 'replace' or 'ignore'.
      */
-    public addLiveEvents(events: MatrixEvent[], duplicateStrategy?: "replace" | "ignore", fromCache = false): void {
+    public addLiveEvents(events: MatrixEvent[], duplicateStrategy?: DuplicateStrategy, fromCache = false): void {
         let i;
         if (duplicateStrategy && ["replace", "ignore"].indexOf(duplicateStrategy) === -1) {
             throw new Error("duplicateStrategy MUST be either 'replace' or 'ignore'");

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -73,6 +73,10 @@ export class Thread extends EventEmitter {
             this.root = event.getId();
         }
 
+        // all the relevant membership info to hydrate events with a sender
+        // is held in the main room timeline
+        // We want to fetch the room state from there and pass it down to this thread
+        // timeline set to let it reconcile an event with its relevant RoomMember
         const roomState = this.room.getLiveTimeline().getState(EventTimeline.FORWARDS);
 
         event.setThread(this);

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -17,7 +17,8 @@ limitations under the License.
 import { EventEmitter } from "events";
 import { MatrixClient } from "../matrix";
 import { MatrixEvent } from "./event";
-import { EventTimelineSet } from './event-timeline-set';
+import { EventTimeline } from "./event-timeline";
+import { EventTimelineSet, DuplicateStrategy } from './event-timeline-set';
 import { Room } from './room';
 
 export enum ThreadEvent {
@@ -72,8 +73,10 @@ export class Thread extends EventEmitter {
             this.root = event.getId();
         }
 
+        const roomState = this.room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+
         event.setThread(this);
-        this.timelineSet.addLiveEvent(event);
+        this.timelineSet.addLiveEvent(event, DuplicateStrategy.Ignore, false, roomState);
 
         if (this.ready) {
             this.client.decryptEventIfNeeded(event, {});


### PR DESCRIPTION
Fixes vector-im/element-web#18719

Events created in a thread do not receive the correct meta data, resulting in an incomplete sender profile as you can see on the screenshot below

<img width="383" alt="134323765-b7ac6104-0d02-44d0-914e-9ea9db6eabda" src="https://user-images.githubusercontent.com/769871/134326745-913c3401-a3ea-49d5-bdf8-d4e4bafe1ed7.png">

The reason is that when an event is added to the timeline, the `event-timeline-set` looks for room state events. This works perfectly well for events in the room's timeline, however threaded events are part of their own timelines which contains no state events.

This pull request adds a way to pass the room's state events down so that the event metadata can be set the same way they would be in the room timeline.
The approach looks a bit odd but at this stage I'm not entirely sure about alternative approaches hence why this is a draft.

Keen to hear your ideas/alternatives to what I'm doing here

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->