### PR TITLE
Make sure to set `callLengthInterval` only once

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1572,10 +1572,13 @@ export class MatrixCall extends EventEmitter {
         // chrome doesn't implement any of the 'onstarted' events yet
         if (this.peerConn.iceConnectionState == 'connected') {
             this.setState(CallState.Connected);
-            this.callLengthInterval = setInterval(() => {
-                this.callLength++;
-                this.emit(CallEvent.LengthChanged, this.callLength);
-            }, 1000);
+
+            if (!this.callLengthInterval) {
+                this.callLengthInterval = setInterval(() => {
+                    this.callLength++;
+                    this.emit(CallEvent.LengthChanged, this.callLength);
+                }, 1000);
+            }
         } else if (this.peerConn.iceConnectionState == 'failed') {
             this.hangup(CallErrorCode.IceFailed, false);
         }


### PR DESCRIPTION
Hopefully, fixes https://github.com/vector-im/element-web/issues/19221
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make sure to set `callLengthInterval` only once ([\#1958](https://github.com/matrix-org/matrix-js-sdk/pull/1958)). Fixes vector-im/element-web#19221. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->