### PR TITLE
Fix incorrect usage of unstable variant of `is_falling_back`

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -107,7 +107,7 @@ export interface IEventRelation {
     "m.in_reply_to"?: {
         event_id: string;
         is_falling_back?: boolean;
-        "io.element.is_falling_back"?: boolean; // unstable variant of `is_falling_back` - MSC3440
+        "io.element.show_reply"?: boolean; // unstable variant of `is_falling_back` - MSC3440
     };
     key?: string;
 }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -196,7 +196,7 @@ export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
         // There is a risk that the `localTimestamp` approximation will not be accurate
         // when threads are used over federation. That could results in the reply
         // count value drifting away from the value returned by the server
-        if (!this.lastEvent || (isThreadReply && event.localTimestamp > this.replyToEvent.localTimestamp)) {
+        if (!this.lastEvent || (isThreadReply && event.localTimestamp > this.lastEvent.localTimestamp)) {
             this.lastEvent = event;
             if (this.lastEvent.getId() !== this.id) {
                 // This counting only works when server side support is enabled


### PR DESCRIPTION
Fixes incorrect unstable msc variant being used

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect usage of unstable variant of `is_falling_back` ([\#2227](https://github.com/matrix-org/matrix-js-sdk/pull/2227)).<!-- CHANGELOG_PREVIEW_END -->