### PR TITLE
Sign backup with cross-signing key when we reset it.

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -953,6 +953,8 @@ export class Crypto extends EventEmitter {
             // sign with the device fingerprint
             await this.signObject(data.auth_data);
 
+            await this.backupManager.enableKeyBackup(data);
+
             builder.addSessionBackup(data);
         }
 


### PR DESCRIPTION
When we reset the key backup, enable it right away.  This ensures that we remember it if `bootstrapCrossSigning` gets called, so that the `auth_data` gets signed by the master key, if a new key is created.  Without this change, `this.backupManager.backupInfo` won't get set until some time after `bootstrapCrossSigning` is called, so it will think that there's no backup, and the `auth_data` will not get signed by the new master key.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Sign backup with cross-signing key when we reset it. ([\#2170](https://github.com/matrix-org/matrix-js-sdk/pull/2170)).<!-- CHANGELOG_PREVIEW_END -->