### PR TITLE
Mark old verification methods as deprecated

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1755,6 +1755,7 @@ export class MatrixClient extends EventEmitter {
      * @param {string} deviceId the device to verify
      *
      * @returns {Verification} a verification object
+     * @deprecated Use `requestVerification` instead.
      */
     public beginKeyVerification(method: string, userId: string, deviceId: string): Verification {
         if (!this.crypto) {
@@ -1917,6 +1918,7 @@ export class MatrixClient extends EventEmitter {
         return this.crypto.checkCrossSigningPrivateKey(privateKey, expectedPublicKey);
     }
 
+    // deprecated: use requestVerification instead
     public legacyDeviceVerification(
         userId: string,
         deviceId: string,


### PR DESCRIPTION
The old verification methods start a verification by sending an `m.key.verification.start` message, rather than an `m.key.verification.request` message.  This behaviour is deprecated in the spec (https://github.com/matrix-org/matrix-doc/pull/3122), so these functions should be deprecated too.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Mark old verification methods as deprecated ([\#1994](https://github.com/matrix-org/matrix-js-sdk/pull/1994)).<!-- CHANGELOG_PREVIEW_END -->