### PR TITLE
Make events pagination responses parse threads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4578,7 +4578,12 @@ export class MatrixClient extends EventEmitter {
                     const stateEvents = res.state.map(this.getEventMapper());
                     room.currentState.setUnknownStateEvents(stateEvents);
                 }
-                room.addEventsToTimeline(matrixEvents, true, room.getLiveTimeline());
+
+                const [timelineEvents, threadedEvents] = this.partitionThreadedEvents(matrixEvents);
+
+                room.addEventsToTimeline(timelineEvents, true, room.getLiveTimeline());
+                this.processThreadEvents(room, threadedEvents);
+
                 room.oldState.paginationToken = res.end;
                 if (res.chunk.length === 0) {
                     room.oldState.paginationToken = null;
@@ -4684,7 +4689,11 @@ export class MatrixClient extends EventEmitter {
                 const stateEvents = res.state.map(this.getEventMapper());
                 timeline.getState(EventTimeline.BACKWARDS).setUnknownStateEvents(stateEvents);
             }
-            timelineSet.addEventsToTimeline(matrixEvents, true, timeline, res.start);
+
+            const [timelineEvents, threadedEvents] = this.partitionThreadedEvents(matrixEvents);
+
+            timelineSet.addEventsToTimeline(timelineEvents, true, timeline, res.start);
+            this.processThreadEvents(timelineSet.room, threadedEvents);
 
             // there is no guarantee that the event ended up in "timeline" (we
             // might have switched to a neighbouring timeline) - so check the
@@ -4817,8 +4826,11 @@ export class MatrixClient extends EventEmitter {
                     matrixEvents[i] = event;
                 }
 
-                eventTimeline.getTimelineSet()
-                    .addEventsToTimeline(matrixEvents, backwards, eventTimeline, token);
+                const [timelineEvents, threadedEvents] = this.partitionThreadedEvents(matrixEvents);
+
+                const timelineSet = eventTimeline.getTimelineSet();
+                timelineSet.addEventsToTimeline(timelineEvents, backwards, eventTimeline, token);
+                this.processThreadEvents(timelineSet.room, threadedEvents);
 
                 // if we've hit the end of the timeline, we need to stop trying to
                 // paginate. We need to keep the 'forwards' token though, to make sure
@@ -4851,8 +4863,12 @@ export class MatrixClient extends EventEmitter {
                 }
                 const token = res.end;
                 const matrixEvents = res.chunk.map(this.getEventMapper());
+
+                const [timelineEvents, threadedEvents] = this.partitionThreadedEvents(matrixEvents);
+
                 eventTimeline.getTimelineSet()
-                    .addEventsToTimeline(matrixEvents, backwards, eventTimeline, token);
+                    .addEventsToTimeline(timelineEvents, backwards, eventTimeline, token);
+                this.processThreadEvents(room, threadedEvents);
 
                 // if we've hit the end of the timeline, we need to stop trying to
                 // paginate. We need to keep the 'forwards' token though, to make sure
@@ -8550,6 +8566,45 @@ export class MatrixClient extends EventEmitter {
             qsStringifyOptions: { arrayFormat: 'repeat' },
             prefix: "/_matrix/client/unstable/im.nheko.summary",
         });
+    }
+
+    public partitionThreadedEvents(events: MatrixEvent[]): [MatrixEvent[], MatrixEvent[]] {
+        if (this.supportsExperimentalThreads) {
+            return events.reduce((memo, event: MatrixEvent) => {
+                const room = this.getRoom(event.getRoomId());
+                // An event should live in the thread timeline if
+                // - It's a reply in thread event
+                // - It's related to a reply in thread event
+                let shouldLiveInThreadTimeline = event.isThreadRelation;
+                if (!shouldLiveInThreadTimeline) {
+                    const parentEventId = event.parentEventId;
+                    const parentEvent = room?.findEventById(parentEventId) || events.find((mxEv: MatrixEvent) => {
+                        return mxEv.getId() === parentEventId;
+                    });
+                    shouldLiveInThreadTimeline = parentEvent?.isThreadRelation;
+                }
+                memo[shouldLiveInThreadTimeline ? 1 : 0].push(event);
+                return memo;
+            }, [[], []]);
+        } else {
+            // When `experimentalThreadSupport` is disabled
+            // treat all events as timelineEvents
+            return [
+                events,
+                [],
+            ];
+        }
+    }
+
+    /**
+     * @experimental
+     */
+    public processThreadEvents(room: Room, threadedEvents: MatrixEvent[]): void {
+        threadedEvents
+            .sort((a, b) => a.getTs() - b.getTs())
+            .forEach(event => {
+                room.addThreadedEvent(event);
+            });
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19587

Possible will do the trick for https://github.com/vector-im/element-web/issues/19607 & https://github.com/vector-im/element-web/issues/19603

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make events pagination responses parse threads ([\#2011](https://github.com/matrix-org/matrix-js-sdk/pull/2011)). Fixes vector-im/element-web#19587.<!-- CHANGELOG_PREVIEW_END -->