### PR TITLE
Fix incorrect TS return type for secret storage and key backup functions

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2244,7 +2244,7 @@ export class MatrixClient extends EventEmitter {
      *     with, or null if it is not present or not encrypted with a trusted
      *     key
      */
-    public isSecretStored(name: string, checkKey: boolean): Promise<Record<string, ISecretStorageKeyInfo>> {
+    public isSecretStored(name: string, checkKey: boolean): Promise<Record<string, ISecretStorageKeyInfo> | null> {
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
@@ -2275,7 +2275,7 @@ export class MatrixClient extends EventEmitter {
      *
      * @return {string} The default key ID or null if no default key ID is set
      */
-    public getDefaultSecretStorageKeyId(): Promise<string> {
+    public getDefaultSecretStorageKeyId(): Promise<string | null> {
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
@@ -2457,9 +2457,9 @@ export class MatrixClient extends EventEmitter {
 
     /**
      * Get information about the current key backup.
-     * @returns {Promise} Information object from API or null
+     * @returns {Promise<IKeyBackupInfo | null>} Information object from API or null
      */
-    public async getKeyBackupVersion(): Promise<IKeyBackupInfo> {
+    public async getKeyBackupVersion(): Promise<IKeyBackupInfo | null> {
         let res;
         try {
             res = await this.http.authedRequest(
@@ -2578,7 +2578,7 @@ export class MatrixClient extends EventEmitter {
      *     encrypted with, or null if it is not present or not encrypted with a
      *     trusted key
      */
-    public isKeyBackupKeyStored(): Promise<Record<string, ISecretStorageKeyInfo>> {
+    public isKeyBackupKeyStored(): Promise<Record<string, ISecretStorageKeyInfo> | null> {
         return Promise.resolve(this.isSecretStored("m.megolm_backup.v1", false /* checkKey */));
     }
 

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -83,7 +83,7 @@ export class SecretStorage {
         private readonly baseApis?: MatrixClient,
     ) {}
 
-    public async getDefaultKeyId(): Promise<string> {
+    public async getDefaultKeyId(): Promise<string | null> {
         const defaultKey = await this.accountDataAdapter.getAccountDataFromServer<{ key: string }>(
             'm.secret_storage.default_key',
         );
@@ -345,7 +345,7 @@ export class SecretStorage {
      *     with, or null if it is not present or not encrypted with a trusted
      *     key
      */
-    public async isStored(name: string, checkKey: boolean): Promise<Record<string, ISecretStorageKeyInfo>> {
+    public async isStored(name: string, checkKey: boolean): Promise<Record<string, ISecretStorageKeyInfo> | null> {
         // check if secret exists
         const secretInfo = await this.accountDataAdapter.getAccountDataFromServer<ISecretInfo>(name);
         if (!secretInfo) return null;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1024,7 +1024,7 @@ export class Crypto extends EventEmitter {
     public isSecretStored(
         name: string,
         checkKey?: boolean,
-    ): Promise<Record<string, ISecretStorageKeyInfo>> {
+    ): Promise<Record<string, ISecretStorageKeyInfo> | null> {
         return this.secretStorage.isStored(name, checkKey);
     }
 
@@ -1035,7 +1035,7 @@ export class Crypto extends EventEmitter {
         return this.secretStorage.request(name, devices);
     }
 
-    public getDefaultSecretStorageKeyId(): Promise<string> {
+    public getDefaultSecretStorageKeyId(): Promise<string | null> {
         return this.secretStorage.getDefaultKeyId();
     }
 


### PR DESCRIPTION
I have found a number of functions can return null values even through the TS types say it is non-nullable. These changes make it so that the TS types match those in the JS Doc and the implementation.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect TS return type for secret storage and key backup functions ([\#2082](https://github.com/matrix-org/matrix-js-sdk/pull/2082)). Contributed by @hughns.<!-- CHANGELOG_PREVIEW_END -->