### PR TITLE
Try to set a sender on search result events if possible

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5422,6 +5422,14 @@ export class MatrixClient extends EventEmitter {
         const resultsLength = roomEvents.results ? roomEvents.results.length : 0;
         for (let i = 0; i < resultsLength; i++) {
             const sr = SearchResult.fromJson(roomEvents.results[i], this.getEventMapper());
+            const room = this.getRoom(sr.context.getEvent().getRoomId());
+            if (room) {
+                // Copy over a known event sender if we can
+                for (const ev of sr.context.getTimeline()) {
+                    const sender = room.getMember(ev.getSender());
+                    if (!ev.sender && sender) ev.sender = sender;
+                }
+            }
             searchResults.results.push(sr);
         }
         return searchResults;


### PR DESCRIPTION
This is to ensure that search results have aesthetic information such as display name and avatar. Though the membership event won't be in context for when the event was sent, it'll at least be something better than a bare user ID.

----

Links:
* https://element-io.atlassian.net/browse/PSFD-455

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Try to set a sender on search result events if possible ([\#2004](https://github.com/matrix-org/matrix-js-sdk/pull/2004)).<!-- CHANGELOG_PREVIEW_END -->