### PR TITLE
[Fix] Nullcheck redactedEvent

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1441,6 +1441,15 @@ export class Room extends EventEmitter {
                 // (in the sender and target fields). We should get those
                 // RoomMember objects to update themselves when the events that
                 // they are based on are changed.
+
+                // Remove any visibility change on this event.
+                this.visibilityEvents.delete(redactId);
+
+                // If this event is a visibility change event, remove it from the
+                // list of visibility changes and update any event affected by it.
+                if (redactedEvent.isVisibilityEvent()) {
+                    this.redactVisibilityChangeEvent(event);
+                }
             }
 
             // FIXME: apply redactions to notification list
@@ -1448,15 +1457,6 @@ export class Room extends EventEmitter {
             // NB: We continue to add the redaction event to the timeline so
             // clients can say "so and so redacted an event" if they wish to. Also
             // this may be needed to trigger an update.
-
-            // Remove any visibility change on this event.
-            this.visibilityEvents.delete(redactId);
-
-            // If this event is a visibility change event, remove it from the
-            // list of visibility changes and update any event affected by it.
-            if (redactedEvent.isVisibilityEvent()) {
-                this.redactVisibilityChangeEvent(event);
-            }
         }
 
         // Implement MSC3531: hiding messages.


### PR DESCRIPTION
We should only check whether a redacted event is a visibility event *if the redacted event is not null*.

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->