### PR TITLE
Add support for MSC3030 `/timestamp_to_event`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8921,11 +8921,11 @@ export class MatrixClient extends EventEmitter {
         * origin_server_ts of the closest event to the timestamp in the given
         * direction
      */
-     public async timestampToEvent(
+    public async timestampToEvent(
         roomId: string,
         timestamp: number,
         dir: Direction,
-     ): Promise<ITimestampToEventResponse> {
+    ): Promise<ITimestampToEventResponse> {
         const path = utils.encodeUri("/rooms/$roomId/timestamp_to_event", {
             $roomId: roomId,
         });
@@ -8934,7 +8934,7 @@ export class MatrixClient extends EventEmitter {
             ts: timestamp,
             dir: dir,
         };
-        
+
         return await this.http.authedRequest(
             undefined,
             "GET",

--- a/src/client.ts
+++ b/src/client.ts
@@ -689,6 +689,11 @@ interface IRoomKeysResponse {
 interface IRoomsKeysResponse {
     rooms: Record<string, IRoomKeysResponse>;
 }
+
+interface ITimestampToEventResponse {
+    event_id: string;
+    origin_server_ts: string;
+}
 /* eslint-enable camelcase */
 
 // We're using this constant for methods overloading and inspect whether a variable
@@ -8908,6 +8913,38 @@ export class MatrixClient extends EventEmitter {
      */
     public async whoami(): Promise<{ user_id: string }> { // eslint-disable-line camelcase
         return this.http.authedRequest(undefined, "GET", "/account/whoami");
+    }
+
+    /**
+     * Find the event_id closest to the given timestamp in the given direction.
+     * @return {Promise} A promise of an object containing the event_id and
+        * origin_server_ts of the closest event to the timestamp in the given
+        * direction
+     */
+     public async timestampToEvent(
+        roomId: string,
+        timestamp: number,
+        dir: Direction,
+     ): Promise<ITimestampToEventResponse> {
+        const path = utils.encodeUri("/rooms/$roomId/timestamp_to_event", {
+            $roomId: roomId,
+        });
+
+        const params: Record<string, string | number> = {
+            ts: timestamp,
+            dir: dir,
+        };
+        
+        return await this.http.authedRequest(
+            undefined,
+            "GET",
+            path,
+            params,
+            undefined,
+            {
+                prefix: "/_matrix/client/unstable/org.matrix.msc3030",
+            },
+        );
     }
 }
 


### PR DESCRIPTION
Add support for MSC3030 `/timestamp_to_event`

 - `/jumptodate` slash command is being worked on in https://github.com/matrix-org/matrix-react-sdk/pull/7372
 - Jump to date headers are being worked on in https://github.com/matrix-org/matrix-react-sdk/pull/7339

Related to https://github.com/vector-im/element-web/issues/7677

Part of MSC3030: https://github.com/matrix-org/matrix-doc/pull/3030

Experimental Synapse implementation added in https://github.com/matrix-org/synapse/pull/9445

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->