### PR TITLE
Improvements to screen-sharing in group calls

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -621,6 +621,24 @@ export class MatrixCall extends EventEmitter {
         this.emit(CallEvent.FeedsChanged, this.feeds);
     }
 
+    /**
+     * Removes local call feed from the call and its tracks from the peer
+     * connection
+     * @param callFeed to remove
+     */
+    public removeLocalFeed(callFeed: CallFeed): void {
+        const senderArray = callFeed.purpose === SDPStreamMetadataPurpose.Usermedia
+            ? this.usermediaSenders
+            : this.screensharingSenders;
+
+        for (const sender of senderArray) {
+            this.peerConn.removeTrack(sender);
+        }
+        // Empty the array
+        senderArray.splice(0, senderArray.length);
+        this.deleteFeedByStream(callFeed.stream);
+    }
+
     private deleteAllFeeds(): void {
         for (const feed of this.feeds) {
             if (!feed.isLocal() || this.stopLocalMediaOnEnd) {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -143,6 +143,15 @@ export class GroupCall extends EventEmitter {
         this.emit(GroupCallEvent.GroupCallStateChanged, newState, oldState);
     }
 
+    public getLocalFeeds(): CallFeed[] {
+        const feeds = [];
+
+        if (this.localCallFeed) feeds.push(this.localCallFeed);
+        if (this.localScreenshareFeed) feeds.push(this.localScreenshareFeed);
+
+        return feeds;
+    }
+
     public async initLocalCallFeed(): Promise<CallFeed> {
         if (this.state !== GroupCallState.LocalCallFeedUninitialized) {
             throw new Error(`Cannot initialize local call feed in the "${this.state}" state.`);
@@ -440,7 +449,7 @@ export class GroupCall extends EventEmitter {
             this.addCall(newCall);
         }
 
-        newCall.answerWithCallFeeds([this.localCallFeed]);
+        newCall.answerWithCallFeeds(this.getLocalFeeds());
     };
 
     /**
@@ -533,7 +542,7 @@ export class GroupCall extends EventEmitter {
             { invitee: member.userId, useToDevice: true, groupCallId: this.groupCallId },
         );
 
-        newCall.placeCallWithCallFeeds([this.localCallFeed]);
+        newCall.placeCallWithCallFeeds(this.getLocalFeeds());
 
         if (this.dataChannelsEnabled) {
             newCall.createDataChannel("datachannel", this.dataChannelOptions);

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -361,7 +361,8 @@ export class GroupCall extends EventEmitter {
 
                 logger.log("Screensharing permissions granted. Setting screensharing enabled on all calls");
 
-                const callFeed = new CallFeed(
+                this.localDesktopCapturerSourceId = desktopCapturerSourceId;
+                this.localScreenshareFeed = new CallFeed(
                     stream,
                     this.client.getUserId(),
                     SDPStreamMetadataPurpose.Screenshare,
@@ -370,10 +371,7 @@ export class GroupCall extends EventEmitter {
                     false,
                     false,
                 );
-
-                this.localScreenshareFeed = callFeed;
-                this.localDesktopCapturerSourceId = desktopCapturerSourceId;
-                this.addScreenshareFeed(callFeed);
+                this.addScreenshareFeed(this.localScreenshareFeed);
 
                 this.emit(
                     GroupCallEvent.LocalScreenshareStateChanged,
@@ -383,7 +381,7 @@ export class GroupCall extends EventEmitter {
                 );
 
                 // TODO: handle errors
-                await Promise.all(this.calls.map(call => call.setScreensharingEnabled(true, desktopCapturerSourceId)));
+                await Promise.all(this.calls.map(call => call.pushLocalFeed(this.localScreenshareFeed)));
 
                 logger.log("screensharing enabled on all calls");
 
@@ -396,7 +394,7 @@ export class GroupCall extends EventEmitter {
                 return false;
             }
         } else {
-            await Promise.all(this.calls.map(call => call.setScreensharingEnabled(false, desktopCapturerSourceId)));
+            await Promise.all(this.calls.map(call => call.removeLocalFeed(this.localScreenshareFeed)));
             this.client.getMediaHandler().stopScreensharingStream(this.localScreenshareFeed.stream);
             this.removeScreenshareFeed(this.localScreenshareFeed);
             this.localScreenshareFeed = undefined;


### PR DESCRIPTION
+ Avoid creating a call feed in each call and instead creates one for the whole group call
+ Adds handling for joining call where someone is already screen-sharing

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->