### PR TITLE
Fix bug with one-way audio after a transfer

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -585,9 +585,11 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     private pushNewLocalFeed(stream: MediaStream, purpose: SDPStreamMetadataPurpose, addToPeerConnection = true): void {
         const userId = this.client.getUserId();
 
-        // TODO: Find out what is going on here
-        // why do we enable audio (and only audio) tracks here? -- matthew
+        // Tracks don't always start off enabled, eg. chrome will give a disabled
+        // audio track if you ask for user media audio and already had one that
+        // you'd set to disabled (presumably because it clones them internally).
         setTracksEnabled(stream.getAudioTracks(), true);
+        setTracksEnabled(stream.getVideoTracks(), true);
 
         // We try to replace an existing feed if there already is one with the same purpose
         const existingFeed = this.getLocalFeeds().find((feed) => feed.purpose === purpose);
@@ -630,7 +632,8 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                     `id="${track.id}", ` +
                     `kind="${track.kind}", ` +
                     `streamId="${callFeed.stream.id}", ` +
-                    `streamPurpose="${callFeed.purpose}"` +
+                    `streamPurpose="${callFeed.purpose}", ` +
+                    `enabled=${track.enabled}` +
                     `) to peer connection`,
                 );
                 senderArray.push(this.peerConn.addTrack(track, callFeed.stream));
@@ -2078,6 +2081,12 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
         try {
             const stream = await this.client.getMediaHandler().getUserMediaStream(audio, video);
+
+            // make sure all the tracks are enabled (same as pushNewLocalFeed -
+            // we probably ought to just have one code path for adding streams)
+            setTracksEnabled(stream.getAudioTracks(), true);
+            setTracksEnabled(stream.getVideoTracks(), true);
+
             const callFeed = new CallFeed({
                 client: this.client,
                 roomId: this.roomId,


### PR DESCRIPTION
Seems chrome at least will give you a disabled audio track if you
already had another user media audio track and disabled it, so make
sure our tracks are enabled when we add them. We already did this
on one code path but it didn't get moved over when a new code path
was added.

On the plus side, we now know the reason for the ancient code that
had the comment asking what it was for, so update that.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix bug with one-way audio after a transfer ([\#2193](https://github.com/matrix-org/matrix-js-sdk/pull/2193)).<!-- CHANGELOG_PREVIEW_END -->