### PR TITLE
Fix bug where calls could break if rejected from somewhere else

### DIFF
--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -258,7 +258,7 @@ export class CallEventHandler {
                         call.onRejectReceived(content as MCallHangupReject);
                     }
 
-                    // @ts-ignore typescript thinks the state can't be 'ended' because we're
+                    // @ts-expect-error typescript thinks the state can't be 'ended' because we're
                     // inside the if block where it wasn't, but it could have changed because
                     // on[Hangup|Reject]Received are side-effecty.
                     if (call.state === CallState.Ended) this.calls.delete(content.call_id);

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -257,7 +257,11 @@ export class CallEventHandler {
                     } else {
                         call.onRejectReceived(content as MCallHangupReject);
                     }
-                    this.calls.delete(content.call_id);
+
+                    // @ts-ignore typescript thinks the state can't be 'ended' because we're
+                    // inside the if block where it wasn't, but it could have changed because
+                    // on[Hangup|Reject]Received are side-effecty.
+                    if (call.state === CallState.Ended) this.calls.delete(content.call_id);
                 }
             }
             return;


### PR DESCRIPTION
When callEventHandler passed a reject event to the call object, it assumed
that always caused the call to end and deleted it from the list, so it
never got any more events. The point of a reject is that it doesn't
end the call if it's already been picked up though. This only removes
the call if it's actually ended.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix bug where calls could break if rejected from somewhere else ([\#2189](https://github.com/matrix-org/matrix-js-sdk/pull/2189)).<!-- CHANGELOG_PREVIEW_END -->