### PR TITLE
Prefer v1-prefix for /hierarchy API

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -50,6 +50,7 @@ import {
     PREFIX_IDENTITY_V2,
     PREFIX_MEDIA_R0,
     PREFIX_R0,
+    PREFIX_V1,
     PREFIX_UNSTABLE,
     retryNetworkOperation,
     UploadContentResponseType,
@@ -8393,7 +8394,21 @@ export class MatrixClient extends EventEmitter {
             from: fromToken,
             limit: limit?.toString(),
         }, undefined, {
-            prefix: "/_matrix/client/unstable/org.matrix.msc2946",
+            prefix: PREFIX_V1,
+        }).catch(e => {
+            if (e.errcode === "M_UNRECOGNIZED") {
+                // fall back to the development prefix
+                return this.http.authedRequest<IRoomHierarchy>(undefined, Method.Get, path, {
+                    suggested_only: String(suggestedOnly),
+                    max_depth: String(maxDepth),
+                    from: fromToken,
+                    limit: String(limit),
+                }, undefined, {
+                    prefix: "/_matrix/client/unstable/org.matrix.msc2946",
+                });
+            }
+
+            throw e;
         }).catch(e => {
             if (e.errcode === "M_UNRECOGNIZED") {
                 // fall back to the older space summary API as it exposes the same data just in a different shape.


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#2080
See See https://github.com/vector-im/element-web/issues/19738#issuecomment-996804209

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->