### PR TITLE
Enable TypeScript declaration maps

### DIFF
--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declarationMap": true,
     "sourceMap": true,
     "noEmit": false,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
This allows go-to-definition to reach the original .ts files for consumers of the package. It emits .d.ts.map files alongside the regular .d.ts files

e.g. in sdk.createClient go-to-definition on createClient will place the cursor at the function in src/matrix.ts rather than inside a definition file lib/matrix.d.ts

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Enable TypeScript declaration maps ([\#1966](https://github.com/matrix-org/matrix-js-sdk/pull/1966)). Contributed by @Alexendoo.<!-- CHANGELOG_PREVIEW_END -->