### PR TITLE
Improved threads reliability with/without server side support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -811,7 +811,7 @@ export class MatrixClient extends EventEmitter {
     // TODO: This should expire: https://github.com/matrix-org/matrix-js-sdk/issues/1020
     protected serverVersionsPromise: Promise<IServerVersions>;
 
-    protected cachedCapabilities: {
+    public cachedCapabilities: {
         capabilities: ICapabilities;
         expiration: number;
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -9062,7 +9062,10 @@ export class MatrixClient extends EventEmitter {
                     const parentEvent = room?.findEventById(parentEventId) || events.find((mxEv: MatrixEvent) => {
                         return mxEv.getId() === parentEventId;
                     });
-                    shouldLiveInThreadTimeline = parentEvent?.isThreadRelation;
+                    if (parentEvent?.isThreadRelation) {
+                        shouldLiveInThreadTimeline = true;
+                        event.setThreadId(parentEvent.threadRootId);
+                    }
 
                     // Copy all the reactions and annotations to the root event
                     // to the thread timeline. They will end up living in both

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -94,6 +94,12 @@ export interface IUnsigned {
     "m.relations"?: Record<RelationType | string, any>; // No common pattern for aggregated relations
 }
 
+export interface IThreadBundledRelationship {
+    latest_event: IEvent;
+    count: number;
+    current_user_participated?: boolean;
+}
+
 export interface IEvent {
     event_id: string;
     type: string;
@@ -1003,6 +1009,10 @@ export class MatrixEvent extends EventEmitter {
 
     public getUnsigned(): IUnsigned {
         return this.event.unsigned || {};
+    }
+
+    public setUnsigned(unsigned: IUnsigned): void {
+        this.event.unsigned = unsigned;
     }
 
     public unmarkLocallyRedacted(): boolean {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -521,7 +521,7 @@ export class MatrixEvent extends EventEmitter {
      * @experimental
      */
     public get isThreadRelation(): boolean {
-        return !!this.threadRootId;
+        return !!this.threadRootId && this.threadId !== this.getId();
     }
 
     /**

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -91,6 +91,7 @@ export interface IUnsigned {
     redacted_because?: IEvent;
     transaction_id?: string;
     invite_room_state?: StrippedState[];
+    "m.relations"?: Record<RelationType | string, any>; // No common pattern for aggregated relations
 }
 
 export interface IEvent {
@@ -1344,11 +1345,8 @@ export class MatrixEvent extends EventEmitter {
         return this.status;
     }
 
-    public getServerAggregatedRelation(relType: RelationType): IAggregatedRelation {
-        const relations = this.getUnsigned()["m.relations"];
-        if (relations) {
-            return relations[relType];
-        }
+    public getServerAggregatedRelation<T>(relType: RelationType): T | undefined {
+        return this.getUnsigned()["m.relations"]?.[relType];
     }
 
     /**
@@ -1357,7 +1355,7 @@ export class MatrixEvent extends EventEmitter {
      * @return {string?}
      */
     public replacingEventId(): string | undefined {
-        const replaceRelation = this.getServerAggregatedRelation(RelationType.Replace);
+        const replaceRelation = this.getServerAggregatedRelation<IAggregatedRelation>(RelationType.Replace);
         if (replaceRelation) {
             return replaceRelation.event_id;
         } else if (this._replacingEvent) {
@@ -1382,7 +1380,7 @@ export class MatrixEvent extends EventEmitter {
      * @return {Date?}
      */
     public replacingEventDate(): Date | undefined {
-        const replaceRelation = this.getServerAggregatedRelation(RelationType.Replace);
+        const replaceRelation = this.getServerAggregatedRelation<IAggregatedRelation>(RelationType.Replace);
         if (replaceRelation) {
             const ts = replaceRelation.origin_server_ts;
             if (Number.isFinite(ts)) {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -528,10 +528,13 @@ export class MatrixEvent extends EventEmitter {
      * @experimental
      */
     public get isThreadRoot(): boolean {
-        // TODO, change the inner working of this getter for it to use the
-        // bundled relationship return on the event, view MSC3440
-        const thread = this.getThread();
-        return thread?.id === this.getId();
+        const threadDetails = this
+            .getServerAggregatedRelation<IThreadBundledRelationship>(RelationType.Thread);
+
+        // Bundled relationships only returned when the sync response is limited
+        // hence us having to check both bundled relation and inspect the thread
+        // model
+        return !!threadDetails || (this.getThread()?.id === this.getId());
     }
 
     public get parentEventId(): string {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -262,6 +262,7 @@ export class MatrixEvent extends EventEmitter {
      * A reference to the thread this event belongs to
      */
     private thread: Thread = null;
+    private threadId: string;
 
     /* Set an approximate timestamp for the event relative the local clock.
      * This will inherently be approximate because it doesn't take into account
@@ -499,10 +500,13 @@ export class MatrixEvent extends EventEmitter {
      * @experimental
      * Get the event ID of the thread head
      */
-    public get threadRootId(): string {
+    public get threadRootId(): string | undefined {
         const relatesTo = this.getWireContent()?.["m.relates_to"];
         if (relatesTo?.rel_type === RelationType.Thread) {
             return relatesTo.event_id;
+        } else {
+            return this.threadId
+                || this.getThread()?.id;
         }
     }
 
@@ -1544,8 +1548,12 @@ export class MatrixEvent extends EventEmitter {
     /**
      * @experimental
      */
-    public getThread(): Thread {
+    public getThread(): Thread | undefined {
         return this.thread;
+    }
+
+    public setThreadId(threadId: string): void {
+        this.threadId = threadId;
     }
 }
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -119,7 +119,7 @@ export interface IEvent {
     age?: number;
 }
 
-interface IAggregatedRelation {
+export interface IAggregatedRelation {
     origin_server_ts: number;
     event_id?: string;
     sender?: string;

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { EventEmitter } from 'events';
 
-import { EventStatus, MatrixEvent } from './event';
+import { EventStatus, MatrixEvent, IAggregatedRelation } from './event';
 import { Room } from './room';
 import { logger } from '../logger';
 import { RelationType } from "../@types/event";
@@ -319,7 +319,7 @@ export class Relations extends EventEmitter {
 
         // the all-knowning server tells us that the event at some point had
         // this timestamp for its replacement, so any following replacement should definitely not be less
-        const replaceRelation = this.targetEvent.getServerAggregatedRelation(RelationType.Replace);
+        const replaceRelation = this.targetEvent.getServerAggregatedRelation<IAggregatedRelation>(RelationType.Replace);
         const minTs = replaceRelation && replaceRelation.origin_server_ts;
 
         const lastReplacement = this.getRelations().reduce((last, event) => {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1571,10 +1571,12 @@ export class Room extends EventEmitter {
                     const timelineSet = this.timelineSets[i];
                     if (timelineSet.getFilter()) {
                         if (timelineSet.getFilter().filterRoomTimeline([event]).length) {
-                            thread.addEvent(event, false);
+                            timelineSet.addEventToTimeline(event,
+                                timelineSet.getLiveTimeline(), false);
                         }
                     } else {
-                        thread.addEvent(event, false);
+                        timelineSet.addEventToTimeline(event,
+                            timelineSet.getLiveTimeline(), false);
                     }
                 }
             }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1393,6 +1393,7 @@ export class Room extends EventEmitter {
 
     public createThread(events: MatrixEvent[]): Thread {
         const thread = new Thread(events, this, this.client);
+        logger.log("createThread", thread.id);
         this.threads.set(thread.id, thread);
         this.reEmitter.reEmit(thread, [
             ThreadEvent.Update,

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -48,8 +48,8 @@ export class Thread extends TypedEventEmitter<ThreadEvent> {
 
     private reEmitter: ReEmitter;
 
-    private _lastReply: MatrixEvent;
-    private _replyCount = 0;
+    private lastReply: MatrixEvent;
+    private replyCount = 0;
 
     constructor(
         events: MatrixEvent[] = [],

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -32,6 +32,7 @@ interface IOpts {
 export interface IMinimalEvent {
     content: IContent;
     type: EventType | string;
+    unsigned?: IUnsigned;
 }
 
 export interface IEphemeral {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -284,7 +284,7 @@ export class SyncApi {
                 leaveRooms = this.mapSyncResponseToRoomArray(data.rooms.leave);
             }
             const rooms = [];
-            leaveRooms.forEach((leaveObj) => {
+            leaveRooms.forEach(async (leaveObj) => {
                 const room = leaveObj.room;
                 rooms.push(room);
                 if (!leaveObj.isBrandNewRoom) {
@@ -310,7 +310,7 @@ export class SyncApi {
                     EventTimeline.BACKWARDS);
 
                 this.processRoomEvents(room, stateEvents, timelineEvents);
-                this.processThreadEvents(room, threadedEvents);
+                await this.processThreadEvents(room, threadedEvents);
 
                 room.recalculate();
                 client.store.storeRoom(room);
@@ -1307,7 +1307,7 @@ export class SyncApi {
             const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
 
             this.processRoomEvents(room, stateEvents, timelineEvents, syncEventData.fromCache);
-            this.processThreadEvents(room, threadedEvents);
+            await this.processThreadEvents(room, threadedEvents);
 
             // set summary after processing events,
             // because it will trigger a name calculation
@@ -1366,7 +1366,7 @@ export class SyncApi {
         });
 
         // Handle leaves (e.g. kicked rooms)
-        leaveRooms.forEach((leaveObj) => {
+        leaveRooms.forEach(async (leaveObj) => {
             const room = leaveObj.room;
             const stateEvents = this.mapSyncEventsFormat(leaveObj.state, room);
             const events = this.mapSyncEventsFormat(leaveObj.timeline, room);
@@ -1375,7 +1375,7 @@ export class SyncApi {
             const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
 
             this.processRoomEvents(room, stateEvents, timelineEvents);
-            this.processThreadEvents(room, threadedEvents);
+            await this.processThreadEvents(room, threadedEvents);
             room.addAccountData(accountDataEvents);
 
             room.recalculate();
@@ -1720,7 +1720,7 @@ export class SyncApi {
     /**
      * @experimental
      */
-    private processThreadEvents(room: Room, threadedEvents: MatrixEvent[]): void {
+    private processThreadEvents(room: Room, threadedEvents: MatrixEvent[]): Promise<void> {
         return this.client.processThreadEvents(room, threadedEvents);
     }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/20708
Fixes https://github.com/vector-im/element-web/issues/20709
Fixes https://github.com/vector-im/element-web/issues/20607
Fixes https://github.com/vector-im/element-web/issues/20605
Fixes https://github.com/vector-im/element-web/issues/20633

- Make threadRootId work for relation of thread relations
- Avoid race conditions creating multiple thread of the same type
- Improve typing for server side aggregated relations
- Use bundled relationships for thread reply count
- Count all events when threads has not server support'
- Improved thread root detection using server side aggregated relations

The tackles three main things that were the root of a lot of recent bugs we have seen in threads

- Better leverages bundled relationships way more than I used to which has a 100% accurate reply count when server side support is enabled.
- Multiple threads model were created for the same thread root during the initial sync due to some race condition. Thread creation used to be synchronous but that can not be the case anymore
- Some `m.replace` and `m.room.redaction` were not partitioned correctly

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->