### PR TITLE
More detailed logging when sharing room keys 

### DIFF
--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -348,7 +348,7 @@ class MegolmEncryption extends EncryptionAlgorithm {
                 (async () => {
                     logger.debug(
                         `Sharing keys (start phase 1) with new Olm sessions in ${this.roomId}`,
-                        devicesWithoutSession
+                        devicesWithoutSession,
                     );
                     const errorDevices = [];
 


### PR DESCRIPTION
These are just some improvements to logging when sharing room keys and comment/variable naming fixes. I did these while I was debugging a UISI bug but then forgot to share.

Signed-off-by: Denis Kasak <dkasak@termina.org.uk>

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->