### PR TITLE
Don't consider alt_aliases when calculating room name

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -622,6 +622,11 @@ describe("Room", function() {
                 }, event: true,
             })]);
         };
+        const setAlias = function(alias) {
+            room.addLiveEvents([utils.mkEvent({
+                type: "m.room.canonical_alias", room: roomId, skey: "", content: { alias }, event: true,
+            })]);
+        };
         const setRoomName = function(name) {
             room.addLiveEvents([utils.mkEvent({
                 type: "m.room.name", room: roomId, user: userA, content: {
@@ -857,7 +862,7 @@ describe("Room", function() {
             "(invite join_rules) rooms if a room name doesn't exist.", function() {
                 const alias = "#room_alias:here";
                 setJoinRule("invite");
-                setAltAliases([alias, "#another:here"]);
+                setAlias(alias);
                 room.recalculate();
                 const name = room.name;
                 expect(name).toEqual(alias);
@@ -867,10 +872,18 @@ describe("Room", function() {
             "(public join_rules) rooms if a room name doesn't exist.", function() {
                 const alias = "#room_alias:here";
                 setJoinRule("public");
-                setAltAliases([alias, "#another:here"]);
+                setAlias(alias);
                 room.recalculate();
                 const name = room.name;
                 expect(name).toEqual(alias);
+            });
+
+            it("should not show alt aliases if a room name does not exist", () => {
+                const alias = "#room_alias:here";
+                setAltAliases([alias, "#another:here"]);
+                room.recalculate();
+                const name = room.name;
+                expect(name).not.toEqual(alias);
             });
 
             it("should show the room name if one exists for private " +

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2205,15 +2205,7 @@ export class Room extends EventEmitter {
             }
         }
 
-        let alias = this.getCanonicalAlias();
-
-        if (!alias) {
-            const aliases = this.getAltAliases();
-
-            if (aliases.length) {
-                alias = aliases[0];
-            }
-        }
+        const alias = this.getCanonicalAlias();
         if (alias) {
             return alias;
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/13887

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Don't consider alt_aliases when calculating room name ([\#2094](https://github.com/matrix-org/matrix-js-sdk/pull/2094)). Fixes vector-im/element-web#13887.<!-- CHANGELOG_PREVIEW_END -->