### PR TITLE
Introduce an encryptAndSendToDevices method

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The SDK supports end-to-end encryption via the Olm and Megolm protocols, using
 [libolm](https://gitlab.matrix.org/matrix-org/olm). It is left up to the
 application to make libolm available, via the ``Olm`` global.
 
-It is also necessary to call ``matrixClient.initCrypto()`` after creating a new
+It is also necessary to call ``await matrixClient.initCrypto()`` after creating a new
 ``MatrixClient`` (but **before** calling ``matrixClient.startClient()``) to
 initialise the crypto layer.
 

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -321,6 +321,12 @@ describe("MegolmDecryption", function() {
                         rotation_period_ms: 9999999999999,
                     },
                 });
+
+                // Fix the mock to call the stuff we need it to
+                mockCrypto.encryptAndSendToDevices = Crypto.prototype.encryptAndSendToDevices;
+                mockCrypto.olmDevice = olmDevice;
+                mockCrypto.baseApis = mockBaseApis;
+
                 mockRoom = {
                     getEncryptionTargetMembers: jest.fn().mockReturnValue(
                         [{ userId: "@alice:home.server" }],

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -584,13 +584,10 @@ class MegolmEncryption extends EncryptionAlgorithm {
         userDeviceMap: IOlmDevice[],
         payload: IPayload,
     ): Promise<void> {
-        const p = this.crypto.encryptAndSendToDevices(
+        return this.crypto.encryptAndSendToDevices(
             userDeviceMap,
             payload,
-        );
-        if (!p) return;
-        return p.then((result) => {
-            if (!result) return;
+        ).then((result) => {
             const { contentMap, deviceInfoByDeviceId } = result;
             // store that we successfully uploaded the keys of the current slice
             for (const userId of Object.keys(contentMap)) {
@@ -603,6 +600,9 @@ class MegolmEncryption extends EncryptionAlgorithm {
                     );
                 }
             }
+        }).catch((error) => {
+            console.error("failed to encryptAndSendToDevices", error);
+            throw error;
         });
     }
 

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -586,9 +586,9 @@ class MegolmEncryption extends EncryptionAlgorithm {
     ): Promise<void> {
         return this.crypto.encryptAndSendToDevices(
             userDeviceMap,
-            payload
+            payload,
         ).then((result) => {
-            const {contentMap, deviceInfoByDeviceId} = result;
+            const { contentMap, deviceInfoByDeviceId } = result;
             // store that we successfully uploaded the keys of the current slice
             for (const userId of Object.keys(contentMap)) {
                 for (const deviceId of Object.keys(contentMap[userId])) {

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -584,10 +584,13 @@ class MegolmEncryption extends EncryptionAlgorithm {
         userDeviceMap: IOlmDevice[],
         payload: IPayload,
     ): Promise<void> {
-        return this.crypto.encryptAndSendToDevices(
+        const p = this.crypto.encryptAndSendToDevices(
             userDeviceMap,
             payload,
-        ).then((result) => {
+        );
+        if (!p) return;
+        return p.then((result) => {
+            if (!result) return;
             const { contentMap, deviceInfoByDeviceId } = result;
             // store that we successfully uploaded the keys of the current slice
             for (const userId of Object.keys(contentMap)) {

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -601,7 +601,7 @@ class MegolmEncryption extends EncryptionAlgorithm {
                 }
             }
         }).catch((error) => {
-            console.error("failed to encryptAndSendToDevices", error);
+            logger.error("failed to encryptAndSendToDevices", error);
             throw error;
         });
     }

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -584,22 +584,23 @@ class MegolmEncryption extends EncryptionAlgorithm {
         userDeviceMap: IOlmDevice[],
         payload: IPayload,
     ): Promise<void> {
-        this.crypto.encryptAndSendToDevices(
+        return this.crypto.encryptAndSendToDevices(
             userDeviceMap,
-            payload
-        ).then(() => {
-            // store that we successfully uploaded the keys of the current slice
-            for (const userId of Object.keys(contentMap)) {
-                for (const deviceId of Object.keys(contentMap[userId])) {
-                    session.markSharedWithDevice(
-                        userId,
-                        deviceId,
-                        deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
-                        chainIndex,
-                    );
+            payload,
+            (contentMap, deviceInfoByDeviceId) => {
+                // store that we successfully uploaded the keys of the current slice
+                for (const userId of Object.keys(contentMap)) {
+                    for (const deviceId of Object.keys(contentMap[userId])) {
+                        session.markSharedWithDevice(
+                            userId,
+                            deviceId,
+                            deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
+                            chainIndex,
+                        );
+                    }
                 }
             }
-        });
+        );
     }
 
     /**

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -586,21 +586,21 @@ class MegolmEncryption extends EncryptionAlgorithm {
     ): Promise<void> {
         return this.crypto.encryptAndSendToDevices(
             userDeviceMap,
-            payload,
-            (contentMap, deviceInfoByDeviceId) => {
-                // store that we successfully uploaded the keys of the current slice
-                for (const userId of Object.keys(contentMap)) {
-                    for (const deviceId of Object.keys(contentMap[userId])) {
-                        session.markSharedWithDevice(
-                            userId,
-                            deviceId,
-                            deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
-                            chainIndex,
-                        );
-                    }
+            payload
+        ).then((result) => {
+            const {contentMap, deviceInfoByDeviceId} = result;
+            // store that we successfully uploaded the keys of the current slice
+            for (const userId of Object.keys(contentMap)) {
+                for (const deviceId of Object.keys(contentMap[userId])) {
+                    session.markSharedWithDevice(
+                        userId,
+                        deviceId,
+                        deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
+                        chainIndex,
+                    );
                 }
             }
-        );
+        });
     }
 
     /**
@@ -1496,6 +1496,9 @@ class MegolmDecryption extends DecryptionAlgorithm {
                     return;
                 }
             }
+
+            // XXX: switch this to use encryptAndSendToDevices() rather than duplicating it?
+
             await olmlib.ensureOlmSessionsForDevices(
                 this.olmDevice, this.baseApis, { [sender]: [device] }, false,
             );
@@ -1552,6 +1555,8 @@ class MegolmDecryption extends DecryptionAlgorithm {
         const deviceId = keyRequest.deviceId;
         const deviceInfo = this.crypto.getStoredDevice(userId, deviceId);
         const body = keyRequest.requestBody;
+
+        // XXX: switch this to use encryptAndSendToDevices()?
 
         this.olmlib.ensureOlmSessionsForDevices(
             this.olmDevice, this.baseApis, {
@@ -1734,6 +1739,8 @@ class MegolmDecryption extends DecryptionAlgorithm {
         logger.log("shared-history sessions", sharedHistorySessions);
         for (const [senderKey, sessionId] of sharedHistorySessions) {
             const payload = await this.buildKeyForwardingMessage(this.roomId, senderKey, sessionId);
+
+            // FIXME: use encryptAndSendToDevices() rather than duplicating it here.
 
             const promises = [];
             const contentMap = {};

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -584,81 +584,21 @@ class MegolmEncryption extends EncryptionAlgorithm {
         userDeviceMap: IOlmDevice[],
         payload: IPayload,
     ): Promise<void> {
-        const contentMap = {};
-        const deviceInfoByDeviceId = new Map<string, DeviceInfo>();
-
-        const promises = [];
-        for (let i = 0; i < userDeviceMap.length; i++) {
-            const encryptedContent = {
-                algorithm: olmlib.OLM_ALGORITHM,
-                sender_key: this.olmDevice.deviceCurve25519Key,
-                ciphertext: {},
-            };
-            const val = userDeviceMap[i];
-            const userId = val.userId;
-            const deviceInfo = val.deviceInfo;
-            const deviceId = deviceInfo.deviceId;
-            deviceInfoByDeviceId.set(deviceId, deviceInfo);
-
-            if (!contentMap[userId]) {
-                contentMap[userId] = {};
-            }
-            contentMap[userId][deviceId] = encryptedContent;
-
-            promises.push(
-                olmlib.encryptMessageForDevice(
-                    encryptedContent.ciphertext,
-                    this.userId,
-                    this.deviceId,
-                    this.olmDevice,
-                    userId,
-                    deviceInfo,
-                    payload,
-                ),
-            );
-        }
-
-        return Promise.all(promises).then(() => {
-            // prune out any devices that encryptMessageForDevice could not encrypt for,
-            // in which case it will have just not added anything to the ciphertext object.
-            // There's no point sending messages to devices if we couldn't encrypt to them,
-            // since that's effectively a blank message.
+        this.crypto.encryptAndSendToDevices(
+            userDeviceMap,
+            payload
+        ).then(() => {
+            // store that we successfully uploaded the keys of the current slice
             for (const userId of Object.keys(contentMap)) {
                 for (const deviceId of Object.keys(contentMap[userId])) {
-                    if (Object.keys(contentMap[userId][deviceId].ciphertext).length === 0) {
-                        logger.log(
-                            "No ciphertext for device " +
-                            userId + ":" + deviceId + ": pruning",
-                        );
-                        delete contentMap[userId][deviceId];
-                    }
-                }
-                // No devices left for that user? Strip that too.
-                if (Object.keys(contentMap[userId]).length === 0) {
-                    logger.log("Pruned all devices for user " + userId);
-                    delete contentMap[userId];
+                    session.markSharedWithDevice(
+                        userId,
+                        deviceId,
+                        deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
+                        chainIndex,
+                    );
                 }
             }
-
-            // Is there anything left?
-            if (Object.keys(contentMap).length === 0) {
-                logger.log("No users left to send to: aborting");
-                return;
-            }
-
-            return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(() => {
-                // store that we successfully uploaded the keys of the current slice
-                for (const userId of Object.keys(contentMap)) {
-                    for (const deviceId of Object.keys(contentMap[userId])) {
-                        session.markSharedWithDevice(
-                            userId,
-                            deviceId,
-                            deviceInfoByDeviceId.get(deviceId).getIdentityKey(),
-                            chainIndex,
-                        );
-                    }
-                }
-            });
         });
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3079,16 +3079,17 @@ export class Crypto extends EventEmitter {
                     this.olmDevice,
                     this.baseApis,
                     devicesByUser,
-                ),
-                olmlib.encryptMessageForDevice(
-                    encryptedContent.ciphertext,
-                    this.userId,
-                    this.deviceId,
-                    this.olmDevice,
-                    userId,
-                    deviceInfo,
-                    payload,
-                ),
+                ).then(()=>
+                    olmlib.encryptMessageForDevice(
+                        encryptedContent.ciphertext,
+                        this.userId,
+                        this.deviceId,
+                        this.olmDevice,
+                        userId,
+                        deviceInfo,
+                        payload,
+                    )
+                )
             );
         }
 
@@ -3122,7 +3123,13 @@ export class Crypto extends EventEmitter {
 
             return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
                 (response)=>({ contentMap, deviceInfoByDeviceId }),
-            );
+            ).catch(error=>{
+                console.error("sendToDevice failed", error);
+                throw error;
+            });
+        }).catch(error=>{
+            console.error("encryptAndSendToDevices promises failed", error);
+            throw error;
         });
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3088,8 +3088,8 @@ export class Crypto extends EventEmitter {
                         userId,
                         deviceInfo,
                         payload,
-                    )
-                )
+                    ),
+                ),
             );
         }
 
@@ -3124,11 +3124,11 @@ export class Crypto extends EventEmitter {
             return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
                 (response)=>({ contentMap, deviceInfoByDeviceId }),
             ).catch(error=>{
-                console.error("sendToDevice failed", error);
+                logger.error("sendToDevice failed", error);
                 throw error;
             });
         }).catch(error=>{
-            console.error("encryptAndSendToDevices promises failed", error);
+            logger.error("encryptAndSendToDevices promises failed", error);
             throw error;
         });
     }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3046,7 +3046,7 @@ export class Crypto extends EventEmitter {
      *     userDeviceMap, and returns the { contentMap, deviceInfoByDeviceId }
      *     of the successfully sent messages.
      */
-    encryptAndSendToDevices(
+    public encryptAndSendToDevices(
         userDeviceMap: IOlmDevice<DeviceInfo>[],
         payload: object,
     ): Promise<{contentMap, deviceInfoByDeviceId}> {
@@ -3121,7 +3121,7 @@ export class Crypto extends EventEmitter {
             }
 
             return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
-                (response)=>({ contentMap, deviceInfoByDeviceId })
+                (response)=>({ contentMap, deviceInfoByDeviceId }),
             );
         });
     }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3033,7 +3033,7 @@ export class Crypto extends EventEmitter {
     /**
      * @private
      * Encrypts and sends a given object via Olm to-device message to a given
-     * set of devices.  Heavily derived from encryptAndSendKeysToDevices in
+     * set of devices.  Factored out from encryptAndSendKeysToDevices in
      * megolm.ts.
      *
      * @param {object<userId, deviceInfo>} userDeviceMap


### PR DESCRIPTION
Factor out `encryptAndSendToDevices` from `megolm.ts`'s `encryptAndSendKeysToDevices()` so it can be used for sending other encrypted payloads (e.g. VoIP signalling).

This PR contains cherry picked commits from https://github.com/matrix-org/matrix-js-sdk/pull/1987 and based it off of the develop branch instead.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Introduce an encryptAndSendToDevices method ([\#2002](https://github.com/matrix-org/matrix-js-sdk/pull/2002)). Contributed by @robertlong.<!-- CHANGELOG_PREVIEW_END -->