### PR TITLE
Revert "Sign backup with cross-signing key when we reset it."

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -953,8 +953,6 @@ export class Crypto extends EventEmitter {
             // sign with the device fingerprint
             await this.signObject(data.auth_data);
 
-            await this.backupManager.enableKeyBackup(data);
-
             builder.addSessionBackup(data);
         }
 


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#2170

cc @uhoreg 

This breaks react-sdk e2e test suite with an error like

```
 * alice joins room "#lltest:localhost" ... failure:  TimeoutError: waiting for selector `.mx_DirectorySearchBox input` failed: timeout 20000ms exceeded
    at new WaitTask (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:509:34)
    at DOMWorld.waitForSelectorInPage (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:420:26)
    at Object.internalHandler.waitFor (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/QueryHandler.js:31:77)
    at DOMWorld.waitForSelector (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/DOMWorld.js:313:29)
    at Frame.waitForSelector (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/FrameManager.js:841:51)
    at Page.waitForSelector (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:1335:33)
    at ElementSession.query (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/lib/src/session.js:133:26)
    at /Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/lib/src/usecases/join.js:36:41
    at Generator.next (<anonymous>)
    at fulfilled (/Users/t3chguy/WebstormProjects/matrix-react-sdk/test/end-to-end-tests/lib/src/usecases/join.js:21:58)
```

Some investigation has shown this is due to the following modal firing for Alice:

![image](https://user-images.githubusercontent.com/2403652/153929460-1a001552-5add-4677-809e-6c2ce5b772e3.png)

Digging deeper I found that the js-sdk split-brained on the current backup version:

![image](https://user-images.githubusercontent.com/2403652/153929532-beaaa84c-e44f-4544-a4b9-e37c1d74dc00.png)
![image](https://user-images.githubusercontent.com/2403652/153929550-acd7c807-da48-409b-ab70-13278b3ff3a7.png)

matrix-org/matrix-js-sdk#2170 seems to not set a current_version which may cause/propagate such a split-brain.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Sign backup with cross-signing key when we reset it." ([\#2175](https://github.com/matrix-org/matrix-js-sdk/pull/2175)).<!-- CHANGELOG_PREVIEW_END -->