### PR TITLE
Make eventType optional for relations

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7152,11 +7152,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             templatedUrl += "/$relationType";
             if (eventType !== null) {
                 templatedUrl += "/$eventType";
-            } else {
-                logger.warn(`eventType: ${eventType} ignored when fetching
-                relations as relationType is null`);
-                eventType = null;
             }
+        } else if (eventType !== null) {
+            logger.warn(`eventType: ${eventType} ignored when fetching
+            relations as relationType is null`);
+            eventType = null;
         }
 
         const path = utils.encodeUri(


### PR DESCRIPTION
As per MSC2675, `eventType` is optional and can be omitted.

https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/2675-aggregations-server.md#querying-relations

Also fixed an issue where the generated URL would be incorrect if someone passed `relationType=null` and a value for `eventType`.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->