### PR TITLE
Fix call upgrades

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -583,8 +583,8 @@ export class MatrixCall extends EventEmitter {
                 new CallFeed({
                     client: this.client,
                     roomId: this.roomId,
-                    audioMuted: stream.getAudioTracks().length === 0,
-                    videoMuted: stream.getVideoTracks().length === 0,
+                    audioMuted: false,
+                    videoMuted: false,
                     userId,
                     stream,
                     purpose,
@@ -822,8 +822,8 @@ export class MatrixCall extends EventEmitter {
                     userId: this.client.getUserId(),
                     stream,
                     purpose: SDPStreamMetadataPurpose.Usermedia,
-                    audioMuted: stream.getAudioTracks().length === 0,
-                    videoMuted: stream.getVideoTracks().length === 0,
+                    audioMuted: false,
+                    videoMuted: false,
                 });
 
                 const feeds = [usermediaFeed];
@@ -2063,8 +2063,8 @@ export class MatrixCall extends EventEmitter {
                 userId: this.client.getUserId(),
                 stream,
                 purpose: SDPStreamMetadataPurpose.Usermedia,
-                audioMuted: stream.getAudioTracks().length === 0,
-                videoMuted: stream.getVideoTracks().length === 0,
+                audioMuted: false,
+                videoMuted: false,
             });
             await this.placeCallWithCallFeeds([callFeed]);
         } catch (e) {

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -29,7 +29,13 @@ export interface ICallFeedOpts {
     userId: string;
     stream: MediaStream;
     purpose: SDPStreamMetadataPurpose;
+    /**
+     * Whether or not the remote SDPStreamMetadata says audio is muted
+     */
     audioMuted: boolean;
+    /**
+     * Whether or not the remote SDPStreamMetadata says video is muted
+     */
     videoMuted: boolean;
 }
 


### PR DESCRIPTION
Type: defect

<hr>

Due to `CallFeed`s mute state being set to muted based on their tracks at the time of their creation we can get stuck with them being muted. This happens because the code that determines if a `CallFeed` is muted looks like this: 

```
return this.stream.getVideoTracks().length === 0 || this.videoMuted;
```

This means that if `videoMuted` is `true` the feed will be muted no matter the present tracks. The `videoMuted` property should only work as an override based on the remote `SPDStreamMetadata`

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix call upgrades ([\#2024](https://github.com/matrix-org/matrix-js-sdk/pull/2024)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->