### PR TITLE
Account for encryption in `maySendMessage()`

### DIFF
--- a/spec/unit/room.spec.js
+++ b/spec/unit/room.spec.js
@@ -1461,7 +1461,7 @@ describe("Room", function() {
     describe("maySendMessage", function() {
         it("should return false if synced membership not join",
         function() {
-            const room = new Room(roomId, null, userA);
+            const room = new Room(roomId, { isRoomEncrypted: () => false }, userA);
             room.updateMyMembership("invite");
             expect(room.maySendMessage()).toEqual(false);
             room.updateMyMembership("leave");

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2199,9 +2199,9 @@ export class Room extends EventEmitter {
      *                   message events into the room.
      */
     public maySendMessage(): boolean {
-        return this.getMyMembership() === 'join' && this.client.isRoomEncrypted(this.roomId)
+        return this.getMyMembership() === 'join' && (this.client.isRoomEncrypted(this.roomId)
             ? this.currentState.maySendEvent(EventType.RoomMessageEncrypted, this.myUserId)
-            : this.currentState.maySendEvent(EventType.RoomMessage, this.myUserId);
+            : this.currentState.maySendEvent(EventType.RoomMessage, this.myUserId));
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2199,8 +2199,9 @@ export class Room extends EventEmitter {
      *                   message events into the room.
      */
     public maySendMessage(): boolean {
-        return this.getMyMembership() === 'join' &&
-            this.currentState.maySendEvent(EventType.RoomMessage, this.myUserId);
+        return this.getMyMembership() === 'join' && this.client.isRoomEncrypted(this.roomId)
+            ? this.currentState.maySendEvent(EventType.RoomMessageEncrypted, this.myUserId)
+            : this.currentState.maySendEvent(EventType.RoomMessage, this.myUserId);
     }
 
     /**


### PR DESCRIPTION
Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Account for encryption in `maySendMessage()` ([\#2159](https://github.com/matrix-org/matrix-js-sdk/pull/2159)). Contributed by @SimonBrandner.<!-- CHANGELOG_PREVIEW_END -->