### PR TITLE
Stabilise token authenticated registration support

### DIFF
--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -60,7 +60,7 @@ export enum AuthType {
     Sso = "m.login.sso",
     SsoUnstable = "org.matrix.login.sso",
     Dummy = "m.login.dummy",
-    RegistrationToken = "org.matrix.msc3231.login.registration_token",
+    RegistrationToken = "m.login.registration_token",
 }
 
 export interface IAuthDict {
@@ -79,7 +79,8 @@ export interface IAuthDict {
     // eslint-disable-next-line camelcase
     threepid_creds?: any;
     threepidCreds?: any;
-    registrationToken?: string;
+    // For m.login.registration_token type
+    token?: string;
 }
 
 class NoAuthFlowFoundError extends Error {

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -61,6 +61,10 @@ export enum AuthType {
     SsoUnstable = "org.matrix.login.sso",
     Dummy = "m.login.dummy",
     RegistrationToken = "m.login.registration_token",
+    // For backwards compatability with servers that have not yet updated to
+    // use the stable "m.login.registration_token" type.
+    // The authentication flow is the same in both cases.
+    UnstableRegistrationToken = "org.matrix.msc3231.login.registration_token",
 }
 
 export interface IAuthDict {


### PR DESCRIPTION
Token authenticated registration was added to the Matrix specification in v1.2:
https://spec.matrix.org/v1.2/client-server-api/#token-authenticated-registration

Signed-off-by: Callum Brown <callum@calcuode.com>


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Stabilise token authenticated registration support ([\#2181](https://github.com/matrix-org/matrix-js-sdk/pull/2181)). Contributed by @govynnus.<!-- CHANGELOG_PREVIEW_END -->