### PR TITLE
Add lint for unused locals

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4924,40 +4924,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         );
     }
 
-    /**
-     * This is an internal method.
-     * @param {MatrixClient} client
-     * @param {string} roomId
-     * @param {string} userId
-     * @param {string} membershipValue
-     * @param {string} reason
-     * @param {module:client.callback} callback Optional.
-     * @return {Promise} Resolves: TODO
-     * @return {module:http-api.MatrixError} Rejects: with an error response.
-     */
-    private setMembershipState(
-        roomId: string,
-        userId: string,
-        membershipValue: string,
-        reason?: string,
-        callback?: Callback,
-    ) {
-        if (utils.isFunction(reason)) {
-            callback = reason as any as Callback; // legacy
-            reason = undefined;
-        }
-
-        const path = utils.encodeUri(
-            "/rooms/$roomId/state/m.room.member/$userId",
-            { $roomId: roomId, $userId: userId },
-        );
-
-        return this.http.authedRequest(callback, Method.Put, path, undefined, {
-            membership: membershipValue,
-            reason: reason,
-        });
-    }
-
     private membershipChange(
         roomId: string,
         userId: string,

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -112,7 +112,7 @@ export class VerificationRequest<
 
     private commonMethods: VerificationMethod[] = [];
     private _phase: Phase;
-    private _cancellingUserId: string;
+    public _cancellingUserId: string; // Used in tests only
     private _verifier: VerificationBase<any, any>;
 
     constructor(

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1079,7 +1079,7 @@ export class MatrixError extends Error {
  * @constructor
  */
 export class ConnectionError extends Error {
-    constructor(message: string, private readonly cause: Error = undefined) {
+    constructor(message: string, cause: Error = undefined) {
         super(message + (cause ? `: ${cause.message}` : ""));
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
+    "noUnusedLocals": true,
     "noEmit": true,
     "declaration": true
   },


### PR DESCRIPTION
TypeScript supports checking for "unused locals", which actually includes
locals, private fields, private methods, etc. If a private thing is actually
needed as part of the API surface, you can change it to public to resolve the
error.

This seems like a good check to have, as it highlights unused bits of code that
perhaps got lost while refactoring. This changes our config to reject them and
fixes up a few existing cases.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->