### PR TITLE
Allow to omit optional params for /relations calls

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Callback } from "../client";
-import { IContent } from "../models/event";
+import { IContent, IEvent } from "../models/event";
 import { Preset, Visibility } from "./partials";
 import { SearchKey } from "./search";
 import { IRoomEventFilter } from "../filter";
@@ -139,4 +139,18 @@ export interface IBindThreePidBody {
     id_access_token: string;
     sid: string;
 }
+
+export interface IRelationsRequestOpts {
+    from?: string;
+    to?: string;
+    limit?: string;
+}
+
+export interface IRelationsResponse {
+    original_event: IEvent;
+    chunk: IEvent[];
+    next_batch?: string;
+    prev_batch?: string;
+}
+
 /* eslint-enable camelcase */


### PR DESCRIPTION
Paves the way for https://github.com/vector-im/element-web/issues/19961

According to MSC2675, relationType and eventType are both optional.

This also creates typing for the request options and the response format

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->