### PR TITLE
Fix redaction reason requiring a restart to appear 

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -921,6 +921,10 @@ export class MatrixEvent extends EventEmitter {
             this.event.unsigned = {};
         }
         this.event.unsigned.redacted_because = redactionEvent.event as IEvent;
+
+        if (this.isEncrypted()) {
+            this.clearEvent.unsigned = { redacted_because: Object.assign({}, redactionEvent.event) as IEvent };
+        }
     }
 
     /**


### PR DESCRIPTION
Type: defect
Improves on https://github.com/vector-im/element-web/issues/20382

<hr>

This only handles the sending side

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix redaction reason requiring a restart to appear  ([\#2097](https://github.com/matrix-org/matrix-js-sdk/pull/2097)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->