### PR TITLE
Use session ids to resolve refresh during invite/answer

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -758,6 +758,7 @@ export class MatrixClient extends EventEmitter {
     protected exportedOlmDeviceToImport: IOlmDevice;
     protected txnCtr = 0;
     protected mediaHandler = new MediaHandler(this);
+    protected sessionId: string;
 
     constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -771,6 +772,7 @@ export class MatrixClient extends EventEmitter {
         this.usingExternalCrypto = opts.usingExternalCrypto;
         this.store = opts.store || new StubStore();
         this.deviceId = opts.deviceId || null;
+        this.sessionId = randomString(10);
 
         const userId = opts.userId || null;
         this.credentials = { userId };
@@ -1257,6 +1259,14 @@ export class MatrixClient extends EventEmitter {
      */
     public getDeviceId(): string {
         return this.deviceId;
+    }
+
+    /**
+     * Get the session ID of this client
+     * @return {string} session ID
+     */
+    public getSessionId(): string {
+        return this.sessionId;
     }
 
     /**

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -319,6 +319,7 @@ export class MatrixCall extends EventEmitter {
     private callLength = 0;
 
     private opponentDeviceId: string;
+    private opponentSessionId: string;
     public groupCallId: string;
 
     constructor(opts: CallOpts) {
@@ -372,6 +373,10 @@ export class MatrixCall extends EventEmitter {
 
     public getOpponentMember(): RoomMember {
         return this.opponentMember;
+    }
+
+    public getOpponentSessionId(): string {
+        return this.opponentSessionId;
     }
 
     public opponentCanBeTransferred(): boolean {
@@ -2002,7 +2007,7 @@ export class MatrixCall extends EventEmitter {
                 eventType,
                 userId: this.invitee || this.getOpponentMember().userId,
                 opponentDeviceId: this.opponentDeviceId,
-                content: { ...realContent, device_id: this.client.deviceId },
+                content: { ...realContent, device_id: this.client.deviceId, session_id: this.client.getSessionId() },
             });
 
             return this.client.sendToDevice(eventType, {
@@ -2010,6 +2015,7 @@ export class MatrixCall extends EventEmitter {
                     [this.opponentDeviceId]: {
                         ...realContent,
                         device_id: this.client.deviceId,
+                        session_id: this.client.getSessionId(),
                     },
                 },
             });
@@ -2339,6 +2345,7 @@ export class MatrixCall extends EventEmitter {
         }
         this.opponentCaps = msg.capabilities || {} as CallCapabilities;
         this.opponentMember = this.client.getRoom(this.roomId).getMember(ev.getSender());
+        this.opponentSessionId = msg.session_id;
     }
 
     private async addBufferedIceCandidates(): Promise<void> {

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -36,6 +36,7 @@ export interface MCallBase {
     call_id: string;
     version: string | number;
     party_id?: string;
+    session_id?: string;
 }
 
 export interface MCallAnswer extends MCallBase {
@@ -54,6 +55,7 @@ export interface MCallInviteNegotiate extends MCallBase {
     lifetime: number;
     capabilities?: CallCapabilities;
     invitee?: string;
+    session_id?: string;
     [SDPStreamMetadataKey]: SDPStreamMetadata;
 }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -671,7 +671,7 @@ export class GroupCall extends EventEmitter {
         }
 
         if (existingCall) {
-            this.replaceCall(existingCall, newCall);
+            this.replaceCall(existingCall, newCall, true);
         } else {
             this.addCall(newCall);
         }
@@ -734,7 +734,7 @@ export class GroupCall extends EventEmitter {
         this.emit(GroupCallEvent.CallsChanged, this.calls);
     }
 
-    private replaceCall(existingCall: MatrixCall, replacementCall: MatrixCall) {
+    private replaceCall(existingCall: MatrixCall, replacementCall: MatrixCall, forceHangup = false) {
         const existingCallIndex = this.calls.indexOf(existingCall);
 
         if (existingCallIndex === -1) {
@@ -743,7 +743,7 @@ export class GroupCall extends EventEmitter {
 
         this.calls.splice(existingCallIndex, 1, replacementCall);
 
-        this.disposeCall(existingCall, CallErrorCode.Replaced);
+        this.disposeCall(existingCall, CallErrorCode.Replaced, forceHangup);
         this.initCall(replacementCall);
 
         this.emit(GroupCallEvent.CallsChanged, this.calls);
@@ -793,7 +793,7 @@ export class GroupCall extends EventEmitter {
         onCallFeedsChanged();
     }
 
-    private disposeCall(call: MatrixCall, hangupReason: CallErrorCode) {
+    private disposeCall(call: MatrixCall, hangupReason: CallErrorCode, forceHangup = false) {
         const opponentMemberId = getCallUserId(call);
 
         if (!opponentMemberId) {
@@ -814,7 +814,7 @@ export class GroupCall extends EventEmitter {
 
         this.callHandlers.delete(opponentMemberId);
 
-        if (call.hangupReason === CallErrorCode.Replaced) {
+        if (call.hangupReason === CallErrorCode.Replaced && !forceHangup) {
             return;
         }
 


### PR DESCRIPTION
This PR is a fix for #1902 that resolves split-brains when a client refreshes before they have answered an incoming call.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->