### PR TITLE
Strip direction override characters from display names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -387,6 +387,18 @@ export function removeHiddenChars(str: string): string {
     return "";
 }
 
+/**
+ * Removes the direction override characters from a string
+ * @param {string} input
+ * @returns string with chars removed
+ */
+export function removeDirectionOverrideChars(str: string): string {
+    if (typeof str === "string") {
+        return str.replace(/[\u202d-\u202e]/g, '');
+    }
+    return "";
+}
+
 export function normalize(str: string): string {
     // Note: we have to match the filter with the removeHiddenChars() because the
     // function strips spaces and other characters (M becomes RN for example, in lowercase).


### PR DESCRIPTION
Strip RLO and LRO characters from name and rawDisplayName so they
can safely be embedded into other text without messing up the text
ordering.

Fixes https://github.com/vector-im/element-web/issues/1712

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Strip direction override characters from display names ([\#1992](https://github.com/matrix-org/matrix-js-sdk/pull/1992)). Fixes vector-im/element-web#1712.<!-- CHANGELOG_PREVIEW_END -->