### PR TITLE
Don't store streams that are only used once

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -937,7 +937,7 @@ export class MatrixCall extends EventEmitter {
             const upgradeVideo = video && !this.hasLocalUserMediaVideoTrack;
             logger.debug(`Upgrading call: audio?=${upgradeAudio} video?=${upgradeVideo}`);
 
-            const stream = await this.client.getMediaHandler().getUserMediaStream(upgradeAudio, upgradeVideo);
+            const stream = await this.client.getMediaHandler().getUserMediaStream(upgradeAudio, upgradeVideo, false);
             if (upgradeAudio && upgradeVideo) {
                 if (this.hasLocalUserMediaAudioTrack) return;
                 if (this.hasLocalUserMediaVideoTrack) return;
@@ -1978,7 +1978,7 @@ export class MatrixCall extends EventEmitter {
     }
 
     private stopAllMedia(): void {
-        logger.debug(`stopAllMedia (stream=${this.localUsermediaStream})`);
+        logger.debug("Stopping all media for call", this.callId);
 
         for (const feed of this.feeds) {
             if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Usermedia) {
@@ -1986,6 +1986,7 @@ export class MatrixCall extends EventEmitter {
             } else if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Screenshare) {
                 this.client.getMediaHandler().stopScreensharingStream(feed.stream);
             } else {
+                logger.debug("Stopping remote stream", feed.stream.id);
                 for (const track of feed.stream.getTracks()) {
                     track.stop();
                 }

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -54,9 +54,12 @@ export class MediaHandler {
     }
 
     /**
+     * @param audio should have an audio track
+     * @param video should have a video track
+     * @param reusable is allowed to be reused by the MediaHandler
      * @returns {MediaStream} based on passed parameters
      */
-    public async getUserMediaStream(audio: boolean, video: boolean): Promise<MediaStream> {
+    public async getUserMediaStream(audio: boolean, video: boolean, reusable = true): Promise<MediaStream> {
         const shouldRequestAudio = audio && await this.hasAudioDevice();
         const shouldRequestVideo = video && await this.hasVideoDevice();
 
@@ -78,7 +81,9 @@ export class MediaHandler {
             stream = await navigator.mediaDevices.getUserMedia(constraints);
         }
 
-        this.userMediaStreams.push(stream);
+        if (reusable) {
+            this.userMediaStreams.push(stream);
+        }
 
         return stream;
     }
@@ -101,9 +106,11 @@ export class MediaHandler {
     }
 
     /**
+     * @param desktopCapturerSourceId sourceId for Electron DesktopCapturer
+     * @param reusable is allowed to be reused by the MediaHandler
      * @returns {MediaStream} based on passed parameters
      */
-    public async getScreensharingStream(desktopCapturerSourceId: string): Promise<MediaStream | null> {
+    public async getScreensharingStream(desktopCapturerSourceId: string, reusable = true): Promise<MediaStream | null> {
         let stream: MediaStream;
 
         if (this.screensharingStreams.length === 0) {
@@ -125,7 +132,9 @@ export class MediaHandler {
             stream = matchingStream.clone();
         }
 
-        this.screensharingStreams.push(stream);
+        if (reusable) {
+            this.screensharingStreams.push(stream);
+        }
 
         return stream;
     }


### PR DESCRIPTION
Type: defect
Notes element-web: Fix enabling video in voice calls working only once
Fixes https://github.com/vector-im/element-web/issues/20932

<hr>

Without this `MediaHandler` would always push the stream we used to get a new track while upgrading a call. We don't keep track of that stream in the call itself, so we never call `stopUserMediaStream()` for it but we `stop()` its tracks. When trying to upgrade a call again `MediaHandler` would try to re-use the stream but its tracks would be empty. Therefore we avoid pushing the stream so that it doesn't get re-used

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't store streams that are only used once ([\#2157](https://github.com/matrix-org/matrix-js-sdk/pull/2157)). Fixes vector-im/element-web#20932. Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->