### PR TITLE
Don't show `Unable to access microphone` when cancelling screensharing dialog

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -934,9 +934,7 @@ export class MatrixCall extends EventEmitter {
                 this.pushLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare);
                 return true;
             } catch (err) {
-                this.emit(CallEvent.Error,
-                    new CallError(CallErrorCode.NoUserMedia, "Failed to get screen-sharing stream: ", err),
-                );
+                logger.error("Failed to get screen-sharing stream:", err);
                 return false;
             }
         } else {
@@ -977,9 +975,7 @@ export class MatrixCall extends EventEmitter {
 
                 return true;
             } catch (err) {
-                this.emit(CallEvent.Error,
-                    new CallError(CallErrorCode.NoUserMedia, "Failed to get screen-sharing stream: ", err),
-                );
+                logger.error("Failed to get screen-sharing stream:", err);
                 return false;
             }
         } else {


### PR DESCRIPTION
Type: defect
Fixes https://github.com/vector-im/element-web/issues/19533

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't show `Unable to access microphone` when cancelling screensharing dialog ([\#2005](https://github.com/matrix-org/matrix-js-sdk/pull/2005)). Fixes vector-im/element-web#19533. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->