### PR TITLE
Change Media Devices Mid-call

### DIFF
--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -94,6 +94,12 @@ class MockMediaStream {
     addEventListener() {}
 }
 
+class MockMediaDeviceInfo {
+    constructor(
+        public kind: "audio" | "video",
+    ) {}
+}
+
 describe('Call', function() {
     let client;
     let call;
@@ -110,6 +116,8 @@ describe('Call', function() {
             mediaDevices: {
                 // @ts-ignore Mock
                 getUserMedia: () => new MockMediaStream("local_stream"),
+                // @ts-ignore Mock
+                enumerateDevices: async () => [new MockMediaDeviceInfo("audio"), new MockMediaDeviceInfo("video")],
             },
         };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -743,7 +743,7 @@ export class MatrixClient extends EventEmitter {
     protected checkTurnServersIntervalID: number;
     protected exportedOlmDeviceToImport: IOlmDevice;
     protected txnCtr = 0;
-    protected mediaHandler = new MediaHandler();
+    protected mediaHandler = new MediaHandler(this);
 
     constructor(opts: IMatrixClientCreateOpts) {
         super();

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -768,6 +768,7 @@ export class MatrixCall extends EventEmitter {
             } catch (e) {
                 if (answerWithVideo) {
                     // Try to answer without video
+                    logger.warn("Failed to getUserMedia(), trying to getUserMedia() without video");
                     this.setState(prevState);
                     this.waitForLocalAVStream = false;
                     await this.answer(answerWithAudio, false);

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -562,8 +562,8 @@ export class MatrixCall extends EventEmitter {
             this.feeds.push(new CallFeed({
                 client: this.client,
                 roomId: this.roomId,
-                audioMuted: false,
-                videoMuted: false,
+                audioMuted: stream.getAudioTracks().length === 0,
+                videoMuted: stream.getVideoTracks().length === 0,
                 userId,
                 stream,
                 purpose,
@@ -993,6 +993,10 @@ export class MatrixCall extends EventEmitter {
      * @returns the new mute state
      */
     public async setLocalVideoMuted(muted: boolean): Promise<boolean> {
+        if (!await this.client.getMediaHandler().hasVideoDevice()) {
+            return this.isLocalVideoMuted();
+        }
+
         if (!this.hasLocalUserMediaVideoTrack && !muted) {
             await this.upgradeCall(false, true);
             return this.isLocalVideoMuted();
@@ -1021,6 +1025,10 @@ export class MatrixCall extends EventEmitter {
      * @returns the new mute state
      */
     public async setMicrophoneMuted(muted: boolean): Promise<boolean> {
+        if (!await this.client.getMediaHandler().hasAudioDevice()) {
+            return this.isMicrophoneMuted();
+        }
+
         if (!this.hasLocalUserMediaAudioTrack && !muted) {
             await this.upgradeCall(true, false);
             return this.isMicrophoneMuted();

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -999,6 +999,23 @@ export class MatrixCall extends EventEmitter {
     }
 
     /**
+     * Request a new local usermedia stream with the current device id.
+     */
+    public async updateLocalUsermediaStream() {
+        const oldStream = this.localUsermediaStream;
+
+        const stream = await this.client.getMediaHandler().getUserMediaStream(
+            this.hasLocalUserMediaAudioTrack,
+            this.hasLocalUserMediaVideoTrack,
+            true,
+        );
+
+        this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Usermedia, true);
+
+        this.client.getMediaHandler().stopUserMediaStream(oldStream);
+    }
+
+    /**
      * Set whether our outbound video should be muted or not.
      * @param {boolean} muted True to mute the outbound video.
      * @returns the new mute state

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -43,23 +43,42 @@ export class MediaHandler {
         this.videoInput = deviceId;
     }
 
+    public async hasAudioDevice() {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        return devices.filter(device => device.kind === "audioinput").length > 0;
+    }
+
+    public async hasVideoDevice() {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        return devices.filter(device => device.kind === "videoinput").length > 0;
+    }
+
     /**
      * @returns {MediaStream} based on passed parameters
      */
     public async getUserMediaStream(audio: boolean, video: boolean): Promise<MediaStream> {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+
+        const audioDevices = devices.filter(device => device.kind === "audioinput");
+        const videoDevices = devices.filter(device => device.kind === "videoinput");
+
+        const shouldRequestAudio = audio && audioDevices.length > 0;
+        const shouldRequestVideo = video && videoDevices.length > 0;
+
         let stream: MediaStream;
 
         // Find a stream with matching tracks
         const matchingStream = this.userMediaStreams.find((stream) => {
-            if (audio !== (stream.getAudioTracks().length > 0)) return false;
-            if (video !== (stream.getVideoTracks().length > 0)) return false;
+            if (shouldRequestAudio !== (stream.getAudioTracks().length > 0)) return false;
+            if (shouldRequestVideo !== (stream.getVideoTracks().length > 0)) return false;
+            return true;
         });
 
         if (matchingStream) {
             logger.log("Cloning user media stream", matchingStream.id);
             stream = matchingStream.clone();
         } else {
-            const constraints = this.getUserMediaContraints(audio, video);
+            const constraints = this.getUserMediaContraints(shouldRequestAudio, shouldRequestVideo);
             logger.log("Getting user media with constraints", constraints);
             stream = await navigator.mediaDevices.getUserMedia(constraints);
         }

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -43,12 +43,12 @@ export class MediaHandler {
         this.videoInput = deviceId;
     }
 
-    public async hasAudioDevice() {
+    public async hasAudioDevice(): Promise<boolean> {
         const devices = await navigator.mediaDevices.enumerateDevices();
         return devices.filter(device => device.kind === "audioinput").length > 0;
     }
 
-    public async hasVideoDevice() {
+    public async hasVideoDevice(): Promise<boolean> {
         const devices = await navigator.mediaDevices.enumerateDevices();
         return devices.filter(device => device.kind === "videoinput").length > 0;
     }
@@ -57,13 +57,8 @@ export class MediaHandler {
      * @returns {MediaStream} based on passed parameters
      */
     public async getUserMediaStream(audio: boolean, video: boolean): Promise<MediaStream> {
-        const devices = await navigator.mediaDevices.enumerateDevices();
-
-        const audioDevices = devices.filter(device => device.kind === "audioinput");
-        const videoDevices = devices.filter(device => device.kind === "videoinput");
-
-        const shouldRequestAudio = audio && audioDevices.length > 0;
-        const shouldRequestVideo = video && videoDevices.length > 0;
+        const shouldRequestAudio = audio && await this.hasAudioDevice();
+        const shouldRequestVideo = video && await this.hasVideoDevice();
 
         let stream: MediaStream;
 


### PR DESCRIPTION
This PR adds the ability to change media devices mid-call using the `mediaHandler.setAudioDevice` and `.setVideoDevice` methods. Calls will automatically be renegotiated for the new media. Note that this implementation attempts to use [sender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack) which avoids renegotiation. In the case where we cannot replace the existing track, it adds a new track and renegotiates the connection.

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/1972

Notes:
`MediaHandler.setAudioDevice` and `.setVideoDevice` now return a promise which can be awaited to determine if setting the new device was successful.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Change Media Devices Mid-call ([\#1977](https://github.com/matrix-org/matrix-js-sdk/pull/1977)). Contributed by @robertlong.<!-- CHANGELOG_PREVIEW_END -->