### PR TITLE
Track if user has participated in a thread or not 

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -115,11 +115,13 @@ export enum MsgType {
     KeyVerificationRequest = "m.key.verification.request",
 }
 
+/* eslint-disable camelcase */
 export interface IThreadBundledRelation {
-    // eslint-disable-next-line camelcase
     latest_event: IEvent;
     count: number;
+    current_user_participated?: boolean;
 }
+/* eslint-enable camelcase */
 
 export const RoomCreateTypeField = "type";
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -42,6 +42,7 @@ export class Thread extends TypedEventEmitter<ThreadEvent> {
     private _head: MatrixEvent;
     private eventToPreview: MatrixEvent = null;
     private replyCount = 0;
+    private _currentUserParticipated = false;
 
     public _hasServerSideSupport = false;
 
@@ -207,6 +208,7 @@ export class Thread extends TypedEventEmitter<ThreadEvent> {
             });
             EventTimeline.setEventMetadata(this.eventToPreview, this.roomState, false);
             this.replyCount = threadBundle.count;
+            this._currentUserParticipated = threadBundle.current_user_participated === true;
         } else {
             this.addEvent(this._head);
             this.replyCount = 0;
@@ -267,6 +269,10 @@ export class Thread extends TypedEventEmitter<ThreadEvent> {
             this.replyCount++;
             this.eventToPreview = event;
             this.emit(ThreadEvent.NewReply, this, event);
+        }
+
+        if (!this._currentUserParticipated) {
+            this._currentUserParticipated = event.getSender() === this.client.getUserId();
         }
 
         this.emit(ThreadEvent.Update, this);
@@ -331,5 +337,9 @@ export class Thread extends TypedEventEmitter<ThreadEvent> {
 
     public get ready(): boolean {
         return this._ready;
+    }
+
+    public get currentUserParticipated(): boolean {
+        return this._currentUserParticipated;
     }
 }


### PR DESCRIPTION
Related to https://github.com/vector-im/element-web/issues/19615 and https://github.com/vector-im/element-web/issues/19996

Will work flawlessly when https://github.com/matrix-org/synapse/pull/11577 has landed

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->