### PR TITLE
Self-destructing messages (partial MSC2228)

### DIFF
--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -68,6 +68,9 @@ describe("MegolmDecryption", function() {
             // 'crypto' implementation.
             const event = new MatrixEvent({
                 type: 'm.room.encrypted',
+                content: {
+                    algorithm: 'm.megolm.v1.aes-sha2',
+                },
             });
             const decryptedData = {
                 clearEvent: {

--- a/spec/unit/crypto/backup.spec.js
+++ b/spec/unit/crypto/backup.spec.js
@@ -224,6 +224,9 @@ describe("MegolmBackup", function() {
             // 'crypto' implementation.
             const event = new MatrixEvent({
                 type: 'm.room.encrypted',
+                content: {
+                    algorithm: 'm.megolm.v1.aes-sha2',
+                },
             });
             const decryptedData = {
                 clearEvent: {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -42,6 +42,8 @@ import { emitPromise } from "../test-utils/test-utils";
 import { ReceiptType } from "../../src/@types/read_receipts";
 import { Thread, ThreadEvent } from "../../src/models/thread";
 
+jest.useFakeTimers();
+
 describe("Room", function() {
     const roomId = "!foo:bar";
     const userA = "@alice:bar";
@@ -2429,7 +2431,7 @@ describe("Room", function() {
                     content: {
                         msgtype: "m.text",
                         body: "TOPSECRET",
-                        [UNSTABLE_MSC2228_SELF_DESTRUCT_AFTER.name]: Date.now()+50,
+                        [UNSTABLE_MSC2228_SELF_DESTRUCT_AFTER.name]: Date.now()+10000,
                     },
                 }),
             ]);
@@ -2446,6 +2448,8 @@ describe("Room", function() {
                 expect(client.store.replaceEvent).toBeCalled();
                 done();
             });
+
+            jest.runAllTimers();
         });
     });
 });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2446,7 +2446,7 @@ describe("Room", function() {
             expect(event.isRedacted()).toBeFalsy();
             expect(event.getContent().body).toBe("TOPSECRET");
 
-            // deleted soon
+            // deleted soon after the self destruct time elapses
             room.on(RoomEvent.Redaction, function(redactionEvent, room) {
                 expect(redactionEvent.getType()).toBe("m.room.redaction");
                 expect(event.getContent().body).toBeFalsy();

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2394,7 +2394,7 @@ describe("Room", function() {
                     replaceEvent: jest.fn(() => Promise.resolve()),
                     save: jest.fn(() => Promise.resolve()),
                 },
-                supportsExperimentalThreads: () => false
+                supportsExperimentalThreads: () => false,
             } as any;
             const room = new Room(roomId, client, userA);
             let callCount = 0;
@@ -2426,7 +2426,7 @@ describe("Room", function() {
                     replaceEvent: jest.fn(() => Promise.resolve()),
                     save: jest.fn(() => Promise.resolve()),
                 },
-                supportsExperimentalThreads: () => false
+                supportsExperimentalThreads: () => false,
             } as any;
             const room = new Room(roomId, client, userA);
             room.addLiveEvents([

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -160,6 +160,16 @@ export const UNSTABLE_MSC3089_BRANCH = new UnstableValue("m.branch", "org.matrix
 export const UNSTABLE_MSC2716_MARKER = new UnstableValue("m.room.marker", "org.matrix.msc2716.marker");
 
 /**
+ * Timestamp after which the event should be redacted for self-destruction
+ * [MSC2228](https://github.com/matrix-org/matrix-doc/pull/2228). Note that this reference is
+ * UNSTABLE and subject to breaking changes, including its eventual removal.
+ */
+export const UNSTABLE_MSC2228_SELF_DESTRUCT_AFTER = new UnstableValue(
+    "m.self_destruct_after",
+    "org.matrix.self_destruct_after",
+);
+
+/**
  * Functional members type for declaring a purpose of room members (e.g. helpful bots).
  * Note that this reference is UNSTABLE and subject to breaking changes, including its
  * eventual removal.

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -925,8 +925,10 @@ export class MatrixEvent extends TypedEventEmitter<EmittedEvents, MatrixEventHan
         if (this.event.type !== EventType.RoomMessageEncrypted) return false;
 
         // an encrypted event can never have an empty content, in such a case
-        // it is probably a redacted event and we can treat it as unencrypted
-        // (see MSC2228)
+        // it is probably an event redacted by the current ephemeral message
+        // implementation and we can treat it as unencrypted to avoid decryption
+        // errors being thrown
+        // https://github.com/matrix-org/synapse/pull/6409
         if (!this.event.content || Object.entries(this.event.content).length === 0) {
             return false;
         }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -920,7 +920,18 @@ export class MatrixEvent extends TypedEventEmitter<EmittedEvents, MatrixEventHan
      * @return {boolean} True if this event is encrypted.
      */
     public isEncrypted(): boolean {
-        return !this.isState() && this.event.type === EventType.RoomMessageEncrypted;
+        if (this.isState()) return false;
+
+        if (this.event.type !== EventType.RoomMessageEncrypted) return false;
+
+        // an encrypted event can never have an empty content, in such a case
+        // it is probably a redacted event and we can treat it as unencrypted
+        // (see MSC2228)
+        if (!this.event.content || Object.entries(this.event.content).length === 0) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2003,7 +2003,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
 
         // generate a local redaction event
         const redactionEvent = new MatrixEvent({
-            event_id: '~'+Math.random(), // TODO
+            event_id: '$was-'+event.getId(),
             type: 'm.room.redaction',
             redacts: event.getId(),
             origin_server_ts: event.getWireContent()['org.matrix.self_destruct_after'],

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2024,7 +2024,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
             logger.error(`error while redacting event from store: ${err.message}`);
         });
 
-        this.emit("Room.redaction", redactionEvent, this);
+        this.emit(RoomEvent.Redaction, redactionEvent, this);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1996,7 +1996,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      * @param {module:models/event.MatrixEvent} event The event to destruct
      */
     // eslint-disable-next-line
-    private async unstable_selfDestructEvent(event: MatrixEvent): Promise<void> {
+    private unstable_selfDestructEvent(event: MatrixEvent): Promise<void> {
         // maybe the server has already sent a m.redaction event or
         // it got redacted manually by a client?
         if (event.isRedacted()) return;
@@ -2018,8 +2018,11 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
         event.makeRedacted(redactionEvent);
 
         // redact also stored event
-        await this.client.store.replaceEvent(event);
-        this.client.store.save(true);
+        this.client.store.replaceEvent(event).then(() => {
+            return this.client.store.save(true);
+        }).catch((err) => {
+            logger.error(`error while redacting event from store: ${err.message}`);
+        });
 
         this.emit("Room.redaction", redactionEvent, this);
     }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2013,8 +2013,11 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
         event.markLocallyRedacted(redactionEvent);
         event.makeRedacted(redactionEvent);
 
+        // redact also stored event
+        await this.client.store.replaceEvent(event);
+        this.client.store.save(true);
+
         this.emit("Room.redaction", redactionEvent, this);
-        // TODO: remove from stored sync data
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1923,6 +1923,10 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
         // MSC2228: is a self destruction time defined?
         // https://github.com/matrix-org/matrix-doc/pull/2228)
         if (
+            (
+                event.getType() === EventType.RoomMessage ||
+                event.getType() === EventType.RoomMessageEncrypted
+            ) &&
             event.getWireContent()[UNSTABLE_MSC2228_SELF_DESTRUCT_AFTER.name] &&
             !event.isSending() &&
             !event.isRedacted()
@@ -1934,7 +1938,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                     this.unstable_selfDestructEvent(event);
                 }, remainingTime);
             } else {
-                // time already expired, destruct immediatly
+                // time already expired, redact immediately
                 this.unstable_selfDestructEvent(event);
             }
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -218,4 +218,6 @@ export interface IStore {
     getClientOptions(): Promise<IStartClientOpts>;
 
     storeClientOptions(options: IStartClientOpts): Promise<void>;
+
+    replaceEvent(event: MatrixEvent): Promise<void>;
 }

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -31,6 +31,7 @@ export interface IIndexedDBBackend {
     getUserPresenceEvents(): Promise<UserTuple[]>;
     getClientOptions(): Promise<IStartClientOpts>;
     storeClientOptions(options: IStartClientOpts): Promise<void>;
+    replaceEvent(event: IEvent): Promise<void>;
 }
 
 export type UserTuple = [userId: string, presenceEvent: Partial<IEvent>];

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -18,7 +18,7 @@ import { IMinimalEvent, IRoomEvent, ISyncData, ISyncResponse, SyncAccumulator } 
 import * as utils from "../utils";
 import * as IndexedDBHelpers from "../indexeddb-helpers";
 import { logger } from '../logger';
-import { IStartClientOpts, IStateEventWithRoomId } from "..";
+import { IStartClientOpts, IStateEventWithRoomId, IEvent } from "..";
 import { ISavedSync } from "./index";
 import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
 

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMinimalEvent, ISyncData, ISyncResponse, SyncAccumulator } from "../sync-accumulator";
+import { IMinimalEvent, IRoomEvent, ISyncData, ISyncResponse, SyncAccumulator } from "../sync-accumulator";
 import * as utils from "../utils";
 import * as IndexedDBHelpers from "../indexeddb-helpers";
 import { logger } from '../logger';
@@ -560,5 +560,18 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             options: options,
         }); // put == UPSERT
         await txnAsPromise(txn);
+    }
+
+    /**
+     * Replaces an event
+     * This is currently only used for redacting events from the stored state.
+     * see [MSC2228](https://github.com/matrix-org/matrix-doc/pull/2228)
+     * @param {event} event the new event
+     */
+    public async replaceEvent(event: IEvent): Promise<void> {
+        const minimalEvent: IRoomEvent = Object.assign({}, event);
+        delete minimalEvent['room_id'];
+
+        this.syncAccumulator.replaceEvent(event.room_id, minimalEvent);
     }
 }

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -18,7 +18,7 @@ import { logger } from "../logger";
 import { defer, IDeferred } from "../utils";
 import { ISavedSync } from "./index";
 import { IStartClientOpts } from "../client";
-import { IStateEventWithRoomId, ISyncResponse } from "..";
+import { IStateEventWithRoomId, ISyncResponse, IEvent } from "..";
 import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -126,6 +126,16 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     }
 
     /**
+     * Replaces an event
+     * This is currently only used for redacting events from the stored state.
+     * see [MSC2228](https://github.com/matrix-org/matrix-doc/pull/2228)
+     * @param {event} event the new event
+     */
+    public async replaceEvent(event: IEvent): Promise<void> {
+        return this.doCmd('replaceEvent', [event]);
+    }
+
+    /**
      * Load all user presence events from the database. This is not cached.
      * @return {Promise<Object[]>} A list of presence events in their raw form.
      */

--- a/src/store/indexeddb-store-worker.ts
+++ b/src/store/indexeddb-store-worker.ts
@@ -103,6 +103,9 @@ export class IndexedDBStoreWorker {
             case 'storeClientOptions':
                 prom = this.backend.storeClientOptions(msg.args[0]);
                 break;
+            case 'replaceEvent':
+                prom = this.backend.replaceEvent(msg.args[0]);
+                break;
         }
 
         if (prom === undefined) {

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -278,6 +278,17 @@ export class IndexedDBStore extends MemoryStore {
     }, "storeClientOptions");
 
     /**
+     * Replaces an event
+     * This is currently only used for redacting events from the stored state.
+     * see [MSC2228](https://github.com/matrix-org/matrix-doc/pull/2228)
+     * @param {MatrixEvent} event the new event
+     */
+    public replaceEvent = this.degradable((event: MatrixEvent): Promise<void> => {
+        const e: IEvent = event.isEncrypted() ? (event.toJSON() as any).encrypted : event.toJSON();
+        return this.backend.replaceEvent(e);
+    }, "replaceEvent");
+
+    /**
      * All member functions of `IndexedDBStore` that access the backend use this wrapper to
      * watch for failures after initial store startup, including `QuotaExceededError` as
      * free disk space changes, etc.

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -420,4 +420,10 @@ export class MemoryStore implements IStore {
         this.clientOptions = Object.assign({}, options);
         return Promise.resolve();
     }
+
+    public async replaceEvent(event: MatrixEvent): Promise<void> {
+        throw new Error(`MemoryStore.replaceEvent() is not implemented yet. 
+            Event will stay in memory as it is. Potential redaction did not succeed.`,
+        );
+    }
 }

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -262,4 +262,8 @@ export class StubStore implements IStore {
     public storeClientOptions(options: object): Promise<void> {
         return Promise.resolve();
     }
+
+    public replaceEvent(event: MatrixEvent): Promise<void> {
+        return Promise.resolve();
+    }
 }

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -669,6 +669,23 @@ export class SyncAccumulator {
     public getNextBatchToken(): string {
         return this.nextBatch;
     }
+
+    /**
+     * Replaces an event
+     * This is currently only used for redacting events from the stored state.
+     * see [MSC2228](https://github.com/matrix-org/matrix-doc/pull/2228)
+     * @param roomId the containing room
+     * @param event new event object
+     */
+    public replaceEvent(roomId: string, event: IRoomEvent) {
+        const currentData = this.joinRooms[roomId];
+
+        for (const e of currentData._timeline) {
+            if (e.event.event_id !== event.event_id) continue;
+            e.event = event;
+            return;
+        }
+    }
 }
 
 function setState(eventMap: Record<string, Record<string, IStateEvent>>, event: IRoomEvent | IStateEvent): void {


### PR DESCRIPTION
Signed-off-by: chandi Langecker <git@chandi.it>

implements partially [MSC2228: Self destructing events](https://github.com/matrix-org/matrix-doc/pull/2228), only its `m.self_destruct_after` field because it is already supported by synapse since [Add ephemeral messages support (MSC2228)](https://github.com/matrix-org/synapse/pull/6409). There is currently no server side support of `m.self_destruct`.

## Open obscurities
1. Is creating redaction event which only exists locally the best way to do that?
1. ~~How to redact the event content from the stored sync?~~
1. How should an `event_id` be generated for an event which only exists locally?
1. Can we safely treat an event without any content as unencrypted?

## Reviewing hints
- it requires a synapse server with `enable_ephemeral_messages: yes`
- create an event with an `org.matrix.self_destruct_after` field in the content set to a future timestamp in msecs

## Outlook
<img src="https://user-images.githubusercontent.com/10246027/135180332-042b78dc-aee2-4595-a8c5-a9e747695e45.gif" width="529" />

### ToDo's
- [x] Basic implementation
- [x] Redaction from store
- [x] Tests
- [x] Changelog entry
- [ ] Review




Notes: Self destructing events (partial implementation of MSC2228)
Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Self destructing events (partial implementation of MSC2228) ([\#1957](https://github.com/matrix-org/matrix-js-sdk/pull/1957)). Contributed by @alangecker.<!-- CHANGELOG_PREVIEW_END -->