### PR TITLE
Check the backup info against the stored private key when determining trust.

### DIFF
--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -323,6 +323,9 @@ export class BackupManager {
                     logger.info("Backup is trusted locally");
                     ret.trusted_locally = true;
                 }
+            } catch {
+                // do nothing -- if we have an error, then we don't mark it as
+                // locally trusted
             } finally {
                 if (algorithm) {
                     algorithm.free();


### PR DESCRIPTION
Currently, when checking if the key backup is trusted, it checks if the stored trusted public key matches the public key in the backup.  This has two problems: 1) we never actually store a trusted public key anywhere, and 2) this would not work for when we switch to symmetric backup.  Instead, this patch checks the cached private key, and checks if the backup info matches the private key, using the algorithm-specific method for checking the key.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Check the backup info against the stored private key when determining trust. ([\#2167](https://github.com/matrix-org/matrix-js-sdk/pull/2167)).<!-- CHANGELOG_PREVIEW_END -->