### PR TITLE
typescript does not find declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "matrix_src_browser": "./src/browser-index.js",
   "matrix_lib_main": "./lib/index.js",
   "matrix_lib_typings": "./lib/index.d.ts",
+  "types": "./lib",
   "author": "matrix.org",
   "license": "Apache-2.0",
   "files": [


### PR DESCRIPTION
In this [commit](https://github.com/matrix-org/matrix-js-sdk/commit/55b489b17a519bc0d557c47ac9fe7ce54690b602#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) you changed the "main" option in package.json. 

For this reason, the package in the develop branch does not work (typescript in my project does't know where to take the declarations, and tries to compile the .ts files from the src directory). 
Your comment says "Resetting package fields for development". Are you sure you haven't forgotten about it? 
Maybe we should add types/typings section in the develop branch?

I am worried that this change will be released into the npm package






<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->