### PR TITLE
Null-guard for thread root event not loaded yet

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1710,7 +1710,6 @@ export class Room extends EventEmitter {
             this.addLiveEvent(events[i], duplicateStrategy, fromCache);
             const thread = this.threads.get(events[i].getId());
             if (thread && !thread.ready) {
-                console.error("Thread: adding root event", events[i].getId());
                 thread.addEvent(events[i], true);
             }
         }


### PR DESCRIPTION
Fixes an issue where the code would have an NPE if the root event was not loaded yet

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->