### PR TITLE
Support m.asset in m.location event content

### DIFF
--- a/spec/unit/location.spec.ts
+++ b/spec/unit/location.spec.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { makeLocationContent } from "../../src/content-helpers";
+import {
+    ASSET_NODE_TYPE,
+    ASSET_TYPE_SELF,
+    LOCATION_EVENT_TYPE,
+    TIMESTAMP_NODE_TYPE,
+} from "../../src/@types/location";
+import { TEXT_NODE_TYPE } from "../../src/@types/extensible_events";
+
+describe("Location", function() {
+    it("should create a valid location with defaults", function() {
+        const loc = makeLocationContent("txt", "geo:foo", 134235435);
+        expect(loc.body).toEqual("txt");
+        expect(loc.msgtype).toEqual("m.location");
+        expect(loc.geo_uri).toEqual("geo:foo");
+        expect(LOCATION_EVENT_TYPE.findIn(loc)).toEqual({
+            uri: "geo:foo",
+            description: undefined,
+        });
+        expect(ASSET_NODE_TYPE.findIn(loc)).toEqual({ type: ASSET_TYPE_SELF });
+        expect(TEXT_NODE_TYPE.findIn(loc)).toEqual("txt");
+        expect(TIMESTAMP_NODE_TYPE.findIn(loc)).toEqual(134235435);
+    });
+
+    it("should create a valid location with explicit properties", function() {
+        const loc = makeLocationContent(
+            "txxt", "geo:bar", 134235436, "desc", "m.something");
+
+        expect(loc.body).toEqual("txxt");
+        expect(loc.msgtype).toEqual("m.location");
+        expect(loc.geo_uri).toEqual("geo:bar");
+        expect(LOCATION_EVENT_TYPE.findIn(loc)).toEqual({
+            uri: "geo:bar",
+            description: "desc",
+        });
+        expect(ASSET_NODE_TYPE.findIn(loc)).toEqual({ type: "m.something" });
+        expect(TEXT_NODE_TYPE.findIn(loc)).toEqual("txxt");
+        expect(TIMESTAMP_NODE_TYPE.findIn(loc)).toEqual(134235436);
+    });
+});

--- a/src/@types/location.ts
+++ b/src/@types/location.ts
@@ -23,7 +23,11 @@ import { TEXT_NODE_TYPE } from "./extensible_events";
 export const LOCATION_EVENT_TYPE = new UnstableValue(
     "m.location", "org.matrix.msc3488.location");
 
+export const ASSET_NODE_TYPE = new UnstableValue("m.asset", "org.matrix.msc3488.asset");
+
 export const TIMESTAMP_NODE_TYPE = new UnstableValue("m.ts", "org.matrix.msc3488.ts");
+
+export const ASSET_TYPE_SELF = "m.self";
 
 /* From the spec at:
  * https://github.com/matrix-org/matrix-doc/blob/matthew/location/proposals/3488-location.md
@@ -36,6 +40,9 @@ export const TIMESTAMP_NODE_TYPE = new UnstableValue("m.ts", "org.matrix.msc3488
         "m.location": {
             "uri": "geo:51.5008,0.1247;u=35",
             "description": "Matthew's whereabouts",
+        },
+        "m.asset": {
+            "type": "m.self"
         },
         "m.text": "Matthew was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
         "m.ts": 1636829458432,
@@ -51,6 +58,9 @@ export interface ILocationContent extends IContent {
     [LOCATION_EVENT_TYPE.name]: {
         uri: string;
         description?: string;
+    };
+    [ASSET_NODE_TYPE.name]: {
+        type: string;
     };
     [TEXT_NODE_TYPE.name]: string;
     [TIMESTAMP_NODE_TYPE.name]: number;

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -18,7 +18,13 @@ limitations under the License.
 
 import { MsgType } from "./@types/event";
 import { TEXT_NODE_TYPE } from "./@types/extensible_events";
-import { ILocationContent, LOCATION_EVENT_TYPE, TIMESTAMP_NODE_TYPE } from "./@types/location";
+import {
+    ASSET_NODE_TYPE,
+    ASSET_TYPE_SELF,
+    ILocationContent,
+    LOCATION_EVENT_TYPE,
+    TIMESTAMP_NODE_TYPE,
+} from "./@types/location";
 
 /**
  * Generates the content for a HTML Message event
@@ -108,12 +114,14 @@ export function makeEmoteMessage(body: string) {
  * @param ts the timestamp when the location was correct (milliseconds since
  *           the UNIX epoch)
  * @param description the (optional) label for this location on the map
+ * @param asset_type the (optional) asset type of this location e.g. "m.self"
  */
 export function makeLocationContent(
     text: string,
     uri: string,
     ts: number,
     description?: string,
+    assetType?: string,
 ): ILocationContent {
     return {
         "body": text,
@@ -123,8 +131,11 @@ export function makeLocationContent(
             uri,
             description,
         },
-        [TIMESTAMP_NODE_TYPE.name]: ts,
+        [ASSET_NODE_TYPE.name]: {
+            type: assetType ?? ASSET_TYPE_SELF,
+        },
         [TEXT_NODE_TYPE.name]: text,
+        [TIMESTAMP_NODE_TYPE.name]: ts,
         // TODO: MSC1767 fallbacks m.image thumbnail
     };
 }


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-doc/blob/matthew/location/proposals/3488-location.md - we have a new requirement to support a `m.asset` property in location event content.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support m.asset in m.location event content ([\#2109](https://github.com/matrix-org/matrix-js-sdk/pull/2109)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->