### PR TITLE
Add support for stopping and resuming sync loop from client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1321,6 +1321,17 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
+     * Main entry point for starting sync.
+     */
+    public startSync(): void {
+        if (this.syncApi == null) {
+            logger.error("Calling sync() while no sync object, this should not happen, cannot start.");
+            return;
+        }
+        this.syncApi.sync();
+    }
+
+    /**
      * Stops the sync object from syncing.
      */
     public stopSync(): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1321,6 +1321,29 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
+     * Stops the sync object from syncing.
+     */
+    public stopSync(): void {
+        if (this.syncApi == null) {
+            logger.error("Calling stopSync() while no sync object, this should not happen, nothing to stop.");
+            return;
+        }
+        this.syncApi.stop();
+    }
+
+    /**
+     * Resumes syncing from where it stopped when stopSync() was called.
+     * This method is only intended to be used following a call to stopSync().
+     */
+    public resumeSync(): void {
+        if (this.syncApi == null) {
+            logger.error("Calling resumeSync() while no sync object, this should not happen, nothing to resume.");
+            return;
+        }
+        this.syncApi.resume();
+    }
+
+    /**
      * Whether the initial sync has completed.
      * @return {boolean} True if at least one sync has happened.
      */

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -734,7 +734,7 @@ export class SyncApi {
     }
 
     /**
-     * Resumes syncing from where it stopped when stop() was called.
+     * Resumes syncing from the store sync token.
      * This method is only intended to be used following a call to stop().
      */
     public resume(): void {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -740,6 +740,11 @@ export class SyncApi {
     public resume(): void {
         debuglog("SyncApi.resume");
 
+        if (this.running === true) {
+            logger.error("Calling resume() while sync is already running, this should not happen.");
+            return;
+        }
+
         this.running = true;
 
         if (global.window && global.window.addEventListener) {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/1996

It is currently not possible for consumers of the client to pause the sync loop and resume it a bit later from where it was stopped. This PR exposes methods on the client to pause and resume the sync loop.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Add support for stopping and resuming sync loop from client.
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add support for stopping and resuming sync loop from client. ([\#1999](https://github.com/matrix-org/matrix-js-sdk/pull/1999)). Fixes #1996. Contributed by @arthurthouzeau.<!-- CHANGELOG_PREVIEW_END -->