### PR TITLE
Fix re-emitter memory leak

### DIFF
--- a/src/ReEmitter.ts
+++ b/src/ReEmitter.ts
@@ -44,7 +44,7 @@ export class ReEmitter {
                 if (eventName === 'error' && this.target.listenerCount('error') === 0) return;
                 this.target.emit(eventName, ...args, source);
             };
-            source.on(eventName, forSource);
+            source.once(eventName, forSource);
         }
     }
 }


### PR DESCRIPTION
Seems that in `ReEmitter.ts` we have been listening to things, but never un-listening after re-emitting events, which made circular events listeners in threads. 
It doesn't seem like an expected behavior.

@dbkr can you double-check that we should've un-listened to the events after emitting them again, or was this behavior correct and threads are using it wrong?

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->