### PR TITLE
Use `ICallFeedOpts` in the `CallFeed` constructor

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -497,7 +497,15 @@ export class MatrixCall extends EventEmitter {
         if (existingFeed) {
             existingFeed.setNewStream(stream);
         } else {
-            this.feeds.push(new CallFeed(stream, userId, purpose, this.client, this.roomId, audioMuted, videoMuted));
+            this.feeds.push(new CallFeed({
+                client: this.client,
+                roomId: this.roomId,
+                userId,
+                stream,
+                purpose,
+                audioMuted,
+                videoMuted,
+            }));
             this.emit(CallEvent.FeedsChanged, this.feeds);
         }
 
@@ -528,7 +536,15 @@ export class MatrixCall extends EventEmitter {
         if (feed) {
             feed.setNewStream(stream);
         } else {
-            this.feeds.push(new CallFeed(stream, userId, purpose, this.client, this.roomId, false, false));
+            this.feeds.push(new CallFeed({
+                client: this.client,
+                roomId: this.roomId,
+                audioMuted: false,
+                videoMuted: false,
+                userId,
+                stream,
+                purpose,
+            }));
             this.emit(CallEvent.FeedsChanged, this.feeds);
         }
 
@@ -543,7 +559,15 @@ export class MatrixCall extends EventEmitter {
         if (existingFeed) {
             existingFeed.setNewStream(stream);
         } else {
-            this.feeds.push(new CallFeed(stream, userId, purpose, this.client, this.roomId, false, false));
+            this.feeds.push(new CallFeed({
+                client: this.client,
+                roomId: this.roomId,
+                audioMuted: false,
+                videoMuted: false,
+                userId,
+                stream,
+                purpose,
+            }));
             this.emit(CallEvent.FeedsChanged, this.feeds);
         }
 

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -22,6 +22,16 @@ import { RoomMember } from "../models/room-member";
 const POLLING_INTERVAL = 250; // ms
 const SPEAKING_THRESHOLD = -60; // dB
 
+export interface ICallFeedOpts {
+    client: MatrixClient;
+    roomId: string;
+    userId: string;
+    stream: MediaStream;
+    purpose: SDPStreamMetadataPurpose;
+    audioMuted: boolean;
+    videoMuted: boolean;
+}
+
 export enum CallFeedEvent {
     NewStream = "new_stream",
     MuteStateChanged = "mute_state_changed",
@@ -30,6 +40,14 @@ export enum CallFeedEvent {
 }
 
 export class CallFeed extends EventEmitter {
+    public stream: MediaStream;
+    public userId: string;
+    public purpose: SDPStreamMetadataPurpose;
+
+    private client: MatrixClient;
+    private roomId: string;
+    private audioMuted: boolean;
+    private videoMuted: boolean;
     private measuringVolumeActivity = false;
     private audioContext: AudioContext;
     private analyser: AnalyserNode;
@@ -38,17 +56,17 @@ export class CallFeed extends EventEmitter {
     private speaking = false;
     private volumeLooperTimeout: number;
 
-    constructor(
-        public stream: MediaStream,
-        public userId: string,
-        public purpose: SDPStreamMetadataPurpose,
-        private client: MatrixClient,
-        private roomId: string,
-        private audioMuted: boolean,
-        private videoMuted: boolean,
-    ) {
+    constructor(opts: ICallFeedOpts) {
         super();
-        this.updateStream(null, stream);
+
+        this.client = opts.client;
+        this.roomId = opts.roomId;
+        this.userId = opts.userId;
+        this.purpose = opts.purpose;
+        this.audioMuted = opts.audioMuted;
+        this.videoMuted = opts.videoMuted;
+
+        this.updateStream(null, opts.stream);
 
         if (this.hasAudioTrack) {
             this.initVolumeMeasuring();


### PR DESCRIPTION
Type: enhancement
Notes: Use `ICallFeedOpts` in the `CallFeed` constructor. To construct a new `CallFeed` object you have to pass `ICallFeedOpts` e.g. `const callFeed = new CallFeed({client: new MatrixClient(...), roomId: "!roomId:example", audioMuted: false, videoMuted: false, userId: "@example:example.org", stream: await navigator.mediaDevices.getUserMedia(), purpose: "m.usermedia"});`

<hr>

This is much more flexible

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Use `ICallFeedOpts` in the `CallFeed` constructor. To construct a new `CallFeed` object you have to pass `ICallFeedOpts` e.g. `const callFeed = new CallFeed({client ([\#1964](https://github.com/matrix-org/matrix-js-sdk/pull/1964)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->