### PR TITLE
Use to-device events for group calls and other improvements

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1285,8 +1285,8 @@ export class MatrixClient extends EventEmitter {
      * @param {string} invitee The user to call in the given room.
      * @return {MatrixCall} the call or null if the browser doesn't support calling.
      */
-    public createCall(roomId: string, invitee?: string): MatrixCall {
-        return createNewMatrixCall(this, roomId, { invitee });
+    public createCall(roomId: string, invitee?: string, useToDevice?: boolean): MatrixCall {
+        return createNewMatrixCall(this, roomId, { invitee, useToDevice });
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1285,8 +1285,8 @@ export class MatrixClient extends EventEmitter {
      * @param {string} invitee The user to call in the given room.
      * @return {MatrixCall} the call or null if the browser doesn't support calling.
      */
-    public createCall(roomId: string, invitee?: string, useToDevice?: boolean): MatrixCall {
-        return createNewMatrixCall(this, roomId, { invitee, useToDevice });
+    public createCall(roomId: string, invitee?: string, useToDevice?: boolean, groupCallId?: string): MatrixCall {
+        return createNewMatrixCall(this, roomId, { invitee, useToDevice, groupCallId });
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1282,11 +1282,10 @@ export class MatrixClient extends EventEmitter {
      * The place*Call methods on the returned call can be used to actually place a call
      *
      * @param {string} roomId The room the call is to be placed in.
-     * @param {string} invitee The user to call in the given room.
      * @return {MatrixCall} the call or null if the browser doesn't support calling.
      */
-    public createCall(roomId: string, invitee?: string, useToDevice?: boolean, groupCallId?: string): MatrixCall {
-        return createNewMatrixCall(this, roomId, { invitee, useToDevice, groupCallId });
+    public createCall(roomId: string): MatrixCall {
+        return createNewMatrixCall(this, roomId);
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1323,7 +1323,13 @@ export class MatrixClient extends EventEmitter {
             await this.sendStateEvent(
                 room.roomId,
                 CONF_ROOM,
-                { active: true, callType: type, dataChannelsEnabled, dataChannelOptions },
+                {
+                    active: true,
+                    callType: type,
+                    conf_id: groupCall.groupCallId,
+                    dataChannelsEnabled,
+                    dataChannelOptions,
+                },
                 "",
             );
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1325,7 +1325,7 @@ export class MatrixClient extends EventEmitter {
                 CONF_ROOM,
                 {
                     active: true,
-                    callType: type,
+                    ["m.type"]: type,
                     conf_id: groupCall.groupCallId,
                     dataChannelsEnabled,
                     dataChannelOptions,

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -238,7 +238,7 @@ export class CallError extends Error {
     }
 }
 
-function genCallID(): string {
+export function genCallID(): string {
     return Date.now().toString() + randomString(16);
 }
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -71,6 +71,7 @@ interface CallOpts {
     client?: any; // Fix when client is TSified
     forceTURN?: boolean;
     turnServers?: Array<TurnServer>;
+    useToDevice?: boolean;
 }
 
 interface TurnServer {
@@ -312,6 +313,8 @@ export class MatrixCall extends EventEmitter {
     private callLengthInterval: number;
     private callLength = 0;
 
+    private useToDevice: boolean;
+
     constructor(opts: CallOpts) {
         super();
         this.roomId = opts.roomId;
@@ -319,6 +322,7 @@ export class MatrixCall extends EventEmitter {
         this.client = opts.client;
         this.forceTURN = opts.forceTURN;
         this.ourPartyId = this.client.deviceId;
+        this.useToDevice = opts.useToDevice;
         // Array of Objects with urls, username, credential keys
         this.turnServers = opts.turnServers || [];
         if (this.turnServers.length === 0 && this.client.isFallbackICEServerAllowed()) {
@@ -2126,13 +2130,14 @@ export function createNewMatrixCall(client: any, roomId: string, options?: CallO
 
     const optionsForceTURN = options ? options.forceTURN : false;
 
-    const opts = {
+    const opts: CallOpts = {
         client: client,
         roomId: roomId,
-        invitee: options && options.invitee,
+        invitee: options?.invitee,
         turnServers: client.getTurnServers(),
         // call level options
         forceTURN: client.forceTURN || optionsForceTURN,
+        useToDevice: options?.useToDevice,
     };
     const call = new MatrixCall(opts);
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2041,7 +2041,7 @@ export class MatrixCall extends EventEmitter {
             this.opponentPartyId = msg.party_id || null;
         }
         this.opponentCaps = msg.capabilities || {} as CallCapabilities;
-        this.opponentMember = ev.sender;
+        this.opponentMember = this.client.getRoom(this.roomId).getMember(ev.getSender());
     }
 
     private async addBufferedIceCandidates(): Promise<void> {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1750,12 +1750,23 @@ export class MatrixCall extends EventEmitter {
      * @param {Object} content
      * @return {Promise}
      */
-    private sendVoipEvent(eventType: string, content: object): Promise<ISendEventResponse> {
-        return this.client.sendEvent(this.roomId, eventType, Object.assign({}, content, {
+    private sendVoipEvent(eventType: string, content: object): Promise<ISendEventResponse | {}> {
+        const realContent = Object.assign({}, content, {
             version: VOIP_PROTO_VERSION,
             call_id: this.callId,
             party_id: this.ourPartyId,
-        }));
+            call_room_id: this.roomId,
+        });
+
+        if (this.useToDevice) {
+            return this.client.sendToDevice(eventType, {
+                [this.invitee || this.getOpponentMember().userId]: {
+                    "*": realContent,
+                },
+            });
+        } else {
+            return this.client.sendEvent(this.roomId, eventType, realContent);
+        }
     }
 
     private queueCandidate(content: RTCIceCandidate): void {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -72,6 +72,7 @@ interface CallOpts {
     forceTURN?: boolean;
     turnServers?: Array<TurnServer>;
     useToDevice?: boolean;
+    groupCallId?: string;
 }
 
 interface TurnServer {
@@ -314,6 +315,7 @@ export class MatrixCall extends EventEmitter {
     private callLength = 0;
 
     private useToDevice: boolean;
+    private groupCallId: string;
 
     constructor(opts: CallOpts) {
         super();
@@ -323,6 +325,7 @@ export class MatrixCall extends EventEmitter {
         this.forceTURN = opts.forceTURN;
         this.ourPartyId = this.client.deviceId;
         this.useToDevice = opts.useToDevice;
+        this.groupCallId = opts.groupCallId;
         // Array of Objects with urls, username, credential keys
         this.turnServers = opts.turnServers || [];
         if (this.turnServers.length === 0 && this.client.isFallbackICEServerAllowed()) {
@@ -1755,7 +1758,7 @@ export class MatrixCall extends EventEmitter {
             version: VOIP_PROTO_VERSION,
             call_id: this.callId,
             party_id: this.ourPartyId,
-            call_room_id: this.roomId,
+            conf_id: this.groupCallId,
         });
 
         if (this.useToDevice) {
@@ -2149,6 +2152,7 @@ export function createNewMatrixCall(client: any, roomId: string, options?: CallO
         // call level options
         forceTURN: client.forceTURN || optionsForceTURN,
         useToDevice: options?.useToDevice,
+        groupCallId: options?.groupCallId,
     };
     const call = new MatrixCall(opts);
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -567,7 +567,7 @@ export class MatrixCall extends EventEmitter {
         logger.info(`Pushed remote stream (id="${stream.id}", active="${stream.active}")`);
     }
 
-    private pushLocalFeed(stream: MediaStream, purpose: SDPStreamMetadataPurpose, addToPeerConnection = true): void {
+    private pushNewLocalFeed(stream: MediaStream, purpose: SDPStreamMetadataPurpose, addToPeerConnection = true): void {
         const userId = this.client.getUserId();
 
         // We try to replace an existing feed if there already is one with the same purpose
@@ -864,7 +864,7 @@ export class MatrixCall extends EventEmitter {
                 if (this.hasLocalUserMediaAudioTrack) return;
                 if (this.hasLocalUserMediaVideoTrack) return;
 
-                this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
+                this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
             } else if (upgradeAudio) {
                 if (this.hasLocalUserMediaAudioTrack) return;
 
@@ -930,7 +930,7 @@ export class MatrixCall extends EventEmitter {
             try {
                 const stream = await this.client.getMediaHandler().getScreensharingStream(desktopCapturerSourceId);
                 if (!stream) return false;
-                this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare);
+                this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare);
                 return true;
             } catch (err) {
                 this.emit(CallEvent.Error,
@@ -972,7 +972,7 @@ export class MatrixCall extends EventEmitter {
                 });
                 sender.replaceTrack(track);
 
-                this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare, false);
+                this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare, false);
 
                 return true;
             } catch (err) {
@@ -1138,7 +1138,7 @@ export class MatrixCall extends EventEmitter {
             return;
         }
 
-        this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
+        this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
         this.setState(CallState.CreateOffer);
 
         logger.debug("gotUserMediaForInvite");
@@ -1197,7 +1197,7 @@ export class MatrixCall extends EventEmitter {
             return;
         }
 
-        this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
+        this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia);
         this.setState(CallState.CreateAnswer);
 
         let myAnswer;

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -606,6 +606,43 @@ export class MatrixCall extends EventEmitter {
         logger.info(`Pushed local stream (id="${stream.id}", active="${stream.active}", purpose="${purpose}")`);
     }
 
+    /**
+     * Pushes supplied feed to the call
+     * @param {CallFeed} callFeed to push
+     * @param {boolean} addToPeerConnection whether to add the tracks to the peer connection
+     */
+    public pushLocalFeed(callFeed: CallFeed, addToPeerConnection = true): void {
+        this.feeds.push(callFeed);
+        this.emit(CallEvent.FeedsChanged, this.feeds);
+
+        if (addToPeerConnection) {
+            const senderArray = callFeed.purpose === SDPStreamMetadataPurpose.Usermedia ?
+                this.usermediaSenders : this.screensharingSenders;
+            // Empty the array
+            senderArray.splice(0, senderArray.length);
+
+            this.emit(CallEvent.FeedsChanged, this.feeds);
+            for (const track of callFeed.stream.getTracks()) {
+                logger.info(
+                    `Adding track (` +
+                    `id="${track.id}", ` +
+                    `kind="${track.kind}", ` +
+                    `streamId="${callFeed.stream}", ` +
+                    `streamPurpose="${callFeed.purpose}"` +
+                    `) to peer connection`,
+                );
+                senderArray.push(this.peerConn.addTrack(track, callFeed.stream));
+            }
+        }
+
+        logger.info(
+            `Pushed local stream `+
+            `(id="${callFeed.stream.id}", `+
+            `active="${callFeed.stream.active}", `+
+            `purpose="${callFeed.purpose}")`,
+        );
+    }
+
     private deleteAllFeeds(): void {
         for (const feed of this.feeds) {
             if (!feed.isLocal() || this.stopLocalMediaOnEnd) {
@@ -781,6 +818,28 @@ export class MatrixCall extends EventEmitter {
         }
     }
 
+    public answerWithCallFeed(callFeed: CallFeed): void {
+        this.stopLocalMediaOnEnd = false;
+        if (this.inviteOrAnswerSent) return;
+
+        logger.debug(`Answering call ${this.callId}`);
+
+        if (!this.localUsermediaStream && !this.waitForLocalAVStream) {
+            this.setState(CallState.WaitLocalMedia);
+            this.waitForLocalAVStream = true;
+
+            try {
+                this.waitForLocalAVStream = false;
+                this.gotCallFeedForAnswer(callFeed);
+            } catch (e) {
+                this.getUserMediaFailed(e);
+                return;
+            }
+        } else if (this.waitForLocalAVStream) {
+            this.setState(CallState.WaitLocalMedia);
+        }
+    }
+
     /**
      * Replace this call with a new call, e.g. for glare resolution. Used by
      * MatrixClient.
@@ -792,7 +851,11 @@ export class MatrixCall extends EventEmitter {
             newCall.waitForLocalAVStream = true;
         } else if ([CallState.CreateOffer, CallState.InviteSent].includes(this.state)) {
             logger.debug("Handing local stream to new call");
-            newCall.gotUserMediaForAnswer(this.localUsermediaStream);
+            if (this.stopLocalMediaOnEnd) {
+                newCall.gotUserMediaForAnswer(this.localUsermediaStream);
+            } else {
+                newCall.gotCallFeedForAnswer(this.localUsermediaFeed);
+            }
         }
         this.successor = newCall;
         this.emit(CallEvent.Replaced, newCall);
@@ -1145,6 +1208,23 @@ export class MatrixCall extends EventEmitter {
         // Now we wait for the negotiationneeded event
     };
 
+    private gotCallFeedForInvite(callFeed: CallFeed): void {
+        if (this.successor) {
+            this.successor.gotCallFeedForAnswer(callFeed);
+            return;
+        }
+        if (this.callHasEnded()) {
+            this.stopAllMedia();
+            return;
+        }
+
+        this.pushLocalFeed(callFeed);
+        this.setState(CallState.CreateOffer);
+
+        logger.debug("gotUserMediaForInvite");
+        // Now we wait for the negotiationneeded event
+    }
+
     private async sendAnswer(): Promise<void> {
         const answerContent = {
             answer: {
@@ -1226,6 +1306,41 @@ export class MatrixCall extends EventEmitter {
             return;
         }
     };
+
+    private async gotCallFeedForAnswer(callFeed: CallFeed): Promise<void> {
+        if (this.callHasEnded()) return;
+
+        this.waitForLocalAVStream = false;
+
+        this.pushLocalFeed(callFeed);
+        this.setState(CallState.CreateAnswer);
+
+        let myAnswer;
+        try {
+            this.getRidOfRTXCodecs();
+            myAnswer = await this.peerConn.createAnswer();
+        } catch (err) {
+            logger.debug("Failed to create answer: ", err);
+            this.terminate(CallParty.Local, CallErrorCode.CreateAnswer, true);
+            return;
+        }
+
+        try {
+            await this.peerConn.setLocalDescription(myAnswer);
+            this.setState(CallState.Connecting);
+
+            // Allow a short time for initial candidates to be gathered
+            await new Promise(resolve => {
+                setTimeout(resolve, 200);
+            });
+
+            this.sendAnswer();
+        } catch (err) {
+            logger.debug("Error setting local description!", err);
+            this.terminate(CallParty.Local, CallErrorCode.SetLocalDescription, true);
+            return;
+        }
+    }
 
     /**
      * Internal
@@ -2016,6 +2131,39 @@ export class MatrixCall extends EventEmitter {
         try {
             const mediaStream = await this.client.getMediaHandler().getUserMediaStream(audio, video);
             this.gotUserMediaForInvite(mediaStream);
+        } catch (e) {
+            this.getUserMediaFailed(e);
+            return;
+        }
+    }
+
+    /**
+     * Place a call to this room with call feed.
+     * @param {CallFeed} callFeed to use
+     * @throws if you have not specified a listener for 'error' events.
+     * @throws if have passed audio=false.
+     */
+    public async placeCallWithCallFeed(callFeed: CallFeed): Promise<void> {
+        this.stopLocalMediaOnEnd = false;
+        this.checkForErrorListener();
+        // XXX Find a better way to do this
+        this.client.callEventHandler.calls.set(this.callId, this);
+        this.setState(CallState.WaitLocalMedia);
+        this.direction = CallDirection.Outbound;
+
+        // make sure we have valid turn creds. Unless something's gone wrong, it should
+        // poll and keep the credentials valid so this should be instant.
+        const haveTurnCreds = await this.client.checkTurnServers();
+        if (!haveTurnCreds) {
+            logger.warn("Failed to get TURN credentials! Proceeding with call anyway...");
+        }
+
+        // create the peer connection now so it can be gathering candidates while we get user
+        // media (assuming a candidate pool size is configured)
+        this.peerConn = this.createPeerConnection();
+
+        try {
+            this.gotCallFeedForInvite(callFeed);
         } catch (e) {
             this.getUserMediaFailed(e);
             return;

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -160,7 +160,11 @@ export class CallEventHandler {
 
     private async handleCallEvent(event: MatrixEvent, isToDevice?: boolean) {
         const content = event.getContent();
-        const callRoomId = event.getRoomId() || content.call_room_id;
+        const callRoomId = (
+            event.getRoomId() ||
+            this.client.groupCallEventHandler.getGroupCallById(content.conf_id)?.room?.roomId
+        );
+        const groupCallId = content.conf_id;
         const type = event.getType() as EventType;
         const weSentTheEvent = event.getSender() === this.client.credentials.userId;
         let call = content.call_id ? this.calls.get(content.call_id) : undefined;
@@ -192,7 +196,7 @@ export class CallEventHandler {
             call = createNewMatrixCall(
                 this.client,
                 callRoomId,
-                { forceTURN: this.client.forceTURN, useToDevice: isToDevice },
+                { forceTURN: this.client.forceTURN, useToDevice: isToDevice, groupCallId },
             );
             if (!call) {
                 logger.log(

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -442,7 +442,7 @@ export class GroupCall extends EventEmitter {
             return;
         }
 
-        const newCall = this.client.createCall(this.room.roomId, member.userId);
+        const newCall = this.client.createCall(this.room.roomId, member.userId, true);
 
         // TODO: Move to call.placeCall()
         const callPromise = this.type === CallType.Video ? newCall.placeVideoCall() : newCall.placeVoiceCall();

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -386,7 +386,7 @@ export class GroupCall extends EventEmitter {
             this.addCall(newCall, sessionId);
         }
 
-        newCall.answerWithCallFeed(this.localCallFeed);
+        newCall.answerWithCallFeeds([this.localCallFeed]);
     };
 
     private onRoomStateMembers = (_event, _state, member: RoomMember) => {
@@ -454,7 +454,7 @@ export class GroupCall extends EventEmitter {
             { invitee: member.userId, useToDevice: true, groupCallId: this.groupCallId },
         );
 
-        newCall.placeCallWithCallFeed(this.localCallFeed);
+        newCall.placeCallWithCallFeeds([this.localCallFeed]);
 
         if (this.dataChannelsEnabled) {
             newCall.createDataChannel("datachannel", this.dataChannelOptions);

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -386,7 +386,7 @@ export class GroupCall extends EventEmitter {
             this.addCall(newCall, sessionId);
         }
 
-        newCall.answer();
+        newCall.answerWithCallFeed(this.localCallFeed);
     };
 
     private onRoomStateMembers = (_event, _state, member: RoomMember) => {
@@ -454,14 +454,11 @@ export class GroupCall extends EventEmitter {
             { invitee: member.userId, useToDevice: true, groupCallId: this.groupCallId },
         );
 
-        // TODO: Move to call.placeCall()
-        const callPromise = this.type === CallType.Video ? newCall.placeVideoCall() : newCall.placeVoiceCall();
+        newCall.placeCallWithCallFeed(this.localCallFeed);
 
-        callPromise.then(() => {
-            if (this.dataChannelsEnabled) {
-                newCall.createDataChannel("datachannel", this.dataChannelOptions);
-            }
-        });
+        if (this.dataChannelsEnabled) {
+            newCall.createDataChannel("datachannel", this.dataChannelOptions);
+        }
 
         if (existingCall) {
             this.replaceCall(existingCall, newCall, sessionId);

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -2,7 +2,7 @@ import EventEmitter from "events";
 import { CallFeed, CallFeedEvent } from "./callFeed";
 import { MatrixClient } from "../client";
 import { randomString } from "../randomstring";
-import { CallErrorCode, CallEvent, CallState, CallType, MatrixCall, setTracksEnabled } from "./call";
+import { CallErrorCode, CallEvent, CallState, CallType, genCallID, MatrixCall, setTracksEnabled } from "./call";
 import { RoomMember } from "../models/room-member";
 import { Room } from "../models/room";
 import { logger } from "../logger";
@@ -63,6 +63,7 @@ export class GroupCall extends EventEmitter {
     public localCallFeed: CallFeed;
     public calls: MatrixCall[] = [];
     public userMediaFeeds: CallFeed[] = [];
+    public groupCallId: string;
 
     private userMediaFeedHandlers: Map<string, IUserMediaFeedHandlers> = new Map();
     private callHandlers: Map<string, ICallHandlers> = new Map();
@@ -82,6 +83,7 @@ export class GroupCall extends EventEmitter {
     ) {
         super();
         this.reEmitter = new ReEmitter(this);
+        this.groupCallId = genCallID();
     }
 
     private setState(newState: GroupCallState): void {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -8,6 +8,7 @@ import { Room } from "../models/room";
 import { logger } from "../logger";
 import { ReEmitter } from "../ReEmitter";
 import { SDPStreamMetadataPurpose } from "./callEventTypes";
+import { createNewMatrixCall } from "./call";
 
 export enum GroupCallEvent {
     GroupCallStateChanged = "group_call_state_changed",
@@ -447,7 +448,11 @@ export class GroupCall extends EventEmitter {
             return;
         }
 
-        const newCall = this.client.createCall(this.room.roomId, member.userId, true, this.groupCallId);
+        const newCall = createNewMatrixCall(
+            this.client,
+            this.room.roomId,
+            { invitee: member.userId, useToDevice: true, groupCallId: this.groupCallId },
+        );
 
         // TODO: Move to call.placeCall()
         const callPromise = this.type === CallType.Video ? newCall.placeVideoCall() : newCall.placeVoiceCall();

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -447,7 +447,7 @@ export class GroupCall extends EventEmitter {
             return;
         }
 
-        const newCall = this.client.createCall(this.room.roomId, member.userId, true);
+        const newCall = this.client.createCall(this.room.roomId, member.userId, true, this.groupCallId);
 
         // TODO: Move to call.placeCall()
         const callPromise = this.type === CallType.Video ? newCall.placeVideoCall() : newCall.placeVoiceCall();

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -61,13 +61,16 @@ export class GroupCallEventHandler {
             dataChannelOptions = { ordered, maxPacketLifeTime, maxRetransmits, protocol };
         }
 
-        return new GroupCall(
+        const groupCall = new GroupCall(
             this.client,
             room,
             callType,
             content?.dataChannelsEnabled,
             dataChannelOptions,
         );
+        groupCall.groupCallId = content["conf_id"];
+
+        return groupCall;
     }
 
     private onRoomStateChanged = (_event: MatrixEvent, state: RoomState): void => {

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -34,6 +34,10 @@ export class GroupCallEventHandler {
         this.client.removeListener("RoomState.events", this.onRoomStateChanged);
     }
 
+    public getGroupCallById(groupCallId: string): GroupCall {
+        return [...this.groupCalls.values()].find((groupCall) => groupCall.groupCallId === groupCallId);
+    }
+
     public createGroupCallFromRoomStateEvent(event: MatrixEvent) {
         const roomId = event.getRoomId();
         const content = event.getContent();


### PR DESCRIPTION
Changes:

+ Use to-device messages for VoIP signalling (for now, they're not encrypted)
+ Don't duplicate local call feeds and add more flexible ways to start/answer calls
+ And bunch of smaller improvements

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->