### PR TITLE
Fix edit history being broken after editing an unencrypted event with an encrypted event

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6015,7 +6015,9 @@ export class MatrixClient extends EventEmitter {
         if (fetchedEventType === EventType.RoomMessageEncrypted) {
             const allEvents = originalEvent ? events.concat(originalEvent) : events;
             await Promise.all(allEvents.map(e => {
-                return new Promise(resolve => e.once("Event.decrypted", resolve));
+                if (e.isEncrypted()) {
+                    return new Promise(resolve => e.once("Event.decrypted", resolve));
+                }
             }));
             events = events.filter(e => e.getType() === eventType);
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19651

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix edit history being broken after editing an unencrypted event with an encrypted event ([\#2013](https://github.com/matrix-org/matrix-js-sdk/pull/2013)). Fixes vector-im/element-web#19651. Contributed by @aaronraimist.<!-- CHANGELOG_PREVIEW_END -->