### PR TITLE
Export `partials` types

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -48,6 +48,7 @@ export * from "./crypto/store/indexeddb-crypto-store";
 export * from "./content-repo";
 export * from './@types/event';
 export * from './@types/PushRules';
+export * from './@types/partials';
 export * from './@types/requests';
 export * from './@types/search';
 export * from './models/room-summary';


### PR DESCRIPTION
Export types from `@types/partials.ts` within the main matrix-js-sdk entrypoint so they can be easily imported by consumers without additional setup, i.e.

```
import { Preset, Visibility } from 'matrix-js-sdk';
```

Signed-off-by: Stanislav Demydiuk <s.demydiuk@gmail.com>


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->