### PR TITLE
TypeScript: opts parameter of client.startClient() is optional

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -954,7 +954,7 @@ export class MatrixClient extends EventEmitter {
      * state change events.
      * @param {Object=} opts Options to apply when syncing.
      */
-    public async startClient(opts: IStartClientOpts) {
+    public async startClient(opts?: IStartClientOpts) {
         if (this.clientRunning) {
             // client is already running.
             return;


### PR DESCRIPTION
![Screenshot_2022-01-14_15-26-01](https://user-images.githubusercontent.com/10872136/149531690-71841b12-8e4c-4a45-9523-8a9f8384e7fd.png)

I've been calling `client.startClient()` without its parameter a lot.

As stated in the JSDocs, the `opts` parameter should be optional.

`Object.assign({}, opts)` is safe with `opts = undefined` and returns an empty object.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->