### PR TITLE
Update sync state to error when aborting due to invalid auth token

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -505,6 +505,7 @@ export class SyncApi {
             // The logout already happened, we just need to stop.
             logger.warn("Token no longer valid - assuming logout");
             this.stop();
+            this.updateSyncState(SyncState.Error, { error });
             return true;
         }
         return false;


### PR DESCRIPTION
Currently the sync state doesn't change when sync fails due to an invalid auth token. This PR ensures that the sync state changes to error when we abort the sync so we can ask the user to login again.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Ensure sync state is set to error when it is aborted due to invalid auth tokens.
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->