### PR TITLE
Implement file versioning for tree spaces

### DIFF
--- a/spec/unit/models/MSC3089Branch.spec.ts
+++ b/spec/unit/models/MSC3089Branch.spec.ts
@@ -247,7 +247,7 @@ describe("MSC3089Branch", () => {
         const fileContents = "contents go here";
         const canaryContents = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
         const canaryFile = {} as IEncryptedFile;
-        const canaryAddl = {canary: true};
+        const canaryAddl = { canary: true };
         indexEvent.getContent = () => ({ active: true, retained: true });
         const stateKeyOrder = [fileEventId2, fileEventId];
         const stateFn = jest.fn()
@@ -316,7 +316,7 @@ describe("MSC3089Branch", () => {
             replacingEventId: () => null,
             getId: () => "$unknown",
         }];
-        staticRoom.getLiveTimeline = () => ({getEvents: () => events}) as EventTimeline;
+        staticRoom.getLiveTimeline = () => ({ getEvents: () => events }) as EventTimeline;
 
         directory.getFile = (evId: string) => {
             expect(evId).toEqual(fileEventId);

--- a/spec/unit/models/MSC3089Branch.spec.ts
+++ b/spec/unit/models/MSC3089Branch.spec.ts
@@ -14,21 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../../../src";
+import { IContent, MatrixClient, MatrixEvent } from "../../../src";
 import { Room } from "../../../src/models/room";
-import { UNSTABLE_MSC3089_BRANCH } from "../../../src/@types/event";
+import { IEncryptedFile, RelationType, UNSTABLE_MSC3089_BRANCH } from "../../../src/@types/event";
 import { EventTimelineSet } from "../../../src/models/event-timeline-set";
 import { EventTimeline } from "../../../src/models/event-timeline";
 import { MSC3089Branch } from "../../../src/models/MSC3089Branch";
+import { MSC3089TreeSpace } from "../../../src/models/MSC3089TreeSpace";
 
 describe("MSC3089Branch", () => {
     let client: MatrixClient;
     // @ts-ignore - TS doesn't know that this is a type
     let indexEvent: any;
+    let directory: MSC3089TreeSpace;
     let branch: MSC3089Branch;
+    let branch2: MSC3089Branch;
 
     const branchRoomId = "!room:example.org";
     const fileEventId = "$file";
+    const fileEventId2 = "$second_file";
 
     const staticTimelineSets = {} as EventTimelineSet;
     const staticRoom = {
@@ -50,7 +54,12 @@ describe("MSC3089Branch", () => {
             getRoomId: () => branchRoomId,
             getStateKey: () => fileEventId,
         });
-        branch = new MSC3089Branch(client, indexEvent);
+        directory = new MSC3089TreeSpace(client, branchRoomId);
+        branch = new MSC3089Branch(client, indexEvent, directory);
+        branch2 = new MSC3089Branch(client, {
+            getRoomId: () => branchRoomId,
+            getStateKey: () => fileEventId2,
+        } as MatrixEvent, directory);
     });
 
     it('should know the file event ID', () => {
@@ -69,13 +78,15 @@ describe("MSC3089Branch", () => {
     });
 
     it('should be able to delete the file', async () => {
+        const eventIdOrder = [fileEventId, fileEventId2];
+
         const stateFn = jest.fn()
             .mockImplementation((roomId: string, eventType: string, content: any, stateKey: string) => {
                 expect(roomId).toEqual(branchRoomId);
                 expect(eventType).toEqual(UNSTABLE_MSC3089_BRANCH.unstable); // test that we're definitely using the unstable value
                 expect(content).toMatchObject({});
                 expect(content['active']).toBeUndefined();
-                expect(stateKey).toEqual(fileEventId);
+                expect(stateKey).toEqual(eventIdOrder[stateFn.mock.calls.length - 1]);
 
                 return Promise.resolve(); // return value not used
             });
@@ -83,16 +94,19 @@ describe("MSC3089Branch", () => {
 
         const redactFn = jest.fn().mockImplementation((roomId: string, eventId: string) => {
             expect(roomId).toEqual(branchRoomId);
-            expect(eventId).toEqual(fileEventId);
+            expect(eventId).toEqual(eventIdOrder[stateFn.mock.calls.length - 1]);
 
             return Promise.resolve(); // return value not used
         });
         client.redactEvent = redactFn;
 
+        branch.getVersionHistory = () => Promise.resolve([branch, branch2]);
+        branch2.getVersionHistory = () => Promise.resolve([branch2]);
+
         await branch.delete();
 
-        expect(stateFn).toHaveBeenCalledTimes(1);
-        expect(redactFn).toHaveBeenCalledTimes(1);
+        expect(stateFn).toHaveBeenCalledTimes(2);
+        expect(redactFn).toHaveBeenCalledTimes(2);
     });
 
     it('should know its name', async () => {
@@ -125,6 +139,22 @@ describe("MSC3089Branch", () => {
         await branch.setName(name);
 
         expect(stateFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be v1 by default', () => {
+        indexEvent.getContent = () => ({ active: true });
+
+        const res = branch.version;
+
+        expect(res).toEqual(1);
+    });
+
+    it('should be vN when set', () => {
+        indexEvent.getContent = () => ({ active: true, version: 3 });
+
+        const res = branch.version;
+
+        expect(res).toEqual(3);
     });
 
     it('should be unlocked by default', async () => {
@@ -169,13 +199,13 @@ describe("MSC3089Branch", () => {
     it('should be able to return event information', async () => {
         const mxcLatter = "example.org/file";
         const fileContent = { isFile: "not quite", url: "mxc://" + mxcLatter };
-        const eventsArr = [
-            { getId: () => "$not-file", getContent: () => ({}) },
-            { getId: () => fileEventId, getContent: () => ({ file: fileContent }) },
-        ];
-        client.getEventTimeline = () => Promise.resolve({
-            getEvents: () => eventsArr,
-        }) as any as Promise<EventTimeline>; // partial
+        const fileEvent = { getId: () => fileEventId, getOriginalContent: () => ({ file: fileContent }) };
+        staticRoom.getUnfilteredTimelineSet = () => ({
+            findEventById: (eventId) => {
+                expect(eventId).toEqual(fileEventId);
+                return fileEvent;
+            },
+        }) as EventTimelineSet;
         client.mxcUrlToHttp = (mxc: string) => {
             expect(mxc).toEqual("mxc://" + mxcLatter);
             return `https://example.org/_matrix/media/v1/download/${mxcLatter}`;
@@ -194,17 +224,109 @@ describe("MSC3089Branch", () => {
     it('should be able to return the event object', async () => {
         const mxcLatter = "example.org/file";
         const fileContent = { isFile: "not quite", url: "mxc://" + mxcLatter };
-        const eventsArr = [
-            { getId: () => "$not-file", getContent: () => ({}) },
-            { getId: () => fileEventId, getContent: () => ({ file: fileContent }) },
-        ];
-        client.getEventTimeline = () => Promise.resolve({
-            getEvents: () => eventsArr,
-        }) as any as Promise<EventTimeline>; // partial
+        const fileEvent = { getId: () => fileEventId, getOriginalContent: () => ({ file: fileContent }) };
+        staticRoom.getUnfilteredTimelineSet = () => ({
+            findEventById: (eventId) => {
+                expect(eventId).toEqual(fileEventId);
+                return fileEvent;
+            },
+        }) as EventTimelineSet;
+        client.mxcUrlToHttp = (mxc: string) => {
+            expect(mxc).toEqual("mxc://" + mxcLatter);
+            return `https://example.org/_matrix/media/v1/download/${mxcLatter}`;
+        };
         client.decryptEventIfNeeded = () => Promise.resolve();
 
         const res = await branch.getFileEvent();
         expect(res).toBeDefined();
-        expect(res).toBe(eventsArr[1]);
+        expect(res).toBe(fileEvent);
+    });
+
+    it('should create new versions of itself', async () => {
+        const canaryName = "canary";
+        const fileContents = "contents go here";
+        const canaryContents = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
+        const canaryFile = {} as IEncryptedFile;
+        const canaryAddl = {canary: true};
+        indexEvent.getContent = () => ({ active: true, retained: true });
+        const stateKeyOrder = [fileEventId2, fileEventId];
+        const stateFn = jest.fn()
+            .mockImplementation((roomId: string, eventType: string, content: any, stateKey: string) => {
+                expect(roomId).toEqual(branchRoomId);
+                expect(eventType).toEqual(UNSTABLE_MSC3089_BRANCH.unstable); // test that we're definitely using the unstable value
+                expect(stateKey).toEqual(stateKeyOrder[stateFn.mock.calls.length - 1]);
+                if (stateKey === fileEventId) {
+                    expect(content).toMatchObject({
+                        retained: true, // canary for copying state
+                        active: false,
+                    });
+                } else if (stateKey === fileEventId2) {
+                    expect(content).toMatchObject({
+                        active: true,
+                        version: 2,
+                        name: canaryName,
+                    });
+                } else {
+                    throw new Error("Unexpected state key: " + stateKey);
+                }
+
+                return Promise.resolve(); // return value not used
+            });
+        client.sendStateEvent = stateFn;
+
+        const createFn = jest.fn().mockImplementation((
+            name: string,
+            contents: ArrayBuffer,
+            info: Partial<IEncryptedFile>,
+            addl: IContent,
+        ) => {
+            expect(name).toEqual(canaryName);
+            expect(contents).toBe(canaryContents);
+            expect(info).toBe(canaryFile);
+            expect(addl).toMatchObject({
+                ...canaryAddl,
+                "m.new_content": true,
+                "m.relates_to": {
+                    "rel_type": RelationType.Replace,
+                    "event_id": fileEventId,
+                },
+            });
+
+            return Promise.resolve({ event_id: fileEventId2 });
+        });
+        directory.createFile = createFn;
+
+        await branch.createNewVersion(canaryName, canaryContents, canaryFile, canaryAddl);
+
+        expect(stateFn).toHaveBeenCalledTimes(2);
+        expect(createFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch file history', async () => {
+        branch2.getFileEvent = () => Promise.resolve({
+            replacingEventId: () => undefined,
+            getId: () => fileEventId2,
+        } as MatrixEvent);
+        branch.getFileEvent = () => Promise.resolve({
+            replacingEventId: () => fileEventId2,
+            getId: () => fileEventId,
+        } as MatrixEvent);
+
+        const events = [await branch.getFileEvent(), await branch2.getFileEvent(), {
+            replacingEventId: () => null,
+            getId: () => "$unknown",
+        }];
+        staticRoom.getLiveTimeline = () => ({getEvents: () => events}) as EventTimeline;
+
+        directory.getFile = (evId: string) => {
+            expect(evId).toEqual(fileEventId);
+            return branch;
+        };
+
+        const results = await branch2.getVersionHistory();
+        expect(results).toMatchObject([
+            branch2,
+            branch,
+        ]);
     });
 });

--- a/spec/unit/models/MSC3089TreeSpace.spec.ts
+++ b/spec/unit/models/MSC3089TreeSpace.spec.ts
@@ -908,6 +908,7 @@ describe("MSC3089TreeSpace", () => {
                 body: fileName,
                 url: mxc,
                 file: fileInfo,
+                metadata: true, // additional content from test
                 [UNSTABLE_MSC3089_LEAF.unstable]: {}, // test to ensure we're definitely using unstable
             });
 
@@ -925,14 +926,82 @@ describe("MSC3089TreeSpace", () => {
                     name: fileName,
                 });
 
-                return Promise.resolve(); // return value not used.
+                return Promise.resolve({ event_id: "wrong" }); // return value shouldn't be used
             });
         client.sendStateEvent = sendStateFn;
 
         const buf = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
 
         // We clone the file info just to make sure it doesn't get mutated for the test.
-        await tree.createFile(fileName, buf, Object.assign({}, fileInfo));
+        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), {metadata: true});
+        expect(result).toMatchObject({ event_id: fileEventId });
+
+        expect(uploadFn).toHaveBeenCalledTimes(1);
+        expect(sendMsgFn).toHaveBeenCalledTimes(1);
+        expect(sendStateFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should upload file versions', async () => {
+        const mxc = "mxc://example.org/file";
+        const fileInfo = {
+            mimetype: "text/plain",
+            // other fields as required by encryption, but ignored here
+        };
+        const fileEventId = "$file";
+        const fileName = "My File.txt";
+        const fileContents = "This is a test file";
+
+        // Mock out Blob for the test environment
+        (<any>global).Blob = MockBlob;
+
+        const uploadFn = jest.fn().mockImplementation((contents: Blob, opts: any) => {
+            expect(contents).toBeInstanceOf(Blob);
+            expect(contents.size).toEqual(fileContents.length);
+            expect(opts).toMatchObject({
+                includeFilename: false,
+                onlyContentUri: true, // because the tests rely on this - we shouldn't really be testing  for this.
+            });
+            return Promise.resolve(mxc);
+        });
+        client.uploadContent = uploadFn;
+
+        const sendMsgFn = jest.fn().mockImplementation((roomId: string, contents: any) => {
+            expect(roomId).toEqual(tree.roomId);
+            const content = {
+                msgtype: MsgType.File,
+                body: fileName,
+                url: mxc,
+                file: fileInfo,
+            };
+            expect(contents).toMatchObject({
+                ...content,
+                "m.new_content": content,
+                [UNSTABLE_MSC3089_LEAF.unstable]: {}, // test to ensure we're definitely using unstable
+            });
+
+            return Promise.resolve({ event_id: fileEventId }); // eslint-disable-line camelcase
+        });
+        client.sendMessage = sendMsgFn;
+
+        const sendStateFn = jest.fn()
+            .mockImplementation((roomId: string, eventType: string, content: any, stateKey: string) => {
+                expect(roomId).toEqual(tree.roomId);
+                expect(eventType).toEqual(UNSTABLE_MSC3089_BRANCH.unstable); // test to ensure we're definitely using unstable
+                expect(stateKey).toEqual(fileEventId);
+                expect(content).toMatchObject({
+                    active: true,
+                    name: fileName,
+                });
+
+                return Promise.resolve({ event_id: "wrong" }); // return value shouldn't be used
+            });
+        client.sendStateEvent = sendStateFn;
+
+        const buf = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
+
+        // We clone the file info just to make sure it doesn't get mutated for the test.
+        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), {"m.new_content": true});
+        expect(result).toMatchObject({ event_id: fileEventId });
 
         expect(uploadFn).toHaveBeenCalledTimes(1);
         expect(sendMsgFn).toHaveBeenCalledTimes(1);
@@ -984,5 +1053,23 @@ describe("MSC3089TreeSpace", () => {
         expect(files).toBeDefined();
         expect(files.length).toEqual(1);
         expect(files[0].indexEvent).toBe(firstFile);
+    });
+
+    it('should list all files', () => {
+        const firstFile = { getContent: () => ({ active: true }) };
+        const secondFile = { getContent: () => ({ active: false }) }; // deliberately inactive
+        room.currentState = {
+            getStateEvents: (eventType: string, stateKey?: string) => {
+                expect(eventType).toEqual(UNSTABLE_MSC3089_BRANCH.unstable); // test to ensure we're definitely using unstable
+                expect(stateKey).toBeUndefined();
+                return [firstFile, secondFile];
+            },
+        };
+
+        const files = tree.listAllFiles();
+        expect(files).toBeDefined();
+        expect(files.length).toEqual(2);
+        expect(files[0].indexEvent).toBe(firstFile);
+        expect(files[1].indexEvent).toBe(secondFile);
     });
 });

--- a/spec/unit/models/MSC3089TreeSpace.spec.ts
+++ b/spec/unit/models/MSC3089TreeSpace.spec.ts
@@ -933,7 +933,7 @@ describe("MSC3089TreeSpace", () => {
         const buf = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
 
         // We clone the file info just to make sure it doesn't get mutated for the test.
-        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), {metadata: true});
+        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), { metadata: true });
         expect(result).toMatchObject({ event_id: fileEventId });
 
         expect(uploadFn).toHaveBeenCalledTimes(1);
@@ -1000,7 +1000,7 @@ describe("MSC3089TreeSpace", () => {
         const buf = Uint8Array.from(Array.from(fileContents).map((_, i) => fileContents.charCodeAt(i)));
 
         // We clone the file info just to make sure it doesn't get mutated for the test.
-        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), {"m.new_content": true});
+        const result = await tree.createFile(fileName, buf, Object.assign({}, fileInfo), { "m.new_content": true });
         expect(result).toMatchObject({ event_id: fileEventId });
 
         expect(uploadFn).toHaveBeenCalledTimes(1);

--- a/src/models/MSC3089Branch.ts
+++ b/src/models/MSC3089Branch.ts
@@ -15,8 +15,9 @@ limitations under the License.
 */
 
 import { MatrixClient } from "../client";
-import { IEncryptedFile, UNSTABLE_MSC3089_BRANCH } from "../@types/event";
-import { MatrixEvent } from "./event";
+import { EventType, IEncryptedFile, RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event";
+import { IContent, MatrixEvent } from "./event";
+import { MSC3089TreeSpace } from "./MSC3089TreeSpace";
 
 /**
  * Represents a [MSC3089](https://github.com/matrix-org/matrix-doc/pull/3089) branch - a reference
@@ -24,7 +25,11 @@ import { MatrixEvent } from "./event";
  * without notice.
  */
 export class MSC3089Branch {
-    public constructor(private client: MatrixClient, public readonly indexEvent: MatrixEvent) {
+    public constructor(
+        private client: MatrixClient,
+        public readonly indexEvent: MatrixEvent,
+        public readonly directory: MSC3089TreeSpace,
+    ) {
         // Nothing to do
     }
 
@@ -42,19 +47,27 @@ export class MSC3089Branch {
         return this.indexEvent.getContent()["active"] === true;
     }
 
+    /**
+     * Version for the file, one-indexed.
+     */
+    public get version(): number {
+        return this.indexEvent.getContent()["version"] ?? 1;
+    }
+
     private get roomId(): string {
         return this.indexEvent.getRoomId();
     }
 
     /**
-     * Deletes the file from the tree.
+     * Deletes the file from the tree, including all prior edits/versions.
      * @returns {Promise<void>} Resolves when complete.
      */
     public async delete(): Promise<void> {
         await this.client.sendStateEvent(this.roomId, UNSTABLE_MSC3089_BRANCH.name, {}, this.id);
         await this.client.redactEvent(this.roomId, this.id);
 
-        // TODO: Delete edit history as well
+        const nextVersion = (await this.getVersionHistory())[1]; // [0] will be us
+        if (nextVersion) await nextVersion.delete(); // implicit recursion
     }
 
     /**
@@ -104,7 +117,7 @@ export class MSC3089Branch {
     public async getFileInfo(): Promise<{ info: IEncryptedFile, httpUrl: string }> {
         const event = await this.getFileEvent();
 
-        const file = event.getContent()['file'];
+        const file = event.getOriginalContent()['file'];
         const httpUrl = this.client.mxcUrlToHttp(file['url']);
 
         return { info: file, httpUrl: httpUrl };
@@ -118,15 +131,88 @@ export class MSC3089Branch {
         const room = this.client.getRoom(this.roomId);
         if (!room) throw new Error("Unknown room");
 
-        const timeline = await this.client.getEventTimeline(room.getUnfilteredTimelineSet(), this.id);
-        if (!timeline) throw new Error("Failed to get timeline for room event");
-
-        const event = timeline.getEvents().find(e => e.getId() === this.id);
+        const event = room.getUnfilteredTimelineSet().findEventById(this.id);
         if (!event) throw new Error("Failed to find event");
 
-        // Sometimes the event context doesn't decrypt for us, so do that.
-        await this.client.decryptEventIfNeeded(event, { emit: false, isRetry: false });
+        // Sometimes the event isn't decrypted for us, so do that. We specifically set `emit: true`
+        // to ensure that the relations system in the sdk will function.
+        await this.client.decryptEventIfNeeded(event, { emit: true, isRetry: true });
 
         return event;
+    }
+
+    /**
+     * Creates a new version of this file.
+     * @param {string} name The name of the file.
+     * @param {ArrayBuffer} encryptedContents The encrypted contents.
+     * @param {Partial<IEncryptedFile>} info The encrypted file information.
+     * @param {IContent} additionalContent Optional event content fields to include in the message.
+     * @returns {Promise<void>} Resolves when uploaded.
+     */
+    public async createNewVersion(
+        name: string,
+        encryptedContents: ArrayBuffer,
+        info: Partial<IEncryptedFile>,
+        additionalContent?: IContent,
+    ): Promise<void> {
+        const fileEventResponse = await this.directory.createFile(name, encryptedContents, info, {
+            ...(additionalContent ?? {}),
+            "m.new_content": true,
+            "m.relates_to": {
+                "rel_type": RelationType.Replace,
+                "event_id": this.id,
+            },
+        });
+
+        // Update the version of the new event
+        await this.client.sendStateEvent(this.roomId, UNSTABLE_MSC3089_BRANCH.name, {
+            active: true,
+            name: name,
+            version: this.version + 1,
+        }, fileEventResponse['event_id']);
+
+        // Deprecate ourselves
+        await this.client.sendStateEvent(this.roomId, UNSTABLE_MSC3089_BRANCH.name, {
+            ...(this.indexEvent.getContent()),
+            active: false,
+        }, this.id);
+    }
+
+    /**
+     * Gets the file's version history, starting at this file.
+     * @returns {Promise<MSC3089Branch[]>} Resolves to the file's version history, with the
+     * first element being the current version and the last element being the first version.
+     */
+    public async getVersionHistory(): Promise<MSC3089Branch[]> {
+        const fileHistory: MSC3089Branch[] = [];
+        fileHistory.push(this); // start with ourselves
+
+        const room = this.client.getRoom(this.roomId);
+        if (!room) throw new Error("Invalid or unknown room");
+
+        // Clone the timeline to reverse it, getting most-recent-first ordering, hopefully
+        // shortening the awful loop below. Without the clone, we can unintentionally mutate
+        // the timeline.
+        const timelineEvents = [...room.getLiveTimeline().getEvents()].reverse();
+
+        // XXX: This is a very inefficient search, but it's the best we can do with the
+        // relations structure we have in the SDK. As of writing, it is not worth the
+        // investment in improving the structure.
+        let childEvent: MatrixEvent;
+        let parentEvent = await this.getFileEvent();
+        do {
+            childEvent = timelineEvents.find(e => e.replacingEventId() === parentEvent.getId());
+            if (childEvent) {
+                const branch = this.directory.getFile(childEvent.getId());
+                if (branch) {
+                    fileHistory.push(branch);
+                    parentEvent = childEvent;
+                } else {
+                    break; // prevent infinite loop
+                }
+            }
+        } while(!!childEvent);
+
+        return fileHistory;
     }
 }

--- a/src/models/MSC3089Branch.ts
+++ b/src/models/MSC3089Branch.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { MatrixClient } from "../client";
-import { EventType, IEncryptedFile, RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event";
+import { IEncryptedFile, RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event";
 import { IContent, MatrixEvent } from "./event";
 import { MSC3089TreeSpace } from "./MSC3089TreeSpace";
 
@@ -211,7 +211,7 @@ export class MSC3089Branch {
                     break; // prevent infinite loop
                 }
             }
-        } while(!!childEvent);
+        } while (childEvent);
 
         return fileHistory;
     }


### PR DESCRIPTION
The diff isn't super clear on how this works, but the general idea is that the MSC3089Branches (files) now know which directory they came from, and the directories (MSC3089TreeSpace) can tell when files are triggering uploads referencing themselves so it can add all the replacement metadata onto the event.

There's a few challenges with how relations work in the js-sdk which has shaped the API surface exposed by this change. Specifically, there is a `getVersionHistory()` function instead of a function to get a certain prior version: the js-sdk doesn't track parent events in the relation structures so cannot determine what the event could have replaced. 

In order to trigger the built-in relations structures, we must trigger decryption with `emit: true`. This is so an internal listener in the relations system can pick up `Event.decrypted`.

***For demo usage of this, please contact me.***

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement file versioning for tree spaces ([\#1952](https://github.com/matrix-org/matrix-js-sdk/pull/1952)).<!-- CHANGELOG_PREVIEW_END -->