### PR TITLE
Remove getCapabilities call for guest users

### DIFF
--- a/spec/unit/matrix-client.spec.js
+++ b/spec/unit/matrix-client.spec.js
@@ -713,7 +713,6 @@ describe("MatrixClient", function() {
     describe("guest rooms", function() {
         it("should only do /sync calls (without filter/pushrules)", function(done) {
             httpLookups = []; // no /pushrules or /filterw
-            httpLookups.push(CAPABILITIES_RESPONSE);
             httpLookups.push({
                 method: "GET",
                 path: "/sync",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1041,7 +1041,9 @@ export class MatrixClient extends EventEmitter {
             this.syncApi.stop();
         }
 
-        await this.getCapabilities(true);
+        if (!this.isGuest()) {
+            await this.getCapabilities(true);
+        }
 
         // shallow-copy the opts dict before modifying and storing it
         this.clientOpts = Object.assign({}, opts) as IStoredClientOpts;
@@ -1467,7 +1469,7 @@ export class MatrixClient extends EventEmitter {
             }
         }
 
-        return this.http.authedRequest(
+        return this.http.request(
             undefined, Method.Get, "/capabilities",
         ).catch((e: Error): void => {
             // We swallow errors because we need a default object anyhow

--- a/src/client.ts
+++ b/src/client.ts
@@ -1469,7 +1469,7 @@ export class MatrixClient extends EventEmitter {
             }
         }
 
-        return this.http.request(
+        return this.http.authedRequest(
             undefined, Method.Get, "/capabilities",
         ).catch((e: Error): void => {
             // We swallow errors because we need a default object anyhow


### PR DESCRIPTION
Regressed by https://github.com/matrix-org/matrix-js-sdk/pull/2093

Capabilities requires authentication and therefore can not be called for guests, https://spec.matrix.org/v1.1/client-server-api/#capabilities-negotiation

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->