### PR TITLE
Correct TypeScript signature of client.sendCompleteEvent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3413,15 +3413,12 @@ export class MatrixClient extends EventEmitter {
     private sendCompleteEvent(
         roomId: string,
         eventObject: any,
-        txnIdOrCallback?: string|Callback,
+        txnId?: string,
         callback?: Callback,
     ): Promise<ISendEventResponse> {
-        let txnId?: string;
-        if (utils.isFunction(txnIdOrCallback)) {
-            callback = txnIdOrCallback; // convert for legacy
+        if (utils.isFunction(txnId)) {
+            callback = txnId as any as Callback; // convert for legacy
             txnId = undefined;
-        } else {
-            txnId = txnIdOrCallback;
         }
 
         if (!txnId) {


### PR DESCRIPTION
* `txnId` is optional and should be marked as such.
* (For legacy reasons?), the function supports omitting the `txnId` parameter. This is not represented in the TypeScript signature.
  * If you want to mark this pattern as deprecated, use JSDoc syntax to add a `@deprecated` warning over a specific TypeScript signature of that function.


<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->