### PR TITLE
Fix wrong event_id being sent for m.in_reply_to of threads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3718,7 +3718,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 content["m.relates_to"]["m.in_reply_to"] = {
                     "event_id": thread.lastReply((ev: MatrixEvent) => {
                         return ev.isThreadRelation && !ev.status;
-                    }),
+                    })?.getId(),
                 };
             }
         }
@@ -3774,7 +3774,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // then listen for the remote echo of that event so that by the time
         // this event does get sent, we have the correct event_id
         const targetId = localEvent.getAssociatedId();
-        if (targetId && targetId.startsWith("~")) {
+        if (targetId?.startsWith("~")) {
             const target = room.getPendingEvents().find(e => e.getId() === targetId);
             target.once(MatrixEventEvent.LocalEventIdReplaced, () => {
                 localEvent.updateAssociatedId(target.getId());


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix wrong event_id being sent for m.in_reply_to of threads ([\#2213](https://github.com/matrix-org/matrix-js-sdk/pull/2213)).<!-- CHANGELOG_PREVIEW_END -->