### PR TITLE
Fix paginateEventTimeline resolve to boolean

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5124,8 +5124,8 @@ export class MatrixClient extends EventEmitter {
                 token,
                 opts.limit,
                 dir,
-                eventTimeline.getFilter());
-            promise.then((res) => {
+                eventTimeline.getFilter(),
+            ).then((res) => {
                 if (res.state) {
                     const roomState = eventTimeline.getState(dir);
                     const stateEvents = res.state.map(this.getEventMapper());

--- a/src/client.ts
+++ b/src/client.ts
@@ -5067,7 +5067,7 @@ export class MatrixClient extends EventEmitter {
 
         let path;
         let params;
-        let promise;
+        let promise: Promise<boolean>;
 
         if (isNotifTimeline) {
             path = "/notifications";


### PR DESCRIPTION
Earlier paginateEventTimeline used to resolve to  chunk instead of resolving to boolean. Now it resolve to boolean as specified in doc.

Signed-off-by: Ajay Bura <ajbura@gmail.com>


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix paginateEventTimeline resolve to boolean ([\#2054](https://github.com/matrix-org/matrix-js-sdk/pull/2054)). Contributed by @ajbura.<!-- CHANGELOG_PREVIEW_END -->