### PR TITLE
Don't remove streams that still have tracks

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1717,7 +1717,12 @@ export class MatrixCall extends EventEmitter {
 
         const stream = ev.streams[0];
         this.pushRemoteFeed(stream);
-        stream.addEventListener("removetrack", () => this.deleteFeedByStream(stream));
+        stream.addEventListener("removetrack", () => {
+            if (stream.getTracks().length === 0) {
+                logger.info(`Stream ID ${stream.id} has no tracks remaining - removing`);
+                this.deleteFeedByStream(stream);
+            }
+        });
     };
 
     private onDataChannel = (ev: RTCDataChannelEvent): void => {


### PR DESCRIPTION
If a renogotiation ends up with one track being removed, we removed
the whole stream, which would cause us to lose, for example, audio
rather than just video.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't remove streams that still have tracks ([\#2104](https://github.com/matrix-org/matrix-js-sdk/pull/2104)).<!-- CHANGELOG_PREVIEW_END -->