### PR TITLE
Fix incorrect type referenced in receiptCacheByEventId.

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -151,7 +151,7 @@ export class Room extends EventEmitter {
     // which pass in an event ID and get back some receipts, so we also store
     // a pre-cached list for this purpose.
     private receipts: Receipts = {}; // { receipt_type: { user_id: IReceipt } }
-    private receiptCacheByEventId: ReceiptCache = {}; // { event_id: IReceipt2[] }
+    private receiptCacheByEventId: ReceiptCache = {}; // { event_id: ICachedReceipt[] }
     private notificationCounts: Partial<Record<NotificationCountType, number>> = {};
     private readonly timelineSets: EventTimelineSet[];
     // any filtered timeline sets we're maintaining for this room


### PR DESCRIPTION
The comments near `receiptCacheByEventId` referred to `IReceipt2`, looking at the definition of the `ReceiptCache` type we see that it is actually `ICachedReceipt`:

https://github.com/matrix-org/matrix-js-sdk/blob/2910e62bb68db2e9bdf9eeb5b5d13d5bb269c424/src/models/room.ts#L99

I looked briefly and I think this has been there since it was converted to TypeScript, `git log -SIReceipt2` only brings up 7aa5a79c86d23c01a3a0212e3079cf83d30dcc0d.

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->