### PR TITLE
Fix event partitioning from non threading ready clients

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -321,7 +321,7 @@ export class SyncApi {
                 // - It's related to a reply in thread event
                 let shouldLiveInThreadTimeline = event.replyInThread;
                 if (!shouldLiveInThreadTimeline) {
-                    const parentEventId = event.getWireContent()["m.relates_to"]?.event_id;
+                    const parentEventId = event.parentEventId;
                     const parentEvent = room?.findEventById(parentEventId) || events.find((mxEv: MatrixEvent) => {
                         return mxEv.getId() === parentEventId;
                     });


### PR DESCRIPTION
The logic was correct, but accessing the wrong property member, thus failing always

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix event partitioning from non threading ready clients ([\#1948](https://github.com/matrix-org/matrix-js-sdk/pull/1948)).<!-- CHANGELOG_PREVIEW_END -->