### PR TITLE
Fix missing threads in thread list

### DIFF
--- a/spec/unit/filter-component.spec.ts
+++ b/spec/unit/filter-component.spec.ts
@@ -126,7 +126,46 @@ describe("Filter Component", function() {
                 event: true,
             });
 
+            const eventWithMultipleRelations = mkEvent({
+                "type": "m.room.message",
+                "content": {},
+                "unsigned": {
+                    "m.relations": {
+                        "testtesttest": {},
+                        "m.annotation": {
+                            "chunk": [
+                                {
+                                    "type": "m.reaction",
+                                    "key": "🤫",
+                                    "count": 1,
+                                },
+                            ],
+                        },
+                        [RelationType.Thread]: {
+                            count: 2,
+                            current_user_participated: true,
+                        },
+                    },
+                },
+                "room": 'roomId',
+                "event": true,
+            });
+
+            const noMatchEvent = mkEvent({
+                "type": "m.room.message",
+                "content": {},
+                "unsigned": {
+                    "m.relations": {
+                        "testtesttest": {},
+                    },
+                },
+                "room": 'roomId',
+                "event": true,
+            });
+
             expect(filter.check(threadRootEvent)).toBe(true);
+            expect(filter.check(eventWithMultipleRelations)).toBe(true);
+            expect(filter.check(noMatchEvent)).toBe(false);
         });
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -5383,7 +5383,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 only: 'highlight',
             };
 
-            if (token && token !== "end") {
+            if (token !== null && token !== "end") {
                 params.from = token;
             }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5383,7 +5383,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 only: 'highlight',
             };
 
-            if (token !== null && token !== "end") {
+            if (token !== "end") {
                 params.from = token;
             }
 

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -183,8 +183,8 @@ export class FilterComponent {
     }
 
     private arrayMatchesFilter(filter: any[], values: any[]): boolean {
-        return values.length > 0 && values.every(value => {
-            return filter.includes(value);
+        return values.length > 0 && filter.every(value => {
+            return values.includes(value);
         });
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -177,7 +177,7 @@ export type RoomEventHandlerMap = {
         oldEventId?: string,
         oldStatus?: EventStatus,
     ) => void;
-    [ThreadEvent.New]: (thread: Thread) => void;
+    [ThreadEvent.New]: (thread: Thread, toStartOfTimeline: boolean) => void;
 } & ThreadHandlerMap;
 
 export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> {
@@ -1435,14 +1435,18 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                 // it. If it wasn't fetched successfully the thread will work
                 // in "limited" mode and won't benefit from all the APIs a homeserver
                 // can provide to enhance the thread experience
-                thread = this.createThread(rootEvent, events);
+                thread = this.createThread(rootEvent, events, toStartOfTimeline);
             }
         }
 
         this.emit(ThreadEvent.Update, thread);
     }
 
-    public createThread(rootEvent: MatrixEvent | undefined, events: MatrixEvent[] = []): Thread | undefined {
+    public createThread(
+        rootEvent: MatrixEvent | undefined,
+        events: MatrixEvent[] = [],
+        toStartOfTimeline: boolean,
+    ): Thread | undefined {
         if (rootEvent) {
             const tl = this.getTimelineForEvent(rootEvent.getId());
             const relatedEvents = tl?.getTimelineSet().getAllRelationsEventForEvent(rootEvent.getId());
@@ -1470,7 +1474,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                 this.lastThread = thread;
             }
 
-            this.emit(ThreadEvent.New, thread);
+            this.emit(ThreadEvent.New, thread, toStartOfTimeline);
             return thread;
         }
     }

--- a/src/timeline-window.ts
+++ b/src/timeline-window.ts
@@ -240,7 +240,7 @@ export class TimelineWindow {
         }
 
         return Boolean(tl.timeline.getNeighbouringTimeline(direction) ||
-            tl.timeline.getPaginationToken(direction));
+            tl.timeline.getPaginationToken(direction) !== null);
     }
 
     /**
@@ -297,7 +297,7 @@ export class TimelineWindow {
 
         // try making a pagination request
         const token = tl.timeline.getPaginationToken(direction);
-        if (!token) {
+        if (token === null) {
             debuglog("TimelineWindow: no token");
             return Promise.resolve(false);
         }


### PR DESCRIPTION
A couple of issues were causing this. We can now paginate in a timeline with no initial pagination token,  the JS-SDK implementation would unfortunately not allow for that. And there was a bug of implementation in the local filter

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->