### PR TITLE
Make createThread more resilient when missing rootEvent

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1,8 +1,8 @@
 import * as utils from "../test-utils";
 import { DuplicateStrategy, EventStatus, MatrixEvent, PendingEventOrdering, RoomEvent } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
-import { RoomState } from "../../src";
-import { Room } from "../../src";
+import { Room } from "../../src/models/room";
+import { RoomState } from "../../src/models/room-state";
 import { RelationType, UNSTABLE_ELEMENT_FUNCTIONAL_USERS } from "../../src/@types/event";
 import { TestClient } from "../TestClient";
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1462,7 +1462,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                 RoomEvent.TimelineReset,
             ]);
 
-            if (!this.lastThread || this.lastThread.rootEvent.localTimestamp < rootEvent.localTimestamp) {
+            if (!this.lastThread || this.lastThread.rootEvent?.localTimestamp < rootEvent?.localTimestamp) {
                 this.lastThread = thread;
             }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21130

Also migrated `room.spec.js` to TypeScript. Important to note that `createMockClient` do not fulfill the `MatrixClient` interface. It was too big of a job to undertake for this fix, hence the `as any` that you can spot here and there.

Better viewed adding `?w=1` to the URL to hide the whitespaces diff, as it looks like our ESLint rules are slightly different for JS and TS files.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->