### PR TITLE
emit aggregate room beacon liveness

### DIFF
--- a/spec/test-utils/emitter.ts
+++ b/spec/test-utils/emitter.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Filter emitter.emit mock calls to find relevant events
  * eg:

--- a/spec/test-utils/emitter.ts
+++ b/spec/test-utils/emitter.ts
@@ -1,0 +1,12 @@
+/**
+ * Filter emitter.emit mock calls to find relevant events
+ * eg:
+ * ```
+ * const emitSpy = jest.spyOn(state, 'emit');
+ * << actions >>
+ * const beaconLivenessEmits = emitCallsByEventType(BeaconEvent.New, emitSpy);
+ * expect(beaconLivenessEmits.length).toBe(1);
+ * ```
+ */
+export const filterEmitCallsByEventType = (eventType: string, spy: jest.SpyInstance<any, unknown[]>) =>
+    spy.mock.calls.filter((args) => args[0] === eventType);

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -119,7 +119,9 @@ describe('Beacon', () => {
             const beacon = new Beacon(liveBeaconEvent);
 
             expect(beacon.beaconInfoId).toEqual(liveBeaconEvent.getId());
+            expect(beacon.roomId).toEqual(roomId);
             expect(beacon.isLive).toEqual(true);
+            expect(beacon.beaconInfoOwner).toEqual(userId);
         });
 
         describe('isLive()', () => {

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -27,6 +27,7 @@ export * from "./http-api";
 export * from "./autodiscovery";
 export * from "./sync-accumulator";
 export * from "./errors";
+export * from "./models/beacon";
 export * from "./models/event";
 export * from "./models/room";
 export * from "./models/group";

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -80,6 +80,23 @@ export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
         }
     }
 
+    /**
+     * Monitor liveness of a beacon
+     * Emits BeaconEvent.LivenessChange when beacon expires
+     */
+    public monitorLiveness(): void {
+        if (this.livenessWatchInterval) {
+            clearInterval(this.livenessWatchInterval);
+        }
+
+        if (this.isLive) {
+            const expiryInMs = (this.beaconInfo?.timestamp + this.beaconInfo?.timeout + 1) - Date.now();
+            if (expiryInMs > 1) {
+                this.livenessWatchInterval = setInterval(this.checkLiveness.bind(this), expiryInMs);
+            }
+        }
+    }
+
     private setBeaconInfo(event: MatrixEvent): void {
         this.beaconInfo = parseBeaconInfoContent(event.getContent());
         this.checkLiveness();
@@ -92,22 +109,6 @@ export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
 
         if (prevLiveness !== this.isLive) {
             this.emit(BeaconEvent.LivenessChange, this.isLive, this);
-        }
-    }
-
-    /**
-     * Monitor liveness of a beacon
-     */
-    public monitorLiveness(): void {
-        if (this.livenessWatchInterval) {
-            clearInterval(this.livenessWatchInterval);
-        }
-
-        if (this.isLive) {
-            const expiryInMs = (this.beaconInfo?.timestamp + this.beaconInfo?.timeout + 1) - Date.now();
-            if (expiryInMs > 1) {
-                this.livenessWatchInterval = setInterval(this.checkLiveness.bind(this), expiryInMs);
-            }
         }
     }
 }

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -22,12 +22,14 @@ import { TypedEventEmitter } from "./typed-event-emitter";
 export enum BeaconEvent {
     New = "Beacon.new",
     Update = "Beacon.update",
+    LivenessChange = "Beacon.LivenessChange",
 }
 
-type EmittedEvents = BeaconEvent.New | BeaconEvent.Update;
+type EmittedEvents = BeaconEvent;
 type EventHandlerMap = {
     [BeaconEvent.New]: (event: MatrixEvent, beacon: Beacon) => void;
     [BeaconEvent.Update]: (event: MatrixEvent, beacon: Beacon) => void;
+    [BeaconEvent.LivenessChange]: (isLive: boolean, beacon: Beacon) => void;
 };
 
 export const isTimestampInDuration = (
@@ -43,18 +45,19 @@ export const isBeaconInfoEventType = (type: string) =>
 // https://github.com/matrix-org/matrix-spec-proposals/pull/3489
 export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
     private beaconInfo: BeaconInfoState;
+    private _isLive: boolean;
+    private livenessWatchInterval: number;
 
     constructor(
         private rootEvent: MatrixEvent,
     ) {
         super();
-        this.beaconInfo = parseBeaconInfoContent(this.rootEvent.getContent());
+        this.setBeaconInfo(this.rootEvent);
         this.emit(BeaconEvent.New, this.rootEvent, this);
     }
 
     public get isLive(): boolean {
-        return this.beaconInfo?.live &&
-            isTimestampInDuration(this.beaconInfo?.timestamp, this.beaconInfo?.timeout, Date.now());
+        return this._isLive;
     }
 
     public get beaconInfoId(): string {
@@ -66,8 +69,45 @@ export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
             throw new Error('Invalid updating event');
         }
         this.rootEvent = beaconInfoEvent;
-        this.beaconInfo = parseBeaconInfoContent(this.rootEvent.getContent());
+        this.setBeaconInfo(this.rootEvent);
 
         this.emit(BeaconEvent.Update, beaconInfoEvent, this);
+    }
+
+    public destroy(): void {
+        if (this.livenessWatchInterval) {
+            clearInterval(this.livenessWatchInterval);
+        }
+    }
+
+    private setBeaconInfo(event: MatrixEvent): void {
+        this.beaconInfo = parseBeaconInfoContent(event.getContent());
+        this.checkLiveness();
+    }
+
+    private checkLiveness(): void {
+        const prevLiveness = this.isLive;
+        this._isLive = this.beaconInfo?.live &&
+            isTimestampInDuration(this.beaconInfo?.timestamp, this.beaconInfo?.timeout, Date.now());
+
+        if (prevLiveness !== this.isLive) {
+            this.emit(BeaconEvent.LivenessChange, this.isLive, this);
+        }
+    }
+
+    /**
+     * Monitor liveness of a beacon
+     */
+    public monitorLiveness(): void {
+        if (this.livenessWatchInterval) {
+            clearInterval(this.livenessWatchInterval);
+        }
+
+        if (this.isLive) {
+            const expiryInMs = (this.beaconInfo?.timestamp + this.beaconInfo?.timeout + 1) - Date.now();
+            if (expiryInMs > 1) {
+                this.livenessWatchInterval = setInterval(this.checkLiveness.bind(this), expiryInMs);
+            }
+        }
     }
 }

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -44,6 +44,7 @@ export const isBeaconInfoEventType = (type: string) =>
 
 // https://github.com/matrix-org/matrix-spec-proposals/pull/3489
 export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
+    public readonly roomId: string;
     private beaconInfo: BeaconInfoState;
     private _isLive: boolean;
     private livenessWatchInterval: number;
@@ -53,6 +54,7 @@ export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
     ) {
         super();
         this.setBeaconInfo(this.rootEvent);
+        this.roomId = this.rootEvent.getRoomId();
         this.emit(BeaconEvent.New, this.rootEvent, this);
     }
 
@@ -62,6 +64,10 @@ export class Beacon extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
 
     public get beaconInfoId(): string {
         return this.rootEvent.getId();
+    }
+
+    public get beaconInfoOwner(): string {
+        return this.rootEvent.getStateKey();
     }
 
     public update(beaconInfoEvent: MatrixEvent): void {

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -431,7 +431,6 @@ export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventH
      * @experimental
      */
     private setBeacon(event: MatrixEvent): void {
-        // if (event.getStateKey() === this.client)
         if (this.beacons.has(event.getId())) {
             return this.beacons.get(event.getId()).update(event);
         }

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -26,7 +26,7 @@ import { MatrixEvent } from "./event";
 import { MatrixClient } from "../client";
 import { GuestAccess, HistoryVisibility, IJoinRuleEventContent, JoinRule } from "../@types/partials";
 import { TypedEventEmitter } from "./typed-event-emitter";
-import { Beacon, isBeaconInfoEventType } from "./beacon";
+import { Beacon, BeaconEvent, isBeaconInfoEventType } from "./beacon";
 
 // possible statuses for out-of-band member loading
 enum OobStatus {
@@ -40,6 +40,7 @@ export enum RoomStateEvent {
     Members = "RoomState.members",
     NewMember = "RoomState.newMember",
     Update = "RoomState.update", // signals batches of updates without specificity
+    BeaconLiveness = "RoomState.BeaconLiveness",
 }
 
 export type RoomStateEventHandlerMap = {
@@ -47,6 +48,7 @@ export type RoomStateEventHandlerMap = {
     [RoomStateEvent.Members]: (event: MatrixEvent, state: RoomState, member: RoomMember) => void;
     [RoomStateEvent.NewMember]: (event: MatrixEvent, state: RoomState, member: RoomMember) => void;
     [RoomStateEvent.Update]: (state: RoomState) => void;
+    [RoomStateEvent.BeaconLiveness]: (state: RoomState, hasLiveBeacons: boolean) => void;
 };
 
 export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventHandlerMap> {
@@ -73,6 +75,7 @@ export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventH
     public paginationToken: string = null;
 
     public readonly beacons = new Map<string, Beacon>();
+    private liveBeaconIds: string[] = [];
 
     /**
      * Construct room state.
@@ -235,6 +238,10 @@ export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventH
         return event ? event : null;
     }
 
+    public get hasLiveBeacons(): boolean {
+        return !!this.liveBeaconIds?.length;
+    }
+
     /**
      * Creates a copy of this room state so that mutations to either won't affect the other.
      * @return {RoomState} the copy of the room state
@@ -330,6 +337,8 @@ export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventH
             this.emit(RoomStateEvent.Events, event, this, lastStateEvent);
         });
 
+        this.onBeaconLivenessChange();
+
         // update higher level data structures. This needs to be done AFTER the
         // core event dict as these structures may depend on other state events in
         // the given array (e.g. disambiguating display names in one go to do both
@@ -418,13 +427,36 @@ export class RoomState extends TypedEventEmitter<RoomStateEvent, RoomStateEventH
         this.events.get(event.getType()).set(event.getStateKey(), event);
     }
 
+    /**
+     * @experimental
+     */
     private setBeacon(event: MatrixEvent): void {
+        // if (event.getStateKey() === this.client)
         if (this.beacons.has(event.getId())) {
             return this.beacons.get(event.getId()).update(event);
         }
 
         const beacon = new Beacon(event);
+        beacon.on(BeaconEvent.LivenessChange, this.onBeaconLivenessChange.bind(this));
         this.beacons.set(beacon.beaconInfoId, beacon);
+    }
+
+    /**
+     * @experimental
+     * Check liveness of room beacons
+     * emit RoomStateEvent.BeaconLiveness when
+     * roomstate.hasLiveBeacons has changed
+     */
+    private onBeaconLivenessChange(): void {
+        const prevHasLiveBeacons = !!this.liveBeaconIds?.length;
+        this.liveBeaconIds = Array.from(this.beacons.values())
+            .filter(beacon => beacon.isLive)
+            .map(beacon => beacon.beaconInfoId);
+
+        const hasLiveBeacons = !!this.liveBeaconIds.length;
+        if (prevHasLiveBeacons !== hasLiveBeacons) {
+            this.emit(RoomStateEvent.BeaconLiveness, this, hasLiveBeacons);
+        }
     }
 
     private getStateEventMatching(event: MatrixEvent): MatrixEvent | null {


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

https://github.com/matrix-org/matrix-spec-proposals/pull/3489

Done: 
- [x] Send `m.beacon_info.*` state events.
- [x] track `m.beacon_info.*` events in room state

In this PR:
- [x] expose and maintain '~user~ room has live beacons' property in room state
- [x] add ability to monitor liveness of beacon

In next PRs:
- [ ] get users own beacons from room state, monitor liveness and show live state
- [ ] produce good unique suffixes for beacon info events
- [ ] geolocate and send `m.beacon` events for live beacons
- [ ] maintain liveness state of beacons (checking for expiry, flipping `isLive` on event content)
- [ ] maintain '**user** has live beacons' property

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * emit aggregate room beacon liveness ([\#2241](https://github.com/matrix-org/matrix-js-sdk/pull/2241)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->