### PR TITLE
Type annotation: MatrixEvent.getRoomId can return undefined

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -350,10 +350,10 @@ export class MatrixEvent extends EventEmitter {
     /**
      * Get the room_id for this event. This will return <code>undefined</code>
      * for <code>m.presence</code> events.
-     * @return {string} The room ID, e.g. <code>!cURbafjkfsMDVwdRDQ:matrix.org
+     * @return {string?} The room ID, e.g. <code>!cURbafjkfsMDVwdRDQ:matrix.org
      * </code>
      */
-    public getRoomId(): string {
+    public getRoomId(): string | undefined {
         return this.event.room_id;
     }
 


### PR DESCRIPTION
Part of #2035

I don't consider this a breaking change as it's just being more honest about the return types, even though this change will make it a pain to upgrade this dependency in TypeScript projects.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->