### PR TITLE
Fix incorrect return value type in getJoinedRooms()

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -568,6 +568,10 @@ interface IRoomInitialSyncResponse {
     presence: Partial<IEvent>; // legacy and undocumented, api is deprecated so this won't get attention
 }
 
+interface IJoinedRoomsResponse {
+    joined_rooms: string[];
+}
+
 interface IJoinedMembersResponse {
     joined: {
         [userId: string]: {
@@ -6674,7 +6678,7 @@ export class MatrixClient extends EventEmitter {
      * @return {Promise} Resolves: A list of the user's current rooms
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public getJoinedRooms(): Promise<string[]> {
+    public getJoinedRooms(): Promise<IJoinedRoomsResponse> {
         const path = utils.encodeUri("/joined_rooms", {});
         return this.http.authedRequest(undefined, "GET", path);
     }


### PR DESCRIPTION
[`_matrix/client/r0/joined_rooms`](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-joined-rooms) returns an object with a single `joined_rooms` property, which is an array of strings:

```json
{
  "joined_rooms": [
    "!foo:example.com"
  ]
}
```

However, the [`getJoinedRooms()` function](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/client.ts#L6677) returns a promised array of strings:

```
public getJoinedRooms(): Promise<string[]> {
```

This PR changes the return value to `Promise<IJoinedRoomsResponse>`, with `IJoinedRoomsResponse` being:

```typescript
interface IJoinedRoomsResponse {
    joined_rooms: string[];
}
```

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect return value type in getJoinedRooms() ([\#1959](https://github.com/matrix-org/matrix-js-sdk/pull/1959)). Contributed by @psrpinto.<!-- CHANGELOG_PREVIEW_END -->