### PR TITLE
Use stable prefixes for MSC2285

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3907,7 +3907,7 @@ export class MatrixClient extends EventEmitter {
         }
 
         const addlContent = {
-            "org.matrix.msc2285.hidden": Boolean(opts.hidden),
+            "m.hidden": Boolean(opts.hidden),
         };
 
         return this.sendReceipt(event, "m.read", addlContent, callback);
@@ -6674,7 +6674,7 @@ export class MatrixClient extends EventEmitter {
         const content = {
             "m.fully_read": rmEventId,
             "m.read": rrEventId,
-            "org.matrix.msc2285.hidden": Boolean(opts ? opts.hidden : false),
+            "m.hidden": Boolean(opts ? opts.hidden : false),
         };
 
         return this.http.authedRequest(undefined, "POST", path, undefined, content);


### PR DESCRIPTION
Type: enhancement
Requires https://github.com/matrix-org/synapse/pull/11073

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use stable prefixes for MSC2285 ([\#1978](https://github.com/matrix-org/matrix-js-sdk/pull/1978)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->