### PR TITLE
Prevent redactions to be sent as pending events

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -432,11 +432,19 @@ export class MatrixEvent extends EventEmitter {
      * or in the main room timeline
      */
     public get replyInThread(): boolean {
-        const replyTo = this.getWireContent()
-            ?.["m.relates_to"]
-            ?.["m.in_reply_to"];
-        return (this.replyEventId
-            && replyTo[UNSTABLE_ELEMENT_REPLY_IN_THREAD.name])
+        /**
+         * UNSTABLE_ELEMENT_REPLY_IN_THREAD can live either
+         * at the m.relates_to and m.in_reply_to level
+         * This will likely change once we settle on a
+         * way to achieve threads
+         * TODO: Clean this up once we have a clear way forward
+         */
+
+        const relatesTo = this.getWireContent()?.["m.relates_to"];
+        const replyTo = relatesTo?.["m.in_reply_to"];
+
+        return relatesTo?.[UNSTABLE_ELEMENT_REPLY_IN_THREAD.name]
+            || (this.replyEventId && replyTo[UNSTABLE_ELEMENT_REPLY_IN_THREAD.name])
             || this.thread instanceof Thread;
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1298,13 +1298,6 @@ export class Room extends EventEmitter {
      * @experimental
      */
     public addThreadedEvent(event: MatrixEvent): void {
-        if (event.getUnsigned().transaction_id) {
-            const existingEvent = this.txnToEvent[event.getUnsigned().transaction_id];
-            if (existingEvent) {
-                // remote echo of an event we sent earlier
-                this.handleRemoteEcho(event, existingEvent);
-            }
-        }
         let thread = this.findEventById(event.parentEventId)?.getThread();
         if (thread) {
             thread.addEvent(event);
@@ -1332,7 +1325,7 @@ export class Room extends EventEmitter {
             const redactId = event.event.redacts;
 
             // if we know about this event, redact its contents now.
-            const redactedEvent = this.getUnfilteredTimelineSet().findEventById(redactId);
+            const redactedEvent = this.findEventById(redactId);
             if (redactedEvent) {
                 redactedEvent.makeRedacted(event);
 


### PR DESCRIPTION
Mitigates vector-im/element-web#19229

Pending events are currently disabled for threaded messages as we have to rework a lot of things to make them work properly.
It makes for a better user experience that is not required at this stage of development. This will be taken care of before the P0 release.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->