### PR TITLE
getStateEvent should return any

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6613,7 +6613,7 @@ export class MatrixClient extends EventEmitter {
         eventType: string,
         stateKey: string,
         callback?: Callback,
-    ): Promise<any> {
+    ): Promise<Record<string, any>> {
         const pathParams = {
             $roomId: roomId,
             $eventType: eventType,

--- a/src/client.ts
+++ b/src/client.ts
@@ -6613,7 +6613,7 @@ export class MatrixClient extends EventEmitter {
         eventType: string,
         stateKey: string,
         callback?: Callback,
-    ): Promise<IStateEventWithRoomId> {
+    ): Promise<any> {
         const pathParams = {
             $roomId: roomId,
             $eventType: eventType,


### PR DESCRIPTION
getStateEvent returns the content of an event, not the whole state event as per https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-state-eventtype-statekey

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->