### PR TITLE
End authentication attempt immediately if we couldn't find an appropriate flow

### DIFF
--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -449,6 +449,7 @@ export class InteractiveAuth {
             } catch (e) {
                 this.attemptAuthDeferred.reject(e);
                 this.attemptAuthDeferred = null;
+                return;
             }
 
             if (


### PR DESCRIPTION
If `InteractiveAuth.doRequest()` fails to obtain an appropriate authentication flow, it should return immediately after rejecting the promise.  If it continues, it'll attempt to check `chosenFlow.stages`, which will cause an error because `chosenFlow` is `null`.  This was breaking the interactive auth spec tests with Node 16.

Notes: none
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
