### PR TITLE
Add support for MSC3575: Sliding Sync

### DIFF
--- a/spec/integ/matrix-client-sliding-sync.spec.js
+++ b/spec/integ/matrix-client-sliding-sync.spec.js
@@ -1,0 +1,213 @@
+import { resolve } from "dns";
+import { SlidingSync, SlidingSyncState, SlidingList } from "../../src/sliding-sync";
+import { TestClient } from "../TestClient";
+
+describe("SlidingSync", () => {
+    let client = null;
+    let httpBackend = null;
+    const selfUserId = "@alice:localhost";
+    const selfAccessToken = "aseukfgwef";
+    const proxyBaseUrl = "http://localhost:8008";
+    const syncUrl = proxyBaseUrl + "/_matrix/client/unstable/org.matrix.msc3575/sync"
+
+    beforeEach(() => {
+        const testClient = new TestClient(selfUserId, "DEVICE", selfAccessToken);
+        httpBackend = testClient.httpBackend;
+        client = testClient.client;
+    });
+
+    afterEach(() => {
+        httpBackend.verifyNoOutstandingExpectation();
+        client.stopClient();
+        return httpBackend.stop();
+    });
+
+    describe("start/stop", () => {
+        it("should start the sync loop upon calling start() and stop it upon calling stop()", async (done) => {
+            const slidingSync = new SlidingSync(proxyBaseUrl, [], {}, client, 1);
+            const fakeResp = {
+                pos: "a",
+                ops: [],
+                counts: [],
+                room_subscriptions: {},
+            };
+            httpBackend.when("POST", syncUrl).respond(200, fakeResp);
+            let deliver = callbackPromise(500, "lifecycle callback was not called");
+            slidingSync.addLifecycleListener(deliver.callback);
+            slidingSync.start();
+            await httpBackend.flush(syncUrl, 1);
+            let lifecycleData = await deliver.promise;
+            expect(lifecycleData[0]).toEqual(SlidingSyncState.RequestFinished);
+            expect(lifecycleData[1]).toEqual(fakeResp);
+            expect(lifecycleData[2]).toBeFalsy();
+            slidingSync.stop();
+            done();
+        });
+    });
+
+    describe("room subscriptions", () => {
+        const roomId = "!foo:bar";
+        const roomSubInfo = {
+            timeline_limit: 1,
+            required_state: [
+                ["m.room.name", ""],
+            ]
+        };
+        const wantRoomData = {
+            name: "foo bar",
+            required_state: [],
+            timeline: [],
+        };
+
+        it("should be able to subscribe/unsubscribe to a room", async (done) => {    
+            // add the subscription
+            const slidingSync = new SlidingSync(proxyBaseUrl, [], roomSubInfo, client, 1);
+            slidingSync.roomSubscriptions.add(roomId);
+            const fakeResp = {
+                pos: "a",
+                ops: [],
+                counts: [],
+                room_subscriptions: {
+                    [roomId]: wantRoomData
+                },
+            };
+            httpBackend.when("POST", syncUrl).check(function(req) {
+                let body = req.data;
+                if (!body) {
+                    body = JSON.parse(req.opts.body);
+                }
+                console.log(body);
+                expect(body.room_subscriptions).toBeTruthy();
+                expect(body.room_subscriptions[roomId]).toEqual(roomSubInfo);
+            }).respond(200, fakeResp);
+            let deliver = callbackPromise(500, "room callback was not called");
+            slidingSync.addRoomDataListener(deliver.callback);
+            slidingSync.start();
+            await httpBackend.flush(syncUrl, 1);
+            let roomData = await deliver.promise;
+            expect(roomData[0]).toEqual(roomId);
+            expect(roomData[1]).toEqual(wantRoomData);
+
+            httpBackend.when("POST", syncUrl).check(function(req) {
+                let body = req.data;
+                if (!body) {
+                    body = JSON.parse(req.opts.body);
+                }
+                console.log("2", body);
+                expect(body.room_subscriptions).toBeFalsy();
+                expect(body.unsubscribe_rooms).toEqual([roomId]);
+            }).respond(200, fakeResp);
+        
+            deliver = callbackPromise(500, "lifecycle callback was not called");
+            slidingSync.addLifecycleListener(deliver.callback);
+        
+            // remove the subscription
+            slidingSync.roomSubscriptions.delete(roomId);
+        
+            // kick the connection to resend the unsub
+            slidingSync.resend();
+            await httpBackend.flush(syncUrl, 2); // flush 2, the one made before the req change and the req change
+            await deliver.promise;
+            slidingSync.stop();
+            done();
+        });
+    });
+
+    describe("lists", () => {
+        it("should be possible to subscribe to a list", async (done) => {
+            // request first 3 rooms
+            let listReq = {
+                ranges:  [[0,2]],
+                sort: ["by_name"],
+                timeline_limit: 1,
+                required_state: [
+                    ["m.room.topic", ""],
+                ],
+                filters: {
+                    is_dm: true,
+                },
+            };
+            let list = new SlidingList(listReq, [[0,5]]);
+            const slidingSync = new SlidingSync(proxyBaseUrl, [list], {}, client, 1);
+            const roomA = "!a:localhost";
+            const roomB = "!b:localhost";
+            const roomC = "!c:localhost";
+            const rooms = [
+                {
+                    room_id: roomA,
+                    name: "A"
+                },
+                {
+                    room_id: roomB,
+                    name: "B"
+                },
+                {
+                    room_id: roomC,
+                    name: "C"
+                },
+            ]
+            httpBackend.when("POST", syncUrl).check(function(req) {
+                let body = req.data;
+                if (!body) {
+                    body = JSON.parse(req.opts.body);
+                }
+                console.log(body);
+                expect(body.lists).toBeTruthy();
+                expect(body.lists[0]).toEqual(listReq);
+            }).respond(200, {
+                pos: "a",
+                ops: [{
+                    op: "SYNC",
+                    list: 0,
+                    range: [0,2],
+                    rooms: rooms,
+                }],
+                counts: [500],
+            });
+            let listenerData = {};
+            slidingSync.addRoomDataListener((roomId, roomData) => {
+                expect(listenerData[roomId]).toBeFalsy();
+                listenerData[roomId] = roomData;
+            });
+            let responseProcessed = new Promise((resolve) => {
+                slidingSync.addLifecycleListener((state)=> {
+                    if (state === SlidingSyncState.Complete) {
+                        resolve();
+                    }
+                });
+            });
+            slidingSync.start();
+            await httpBackend.flush(syncUrl, 1);
+            await responseProcessed;
+
+            expect(listenerData[roomA]).toEqual(rooms[0]);
+            expect(listenerData[roomB]).toEqual(rooms[1]);
+            expect(listenerData[roomC]).toEqual(rooms[2]);
+            slidingSync.stop();
+            done();
+        });
+    });
+});
+
+function timeout(delayMs, reason) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            reject(`timeout: ${delayMs}ms - ${reason}`);
+        }, delayMs);
+    });
+}
+
+// resolves the promise when the callback is invoked. Rejects the promise after the timeout with reason.
+function callbackPromise(timeoutMs, reason) {
+    let r;
+    const cb = (...rest) => {
+        r(rest);
+    };
+    const p = new Promise((resolve) => {
+        r = resolve;
+    });
+    return {
+        promise: Promise.race([p, timeout(timeoutMs, reason)]),
+        callback: cb,
+    }
+}

--- a/spec/integ/matrix-client-sliding-sync.spec.js
+++ b/spec/integ/matrix-client-sliding-sync.spec.js
@@ -54,6 +54,7 @@ describe("SlidingSync", () => {
         };
         const wantRoomData = {
             name: "foo bar",
+            room_id: roomId,
             required_state: [],
             timeline: [],
         };
@@ -126,23 +127,28 @@ describe("SlidingSync", () => {
                     is_dm: true,
                 },
             };
-            let list = new SlidingList(listReq, [[0,5]]);
-            const slidingSync = new SlidingSync(proxyBaseUrl, [list], {}, client, 1);
+            const slidingSync = new SlidingSync(proxyBaseUrl, [listReq], {}, client, 1);
             const roomA = "!a:localhost";
             const roomB = "!b:localhost";
             const roomC = "!c:localhost";
             const rooms = [
                 {
                     room_id: roomA,
-                    name: "A"
+                    name: "A",
+                    required_state: [],
+                    timeline: [],
                 },
                 {
                     room_id: roomB,
-                    name: "B"
+                    name: "B",
+                    required_state: [],
+                    timeline: [],
                 },
                 {
                     room_id: roomC,
-                    name: "C"
+                    name: "C",
+                    required_state: [],
+                    timeline: [],
                 },
             ]
             httpBackend.when("POST", syncUrl).check(function(req) {

--- a/spec/integ/matrix-client-sliding-sync.spec.js
+++ b/spec/integ/matrix-client-sliding-sync.spec.js
@@ -1,4 +1,3 @@
-import { resolve } from "dns";
 import { SlidingSync, SlidingSyncState, SlidingList } from "../../src/sliding-sync";
 import { TestClient } from "../TestClient";
 

--- a/spec/integ/matrix-client-sliding-sync.spec.js
+++ b/spec/integ/matrix-client-sliding-sync.spec.js
@@ -108,8 +108,6 @@ describe("SlidingSync", () => {
             // remove the subscription
             slidingSync.modifyRoomSubscriptions(new Set());
         
-            // kick the connection to resend the unsub
-            slidingSync.resend();
             await httpBackend.flush(syncUrl, 2); // flush 2, the one made before the req change and the req change
             await p;
             slidingSync.stop();

--- a/src/client.ts
+++ b/src/client.ts
@@ -179,7 +179,7 @@ import { MediaHandler } from "./webrtc/mediaHandler";
 import { IRefreshTokenResponse } from "./@types/auth";
 import { TypedEventEmitter } from "./models/typed-event-emitter";
 import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse } from "./sliding-sync";
-import { SlidingSyncApi } from "./sliding-sync-sdk";
+import { SlidingSyncSdk } from "./sliding-sync-sdk";
 
 export type Store = IStore;
 export type SessionStore = WebStorageSessionStore;
@@ -910,7 +910,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected verificationMethods: VerificationMethod[];
     protected fallbackICEServerAllowed = false;
     protected roomList: RoomList;
-    protected syncApi: SlidingSyncApi;
+    protected syncApi: SlidingSyncSdk;
     public pushRules: IPushRules;
     protected syncLeftRoomsPromise: Promise<Room[]>;
     protected syncedLeftRooms = false;
@@ -1174,7 +1174,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
             return this.canResetTimelineCallback(roomId);
         };
-        this.syncApi = new SlidingSyncApi(this, this.clientOpts);
+        this.syncApi = new SlidingSyncSdk(this, this.clientOpts);
         this.syncApi.sync();
 
         if (this.clientOpts.clientWellKnownPollPeriod !== undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8820,7 +8820,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param {MSC3575SlidingSyncRequest} req The request to make.
      * @param {string} proxyBaseUrl The base URL for the sliding sync proxy.
      * @returns {MSC3575SlidingSyncResponse} The sliding sync response, or a standard error.
-     * @throws on non 2xx status codes with an object {"httpStatus":number}
+     * @throws on non 2xx status codes with an object with a field "httpStatus":number.
      */
     public slidingSync(
         req: MSC3575SlidingSyncRequest, proxyBaseUrl?: string,

--- a/src/client.ts
+++ b/src/client.ts
@@ -8808,9 +8808,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * Perform a single MSC3575 sliding sync request.
      * @param {MSC3575SlidingSyncRequest} req The request to make.
+     * @param {string} proxyBaseUrl The base URL for the sliding sync proxy.
      * @returns {MSC3575SlidingSyncResponse} The sliding sync response, or a standard error.
+     * @throws on non 2xx status codes with an object {"httpStatus":number}
      */
-    public slidingSync(req: MSC3575SlidingSyncRequest): IAbortablePromise<MSC3575SlidingSyncResponse|MatrixError> {
+    public slidingSync(req: MSC3575SlidingSyncRequest, proxyBaseUrl?: string): IAbortablePromise<MSC3575SlidingSyncResponse> {
         const qps: Record<string, any> = {};
         if (req.pos) {
             qps.pos = req.pos;
@@ -8820,7 +8822,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             qps.timeout = req.timeout;
             delete req.timeout;
         }
-        return this.http.authedRequest<MSC3575SlidingSyncResponse|MatrixError>(
+        const clientTimeout = req.clientTimeout;
+        delete req.clientTimeout;
+        return this.http.authedRequest<MSC3575SlidingSyncResponse>(
             undefined,
             Method.Post,
             "/sync",
@@ -8828,6 +8832,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             req,
             {
                 prefix: "/_matrix/client/unstable/org.matrix.msc3575",
+                baseUrl: proxyBaseUrl,
+                localTimeoutMs: clientTimeout,
             },
         );
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1179,8 +1179,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
             return this.canResetTimelineCallback(roomId);
         };
-        if (opts.slidingSync) {
-            this.syncApi = new SlidingSyncSdk(opts.slidingSync, this, this.clientOpts);
+        if (this.clientOpts.slidingSync) {
+            this.syncApi = new SlidingSyncSdk(this.clientOpts.slidingSync, this, this.clientOpts);
         } else {
             this.syncApi = new SyncApi(this, this.clientOpts);
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -179,6 +179,7 @@ import { MediaHandler } from "./webrtc/mediaHandler";
 import { IRefreshTokenResponse } from "./@types/auth";
 import { TypedEventEmitter } from "./models/typed-event-emitter";
 import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse } from "./sliding-sync";
+import { SlidingSyncApi } from "./sliding-sync-sdk";
 
 export type Store = IStore;
 export type SessionStore = WebStorageSessionStore;
@@ -909,7 +910,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected verificationMethods: VerificationMethod[];
     protected fallbackICEServerAllowed = false;
     protected roomList: RoomList;
-    protected syncApi: SyncApi;
+    protected syncApi: SlidingSyncApi;
     public pushRules: IPushRules;
     protected syncLeftRoomsPromise: Promise<Room[]>;
     protected syncedLeftRooms = false;
@@ -1173,7 +1174,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
             return this.canResetTimelineCallback(roomId);
         };
-        this.syncApi = new SyncApi(this, this.clientOpts);
+        this.syncApi = new SlidingSyncApi(this, this.clientOpts);
         this.syncApi.sync();
 
         if (this.clientOpts.clientWellKnownPollPeriod !== undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -8822,7 +8822,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns {MSC3575SlidingSyncResponse} The sliding sync response, or a standard error.
      * @throws on non 2xx status codes with an object {"httpStatus":number}
      */
-    public slidingSync(req: MSC3575SlidingSyncRequest, proxyBaseUrl?: string): IAbortablePromise<MSC3575SlidingSyncResponse> {
+    public slidingSync(
+        req: MSC3575SlidingSyncRequest, proxyBaseUrl?: string,
+    ): IAbortablePromise<MSC3575SlidingSyncResponse> {
         const qps: Record<string, any> = {};
         if (req.pos) {
             qps.pos = req.pos;

--- a/src/conn-management.ts
+++ b/src/conn-management.ts
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as utils from "./utils";
+import { IDeferred } from "./utils";
+import { MatrixClient } from "./client";
+import { ISyncStateData } from "./sync";
+import { Method } from "./http-api";
+import {SyncState } from "./sync";
+
+/**
+ * ConnectionManagement is a class which handles keep-alives and invokes a callback when the connection
+ * is alive/dead. Uses /versions as a keep-alive endpoint.
+ */
+export class ConnectionManagement {
+    private keepAliveTimer: number = null;
+    private connectionReturnedDefer: IDeferred<boolean> = null;
+    private client: MatrixClient;
+    private callback: (newState: SyncState, data?: ISyncStateData) => void;
+
+    constructor(client, callback) {
+        this.client = client;
+        this.callback = callback;
+    }
+
+    /**
+     * Retry a backed off syncing request immediately. This should only be used when
+     * the user <b>explicitly</b> attempts to retry their lost connection.
+     * @return {boolean} True if this resulted in a request being retried.
+     */
+    public retryImmediately(): boolean {
+        if (!this.connectionReturnedDefer) {
+            return false;
+        }
+        this.startKeepAlives(0);
+        return true;
+    }
+
+    public start(): void {
+        if (global.window && global.window.addEventListener) {
+            global.window.addEventListener("online", this.onOnline, false);
+        }
+    }
+
+    public stop(): void {
+        // It is necessary to check for the existance of
+        // global.window AND global.window.removeEventListener.
+        // Some platforms (e.g. React Native) register global.window,
+        // but do not have global.window.removeEventListener.
+        if (global.window && global.window.removeEventListener) {
+            global.window.removeEventListener("online", this.onOnline, false);
+        }
+        
+        if (this.keepAliveTimer) {
+            clearTimeout(this.keepAliveTimer);
+            this.keepAliveTimer = null;
+        }
+    }
+
+    /**
+     * Make a dummy call to /_matrix/client/versions, to see if the HS is
+     * reachable.
+     *
+     * On failure, schedules a call back to itself. On success, resolves
+     * this.connectionReturnedDefer.
+     *
+     * @param {boolean} connDidFail True if a connectivity failure has been detected. Optional.
+     */
+    private async pokeKeepAlive(connDidFail = false) {
+        const success = () => {
+            clearTimeout(this.keepAliveTimer);
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.resolve(connDidFail);
+                this.connectionReturnedDefer = null;
+            }
+        };
+
+        try {
+            await this.client.http.request(
+                undefined, // callback
+                Method.Get, "/_matrix/client/versions",
+                undefined, // queryParams
+                undefined, // data
+                {
+                    prefix: '',
+                    localTimeoutMs: 15 * 1000,
+                },
+            )
+            success();
+        } catch (err) {
+            if (err.httpStatus == 400 || err.httpStatus == 404) {
+                // treat this as a success because the server probably just doesn't
+                // support /versions: point is, we're getting a response.
+                // We wait a short time though, just in case somehow the server
+                // is in a mode where it 400s /versions responses and sync etc.
+                // responses fail, this will mean we don't hammer in a loop.
+                this.keepAliveTimer = setTimeout(success, 2000);
+            } else {
+                connDidFail = true;
+                this.keepAliveTimer = setTimeout(
+                    this.pokeKeepAlive.bind(this, connDidFail),
+                    5000 + Math.floor(Math.random() * 5000),
+                );
+                // A keepalive has failed, so we emit the
+                // error state (whether or not this is the
+                // first failure).
+                // Note we do this after setting the timer:
+                // this lets the unit tests advance the mock
+                // clock when they get the error.
+                this.callback(SyncState.Error, { error: err });
+            }
+        }
+    }
+
+    /**
+     * Starts polling the connectivity check endpoint
+     * @param {number} delay How long to delay until the first poll.
+     *        defaults to a short, randomised interval (to prevent
+     *        tightlooping if /versions succeeds but /sync etc. fail).
+     * @return {promise} which resolves once the connection returns
+     */
+     private startKeepAlives(delay?: number): Promise<boolean> {
+        if (delay === undefined) {
+            delay = 2000 + Math.floor(Math.random() * 5000);
+        }
+
+        if (this.keepAliveTimer !== null) {
+            clearTimeout(this.keepAliveTimer);
+        }
+        if (delay > 0) {
+            this.keepAliveTimer = setTimeout(this.pokeKeepAlive.bind(this), delay);
+        } else {
+            this.pokeKeepAlive();
+        }
+        if (!this.connectionReturnedDefer) {
+            this.connectionReturnedDefer = utils.defer();
+        }
+        return this.connectionReturnedDefer.promise;
+    }
+
+    /**
+     * Event handler for the 'online' event
+     * This event is generally unreliable and precise behaviour
+     * varies between browsers, so we poll for connectivity too,
+     * but this might help us reconnect a little faster.
+     */
+    private onOnline = (): void => {
+        this.startKeepAlives(0);
+    };
+}

--- a/src/conn-management.ts
+++ b/src/conn-management.ts
@@ -19,7 +19,7 @@ import { IDeferred } from "./utils";
 import { MatrixClient } from "./client";
 import { ISyncStateData } from "./sync";
 import { Method } from "./http-api";
-import {SyncState } from "./sync";
+import { SyncState } from "./sync";
 
 /**
  * ConnectionManagement is a class which handles keep-alives and invokes a callback when the connection
@@ -63,7 +63,7 @@ export class ConnectionManagement {
         if (global.window && global.window.removeEventListener) {
             global.window.removeEventListener("online", this.onOnline, false);
         }
-        
+
         if (this.keepAliveTimer) {
             clearTimeout(this.keepAliveTimer);
             this.keepAliveTimer = null;
@@ -98,7 +98,7 @@ export class ConnectionManagement {
                     prefix: '',
                     localTimeoutMs: 15 * 1000,
                 },
-            )
+            );
             success();
         } catch (err) {
             if (err.httpStatus == 400 || err.httpStatus == 404) {
@@ -132,7 +132,7 @@ export class ConnectionManagement {
      *        tightlooping if /versions succeeds but /sync etc. fail).
      * @return {promise} which resolves once the connection returns
      */
-     private startKeepAlives(delay?: number): Promise<boolean> {
+    private startKeepAlives(delay?: number): Promise<boolean> {
         if (delay === undefined) {
             delay = 2000 + Math.floor(Math.random() * 5000);
         }

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -106,6 +106,7 @@ interface IRequest extends _Request {
 
 interface IRequestOpts<T> {
     prefix?: string;
+    baseUrl?: string;
     localTimeoutMs?: number;
     headers?: Record<string, string>;
     json?: boolean; // defaults to true
@@ -570,6 +571,9 @@ export class MatrixHttpApi {
      *
      * @param {string=} opts.prefix The full prefix to use e.g.
      * "/_matrix/client/v2_alpha". If not specified, uses this.opts.prefix.
+     * 
+     * @param {string=} opts.baseUrl The alternative base url to use.
+     * If not specified, uses this.opts.baseUrl
      *
      * @param {Object=} opts.headers map of additional request headers
      *
@@ -666,7 +670,8 @@ export class MatrixHttpApi {
         opts?: O,
     ): IAbortablePromise<ResponseType<T, O>> {
         const prefix = opts?.prefix ?? this.opts.prefix;
-        const fullUri = this.opts.baseUrl + prefix + path;
+        const baseUrl = opts?.baseUrl ?? this.opts.baseUrl;
+        const fullUri =  baseUrl + prefix + path;
 
         return this.requestOtherUrl<T, O>(callback, method, fullUri, queryParams, data, opts);
     }

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -571,7 +571,7 @@ export class MatrixHttpApi {
      *
      * @param {string=} opts.prefix The full prefix to use e.g.
      * "/_matrix/client/v2_alpha". If not specified, uses this.opts.prefix.
-     * 
+     *
      * @param {string=} opts.baseUrl The alternative base url to use.
      * If not specified, uses this.opts.baseUrl
      *
@@ -671,7 +671,7 @@ export class MatrixHttpApi {
     ): IAbortablePromise<ResponseType<T, O>> {
         const prefix = opts?.prefix ?? this.opts.prefix;
         const baseUrl = opts?.baseUrl ?? this.opts.baseUrl;
-        const fullUri =  baseUrl + prefix + path;
+        const fullUri = baseUrl + prefix + path;
 
         return this.requestOtherUrl<T, O>(callback, method, fullUri, queryParams, data, opts);
     }

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { User, UserEvent } from "./models/user";
 import { NotificationCountType, Room, RoomEvent } from "./models/room";
-import {ConnectionManagement } from "./conn-management";
+import { ConnectionManagement } from "./conn-management";
 import { logger } from './logger';
 import * as utils from "./utils";
 import { EventTimeline } from "./models/event-timeline";
@@ -24,24 +24,19 @@ import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } fr
 import { ISyncStateData } from "./sync";
 import { MatrixEvent } from "./models/event";
 import {
-    Category,
-    IEphemeral,
-    IInvitedRoom,
-    IInviteState,
-    IJoinedRoom,
-    ILeftRoom,
     IMinimalEvent,
     IRoomEvent,
     IStateEvent,
     IStrippedState,
-    ISyncResponse,
-    ITimeline,
 } from "./sync-accumulator";
 import { MatrixError } from "./http-api";
 import { RoomStateEvent } from "./models/room-state";
 import { RoomMemberEvent } from "./models/room-member";
-import {SyncState } from "./sync";
-import { MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingSync, SlidingSyncEvent, SlidingSyncState } from "./sliding-sync";
+import { SyncState } from "./sync";
+import {
+    MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingSync,
+    SlidingSyncEvent, SlidingSyncState,
+} from "./sliding-sync";
 
 const DEBUG = true;
 
@@ -70,7 +65,10 @@ export class SlidingSyncSdk {
     private failCount: number;
     private notifEvents: MatrixEvent[] = []; // accumulator of sync events in the current sync response
 
-    constructor(slidingSync: SlidingSync, private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
+    constructor(
+        slidingSync: SlidingSync, private readonly client: MatrixClient,
+        private readonly opts: Partial<IStoredClientOpts> = {},
+    ) {
         this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
         this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
         this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
@@ -106,7 +104,7 @@ export class SlidingSyncSdk {
         } else {
             room = this.client.store.getRoom(roomData.room_id);
             if (!room) {
-                console.error("initial flag not set but no stored room exists for room ", roomData.room_id, roomData);
+                debuglog("initial flag not set but no stored room exists for room ", roomData.room_id, roomData);
                 return;
             }
         }
@@ -114,7 +112,7 @@ export class SlidingSyncSdk {
     }
 
     private onLifecycle(state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err?: Error) {
-        console.log("onLifecycle", state, err);
+        debuglog("onLifecycle", state, err);
         switch (state) {
             case SlidingSyncState.Complete:
                 this.purgeNotifications();
@@ -140,9 +138,12 @@ export class SlidingSyncSdk {
             case SlidingSyncState.RequestFinished:
                 if (err) {
                     this.failCount += 1;
-                    this.updateSyncState(this.failCount > FAILED_SYNC_ERROR_THRESHOLD ? SyncState.Error : SyncState.Reconnecting, {
-                        error: new MatrixError(err),
-                    });
+                    this.updateSyncState(
+                        this.failCount > FAILED_SYNC_ERROR_THRESHOLD ? SyncState.Error : SyncState.Reconnecting,
+                        {
+                            error: new MatrixError(err),
+                        },
+                    );
                 } else {
                     this.failCount = 0;
                 }
@@ -532,7 +533,7 @@ export class SlidingSyncSdk {
      * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
      * is earlier in time. Higher index is later.
      */
-     private addNotifications(timelineEventList: MatrixEvent[]): void {
+    private addNotifications(timelineEventList: MatrixEvent[]): void {
         // gather our notifications into this.notifEvents
         if (!this.client.getNotifTimelineSet()) {
             return;
@@ -557,7 +558,7 @@ export class SlidingSyncSdk {
         this.notifEvents.sort(function(a, b) {
             return a.getTs() - b.getTs();
         });
-        this.notifEvents.forEach(function(event) {
+        this.notifEvents.forEach((event) => {
             this.client.getNotifTimelineSet().addLiveEvent(event);
         });
         this.notifEvents = [];
@@ -588,10 +589,9 @@ function ensureNameEvent(client: MatrixClient, roomData: MSC3575RoomData): MSC35
         },
         sender: client.getUserId(),
         origin_server_ts: new Date().getTime(),
-    })
+    });
     return roomData;
 }
-
 
 // Helper functions which set up JS SDK structs are below and are identical to the sync v2 counterparts,
 // just outside the class.
@@ -607,7 +607,6 @@ function createNewUser(client: MatrixClient, userId: string): User {
     ]);
     return user;
 }
-
 
 function createRoom(client: MatrixClient, roomId: string, opts: Partial<IStoredClientOpts>): Room { // XXX cargoculted from sync.ts
     const {

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -1,0 +1,1410 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { User, UserEvent } from "./models/user";
+import { NotificationCountType, Room, RoomEvent } from "./models/room";
+import * as utils from "./utils";
+import { IDeferred } from "./utils";
+import { EventTimeline } from "./models/event-timeline";
+import { PushProcessor } from "./pushprocessor";
+import { logger } from './logger';
+import { InvalidStoreError } from './errors';
+import { IAbortablePromise } from "./@types/partials";
+import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
+import {
+    IEphemeral,
+    IInvitedRoom,
+    IInviteState,
+    IJoinedRoom,
+    ILeftRoom,
+    IMinimalEvent,
+    IRoomEvent,
+    IStateEvent,
+    IStrippedState,
+    ISyncResponse,
+    ITimeline,
+} from "./sync-accumulator";
+import { MatrixEvent } from "./models/event";
+import { MatrixError, Method } from "./http-api";
+import { ISavedSync } from "./store";
+import { EventType } from "./@types/event";
+import { IPushRules } from "./@types/PushRules";
+import { RoomStateEvent } from "./models/room-state";
+import { RoomMemberEvent } from "./models/room-member";
+import {SyncState } from "./sync";
+
+const DEBUG = true;
+
+const BUFFER_PERIOD_MS = 80 * 1000;
+
+// Number of consecutive failed syncs that will lead to a syncState of ERROR as opposed
+// to RECONNECTING. This is needed to inform the client of server issues when the
+// keepAlive is successful but the server /sync fails.
+const FAILED_SYNC_ERROR_THRESHOLD = 3;
+
+function debuglog(...params) {
+    if (!DEBUG) {
+        return;
+    }
+    logger.log(...params);
+}
+
+interface ISyncOptions {
+    filterId?: string;
+    hasSyncedBefore?: boolean;
+}
+
+export interface ISyncStateData {
+    error?: MatrixError;
+    oldSyncToken?: string;
+    nextSyncToken?: string;
+    catchingUp?: boolean;
+    fromCache?: boolean;
+}
+
+interface ISyncQueryParams {
+    timeout: number;
+    pos?: string;
+    _cacheBuster?: string | number; // not part of the API itself
+}
+
+// http-api mangles an abort method onto its promises
+interface IRequestPromise<T> extends Promise<T> {
+    abort(): void;
+}
+
+type WrappedRoom<T> = T & {
+    room: Room;
+    isBrandNewRoom: boolean;
+};
+
+/**
+ * <b>Internal class - unstable.</b>
+ * Construct an entity which is able to sync with a homeserver.
+ * @constructor
+ * @param {MatrixClient} client The matrix client instance to use.
+ * @param {Object} opts Config options
+ * @param {module:crypto=} opts.crypto Crypto manager
+ * @param {Function=} opts.canResetEntireTimeline A function which is called
+ * with a room ID and returns a boolean. It should return 'true' if the SDK can
+ * SAFELY remove events from this room. It may not be safe to remove events if
+ * there are other references to the timelines for this room.
+ * Default: returns false.
+ * @param {Boolean=} opts.disablePresence True to perform syncing without automatically
+ * updating presence.
+ */
+export class SlidingSyncApi {
+    private currentSyncRequest: IRequestPromise<ISyncResponse> = null;
+    private syncState: SyncState = null;
+    private syncStateData: ISyncStateData = null; // additional data (eg. error object for failed sync)
+    private catchingUp = false;
+    private running = false;
+    private keepAliveTimer: number = null;
+    private connectionReturnedDefer: IDeferred<boolean> = null;
+    private notifEvents: MatrixEvent[] = []; // accumulator of sync events in the current sync response
+    private failedSyncCount = 0; // Number of consecutive failed /sync requests
+    private storeIsInvalid = false; // flag set if the store needs to be cleared before we can start
+
+    constructor(private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
+        this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
+        this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
+        this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
+        this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
+        this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
+
+        if (!opts.canResetEntireTimeline) {
+            opts.canResetEntireTimeline = (roomId: string) => {
+                return false;
+            };
+        }
+
+        if (client.getNotifTimelineSet()) {
+            client.reEmitter.reEmit(client.getNotifTimelineSet(), [
+                RoomEvent.Timeline,
+                RoomEvent.TimelineReset,
+            ]);
+        }
+    }
+
+    /**
+     * @param {string} roomId
+     * @return {Room}
+     */
+    public createRoom(roomId: string): Room {
+        const client = this.client;
+        const {
+            timelineSupport,
+            unstableClientRelationAggregation,
+        } = client;
+        const room = new Room(roomId, client, client.getUserId(), {
+            lazyLoadMembers: this.opts.lazyLoadMembers,
+            pendingEventOrdering: this.opts.pendingEventOrdering,
+            timelineSupport,
+            unstableClientRelationAggregation,
+        });
+        client.reEmitter.reEmit(room, [
+            RoomEvent.Name,
+            RoomEvent.Redaction,
+            RoomEvent.RedactionCancelled,
+            RoomEvent.Receipt,
+            RoomEvent.Tags,
+            RoomEvent.LocalEchoUpdated,
+            RoomEvent.AccountData,
+            RoomEvent.MyMembership,
+            RoomEvent.Timeline,
+            RoomEvent.TimelineReset,
+        ]);
+        this.registerStateListeners(room);
+        return room;
+    }
+
+    /**
+     * @param {Room} room
+     * @private
+     */
+    private registerStateListeners(room: Room): void {
+        const client = this.client;
+        // we need to also re-emit room state and room member events, so hook it up
+        // to the client now. We need to add a listener for RoomState.members in
+        // order to hook them correctly.
+        client.reEmitter.reEmit(room.currentState, [
+            RoomStateEvent.Events,
+            RoomStateEvent.Members,
+            RoomStateEvent.NewMember,
+            RoomStateEvent.Update,
+        ]);
+        room.currentState.on(RoomStateEvent.NewMember, function(event, state, member) {
+            member.user = client.getUser(member.userId);
+            client.reEmitter.reEmit(member, [
+                RoomMemberEvent.Name,
+                RoomMemberEvent.Typing,
+                RoomMemberEvent.PowerLevel,
+                RoomMemberEvent.Membership,
+            ]);
+        });
+    }
+
+    /**
+     * @param {Room} room
+     * @private
+     */
+    private deregisterStateListeners(room: Room): void {
+        // could do with a better way of achieving this.
+        room.currentState.removeAllListeners(RoomStateEvent.Events);
+        room.currentState.removeAllListeners(RoomStateEvent.Members);
+        room.currentState.removeAllListeners(RoomStateEvent.NewMember);
+    }
+
+    /**
+     * Sync rooms the user has left.
+     * @return {Promise} Resolved when they've been added to the store.
+     */
+    public async syncLeftRooms() {
+        return []; // TODO
+    }
+
+    /**
+     * Peek into a room. This will result in the room in question being synced so it
+     * is accessible via getRooms(). Live updates for the room will be provided.
+     * @param {string} roomId The room ID to peek into.
+     * @return {Promise} A promise which resolves once the room has been added to the
+     * store.
+     */
+    public async peek(roomId: string): Promise<Room> {
+        return null; // TODO
+    }
+
+    /**
+     * Stop polling for updates in the peeked room. NOPs if there is no room being
+     * peeked.
+     */
+    public stopPeeking(): void {
+        // TODO
+    }
+
+    /**
+     * Returns the current state of this sync object
+     * @see module:client~MatrixClient#event:"sync"
+     * @return {?String}
+     */
+    public getSyncState(): SyncState {
+        return this.syncState;
+    }
+
+    /**
+     * Returns the additional data object associated with
+     * the current sync state, or null if there is no
+     * such data.
+     * Sync errors, if available, are put in the 'error' key of
+     * this object.
+     * @return {?Object}
+     */
+    public getSyncStateData(): ISyncStateData {
+        return this.syncStateData;
+    }
+
+    public async recoverFromSyncStartupError(savedSyncPromise: Promise<void>, err: MatrixError): Promise<void> {
+        // Wait for the saved sync to complete - we send the pushrules and filter requests
+        // before the saved sync has finished so they can run in parallel, but only process
+        // the results after the saved sync is done. Equivalently, we wait for it to finish
+        // before reporting failures from these functions.
+        await savedSyncPromise;
+        const keepaliveProm = this.startKeepAlives();
+        this.updateSyncState(SyncState.Error, { error: err });
+        await keepaliveProm;
+    }
+
+    /**
+     * Is the lazy loading option different than in previous session?
+     * @param {boolean} lazyLoadMembers current options for lazy loading
+     * @return {boolean} whether or not the option has changed compared to the previous session */
+    private async wasLazyLoadingToggled(lazyLoadMembers = false): Promise<boolean> {
+        // assume it was turned off before
+        // if we don't know any better
+        let lazyLoadMembersBefore = false;
+        const isStoreNewlyCreated = await this.client.store.isNewlyCreated();
+        if (!isStoreNewlyCreated) {
+            const prevClientOptions = await this.client.store.getClientOptions();
+            if (prevClientOptions) {
+                lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
+            }
+            return lazyLoadMembersBefore !== lazyLoadMembers;
+        }
+        return false;
+    }
+
+    private shouldAbortSync(error: MatrixError): boolean {
+        if (error.errcode === "M_UNKNOWN_TOKEN") {
+            // The logout already happened, we just need to stop.
+            logger.warn("Token no longer valid - assuming logout");
+            this.stop();
+            this.updateSyncState(SyncState.Error, { error });
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Main entry point
+     */
+    public sync(): void {
+        const client = this.client;
+
+        this.running = true;
+
+        if (global.window && global.window.addEventListener) {
+            global.window.addEventListener("online", this.onOnline, false);
+        }
+
+        let savedSyncPromise = Promise.resolve();
+        let savedSyncToken = null;
+
+        // We need to do one-off checks before we can begin the /sync loop.
+        // These are:
+        //   1) We need to get push rules so we can check if events should bing as we get
+        //      them from /sync.
+        //   2) We need to get/create a filter which we can use for /sync.
+        //   3) We need to check the lazy loading option matches what was used in the
+        //       stored sync. If it doesn't, we can't use the stored sync.
+
+        const getPushRules = async () => {
+            try {
+                debuglog("Getting push rules...");
+                const result = await client.getPushRules();
+                debuglog("Got push rules");
+
+                client.pushRules = result;
+            } catch (err) {
+                logger.error("Getting push rules failed", err);
+                if (this.shouldAbortSync(err)) return;
+                // wait for saved sync to complete before doing anything else,
+                // otherwise the sync state will end up being incorrect
+                debuglog("Waiting for saved sync before retrying push rules...");
+                await this.recoverFromSyncStartupError(savedSyncPromise, err);
+                getPushRules();
+                return;
+            }
+            checkLazyLoadStatus(); // advance to the next stage
+        };
+
+        const checkLazyLoadStatus = async () => {
+            debuglog("Checking lazy load status...");
+            if (this.opts.lazyLoadMembers && client.isGuest()) {
+                this.opts.lazyLoadMembers = false;
+            }
+            if (this.opts.lazyLoadMembers) {
+                debuglog("Checking server lazy load support...");
+                const supported = await client.doesServerSupportLazyLoading();
+                if (supported) {
+                    debuglog("Enabling lazy load on sync filter...");
+                    this.opts.lazyLoadMembers = false; // TODO
+                } else {
+                    debuglog("LL: lazy loading requested but not supported " +
+                        "by server, so disabling");
+                    this.opts.lazyLoadMembers = false;
+                }
+            }
+            // need to vape the store when enabling LL and wasn't enabled before
+            debuglog("Checking whether lazy loading has changed in store...");
+            const shouldClear = await this.wasLazyLoadingToggled(this.opts.lazyLoadMembers);
+            if (shouldClear) {
+                this.storeIsInvalid = true;
+                const reason = InvalidStoreError.TOGGLED_LAZY_LOADING;
+                const error = new InvalidStoreError(reason, !!this.opts.lazyLoadMembers);
+                this.updateSyncState(SyncState.Error, { error });
+                // bail out of the sync loop now: the app needs to respond to this error.
+                // we leave the state as 'ERROR' which isn't great since this normally means
+                // we're retrying. The client must be stopped before clearing the stores anyway
+                // so the app should stop the client, clear the store and start it again.
+                logger.warn("InvalidStoreError: store is not usable: stopping sync.");
+                return;
+            }
+            if (this.opts.lazyLoadMembers && this.opts.crypto) {
+                this.opts.crypto.enableLazyLoading();
+            }
+            try {
+                debuglog("Storing client options...");
+                await this.client.storeClientOptions();
+                debuglog("Stored client options");
+            } catch (err) {
+                logger.error("Storing client options failed", err);
+                throw err;
+            }
+
+            getFilter(); // Now get the filter and start syncing
+        };
+
+        const getFilter = async () => {
+            debuglog("Getting filter...");
+            // reset the notifications timeline to prepare it to paginate from
+            // the current point in time.
+            // The right solution would be to tie /sync pagination tokens into
+            // /notifications API somehow.
+            client.resetNotifTimelineSet();
+
+            if (this.currentSyncRequest === null) {
+                // Send this first sync request here so we can then wait for the saved
+                // sync data to finish processing before we process the results of this one.
+                debuglog("Sending first sync request...");
+                this.currentSyncRequest = this.doSyncRequest({ }, savedSyncToken);
+            }
+
+            // Now wait for the saved sync to finish...
+            debuglog("Waiting for saved sync before starting sync processing...");
+            await savedSyncPromise;
+            this.doSync({ });
+        };
+
+        if (client.isGuest()) {
+            // no push rules for guests, no access to POST filter for guests.
+            this.doSync({});
+        } else {
+            // Pull the saved sync token out first, before the worker starts sending
+            // all the sync data which could take a while. This will let us send our
+            // first incremental sync request before we've processed our saved data.
+            debuglog("Getting saved sync token...");
+            savedSyncPromise = client.store.getSavedSyncToken().then((tok) => {
+                debuglog("Got saved sync token");
+                savedSyncToken = tok;
+                debuglog("Getting saved sync...");
+                return client.store.getSavedSync();
+            }).then((savedSync) => {
+                debuglog(`Got reply from saved sync, exists? ${!!savedSync}`);
+                if (savedSync) {
+                    return this.syncFromCache(savedSync);
+                }
+            }).catch(err => {
+                logger.error("Getting saved sync failed", err);
+            });
+            // Now start the first incremental sync request: this can also
+            // take a while so if we set it going now, we can wait for it
+            // to finish while we process our saved sync data.
+            getPushRules();
+        }
+    }
+
+    /**
+     * Stops the sync object from syncing.
+     */
+    public stop(): void {
+        debuglog("SyncApi.stop");
+        // It is necessary to check for the existance of
+        // global.window AND global.window.removeEventListener.
+        // Some platforms (e.g. React Native) register global.window,
+        // but do not have global.window.removeEventListener.
+        if (global.window && global.window.removeEventListener) {
+            global.window.removeEventListener("online", this.onOnline, false);
+        }
+        this.running = false;
+        if (this.currentSyncRequest) {
+            this.currentSyncRequest.abort();
+        }
+        if (this.keepAliveTimer) {
+            clearTimeout(this.keepAliveTimer);
+            this.keepAliveTimer = null;
+        }
+    }
+
+    /**
+     * Retry a backed off syncing request immediately. This should only be used when
+     * the user <b>explicitly</b> attempts to retry their lost connection.
+     * @return {boolean} True if this resulted in a request being retried.
+     */
+    public retryImmediately(): boolean {
+        if (!this.connectionReturnedDefer) {
+            return false;
+        }
+        this.startKeepAlives(0);
+        return true;
+    }
+    /**
+     * Process a single set of cached sync data.
+     * @param {Object} savedSync a saved sync that was persisted by a store. This
+     * should have been acquired via client.store.getSavedSync().
+     */
+    private async syncFromCache(savedSync: ISavedSync): Promise<void> {
+        debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
+
+        const nextSyncToken = savedSync.nextBatch;
+
+        // Set sync token for future incremental syncing
+        this.client.store.setSyncToken(nextSyncToken);
+
+        // No previous sync, set old token to null
+        const syncEventData = {
+            oldSyncToken: null,
+            nextSyncToken,
+            catchingUp: false,
+            fromCache: true,
+        };
+
+        const data: ISyncResponse = {
+            next_batch: nextSyncToken,
+            rooms: savedSync.roomsData,
+            groups: savedSync.groupsData,
+            account_data: {
+                events: savedSync.accountData,
+            },
+        };
+
+        try {
+            await this.processSyncResponse(syncEventData, data);
+        } catch (e) {
+            logger.error("Error processing cached sync", e.stack || e);
+        }
+
+        // Don't emit a prepared if we've bailed because the store is invalid:
+        // in this case the client will not be usable until stopped & restarted
+        // so this would be useless and misleading.
+        if (!this.storeIsInvalid) {
+            this.updateSyncState(SyncState.Prepared, syncEventData);
+        }
+    }
+
+    /**
+     * Invoke me to do /sync calls
+     * @param {Object} syncOptions
+     * @param {string} syncOptions.filterId
+     * @param {boolean} syncOptions.hasSyncedBefore
+     */
+    private async doSync(syncOptions: ISyncOptions): Promise<void> {
+        const client = this.client;
+
+        if (!this.running) {
+            debuglog("Sync no longer running: exiting.");
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.reject();
+                this.connectionReturnedDefer = null;
+            }
+            this.updateSyncState(SyncState.Stopped);
+            return;
+        }
+
+        const syncToken = client.store.getSyncToken();
+
+        let data;
+        try {
+            //debuglog('Starting sync since=' + syncToken);
+            if (this.currentSyncRequest === null) {
+                this.currentSyncRequest = this.doSyncRequest(syncOptions, syncToken);
+            }
+            data = await this.currentSyncRequest;
+        } catch (e) {
+            this.onSyncError(e, syncOptions);
+            return;
+        } finally {
+            this.currentSyncRequest = null;
+        }
+
+        //debuglog('Completed sync, next_batch=' + data.next_batch);
+
+        // set the sync token NOW *before* processing the events. We do this so
+        // if something barfs on an event we can skip it rather than constantly
+        // polling with the same token.
+        client.store.setSyncToken(data.next_batch);
+
+        // Reset after a successful sync
+        this.failedSyncCount = 0;
+
+        await client.store.setSyncData(data);
+
+        const syncEventData = {
+            oldSyncToken: syncToken,
+            nextSyncToken: data.next_batch,
+            catchingUp: this.catchingUp,
+        };
+
+        if (this.opts.crypto) {
+            // tell the crypto module we're about to process a sync
+            // response
+            await this.opts.crypto.onSyncWillProcess(syncEventData);
+        }
+
+        try {
+            await this.processSyncResponse(syncEventData, data);
+        } catch (e) {
+            // log the exception with stack if we have it, else fall back
+            // to the plain description
+            logger.error("Caught /sync error", e.stack || e);
+
+            // Emit the exception for client handling
+            this.client.emit(ClientEvent.SyncUnexpectedError, e);
+        }
+
+        // update this as it may have changed
+        syncEventData.catchingUp = this.catchingUp;
+
+        // emit synced events
+        if (!syncOptions.hasSyncedBefore) {
+            this.updateSyncState(SyncState.Prepared, syncEventData);
+            syncOptions.hasSyncedBefore = true;
+        }
+
+        // tell the crypto module to do its processing. It may block (to do a
+        // /keys/changes request).
+        if (this.opts.crypto) {
+            await this.opts.crypto.onSyncCompleted(syncEventData);
+        }
+
+        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
+        this.updateSyncState(SyncState.Syncing, syncEventData);
+
+        if (client.store.wantsSave()) {
+            // We always save the device list (if it's dirty) before saving the sync data:
+            // this means we know the saved device list data is at least as fresh as the
+            // stored sync data which means we don't have to worry that we may have missed
+            // device changes. We can also skip the delay since we're not calling this very
+            // frequently (and we don't really want to delay the sync for it).
+            if (this.opts.crypto) {
+                await this.opts.crypto.saveDeviceList(0);
+            }
+
+            // tell databases that everything is now in a consistent state and can be saved.
+            client.store.save();
+        }
+
+        // Begin next sync
+        this.doSync(syncOptions);
+    }
+
+    private doSyncRequest(syncOptions: ISyncOptions, pos: string): IRequestPromise<ISyncResponse> {
+        const qps = this.getSyncQueryParams(syncOptions, pos);
+        return this.client.http.authedRequest(
+            undefined, Method.Get, "/sync", qps as any, undefined,
+            {
+                localTimeoutMs: qps.timeout + BUFFER_PERIOD_MS,
+            },
+        );
+    }
+
+    private getSyncQueryParams(syncOptions: ISyncOptions, pos: string): ISyncQueryParams {
+        let pollTimeout = this.opts.pollTimeout;
+
+        if (this.getSyncState() !== 'SYNCING' || this.catchingUp) {
+            // unless we are happily syncing already, we want the server to return
+            // as quickly as possible, even if there are no events queued. This
+            // serves two purposes:
+            //
+            // * When the connection dies, we want to know asap when it comes back,
+            //   so that we can hide the error from the user. (We don't want to
+            //   have to wait for an event or a timeout).
+            //
+            // * We want to know if the server has any to_device messages queued up
+            //   for us. We do that by calling it with a zero timeout until it
+            //   doesn't give us any more to_device messages.
+            this.catchingUp = true;
+            pollTimeout = 0;
+        }
+
+        const qps: ISyncQueryParams = {
+            timeout: pollTimeout,
+        };
+
+        if (pos) {
+            qps.pos = pos;
+        } else {
+            // use a cachebuster for initialsyncs, to make sure that
+            // we don't get a stale sync
+            // (https://github.com/vector-im/vector-web/issues/1354)
+            qps._cacheBuster = Date.now();
+        }
+
+        if (this.getSyncState() == 'ERROR' || this.getSyncState() == 'RECONNECTING') {
+            // we think the connection is dead. If it comes back up, we won't know
+            // about it till /sync returns. If the timeout= is high, this could
+            // be a long time. Set it to 0 when doing retries so we don't have to wait
+            // for an event or a timeout before emiting the SYNCING event.
+            qps.timeout = 0;
+        }
+
+        return qps;
+    }
+
+    private onSyncError(err: MatrixError, syncOptions: ISyncOptions): void {
+        if (!this.running) {
+            debuglog("Sync no longer running: exiting");
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.reject();
+                this.connectionReturnedDefer = null;
+            }
+            this.updateSyncState(SyncState.Stopped);
+            return;
+        }
+
+        logger.error("/sync error %s", err);
+        logger.error(err);
+
+        if (this.shouldAbortSync(err)) {
+            return;
+        }
+
+        this.failedSyncCount++;
+        logger.log('Number of consecutive failed sync requests:', this.failedSyncCount);
+
+        debuglog("Starting keep-alive");
+        // Note that we do *not* mark the sync connection as
+        // lost yet: we only do this if a keepalive poke
+        // fails, since long lived HTTP connections will
+        // go away sometimes and we shouldn't treat this as
+        // erroneous. We set the state to 'reconnecting'
+        // instead, so that clients can observe this state
+        // if they wish.
+        this.startKeepAlives().then((connDidFail) => {
+            // Only emit CATCHUP if we detected a connectivity error: if we didn't,
+            // it's quite likely the sync will fail again for the same reason and we
+            // want to stay in ERROR rather than keep flip-flopping between ERROR
+            // and CATCHUP.
+            if (connDidFail && this.getSyncState() === SyncState.Error) {
+                this.updateSyncState(SyncState.Catchup, {
+                    oldSyncToken: null,
+                    nextSyncToken: null,
+                    catchingUp: true,
+                });
+            }
+            this.doSync(syncOptions);
+        });
+
+        this.currentSyncRequest = null;
+        // Transition from RECONNECTING to ERROR after a given number of failed syncs
+        this.updateSyncState(
+            this.failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
+                SyncState.Error : SyncState.Reconnecting,
+            { error: err },
+        );
+    }
+
+    /**
+     * Process data returned from a sync response and propagate it
+     * into the model objects
+     *
+     * @param {Object} syncEventData Object containing sync tokens associated with this sync
+     * @param {Object} data The response from /sync
+     */
+    private async processSyncResponse(syncEventData: ISyncStateData, data: ISyncResponse): Promise<void> {
+        const client = this.client;
+
+        // data looks like:
+        // {
+        // }
+
+        // handle presence events (User objects)
+        if (data.presence && Array.isArray(data.presence.events)) {
+            data.presence.events.map(client.getEventMapper()).forEach(
+                function(presenceEvent) {
+                    let user = client.store.getUser(presenceEvent.getSender());
+                    if (user) {
+                        user.setPresenceEvent(presenceEvent);
+                    } else {
+                        user = createNewUser(client, presenceEvent.getSender());
+                        user.setPresenceEvent(presenceEvent);
+                        client.store.storeUser(user);
+                    }
+                    client.emit(ClientEvent.Event, presenceEvent);
+                });
+        }
+
+        // handle non-room account_data
+        if (data.account_data && Array.isArray(data.account_data.events)) {
+            const events = data.account_data.events.map(client.getEventMapper());
+            const prevEventsMap = events.reduce((m, c) => {
+                m[c.getId()] = client.store.getAccountData(c.getType());
+                return m;
+            }, {});
+            client.store.storeAccountDataEvents(events);
+            events.forEach(
+                function(accountDataEvent) {
+                    // Honour push rules that come down the sync stream but also
+                    // honour push rules that were previously cached. Base rules
+                    // will be updated when we receive push rules via getPushRules
+                    // (see sync) before syncing over the network.
+                    if (accountDataEvent.getType() === EventType.PushRules) {
+                        const rules = accountDataEvent.getContent<IPushRules>();
+                        client.pushRules = PushProcessor.rewriteDefaultRules(rules);
+                    }
+                    const prevEvent = prevEventsMap[accountDataEvent.getId()];
+                    client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
+                    return accountDataEvent;
+                },
+            );
+        }
+
+        // handle to-device events
+        if (data.to_device && Array.isArray(data.to_device.events) &&
+            data.to_device.events.length > 0
+        ) {
+            const cancelledKeyVerificationTxns = [];
+            data.to_device.events
+                .map(client.getEventMapper())
+                .map((toDeviceEvent) => { // map is a cheap inline forEach
+                    // We want to flag m.key.verification.start events as cancelled
+                    // if there's an accompanying m.key.verification.cancel event, so
+                    // we pull out the transaction IDs from the cancellation events
+                    // so we can flag the verification events as cancelled in the loop
+                    // below.
+                    if (toDeviceEvent.getType() === "m.key.verification.cancel") {
+                        const txnId = toDeviceEvent.getContent()['transaction_id'];
+                        if (txnId) {
+                            cancelledKeyVerificationTxns.push(txnId);
+                        }
+                    }
+
+                    // as mentioned above, .map is a cheap inline forEach, so return
+                    // the unmodified event.
+                    return toDeviceEvent;
+                })
+                .forEach(
+                    function(toDeviceEvent) {
+                        const content = toDeviceEvent.getContent();
+                        if (
+                            toDeviceEvent.getType() == "m.room.message" &&
+                            content.msgtype == "m.bad.encrypted"
+                        ) {
+                            // the mapper already logged a warning.
+                            logger.log(
+                                'Ignoring undecryptable to-device event from ' +
+                                toDeviceEvent.getSender(),
+                            );
+                            return;
+                        }
+
+                        if (toDeviceEvent.getType() === "m.key.verification.start"
+                            || toDeviceEvent.getType() === "m.key.verification.request") {
+                            const txnId = content['transaction_id'];
+                            if (cancelledKeyVerificationTxns.includes(txnId)) {
+                                toDeviceEvent.flagCancelled();
+                            }
+                        }
+
+                        client.emit(ClientEvent.ToDeviceEvent, toDeviceEvent);
+                    },
+                );
+        } else {
+            // no more to-device events: we can stop polling with a short timeout.
+            this.catchingUp = false;
+        }
+
+        // the returned json structure is a bit crap, so make it into a
+        // nicer form (array) after applying sanity to make sure we don't fail
+        // on missing keys (on the off chance)
+        let inviteRooms: WrappedRoom<IInvitedRoom>[] = [];
+        let joinRooms: WrappedRoom<IJoinedRoom>[] = [];
+        let leaveRooms: WrappedRoom<ILeftRoom>[] = [];
+
+        if (data.rooms) {
+            if (data.rooms.invite) {
+                inviteRooms = this.mapSyncResponseToRoomArray(data.rooms.invite);
+            }
+            if (data.rooms.join) {
+                joinRooms = this.mapSyncResponseToRoomArray(data.rooms.join);
+            }
+            if (data.rooms.leave) {
+                leaveRooms = this.mapSyncResponseToRoomArray(data.rooms.leave);
+            }
+        }
+
+        this.notifEvents = [];
+
+        // Handle invites
+        inviteRooms.forEach((inviteObj) => {
+            const room = inviteObj.room;
+            const stateEvents = this.mapSyncEventsFormat(inviteObj.invite_state, room);
+
+            this.processRoomEvents(room, stateEvents);
+            if (inviteObj.isBrandNewRoom) {
+                room.recalculate();
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+            stateEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            room.updateMyMembership("invite");
+        });
+
+        // Handle joins
+        await utils.promiseMapSeries(joinRooms, async (joinObj) => {
+            const room = joinObj.room;
+            const stateEvents = this.mapSyncEventsFormat(joinObj.state, room);
+            // Prevent events from being decrypted ahead of time
+            // this helps large account to speed up faster
+            // room::decryptCriticalEvent is in charge of decrypting all the events
+            // required for a client to function properly
+            const events = this.mapSyncEventsFormat(joinObj.timeline, room, false);
+            const ephemeralEvents = this.mapSyncEventsFormat(joinObj.ephemeral);
+            const accountDataEvents = this.mapSyncEventsFormat(joinObj.account_data);
+
+            const encrypted = client.isRoomEncrypted(room.roomId);
+            // we do this first so it's correct when any of the events fire
+            if (joinObj.unread_notifications) {
+                room.setUnreadNotificationCount(
+                    NotificationCountType.Total,
+                    joinObj.unread_notifications.notification_count,
+                );
+
+                // We track unread notifications ourselves in encrypted rooms, so don't
+                // bother setting it here. We trust our calculations better than the
+                // server's for this case, and therefore will assume that our non-zero
+                // count is accurate.
+                if (!encrypted
+                    || (encrypted && room.getUnreadNotificationCount(NotificationCountType.Highlight) <= 0)) {
+                    room.setUnreadNotificationCount(
+                        NotificationCountType.Highlight,
+                        joinObj.unread_notifications.highlight_count,
+                    );
+                }
+            }
+
+            joinObj.timeline = joinObj.timeline || {} as ITimeline;
+
+            if (joinObj.isBrandNewRoom) {
+                // set the back-pagination token. Do this *before* adding any
+                // events so that clients can start back-paginating.
+                room.getLiveTimeline().setPaginationToken(
+                    joinObj.timeline.prev_batch, EventTimeline.BACKWARDS);
+            } else if (joinObj.timeline.limited) {
+                let limited = true;
+
+                // we've got a limited sync, so we *probably* have a gap in the
+                // timeline, so should reset. But we might have been peeking or
+                // paginating and already have some of the events, in which
+                // case we just want to append any subsequent events to the end
+                // of the existing timeline.
+                //
+                // This is particularly important in the case that we already have
+                // *all* of the events in the timeline - in that case, if we reset
+                // the timeline, we'll end up with an entirely empty timeline,
+                // which we'll try to paginate but not get any new events (which
+                // will stop us linking the empty timeline into the chain).
+                //
+                for (let i = events.length - 1; i >= 0; i--) {
+                    const eventId = events[i].getId();
+                    if (room.getTimelineForEvent(eventId)) {
+                        debuglog("Already have event " + eventId + " in limited " +
+                            "sync - not resetting");
+                        limited = false;
+
+                        // we might still be missing some of the events before i;
+                        // we don't want to be adding them to the end of the
+                        // timeline because that would put them out of order.
+                        events.splice(0, i);
+
+                        // XXX: there's a problem here if the skipped part of the
+                        // timeline modifies the state set in stateEvents, because
+                        // we'll end up using the state from stateEvents rather
+                        // than the later state from timelineEvents. We probably
+                        // need to wind stateEvents forward over the events we're
+                        // skipping.
+
+                        break;
+                    }
+                }
+
+                if (limited) {
+                    this.deregisterStateListeners(room);
+                    room.resetLiveTimeline(
+                        joinObj.timeline.prev_batch,
+                        this.opts.canResetEntireTimeline(room.roomId) ?
+                            null : syncEventData.oldSyncToken,
+                    );
+
+                    // We have to assume any gap in any timeline is
+                    // reason to stop incrementally tracking notifications and
+                    // reset the timeline.
+                    client.resetNotifTimelineSet();
+
+                    this.registerStateListeners(room);
+                }
+            }
+
+            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
+
+            this.processRoomEvents(room, stateEvents, timelineEvents, syncEventData.fromCache);
+
+            // set summary after processing events,
+            // because it will trigger a name calculation
+            // which needs the room state to be up to date
+            if (joinObj.summary) {
+                room.setSummary(joinObj.summary);
+            }
+
+            // we deliberately don't add ephemeral events to the timeline
+            room.addEphemeralEvents(ephemeralEvents);
+
+            // we deliberately don't add accountData to the timeline
+            room.addAccountData(accountDataEvents);
+
+            room.recalculate();
+            if (joinObj.isBrandNewRoom) {
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+
+            this.processEventsForNotifs(room, events);
+
+            const processRoomEvent = async (e) => {
+                client.emit(ClientEvent.Event, e);
+                if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
+                    await this.opts.crypto.onCryptoEvent(e);
+                }
+                if (e.isState() && e.getType() === "im.vector.user_status") {
+                    let user = client.store.getUser(e.getStateKey());
+                    if (user) {
+                        user.unstable_updateStatusMessage(e);
+                    } else {
+                        user = createNewUser(client, e.getStateKey());
+                        user.unstable_updateStatusMessage(e);
+                        client.store.storeUser(user);
+                    }
+                }
+            };
+
+            await utils.promiseMapSeries(stateEvents, processRoomEvent);
+            await utils.promiseMapSeries(timelineEvents, processRoomEvent);
+            await utils.promiseMapSeries(threadedEvents, processRoomEvent);
+            ephemeralEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            accountDataEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+
+            room.updateMyMembership("join");
+
+            // Decrypt only the last message in all rooms to make sure we can generate a preview
+            // And decrypt all events after the recorded read receipt to ensure an accurate
+            // notification count
+            room.decryptCriticalEvents();
+        });
+
+        // Handle leaves (e.g. kicked rooms)
+        leaveRooms.forEach(async (leaveObj) => {
+            const room = leaveObj.room;
+            const stateEvents = this.mapSyncEventsFormat(leaveObj.state, room);
+            const events = this.mapSyncEventsFormat(leaveObj.timeline, room);
+            const accountDataEvents = this.mapSyncEventsFormat(leaveObj.account_data);
+
+            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
+
+            this.processRoomEvents(room, stateEvents, timelineEvents);
+            room.addAccountData(accountDataEvents);
+
+            room.recalculate();
+            if (leaveObj.isBrandNewRoom) {
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+
+            this.processEventsForNotifs(room, events);
+
+            stateEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            timelineEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            threadedEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            accountDataEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+
+            room.updateMyMembership("leave");
+        });
+
+        // update the notification timeline, if appropriate.
+        // we only do this for live events, as otherwise we can't order them sanely
+        // in the timeline relative to ones paginated in by /notifications.
+        // XXX: we could fix this by making EventTimeline support chronological
+        // ordering... but it doesn't, right now.
+        if (syncEventData.oldSyncToken && this.notifEvents.length) {
+            this.notifEvents.sort(function(a, b) {
+                return a.getTs() - b.getTs();
+            });
+            this.notifEvents.forEach(function(event) {
+                client.getNotifTimelineSet().addLiveEvent(event);
+            });
+        }
+
+        // Handle device list updates
+        if (data.device_lists) {
+            if (this.opts.crypto) {
+                await this.opts.crypto.handleDeviceListChanges(syncEventData, data.device_lists);
+            } else {
+                // FIXME if we *don't* have a crypto module, we still need to
+                // invalidate the device lists. But that would require a
+                // substantial bit of rework :/.
+            }
+        }
+
+        // Handle one_time_keys_count
+        if (this.opts.crypto && data.device_one_time_keys_count) {
+            const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
+            this.opts.crypto.updateOneTimeKeyCount(currentCount);
+        }
+        if (this.opts.crypto &&
+            (data["device_unused_fallback_key_types"] ||
+                data["org.matrix.msc2732.device_unused_fallback_key_types"])) {
+            // The presence of device_unused_fallback_key_types indicates that the
+            // server supports fallback keys. If there's no unused
+            // signed_curve25519 fallback key we need a new one.
+            const unusedFallbackKeys = data["device_unused_fallback_key_types"] ||
+                data["org.matrix.msc2732.device_unused_fallback_key_types"];
+            this.opts.crypto.setNeedsNewFallback(
+                unusedFallbackKeys instanceof Array &&
+                !unusedFallbackKeys.includes("signed_curve25519"),
+            );
+        }
+    }
+
+    /**
+     * Starts polling the connectivity check endpoint
+     * @param {number} delay How long to delay until the first poll.
+     *        defaults to a short, randomised interval (to prevent
+     *        tightlooping if /versions succeeds but /sync etc. fail).
+     * @return {promise} which resolves once the connection returns
+     */
+    private startKeepAlives(delay?: number): Promise<boolean> {
+        if (delay === undefined) {
+            delay = 2000 + Math.floor(Math.random() * 5000);
+        }
+
+        if (this.keepAliveTimer !== null) {
+            clearTimeout(this.keepAliveTimer);
+        }
+        if (delay > 0) {
+            this.keepAliveTimer = setTimeout(this.pokeKeepAlive.bind(this), delay);
+        } else {
+            this.pokeKeepAlive();
+        }
+        if (!this.connectionReturnedDefer) {
+            this.connectionReturnedDefer = utils.defer();
+        }
+        return this.connectionReturnedDefer.promise;
+    }
+
+    /**
+     * Make a dummy call to /_matrix/client/versions, to see if the HS is
+     * reachable.
+     *
+     * On failure, schedules a call back to itself. On success, resolves
+     * this.connectionReturnedDefer.
+     *
+     * @param {boolean} connDidFail True if a connectivity failure has been detected. Optional.
+     */
+    private pokeKeepAlive(connDidFail = false): void {
+        const success = () => {
+            clearTimeout(this.keepAliveTimer);
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.resolve(connDidFail);
+                this.connectionReturnedDefer = null;
+            }
+        };
+
+        this.client.http.request(
+            undefined, // callback
+            Method.Get, "/_matrix/client/versions",
+            undefined, // queryParams
+            undefined, // data
+            {
+                prefix: '',
+                localTimeoutMs: 15 * 1000,
+            },
+        ).then(() => {
+            success();
+        }, (err) => {
+            if (err.httpStatus == 400 || err.httpStatus == 404) {
+                // treat this as a success because the server probably just doesn't
+                // support /versions: point is, we're getting a response.
+                // We wait a short time though, just in case somehow the server
+                // is in a mode where it 400s /versions responses and sync etc.
+                // responses fail, this will mean we don't hammer in a loop.
+                this.keepAliveTimer = setTimeout(success, 2000);
+            } else {
+                connDidFail = true;
+                this.keepAliveTimer = setTimeout(
+                    this.pokeKeepAlive.bind(this, connDidFail),
+                    5000 + Math.floor(Math.random() * 5000),
+                );
+                // A keepalive has failed, so we emit the
+                // error state (whether or not this is the
+                // first failure).
+                // Note we do this after setting the timer:
+                // this lets the unit tests advance the mock
+                // clock when they get the error.
+                this.updateSyncState(SyncState.Error, { error: err });
+            }
+        });
+    }
+
+    /**
+     * @param {Object} obj
+     * @return {Object[]}
+     */
+    private mapSyncResponseToRoomArray<T extends ILeftRoom | IJoinedRoom | IInvitedRoom>(
+        obj: Record<string, T>,
+    ): Array<WrappedRoom<T>> {
+        // Maps { roomid: {stuff}, roomid: {stuff} }
+        // to
+        // [{stuff+Room+isBrandNewRoom}, {stuff+Room+isBrandNewRoom}]
+        const client = this.client;
+        return Object.keys(obj).map((roomId) => {
+            const arrObj = obj[roomId] as T & { room: Room, isBrandNewRoom: boolean };
+            let room = client.store.getRoom(roomId);
+            let isBrandNewRoom = false;
+            if (!room) {
+                room = this.createRoom(roomId);
+                isBrandNewRoom = true;
+            }
+            arrObj.room = room;
+            arrObj.isBrandNewRoom = isBrandNewRoom;
+            return arrObj;
+        });
+    }
+
+    /**
+     * @param {Object} obj
+     * @param {Room} room
+     * @param {boolean} decrypt
+     * @return {MatrixEvent[]}
+     */
+    private mapSyncEventsFormat(
+        obj: IInviteState | ITimeline | IEphemeral,
+        room?: Room,
+        decrypt = true,
+    ): MatrixEvent[] {
+        if (!obj || !Array.isArray(obj.events)) {
+            return [];
+        }
+        const mapper = this.client.getEventMapper({ decrypt });
+        return (obj.events as Array<IStrippedState | IRoomEvent | IStateEvent | IMinimalEvent>).map(function(e) {
+            if (room) {
+                e["room_id"] = room.roomId;
+            }
+            return mapper(e);
+        });
+    }
+
+    /**
+     * @param {Room} room
+     */
+    private resolveInvites(room: Room): void {
+        if (!room || !this.opts.resolveInvitesToProfiles) {
+            return;
+        }
+        const client = this.client;
+        // For each invited room member we want to give them a displayname/avatar url
+        // if they have one (the m.room.member invites don't contain this).
+        room.getMembersWithMembership("invite").forEach(function(member) {
+            if (member._requestedProfileInfo) return;
+            member._requestedProfileInfo = true;
+            // try to get a cached copy first.
+            const user = client.getUser(member.userId);
+            let promise;
+            if (user) {
+                promise = Promise.resolve({
+                    avatar_url: user.avatarUrl,
+                    displayname: user.displayName,
+                });
+            } else {
+                promise = client.getProfileInfo(member.userId);
+            }
+            promise.then(function(info) {
+                // slightly naughty by doctoring the invite event but this means all
+                // the code paths remain the same between invite/join display name stuff
+                // which is a worthy trade-off for some minor pollution.
+                const inviteEvent = member.events.member;
+                if (inviteEvent.getContent().membership !== "invite") {
+                    // between resolving and now they have since joined, so don't clobber
+                    return;
+                }
+                inviteEvent.getContent().avatar_url = info.avatar_url;
+                inviteEvent.getContent().displayname = info.displayname;
+                // fire listeners
+                member.setMembershipEvent(inviteEvent, room.currentState);
+            }, function(err) {
+                // OH WELL.
+            });
+        });
+    }
+
+    /**
+     * @param {Room} room
+     * @param {MatrixEvent[]} stateEventList A list of state events. This is the state
+     * at the *START* of the timeline list if it is supplied.
+     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
+     * @param {boolean} fromCache whether the sync response came from cache
+     * is earlier in time. Higher index is later.
+     */
+    private processRoomEvents(
+        room: Room,
+        stateEventList: MatrixEvent[],
+        timelineEventList?: MatrixEvent[],
+        fromCache = false,
+    ): void {
+        // If there are no events in the timeline yet, initialise it with
+        // the given state events
+        const liveTimeline = room.getLiveTimeline();
+        const timelineWasEmpty = liveTimeline.getEvents().length == 0;
+        if (timelineWasEmpty) {
+            // Passing these events into initialiseState will freeze them, so we need
+            // to compute and cache the push actions for them now, otherwise sync dies
+            // with an attempt to assign to read only property.
+            // XXX: This is pretty horrible and is assuming all sorts of behaviour from
+            // these functions that it shouldn't be. We should probably either store the
+            // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise
+            // find some solution where MatrixEvents are immutable but allow for a cache
+            // field.
+            for (const ev of stateEventList) {
+                this.client.getPushActionsForEvent(ev);
+            }
+            liveTimeline.initialiseState(stateEventList);
+        }
+
+        this.resolveInvites(room);
+
+        // recalculate the room name at this point as adding events to the timeline
+        // may make notifications appear which should have the right name.
+        // XXX: This looks suspect: we'll end up recalculating the room once here
+        // and then again after adding events (processSyncResponse calls it after
+        // calling us) even if no state events were added. It also means that if
+        // one of the room events in timelineEventList is something that needs
+        // a recalculation (like m.room.name) we won't recalculate until we've
+        // finished adding all the events, which will cause the notification to have
+        // the old room name rather than the new one.
+        room.recalculate();
+
+        // If the timeline wasn't empty, we process the state events here: they're
+        // defined as updates to the state before the start of the timeline, so this
+        // starts to roll the state forward.
+        // XXX: That's what we *should* do, but this can happen if we were previously
+        // peeking in a room, in which case we obviously do *not* want to add the
+        // state events here onto the end of the timeline. Historically, the js-sdk
+        // has just set these new state events on the old and new state. This seems
+        // very wrong because there could be events in the timeline that diverge the
+        // state, in which case this is going to leave things out of sync. However,
+        // for now I think it;s best to behave the same as the code has done previously.
+        if (!timelineWasEmpty) {
+            // XXX: As above, don't do this...
+            //room.addLiveEvents(stateEventList || []);
+            // Do this instead...
+            room.oldState.setStateEvents(stateEventList || []);
+            room.currentState.setStateEvents(stateEventList || []);
+        }
+        // execute the timeline events. This will continue to diverge the current state
+        // if the timeline has any state events in it.
+        // This also needs to be done before running push rules on the events as they need
+        // to be decorated with sender etc.
+        room.addLiveEvents(timelineEventList || [], null, fromCache);
+    }
+
+    /**
+     * Takes a list of timelineEvents and adds and adds to notifEvents
+     * as appropriate.
+     * This must be called after the room the events belong to has been stored.
+     *
+     * @param {Room} room
+     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
+     * is earlier in time. Higher index is later.
+     */
+    private processEventsForNotifs(room: Room, timelineEventList: MatrixEvent[]): void {
+        // gather our notifications into this.notifEvents
+        if (this.client.getNotifTimelineSet()) {
+            for (let i = 0; i < timelineEventList.length; i++) {
+                const pushActions = this.client.getPushActionsForEvent(timelineEventList[i]);
+                if (pushActions && pushActions.notify &&
+                    pushActions.tweaks && pushActions.tweaks.highlight) {
+                    this.notifEvents.push(timelineEventList[i]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the sync state and emits an event to say so
+     * @param {String} newState The new state string
+     * @param {Object} data Object of additional data to emit in the event
+     */
+    private updateSyncState(newState: SyncState, data?: ISyncStateData): void {
+        const old = this.syncState;
+        this.syncState = newState;
+        this.syncStateData = data;
+        this.client.emit(ClientEvent.Sync, this.syncState, old, data);
+    }
+
+    /**
+     * Event handler for the 'online' event
+     * This event is generally unreliable and precise behaviour
+     * varies between browsers, so we poll for connectivity too,
+     * but this might help us reconnect a little faster.
+     */
+    private onOnline = (): void => {
+        debuglog("Browser thinks we are back online");
+        this.startKeepAlives(0);
+    };
+}
+
+function createNewUser(client: MatrixClient, userId: string): User {
+    const user = new User(userId);
+    client.reEmitter.reEmit(user, [
+        UserEvent.AvatarUrl,
+        UserEvent.DisplayName,
+        UserEvent.Presence,
+        UserEvent.CurrentlyActive,
+        UserEvent.LastPresenceTs,
+    ]);
+    return user;
+}

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -16,33 +16,16 @@ limitations under the License.
 
 import { User, UserEvent } from "./models/user";
 import { NotificationCountType, Room, RoomEvent } from "./models/room";
-import { IAbortablePromise } from "./@types/partials";
-import * as utils from "./utils";
-import { IDeferred } from "./utils";
-import { EventTimeline } from "./models/event-timeline";
-import { PushProcessor } from "./pushprocessor";
+import {ConnectionManagement } from "./conn-management";
 import { logger } from './logger';
 import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
-import {
-    IEphemeral,
-    IInvitedRoom,
-    IInviteState,
-    IJoinedRoom,
-    ILeftRoom,
-    IMinimalEvent,
-    IRoomEvent,
-    IStateEvent,
-    IStrippedState,
-    ISyncResponse,
-    ITimeline,
-} from "./sync-accumulator";
+import { ISyncStateData } from "./sync";
 import { MatrixEvent } from "./models/event";
-import { MatrixError, Method } from "./http-api";
-import { EventType } from "./@types/event";
-import { IPushRules } from "./@types/PushRules";
+import { MatrixError } from "./http-api";
 import { RoomStateEvent } from "./models/room-state";
 import { RoomMemberEvent } from "./models/room-member";
 import {SyncState } from "./sync";
+import { MSC3575SlidingSyncResponse, SlidingList, SlidingSync, SlidingSyncState } from "./sliding-sync";
 
 const DEBUG = true;
 
@@ -58,24 +41,6 @@ function debuglog(...params) {
     logger.log(...params);
 }
 
-interface ISyncOptions {
-    filterId?: string;
-    hasSyncedBefore?: boolean;
-}
-
-export interface ISyncStateData {
-    error?: MatrixError;
-    oldSyncToken?: string;
-    nextSyncToken?: string;
-    catchingUp?: boolean;
-    fromCache?: boolean;
-}
-
-type WrappedRoom<T> = T & {
-    room: Room;
-    isBrandNewRoom: boolean;
-};
-
 /**
  * <b>Internal class - unstable.</b>
  * Construct an entity which is able to sync with a homeserver.
@@ -88,28 +53,14 @@ type WrappedRoom<T> = T & {
  * SAFELY remove events from this room. It may not be safe to remove events if
  * there are other references to the timelines for this room.
  * Default: returns false.
- * @param {Boolean=} opts.disablePresence True to perform syncing without automatically
- * updating presence.
  */
 export class SlidingSyncApi {
-    /*
-createRoom
-getSyncState
-getSyncStateData
-retryImmediately
-stop
-sync
-syncLeftRooms
-*/
-    private currentSyncRequest: IAbortablePromise<ISyncResponse> = null;
     private syncState: SyncState = null;
-    private syncStateData: ISyncStateData = null; // additional data (eg. error object for failed sync)
-    private catchingUp = false;
-    private running = false;
-    private keepAliveTimer: number = null;
-    private connectionReturnedDefer: IDeferred<boolean> = null;
-    private notifEvents: MatrixEvent[] = []; // accumulator of sync events in the current sync response
-    private failedSyncCount = 0; // Number of consecutive failed /sync requests
+    private syncStateData: ISyncStateData;
+    private slidingSync: SlidingSync;
+    private connManagement: ConnectionManagement;
+    private lastPos: string;
+    private failCount: number;
 
     constructor(private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
         this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
@@ -130,75 +81,55 @@ syncLeftRooms
                 RoomEvent.TimelineReset,
             ]);
         }
+        this.client = client;
+        this.connManagement = new ConnectionManagement(client, this.updateSyncState.bind(this));
+        this.lastPos = null;
+        this.failCount = 0;
+
+        // TODO: dependency inject
+        this.slidingSync = new SlidingSync("http://localhost:8008", [
+            new SlidingList({
+                ranges: [[0,20]],
+                sort: [],
+                required_state: [
+                    ["m.room.join_rules", ""],
+                    ["m.room.avatar", ""],
+                    ["m.room.tombstone", ""],
+                ],
+                timeline_limit: 1,
+            }),
+        ], {}, client, 30 * 1000);
+        this.slidingSync.addLifecycleListener(this.onLifecycle.bind(this));
+        this.slidingSync.addRoomDataListener(this.onRoomData.bind(this));
     }
 
-    /**
-     * @param {string} roomId
-     * @return {Room}
-     */
-    public createRoom(roomId: string): Room { // XXX cargoculted from sync.ts
-        const client = this.client;
-        const {
-            timelineSupport,
-            unstableClientRelationAggregation,
-        } = client;
-        const room = new Room(roomId, client, client.getUserId(), {
-            lazyLoadMembers: this.opts.lazyLoadMembers,
-            pendingEventOrdering: this.opts.pendingEventOrdering,
-            timelineSupport,
-            unstableClientRelationAggregation,
-        });
-        client.reEmitter.reEmit(room, [
-            RoomEvent.Name,
-            RoomEvent.Redaction,
-            RoomEvent.RedactionCancelled,
-            RoomEvent.Receipt,
-            RoomEvent.Tags,
-            RoomEvent.LocalEchoUpdated,
-            RoomEvent.AccountData,
-            RoomEvent.MyMembership,
-            RoomEvent.Timeline,
-            RoomEvent.TimelineReset,
-        ]);
-        this.registerStateListeners(room);
-        return room;
+    private onRoomData(roomId: string, roomData: object) {
+        console.log("onRoomData", roomId, JSON.stringify(roomData));
     }
 
-    /**
-     * @param {Room} room
-     * @private
-     */
-    private registerStateListeners(room: Room): void { // XXX cargoculted from sync.ts
-        const client = this.client;
-        // we need to also re-emit room state and room member events, so hook it up
-        // to the client now. We need to add a listener for RoomState.members in
-        // order to hook them correctly.
-        client.reEmitter.reEmit(room.currentState, [
-            RoomStateEvent.Events,
-            RoomStateEvent.Members,
-            RoomStateEvent.NewMember,
-            RoomStateEvent.Update,
-        ]);
-        room.currentState.on(RoomStateEvent.NewMember, function(event, state, member) {
-            member.user = client.getUser(member.userId);
-            client.reEmitter.reEmit(member, [
-                RoomMemberEvent.Name,
-                RoomMemberEvent.Typing,
-                RoomMemberEvent.PowerLevel,
-                RoomMemberEvent.Membership,
-            ]);
-        });
-    }
-
-    /**
-     * @param {Room} room
-     * @private
-     */
-    private deregisterStateListeners(room: Room): void { // XXX cargoculted from sync.ts
-        // could do with a better way of achieving this.
-        room.currentState.removeAllListeners(RoomStateEvent.Events);
-        room.currentState.removeAllListeners(RoomStateEvent.Members);
-        room.currentState.removeAllListeners(RoomStateEvent.NewMember);
+    private onLifecycle(state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err?: Error) {
+        console.log("onLifecycle", state, err);
+        switch (state) {
+            case SlidingSyncState.Complete:
+                this.updateSyncState(this.lastPos ? SyncState.Syncing : SyncState.Prepared, {
+                    oldSyncToken: this.lastPos,
+                    nextSyncToken: resp.pos,
+                    catchingUp: false,
+                    fromCache: false,
+                });
+                this.lastPos = resp.pos;
+                break;
+            case SlidingSyncState.RequestFinished:
+                if (err) {
+                    this.failCount += 1;
+                    this.updateSyncState(this.failCount > FAILED_SYNC_ERROR_THRESHOLD ? SyncState.Error : SyncState.Reconnecting, {
+                        error: new MatrixError(err),
+                    });
+                } else {
+                    this.failCount = 0;
+                }
+                break;
+        }
     }
 
     /**
@@ -237,6 +168,10 @@ syncLeftRooms
         return this.syncState;
     }
 
+    public retryImmediately() {
+        return this.connManagement.retryImmediately();
+    }
+
     /**
      * Returns the additional data object associated with
      * the current sync state, or null if there is no
@@ -261,91 +196,31 @@ syncLeftRooms
     }
 
     /**
-     * Main entry point
+     * Main entry point. Blocks until stop() is called.
      */
     public async sync() {
-        const client = this.client;
-        this.running = true;
-        if (global.window && global.window.addEventListener) {
-            global.window.addEventListener("online", this.onOnline, false);
-        }
-        let savedSyncToken = null;
+        this.connManagement.start();
+        debuglog("Sliding sync init loop");
 
-        // We need to do one-off checks before we can begin the /sync loop.
-        // These are:
         //   1) We need to get push rules so we can check if events should bing as we get
         //      them from /sync.
-        //   2) We need to get/create a filter which we can use for /sync.
-        //   3) We need to check the lazy loading option matches what was used in the
-        //       stored sync. If it doesn't, we can't use the stored sync.
-
-        const getPushRules = async () => {
+        while (true) {
             try {
                 debuglog("Getting push rules...");
-                const result = await client.getPushRules();
+                const result = await this.client.getPushRules();
                 debuglog("Got push rules");
-
-                client.pushRules = result;
+                this.client.pushRules = result;
+                break;
             } catch (err) {
                 logger.error("Getting push rules failed", err);
-                if (this.shouldAbortSync(err)) return;
-                getPushRules();
-                return;
-            }
-            checkLazyLoadStatus(); // advance to the next stage
-        };
-
-        const checkLazyLoadStatus = async () => {
-            debuglog("Checking lazy load status...");
-            if (this.opts.lazyLoadMembers && client.isGuest()) {
-                this.opts.lazyLoadMembers = false;
-            }
-            if (this.opts.lazyLoadMembers) {
-                debuglog("Checking server lazy load support...");
-                const supported = await client.doesServerSupportLazyLoading();
-                if (supported) {
-                    debuglog("Enabling lazy load on sync filter...");
-                    this.opts.lazyLoadMembers = false; // TODO
-                } else {
-                    debuglog("LL: lazy loading requested but not supported " +
-                        "by server, so disabling");
-                    this.opts.lazyLoadMembers = false;
+                if (this.shouldAbortSync(err)) {
+                    return;
                 }
             }
-            if (this.opts.lazyLoadMembers && this.opts.crypto) {
-                this.opts.crypto.enableLazyLoading();
-            }
-            try {
-                debuglog("Storing client options...");
-                await this.client.storeClientOptions();
-                debuglog("Stored client options");
-            } catch (err) {
-                logger.error("Storing client options failed", err);
-                throw err;
-            }
+        }
 
-            getFilter(); // Now get the filter and start syncing
-        };
-
-        const getFilter = async () => {
-            debuglog("Getting filter...");
-            // reset the notifications timeline to prepare it to paginate from
-            // the current point in time.
-            // The right solution would be to tie /sync pagination tokens into
-            // /notifications API somehow.
-            client.resetNotifTimelineSet();
-
-            if (this.currentSyncRequest === null) {
-                // Send this first sync request here so we can then wait for the saved
-                // sync data to finish processing before we process the results of this one.
-                debuglog("Sending first sync request...");
-                // XXX TODO this.currentSyncRequest = this.doSyncRequest({ }, savedSyncToken);
-            }
-
-            this.doSync({});
-        };
-
-        await getPushRules();
+        // start syncing
+        await this.slidingSync.start();
     }
 
     /**
@@ -353,838 +228,8 @@ syncLeftRooms
      */
     public stop(): void {
         debuglog("SyncApi.stop");
-        // It is necessary to check for the existance of
-        // global.window AND global.window.removeEventListener.
-        // Some platforms (e.g. React Native) register global.window,
-        // but do not have global.window.removeEventListener.
-        if (global.window && global.window.removeEventListener) {
-            global.window.removeEventListener("online", this.onOnline, false);
-        }
-        this.running = false;
-        if (this.currentSyncRequest) {
-            this.currentSyncRequest.abort();
-        }
-        if (this.keepAliveTimer) {
-            clearTimeout(this.keepAliveTimer);
-            this.keepAliveTimer = null;
-        }
-    }
-
-    /**
-     * Retry a backed off syncing request immediately. This should only be used when
-     * the user <b>explicitly</b> attempts to retry their lost connection.
-     * @return {boolean} True if this resulted in a request being retried.
-     */
-    public retryImmediately(): boolean {
-        if (!this.connectionReturnedDefer) {
-            return false;
-        }
-        this.startKeepAlives(0);
-        return true;
-    }
-
-    /**
-     * Invoke me to do /sync calls
-     * @param {Object} syncOptions
-     * @param {string} syncOptions.filterId
-     * @param {boolean} syncOptions.hasSyncedBefore
-     */
-    private async doSync(syncOptions: ISyncOptions): Promise<void> {
-        const client = this.client;
-        while (true) {
-            if (!this.running) {
-                debuglog("Sync no longer running: exiting.");
-                if (this.connectionReturnedDefer) {
-                    this.connectionReturnedDefer.reject();
-                    this.connectionReturnedDefer = null;
-                }
-                this.updateSyncState(SyncState.Stopped);
-                return;
-            }
-
-            const syncToken = client.store.getSyncToken();
-
-            let data;
-            try {
-                //debuglog('Starting sync since=' + syncToken);
-                if (this.currentSyncRequest === null) {
-                    // XXX TODO this.currentSyncRequest = this.doSyncRequest(syncOptions, syncToken);
-                }
-                data = await this.currentSyncRequest;
-            } catch (e) {
-                this.onSyncError(e, syncOptions);
-                return;
-            } finally {
-                this.currentSyncRequest = null;
-            }
-
-            //debuglog('Completed sync, next_batch=' + data.next_batch);
-
-            // set the sync token NOW *before* processing the events. We do this so
-            // if something barfs on an event we can skip it rather than constantly
-            // polling with the same token.
-            client.store.setSyncToken(data.next_batch);
-
-            // Reset after a successful sync
-            this.failedSyncCount = 0;
-
-            await client.store.setSyncData(data);
-
-            const syncEventData = {
-                oldSyncToken: syncToken,
-                nextSyncToken: data.next_batch,
-                catchingUp: this.catchingUp,
-            };
-
-            if (this.opts.crypto) {
-                // tell the crypto module we're about to process a sync
-                // response
-                await this.opts.crypto.onSyncWillProcess(syncEventData);
-            }
-
-            try {
-                await this.processSyncResponse(syncEventData, data);
-            } catch (e) {
-                // log the exception with stack if we have it, else fall back
-                // to the plain description
-                logger.error("Caught /sync error", e.stack || e);
-
-                // Emit the exception for client handling
-                this.client.emit(ClientEvent.SyncUnexpectedError, e);
-            }
-
-            // update this as it may have changed
-            syncEventData.catchingUp = this.catchingUp;
-
-            // emit synced events
-            if (!syncOptions.hasSyncedBefore) {
-                this.updateSyncState(SyncState.Prepared, syncEventData);
-                syncOptions.hasSyncedBefore = true;
-            }
-
-            // tell the crypto module to do its processing. It may block (to do a
-            // /keys/changes request).
-            if (this.opts.crypto) {
-                await this.opts.crypto.onSyncCompleted(syncEventData);
-            }
-
-            // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
-            this.updateSyncState(SyncState.Syncing, syncEventData);
-
-            if (client.store.wantsSave()) {
-                // We always save the device list (if it's dirty) before saving the sync data:
-                // this means we know the saved device list data is at least as fresh as the
-                // stored sync data which means we don't have to worry that we may have missed
-                // device changes. We can also skip the delay since we're not calling this very
-                // frequently (and we don't really want to delay the sync for it).
-                if (this.opts.crypto) {
-                    await this.opts.crypto.saveDeviceList(0);
-                }
-
-                // tell databases that everything is now in a consistent state and can be saved.
-                client.store.save();
-            }
-        }
-    }
-
-    private onSyncError(err: MatrixError, syncOptions: ISyncOptions): void {
-        if (!this.running) {
-            debuglog("Sync no longer running: exiting");
-            if (this.connectionReturnedDefer) {
-                this.connectionReturnedDefer.reject();
-                this.connectionReturnedDefer = null;
-            }
-            this.updateSyncState(SyncState.Stopped);
-            return;
-        }
-
-        logger.error("/sync error %s", err);
-        logger.error(err);
-
-        if (this.shouldAbortSync(err)) {
-            return;
-        }
-
-        this.failedSyncCount++;
-        logger.log('Number of consecutive failed sync requests:', this.failedSyncCount);
-
-        debuglog("Starting keep-alive");
-        // Note that we do *not* mark the sync connection as
-        // lost yet: we only do this if a keepalive poke
-        // fails, since long lived HTTP connections will
-        // go away sometimes and we shouldn't treat this as
-        // erroneous. We set the state to 'reconnecting'
-        // instead, so that clients can observe this state
-        // if they wish.
-        this.startKeepAlives().then((connDidFail) => {
-            // Only emit CATCHUP if we detected a connectivity error: if we didn't,
-            // it's quite likely the sync will fail again for the same reason and we
-            // want to stay in ERROR rather than keep flip-flopping between ERROR
-            // and CATCHUP.
-            if (connDidFail && this.getSyncState() === SyncState.Error) {
-                this.updateSyncState(SyncState.Catchup, {
-                    oldSyncToken: null,
-                    nextSyncToken: null,
-                    catchingUp: true,
-                });
-            }
-            this.doSync(syncOptions);
-        });
-
-        this.currentSyncRequest = null;
-        // Transition from RECONNECTING to ERROR after a given number of failed syncs
-        this.updateSyncState(
-            this.failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
-                SyncState.Error : SyncState.Reconnecting,
-            { error: err },
-        );
-    }
-
-    /**
-     * Process data returned from a sync response and propagate it
-     * into the model objects
-     *
-     * @param {Object} syncEventData Object containing sync tokens associated with this sync
-     * @param {Object} data The response from /sync
-     */
-    private async processSyncResponse(syncEventData: ISyncStateData, data: ISyncResponse): Promise<void> {
-        const client = this.client;
-
-        // data looks like:
-        // {
-        // }
-
-        // handle presence events (User objects)
-        if (data.presence && Array.isArray(data.presence.events)) {
-            data.presence.events.map(client.getEventMapper()).forEach(
-                function(presenceEvent) {
-                    let user = client.store.getUser(presenceEvent.getSender());
-                    if (user) {
-                        user.setPresenceEvent(presenceEvent);
-                    } else {
-                        user = createNewUser(client, presenceEvent.getSender());
-                        user.setPresenceEvent(presenceEvent);
-                        client.store.storeUser(user);
-                    }
-                    client.emit(ClientEvent.Event, presenceEvent);
-                });
-        }
-
-        // handle non-room account_data
-        if (data.account_data && Array.isArray(data.account_data.events)) {
-            const events = data.account_data.events.map(client.getEventMapper());
-            const prevEventsMap = events.reduce((m, c) => {
-                m[c.getId()] = client.store.getAccountData(c.getType());
-                return m;
-            }, {});
-            client.store.storeAccountDataEvents(events);
-            events.forEach(
-                function(accountDataEvent) {
-                    // Honour push rules that come down the sync stream but also
-                    // honour push rules that were previously cached. Base rules
-                    // will be updated when we receive push rules via getPushRules
-                    // (see sync) before syncing over the network.
-                    if (accountDataEvent.getType() === EventType.PushRules) {
-                        const rules = accountDataEvent.getContent<IPushRules>();
-                        client.pushRules = PushProcessor.rewriteDefaultRules(rules);
-                    }
-                    const prevEvent = prevEventsMap[accountDataEvent.getId()];
-                    client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
-                    return accountDataEvent;
-                },
-            );
-        }
-
-        // handle to-device events
-        if (data.to_device && Array.isArray(data.to_device.events) &&
-            data.to_device.events.length > 0
-        ) {
-            const cancelledKeyVerificationTxns = [];
-            data.to_device.events
-                .map(client.getEventMapper())
-                .map((toDeviceEvent) => { // map is a cheap inline forEach
-                    // We want to flag m.key.verification.start events as cancelled
-                    // if there's an accompanying m.key.verification.cancel event, so
-                    // we pull out the transaction IDs from the cancellation events
-                    // so we can flag the verification events as cancelled in the loop
-                    // below.
-                    if (toDeviceEvent.getType() === "m.key.verification.cancel") {
-                        const txnId = toDeviceEvent.getContent()['transaction_id'];
-                        if (txnId) {
-                            cancelledKeyVerificationTxns.push(txnId);
-                        }
-                    }
-
-                    // as mentioned above, .map is a cheap inline forEach, so return
-                    // the unmodified event.
-                    return toDeviceEvent;
-                })
-                .forEach(
-                    function(toDeviceEvent) {
-                        const content = toDeviceEvent.getContent();
-                        if (
-                            toDeviceEvent.getType() == "m.room.message" &&
-                            content.msgtype == "m.bad.encrypted"
-                        ) {
-                            // the mapper already logged a warning.
-                            logger.log(
-                                'Ignoring undecryptable to-device event from ' +
-                                toDeviceEvent.getSender(),
-                            );
-                            return;
-                        }
-
-                        if (toDeviceEvent.getType() === "m.key.verification.start"
-                            || toDeviceEvent.getType() === "m.key.verification.request") {
-                            const txnId = content['transaction_id'];
-                            if (cancelledKeyVerificationTxns.includes(txnId)) {
-                                toDeviceEvent.flagCancelled();
-                            }
-                        }
-
-                        client.emit(ClientEvent.ToDeviceEvent, toDeviceEvent);
-                    },
-                );
-        } else {
-            // no more to-device events: we can stop polling with a short timeout.
-            this.catchingUp = false;
-        }
-
-        // the returned json structure is a bit crap, so make it into a
-        // nicer form (array) after applying sanity to make sure we don't fail
-        // on missing keys (on the off chance)
-        let inviteRooms: WrappedRoom<IInvitedRoom>[] = [];
-        let joinRooms: WrappedRoom<IJoinedRoom>[] = [];
-        let leaveRooms: WrappedRoom<ILeftRoom>[] = [];
-
-        if (data.rooms) {
-            if (data.rooms.invite) {
-                inviteRooms = this.mapSyncResponseToRoomArray(data.rooms.invite);
-            }
-            if (data.rooms.join) {
-                joinRooms = this.mapSyncResponseToRoomArray(data.rooms.join);
-            }
-            if (data.rooms.leave) {
-                leaveRooms = this.mapSyncResponseToRoomArray(data.rooms.leave);
-            }
-        }
-
-        this.notifEvents = [];
-
-        // Handle invites
-        inviteRooms.forEach((inviteObj) => {
-            const room = inviteObj.room;
-            const stateEvents = this.mapSyncEventsFormat(inviteObj.invite_state, room);
-
-            this.processRoomEvents(room, stateEvents);
-            if (inviteObj.isBrandNewRoom) {
-                room.recalculate();
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-            stateEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            room.updateMyMembership("invite");
-        });
-
-        // Handle joins
-        await utils.promiseMapSeries(joinRooms, async (joinObj) => {
-            const room = joinObj.room;
-            const stateEvents = this.mapSyncEventsFormat(joinObj.state, room);
-            // Prevent events from being decrypted ahead of time
-            // this helps large account to speed up faster
-            // room::decryptCriticalEvent is in charge of decrypting all the events
-            // required for a client to function properly
-            const events = this.mapSyncEventsFormat(joinObj.timeline, room, false);
-            const ephemeralEvents = this.mapSyncEventsFormat(joinObj.ephemeral);
-            const accountDataEvents = this.mapSyncEventsFormat(joinObj.account_data);
-
-            const encrypted = client.isRoomEncrypted(room.roomId);
-            // we do this first so it's correct when any of the events fire
-            if (joinObj.unread_notifications) {
-                room.setUnreadNotificationCount(
-                    NotificationCountType.Total,
-                    joinObj.unread_notifications.notification_count,
-                );
-
-                // We track unread notifications ourselves in encrypted rooms, so don't
-                // bother setting it here. We trust our calculations better than the
-                // server's for this case, and therefore will assume that our non-zero
-                // count is accurate.
-                if (!encrypted
-                    || (encrypted && room.getUnreadNotificationCount(NotificationCountType.Highlight) <= 0)) {
-                    room.setUnreadNotificationCount(
-                        NotificationCountType.Highlight,
-                        joinObj.unread_notifications.highlight_count,
-                    );
-                }
-            }
-
-            joinObj.timeline = joinObj.timeline || {} as ITimeline;
-
-            if (joinObj.isBrandNewRoom) {
-                // set the back-pagination token. Do this *before* adding any
-                // events so that clients can start back-paginating.
-                room.getLiveTimeline().setPaginationToken(
-                    joinObj.timeline.prev_batch, EventTimeline.BACKWARDS);
-            } else if (joinObj.timeline.limited) {
-                let limited = true;
-
-                // we've got a limited sync, so we *probably* have a gap in the
-                // timeline, so should reset. But we might have been peeking or
-                // paginating and already have some of the events, in which
-                // case we just want to append any subsequent events to the end
-                // of the existing timeline.
-                //
-                // This is particularly important in the case that we already have
-                // *all* of the events in the timeline - in that case, if we reset
-                // the timeline, we'll end up with an entirely empty timeline,
-                // which we'll try to paginate but not get any new events (which
-                // will stop us linking the empty timeline into the chain).
-                //
-                for (let i = events.length - 1; i >= 0; i--) {
-                    const eventId = events[i].getId();
-                    if (room.getTimelineForEvent(eventId)) {
-                        debuglog("Already have event " + eventId + " in limited " +
-                            "sync - not resetting");
-                        limited = false;
-
-                        // we might still be missing some of the events before i;
-                        // we don't want to be adding them to the end of the
-                        // timeline because that would put them out of order.
-                        events.splice(0, i);
-
-                        // XXX: there's a problem here if the skipped part of the
-                        // timeline modifies the state set in stateEvents, because
-                        // we'll end up using the state from stateEvents rather
-                        // than the later state from timelineEvents. We probably
-                        // need to wind stateEvents forward over the events we're
-                        // skipping.
-
-                        break;
-                    }
-                }
-
-                if (limited) {
-                    this.deregisterStateListeners(room);
-                    room.resetLiveTimeline(
-                        joinObj.timeline.prev_batch,
-                        this.opts.canResetEntireTimeline(room.roomId) ?
-                            null : syncEventData.oldSyncToken,
-                    );
-
-                    // We have to assume any gap in any timeline is
-                    // reason to stop incrementally tracking notifications and
-                    // reset the timeline.
-                    client.resetNotifTimelineSet();
-
-                    this.registerStateListeners(room);
-                }
-            }
-
-            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
-
-            this.processRoomEvents(room, stateEvents, timelineEvents, syncEventData.fromCache);
-
-            // set summary after processing events,
-            // because it will trigger a name calculation
-            // which needs the room state to be up to date
-            if (joinObj.summary) {
-                room.setSummary(joinObj.summary);
-            }
-
-            // we deliberately don't add ephemeral events to the timeline
-            room.addEphemeralEvents(ephemeralEvents);
-
-            // we deliberately don't add accountData to the timeline
-            room.addAccountData(accountDataEvents);
-
-            room.recalculate();
-            if (joinObj.isBrandNewRoom) {
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-
-            this.processEventsForNotifs(room, events);
-
-            const processRoomEvent = async (e) => {
-                client.emit(ClientEvent.Event, e);
-                if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
-                    await this.opts.crypto.onCryptoEvent(e);
-                }
-                if (e.isState() && e.getType() === "im.vector.user_status") {
-                    let user = client.store.getUser(e.getStateKey());
-                    if (user) {
-                        user.unstable_updateStatusMessage(e);
-                    } else {
-                        user = createNewUser(client, e.getStateKey());
-                        user.unstable_updateStatusMessage(e);
-                        client.store.storeUser(user);
-                    }
-                }
-            };
-
-            await utils.promiseMapSeries(stateEvents, processRoomEvent);
-            await utils.promiseMapSeries(timelineEvents, processRoomEvent);
-            await utils.promiseMapSeries(threadedEvents, processRoomEvent);
-            ephemeralEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            accountDataEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-
-            room.updateMyMembership("join");
-
-            // Decrypt only the last message in all rooms to make sure we can generate a preview
-            // And decrypt all events after the recorded read receipt to ensure an accurate
-            // notification count
-            room.decryptCriticalEvents();
-        });
-
-        // Handle leaves (e.g. kicked rooms)
-        leaveRooms.forEach(async (leaveObj) => {
-            const room = leaveObj.room;
-            const stateEvents = this.mapSyncEventsFormat(leaveObj.state, room);
-            const events = this.mapSyncEventsFormat(leaveObj.timeline, room);
-            const accountDataEvents = this.mapSyncEventsFormat(leaveObj.account_data);
-
-            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
-
-            this.processRoomEvents(room, stateEvents, timelineEvents);
-            room.addAccountData(accountDataEvents);
-
-            room.recalculate();
-            if (leaveObj.isBrandNewRoom) {
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-
-            this.processEventsForNotifs(room, events);
-
-            stateEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            timelineEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            threadedEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            accountDataEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-
-            room.updateMyMembership("leave");
-        });
-
-        // update the notification timeline, if appropriate.
-        // we only do this for live events, as otherwise we can't order them sanely
-        // in the timeline relative to ones paginated in by /notifications.
-        // XXX: we could fix this by making EventTimeline support chronological
-        // ordering... but it doesn't, right now.
-        if (syncEventData.oldSyncToken && this.notifEvents.length) {
-            this.notifEvents.sort(function(a, b) {
-                return a.getTs() - b.getTs();
-            });
-            this.notifEvents.forEach(function(event) {
-                client.getNotifTimelineSet().addLiveEvent(event);
-            });
-        }
-
-        // Handle device list updates
-        if (data.device_lists) {
-            if (this.opts.crypto) {
-                await this.opts.crypto.handleDeviceListChanges(syncEventData, data.device_lists);
-            } else {
-                // FIXME if we *don't* have a crypto module, we still need to
-                // invalidate the device lists. But that would require a
-                // substantial bit of rework :/.
-            }
-        }
-
-        // Handle one_time_keys_count
-        if (this.opts.crypto && data.device_one_time_keys_count) {
-            const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
-            this.opts.crypto.updateOneTimeKeyCount(currentCount);
-        }
-        if (this.opts.crypto &&
-            (data["device_unused_fallback_key_types"] ||
-                data["org.matrix.msc2732.device_unused_fallback_key_types"])) {
-            // The presence of device_unused_fallback_key_types indicates that the
-            // server supports fallback keys. If there's no unused
-            // signed_curve25519 fallback key we need a new one.
-            const unusedFallbackKeys = data["device_unused_fallback_key_types"] ||
-                data["org.matrix.msc2732.device_unused_fallback_key_types"];
-            this.opts.crypto.setNeedsNewFallback(
-                unusedFallbackKeys instanceof Array &&
-                !unusedFallbackKeys.includes("signed_curve25519"),
-            );
-        }
-    }
-
-    /**
-     * Starts polling the connectivity check endpoint
-     * @param {number} delay How long to delay until the first poll.
-     *        defaults to a short, randomised interval (to prevent
-     *        tightlooping if /versions succeeds but /sync etc. fail).
-     * @return {promise} which resolves once the connection returns
-     */
-    private startKeepAlives(delay?: number): Promise<boolean> {
-        if (delay === undefined) {
-            delay = 2000 + Math.floor(Math.random() * 5000);
-        }
-
-        if (this.keepAliveTimer !== null) {
-            clearTimeout(this.keepAliveTimer);
-        }
-        if (delay > 0) {
-            this.keepAliveTimer = setTimeout(this.pokeKeepAlive.bind(this), delay);
-        } else {
-            this.pokeKeepAlive();
-        }
-        if (!this.connectionReturnedDefer) {
-            this.connectionReturnedDefer = utils.defer();
-        }
-        return this.connectionReturnedDefer.promise;
-    }
-
-    /**
-     * Make a dummy call to /_matrix/client/versions, to see if the HS is
-     * reachable.
-     *
-     * On failure, schedules a call back to itself. On success, resolves
-     * this.connectionReturnedDefer.
-     *
-     * @param {boolean} connDidFail True if a connectivity failure has been detected. Optional.
-     */
-    private pokeKeepAlive(connDidFail = false): void {
-        const success = () => {
-            clearTimeout(this.keepAliveTimer);
-            if (this.connectionReturnedDefer) {
-                this.connectionReturnedDefer.resolve(connDidFail);
-                this.connectionReturnedDefer = null;
-            }
-        };
-
-        this.client.http.request(
-            undefined, // callback
-            Method.Get, "/_matrix/client/versions",
-            undefined, // queryParams
-            undefined, // data
-            {
-                prefix: '',
-                localTimeoutMs: 15 * 1000,
-            },
-        ).then(() => {
-            success();
-        }, (err) => {
-            if (err.httpStatus == 400 || err.httpStatus == 404) {
-                // treat this as a success because the server probably just doesn't
-                // support /versions: point is, we're getting a response.
-                // We wait a short time though, just in case somehow the server
-                // is in a mode where it 400s /versions responses and sync etc.
-                // responses fail, this will mean we don't hammer in a loop.
-                this.keepAliveTimer = setTimeout(success, 2000);
-            } else {
-                connDidFail = true;
-                this.keepAliveTimer = setTimeout(
-                    this.pokeKeepAlive.bind(this, connDidFail),
-                    5000 + Math.floor(Math.random() * 5000),
-                );
-                // A keepalive has failed, so we emit the
-                // error state (whether or not this is the
-                // first failure).
-                // Note we do this after setting the timer:
-                // this lets the unit tests advance the mock
-                // clock when they get the error.
-                this.updateSyncState(SyncState.Error, { error: err });
-            }
-        });
-    }
-
-    /**
-     * @param {Object} obj
-     * @return {Object[]}
-     */
-    private mapSyncResponseToRoomArray<T extends ILeftRoom | IJoinedRoom | IInvitedRoom>(
-        obj: Record<string, T>,
-    ): Array<WrappedRoom<T>> {
-        // Maps { roomid: {stuff}, roomid: {stuff} }
-        // to
-        // [{stuff+Room+isBrandNewRoom}, {stuff+Room+isBrandNewRoom}]
-        const client = this.client;
-        return Object.keys(obj).map((roomId) => {
-            const arrObj = obj[roomId] as T & { room: Room, isBrandNewRoom: boolean };
-            let room = client.store.getRoom(roomId);
-            let isBrandNewRoom = false;
-            if (!room) {
-                room = this.createRoom(roomId);
-                isBrandNewRoom = true;
-            }
-            arrObj.room = room;
-            arrObj.isBrandNewRoom = isBrandNewRoom;
-            return arrObj;
-        });
-    }
-
-    /**
-     * @param {Object} obj
-     * @param {Room} room
-     * @param {boolean} decrypt
-     * @return {MatrixEvent[]}
-     */
-    private mapSyncEventsFormat(
-        obj: IInviteState | ITimeline | IEphemeral,
-        room?: Room,
-        decrypt = true,
-    ): MatrixEvent[] {
-        if (!obj || !Array.isArray(obj.events)) {
-            return [];
-        }
-        const mapper = this.client.getEventMapper({ decrypt });
-        return (obj.events as Array<IStrippedState | IRoomEvent | IStateEvent | IMinimalEvent>).map(function(e) {
-            if (room) {
-                e["room_id"] = room.roomId;
-            }
-            return mapper(e);
-        });
-    }
-
-    /**
-     * @param {Room} room
-     */
-    private resolveInvites(room: Room): void {
-        if (!room || !this.opts.resolveInvitesToProfiles) {
-            return;
-        }
-        const client = this.client;
-        // For each invited room member we want to give them a displayname/avatar url
-        // if they have one (the m.room.member invites don't contain this).
-        room.getMembersWithMembership("invite").forEach(function(member) {
-            if (member._requestedProfileInfo) return;
-            member._requestedProfileInfo = true;
-            // try to get a cached copy first.
-            const user = client.getUser(member.userId);
-            let promise;
-            if (user) {
-                promise = Promise.resolve({
-                    avatar_url: user.avatarUrl,
-                    displayname: user.displayName,
-                });
-            } else {
-                promise = client.getProfileInfo(member.userId);
-            }
-            promise.then(function(info) {
-                // slightly naughty by doctoring the invite event but this means all
-                // the code paths remain the same between invite/join display name stuff
-                // which is a worthy trade-off for some minor pollution.
-                const inviteEvent = member.events.member;
-                if (inviteEvent.getContent().membership !== "invite") {
-                    // between resolving and now they have since joined, so don't clobber
-                    return;
-                }
-                inviteEvent.getContent().avatar_url = info.avatar_url;
-                inviteEvent.getContent().displayname = info.displayname;
-                // fire listeners
-                member.setMembershipEvent(inviteEvent, room.currentState);
-            }, function(err) {
-                // OH WELL.
-            });
-        });
-    }
-
-    /**
-     * @param {Room} room
-     * @param {MatrixEvent[]} stateEventList A list of state events. This is the state
-     * at the *START* of the timeline list if it is supplied.
-     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
-     * @param {boolean} fromCache whether the sync response came from cache
-     * is earlier in time. Higher index is later.
-     */
-    private processRoomEvents(
-        room: Room,
-        stateEventList: MatrixEvent[],
-        timelineEventList?: MatrixEvent[],
-        fromCache = false,
-    ): void {
-        // If there are no events in the timeline yet, initialise it with
-        // the given state events
-        const liveTimeline = room.getLiveTimeline();
-        const timelineWasEmpty = liveTimeline.getEvents().length == 0;
-        if (timelineWasEmpty) {
-            // Passing these events into initialiseState will freeze them, so we need
-            // to compute and cache the push actions for them now, otherwise sync dies
-            // with an attempt to assign to read only property.
-            // XXX: This is pretty horrible and is assuming all sorts of behaviour from
-            // these functions that it shouldn't be. We should probably either store the
-            // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise
-            // find some solution where MatrixEvents are immutable but allow for a cache
-            // field.
-            for (const ev of stateEventList) {
-                this.client.getPushActionsForEvent(ev);
-            }
-            liveTimeline.initialiseState(stateEventList);
-        }
-
-        this.resolveInvites(room);
-
-        // recalculate the room name at this point as adding events to the timeline
-        // may make notifications appear which should have the right name.
-        // XXX: This looks suspect: we'll end up recalculating the room once here
-        // and then again after adding events (processSyncResponse calls it after
-        // calling us) even if no state events were added. It also means that if
-        // one of the room events in timelineEventList is something that needs
-        // a recalculation (like m.room.name) we won't recalculate until we've
-        // finished adding all the events, which will cause the notification to have
-        // the old room name rather than the new one.
-        room.recalculate();
-
-        // If the timeline wasn't empty, we process the state events here: they're
-        // defined as updates to the state before the start of the timeline, so this
-        // starts to roll the state forward.
-        // XXX: That's what we *should* do, but this can happen if we were previously
-        // peeking in a room, in which case we obviously do *not* want to add the
-        // state events here onto the end of the timeline. Historically, the js-sdk
-        // has just set these new state events on the old and new state. This seems
-        // very wrong because there could be events in the timeline that diverge the
-        // state, in which case this is going to leave things out of sync. However,
-        // for now I think it;s best to behave the same as the code has done previously.
-        if (!timelineWasEmpty) {
-            // XXX: As above, don't do this...
-            //room.addLiveEvents(stateEventList || []);
-            // Do this instead...
-            room.oldState.setStateEvents(stateEventList || []);
-            room.currentState.setStateEvents(stateEventList || []);
-        }
-        // execute the timeline events. This will continue to diverge the current state
-        // if the timeline has any state events in it.
-        // This also needs to be done before running push rules on the events as they need
-        // to be decorated with sender etc.
-        room.addLiveEvents(timelineEventList || [], null, fromCache);
-    }
-
-    /**
-     * Takes a list of timelineEvents and adds and adds to notifEvents
-     * as appropriate.
-     * This must be called after the room the events belong to has been stored.
-     *
-     * @param {Room} room
-     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
-     * is earlier in time. Higher index is later.
-     */
-    private processEventsForNotifs(room: Room, timelineEventList: MatrixEvent[]): void {
-        // gather our notifications into this.notifEvents
-        if (this.client.getNotifTimelineSet()) {
-            for (let i = 0; i < timelineEventList.length; i++) {
-                const pushActions = this.client.getPushActionsForEvent(timelineEventList[i]);
-                if (pushActions && pushActions.notify &&
-                    pushActions.tweaks && pushActions.tweaks.highlight) {
-                    this.notifEvents.push(timelineEventList[i]);
-                }
-            }
-        }
+        this.slidingSync.stop();
+        this.connManagement.stop();
     }
 
     /**
@@ -1198,18 +243,11 @@ syncLeftRooms
         this.syncStateData = data;
         this.client.emit(ClientEvent.Sync, this.syncState, old, data);
     }
-
-    /**
-     * Event handler for the 'online' event
-     * This event is generally unreliable and precise behaviour
-     * varies between browsers, so we poll for connectivity too,
-     * but this might help us reconnect a little faster.
-     */
-    private onOnline = (): void => {
-        debuglog("Browser thinks we are back online");
-        this.startKeepAlives(0);
-    };
 }
+
+
+// Helper functions which set up JS SDK structs are below and are identical to the sync v2 counterparts,
+// just outside the class.
 
 function createNewUser(client: MatrixClient, userId: string): User {
     const user = new User(userId);
@@ -1221,4 +259,60 @@ function createNewUser(client: MatrixClient, userId: string): User {
         UserEvent.LastPresenceTs,
     ]);
     return user;
+}
+
+
+function createRoom(client: MatrixClient, roomId: string, opts: IStoredClientOpts): Room { // XXX cargoculted from sync.ts
+    const {
+        timelineSupport,
+        unstableClientRelationAggregation,
+    } = client;
+    const room = new Room(roomId, client, client.getUserId(), {
+        lazyLoadMembers: opts.lazyLoadMembers,
+        pendingEventOrdering: opts.pendingEventOrdering,
+        timelineSupport,
+        unstableClientRelationAggregation,
+    });
+    client.reEmitter.reEmit(room, [
+        RoomEvent.Name,
+        RoomEvent.Redaction,
+        RoomEvent.RedactionCancelled,
+        RoomEvent.Receipt,
+        RoomEvent.Tags,
+        RoomEvent.LocalEchoUpdated,
+        RoomEvent.AccountData,
+        RoomEvent.MyMembership,
+        RoomEvent.Timeline,
+        RoomEvent.TimelineReset,
+    ]);
+    registerStateListeners(client, room);
+    return room;
+}
+
+function registerStateListeners(client: MatrixClient, room: Room): void { // XXX cargoculted from sync.ts
+    // we need to also re-emit room state and room member events, so hook it up
+    // to the client now. We need to add a listener for RoomState.members in
+    // order to hook them correctly.
+    client.reEmitter.reEmit(room.currentState, [
+        RoomStateEvent.Events,
+        RoomStateEvent.Members,
+        RoomStateEvent.NewMember,
+        RoomStateEvent.Update,
+    ]);
+    room.currentState.on(RoomStateEvent.NewMember, function(event, state, member) {
+        member.user = client.getUser(member.userId);
+        client.reEmitter.reEmit(member, [
+            RoomMemberEvent.Name,
+            RoomMemberEvent.Typing,
+            RoomMemberEvent.PowerLevel,
+            RoomMemberEvent.Membership,
+        ]);
+    });
+}
+
+function deregisterStateListeners(room: Room): void { // XXX cargoculted from sync.ts
+    // could do with a better way of achieving this.
+    room.currentState.removeAllListeners(RoomStateEvent.Events);
+    room.currentState.removeAllListeners(RoomStateEvent.Members);
+    room.currentState.removeAllListeners(RoomStateEvent.NewMember);
 }

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -41,7 +41,7 @@ import { MatrixError } from "./http-api";
 import { RoomStateEvent } from "./models/room-state";
 import { RoomMemberEvent } from "./models/room-member";
 import {SyncState } from "./sync";
-import { MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingSync, SlidingSyncState } from "./sliding-sync";
+import { MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingSync, SlidingSyncEvent, SlidingSyncState } from "./sliding-sync";
 
 const DEBUG = true;
 
@@ -58,19 +58,10 @@ function debuglog(...params) {
 }
 
 /**
- * <b>Internal class - unstable.</b>
- * Construct an entity which is able to sync with a homeserver.
- * @constructor
- * @param {MatrixClient} client The matrix client instance to use.
- * @param {Object} opts Config options
- * @param {module:crypto=} opts.crypto Crypto manager
- * @param {Function=} opts.canResetEntireTimeline A function which is called
- * with a room ID and returns a boolean. It should return 'true' if the SDK can
- * SAFELY remove events from this room. It may not be safe to remove events if
- * there are other references to the timelines for this room.
- * Default: returns false.
+ * A copy of SyncApi such that it can be used as a drop-in replacement for sync v2. For the actual
+ * sliding sync API, see sliding-sync.ts or the class SlidingSync.
  */
-export class SlidingSyncApi {
+export class SlidingSyncSdk {
     private syncState: SyncState = null;
     private syncStateData: ISyncStateData;
     private slidingSync: SlidingSync;
@@ -118,8 +109,8 @@ export class SlidingSyncApi {
                 timeline_limit: 20,
             },
         ], {}, client, 20 * 1000);
-        this.slidingSync.addLifecycleListener(this.onLifecycle.bind(this));
-        this.slidingSync.addRoomDataListener(this.onRoomData.bind(this));
+        this.slidingSync.on(SlidingSyncEvent.Lifecycle, this.onLifecycle.bind(this));
+        this.slidingSync.on(SlidingSyncEvent.RoomData, this.onRoomData.bind(this));
     }
 
     private onRoomData(roomId: string, roomData: MSC3575RoomData) {

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -22,7 +22,6 @@ import { EventTimeline } from "./models/event-timeline";
 import { PushProcessor } from "./pushprocessor";
 import { logger } from './logger';
 import { InvalidStoreError } from './errors';
-import { IAbortablePromise } from "./@types/partials";
 import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
 import {
     IEphemeral,
@@ -107,6 +106,16 @@ type WrappedRoom<T> = T & {
  * updating presence.
  */
 export class SlidingSyncApi {
+    /*
+    createRoom
+getSyncState
+getSyncStateData
+recoverFromSyncStartupError
+retryImmediately
+stop
+sync
+syncLeftRooms
+*/
     private currentSyncRequest: IRequestPromise<ISyncResponse> = null;
     private syncState: SyncState = null;
     private syncStateData: ISyncStateData = null; // additional data (eg. error object for failed sync)

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -41,7 +41,7 @@ import { MatrixError } from "./http-api";
 import { RoomStateEvent } from "./models/room-state";
 import { RoomMemberEvent } from "./models/room-member";
 import {SyncState } from "./sync";
-import { MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingList, SlidingSync, SlidingSyncState } from "./sliding-sync";
+import { MSC3575RoomData, MSC3575SlidingSyncResponse, SlidingSync, SlidingSyncState } from "./sliding-sync";
 
 const DEBUG = true;
 
@@ -105,7 +105,7 @@ export class SlidingSyncApi {
 
         // TODO: dependency inject
         this.slidingSync = new SlidingSync("http://localhost:8008", [
-            new SlidingList({
+            {
                 ranges: [[0,20]],
                 sort: ["by_highlight_count", "by_notification_count", "by_recency"],
                 required_state: [
@@ -116,7 +116,7 @@ export class SlidingSyncApi {
                     ["m.room.member", this.client.getUserId()],
                 ],
                 timeline_limit: 20,
-            }),
+            },
         ], {}, client, 20 * 1000);
         this.slidingSync.addLifecycleListener(this.onLifecycle.bind(this));
         this.slidingSync.addRoomDataListener(this.onRoomData.bind(this));

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -225,6 +225,9 @@ export class SlidingSync {
      * @param {object} roomData The raw sliding sync response JSON.
      */
     private _invokeRoomDataListeners(roomId: string, roomData: MSC3575RoomData) {
+        if (!roomData.required_state) { roomData.required_state = []; }
+        if (!roomData.timeline) { roomData.timeline = []; }
+        if (!roomData.room_id) { roomData.room_id = roomId; }
         this.roomDataCallbacks.forEach((callback) => {
             callback(roomId, roomData);
         });

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -108,7 +108,7 @@ export enum SlidingSyncState {
      * @param {MSC3575List} list The default list values to apply for this list, including default
      * ranges, required_state, timeline_limit, etc.
      */
-    constructor(list: MSC3575List, defaultListRange: number[][]) {
+    constructor(list: MSC3575List, defaultListRange?: number[][]) {
         defaultListRange = defaultListRange || [[0,20]];
         list.filters = list.filters || {};
         list.ranges = list.ranges || defaultListRange;
@@ -166,7 +166,7 @@ export class SlidingSync {
     roomSubscriptions: Set<string>;
     private roomSubscriptionInfo: MSC3575RoomSubscription;
     private roomDataCallbacks: ((roomId: string, roomData: object) => void)[]; // array of functions
-    private lifecycleCallbacks: ((state: SlidingSyncState, resp: object, err: Error) => void)[];
+    private lifecycleCallbacks: ((state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err: Error) => void)[];
 
     private pendingReq?: IAbortablePromise<MSC3575SlidingSyncResponse>;
 
@@ -203,7 +203,7 @@ export class SlidingSync {
      * Listen for high-level lifecycle events on the sync connection
      * @param {function} callback The callback to invoke.
      */
-    addLifecycleListener(callback: (state: SlidingSyncState, resp: object, err: Error) => void) {
+    addLifecycleListener(callback: (state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err: Error) => void) {
         this.lifecycleCallbacks.push(callback);
     }
 
@@ -224,7 +224,7 @@ export class SlidingSync {
      * @param {object} resp The raw sync response JSON
      * @param {Error?} err Any error that occurred when making the request e.g network errors.
      */
-    private _invokeLifecycleListeners(state: SlidingSyncState, resp: object, err?: Error) {
+    private _invokeLifecycleListeners(state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err?: Error) {
         this.lifecycleCallbacks.forEach((callback) => {
             callback(state, resp, err);
         });

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -14,37 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { User, UserEvent } from "./models/user";
-import { NotificationCountType, Room, RoomEvent } from "./models/room";
-import * as utils from "./utils";
-import { IDeferred } from "./utils";
-import { EventTimeline } from "./models/event-timeline";
-import { PushProcessor } from "./pushprocessor";
 import { logger } from './logger';
-import { InvalidStoreError } from './errors';
-import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
-import {
-    Category,
-    IEphemeral,
-    IInvitedRoom,
-    IInviteState,
-    IJoinedRoom,
-    ILeftRoom,
-    IMinimalEvent,
-    IRoomEvent,
-    IStateEvent,
-    IStrippedState,
-    ISyncResponse,
-    ITimeline,
-} from "./sync-accumulator";
-import { MatrixEvent } from "./models/event";
-import { MatrixError, Method } from "./http-api";
-import { ISavedSync } from "./store";
-import { EventType } from "./@types/event";
-import { IPushRules } from "./@types/PushRules";
-import { RoomStateEvent } from "./models/room-state";
-import { RoomMemberEvent } from "./models/room-member";
-import {SyncState } from "./sync";
+import { IAbortablePromise } from "./@types/partials";
+import { MatrixClient } from "./client";
 
 const DEBUG = true;
 
@@ -52,7 +24,7 @@ const DEBUG = true;
 // beyond that and wedge forever, so we need to track how long we are willing
 // to keep open the connection. This constant is *ADDED* to the timeout= value
 // to determine the max time we're willing to wait.
-const BUFFER_PERIOD_MS = 80 * 1000;
+const BUFFER_PERIOD_MS = 10 * 1000;
 
 // Number of consecutive failed syncs that will lead to a syncState of ERROR as opposed
 // to RECONNECTING. This is needed to inform the client of server issues when the
@@ -70,18 +42,18 @@ function debuglog(...params) {
  * Represents a subscription to a room or set of rooms. Controls which events are returned.
  */
 export interface MSC3575RoomSubscription {
-    required_state: string[][];
-    timeline_limit: number;
+    required_state?: string[][];
+    timeline_limit?: number;
 };
 
 /**
  * Controls which rooms are returned in a given list.
  */
 export interface MSC3575Filter {
-    is_dm: boolean | undefined;
-    is_encrypted: boolean | undefined;
-    is_invite: boolean | undefined;
-    room_name_like: string | undefined;
+    is_dm?: boolean;
+    is_encrypted?: boolean;
+    is_invite?: boolean;
+    room_name_like?: string;
 };
 
 /**
@@ -89,8 +61,8 @@ export interface MSC3575Filter {
  */
 export interface MSC3575List extends MSC3575RoomSubscription {
     ranges: number[][];
-    sort: string[];
-    filters: MSC3575Filter;
+    sort?: string[];
+    filters?: MSC3575Filter;
 };
 
 /**
@@ -98,14 +70,15 @@ export interface MSC3575List extends MSC3575RoomSubscription {
  */
 export interface MSC3575SlidingSyncRequest {
     // json body params
-    lists: MSC3575List[];
-    unsubscribe_rooms: string[];
-    room_subscriptions: Record<string, MSC3575RoomSubscription>;
-    extensions: object;
+    lists?: MSC3575List[];
+    unsubscribe_rooms?: string[];
+    room_subscriptions?: Record<string, MSC3575RoomSubscription>;
+    extensions?: object;
 
     // query params
-    pos: string | undefined;
-    timeout: number | undefined;
+    pos?: string;
+    timeout?: number;
+    clientTimeout?: number;
 };
 
 /**
@@ -119,1348 +92,384 @@ export interface MSC3575SlidingSyncResponse {
     extensions: object;
 };
 
-interface ISyncOptions {
-    filterId?: string;
-    hasSyncedBefore?: boolean;
+export enum SlidingSyncState {
+    RequestFinished = "FINISHED",
+    Complete = "COMPLETE",
 }
-
-export interface ISyncStateData {
-    error?: MatrixError;
-    oldSyncToken?: string;
-    nextSyncToken?: string;
-    catchingUp?: boolean;
-    fromCache?: boolean;
-}
-
-interface ISyncQueryParams {
-    timeout: number;
-    pos?: string;
-    _cacheBuster?: string | number; // not part of the API itself
-}
-
-// http-api mangles an abort method onto its promises
-interface IRequestPromise<T> extends Promise<T> {
-    abort(): void;
-}
-
-type WrappedRoom<T> = T & {
-    room: Room;
-    isBrandNewRoom: boolean;
-};
 
 /**
- * <b>Internal class - unstable.</b>
- * Construct an entity which is able to sync with a homeserver.
- * @constructor
- * @param {MatrixClient} client The matrix client instance to use.
- * @param {Object} opts Config options
- * @param {module:crypto=} opts.crypto Crypto manager
- * @param {Function=} opts.canResetEntireTimeline A function which is called
- * with a room ID and returns a boolean. It should return 'true' if the SDK can
- * SAFELY remove events from this room. It may not be safe to remove events if
- * there are other references to the timelines for this room.
- * Default: returns false.
- * @param {Boolean=} opts.disablePresence True to perform syncing without automatically
- * updating presence.
+ * SlidingList represents a single list in sliding sync. The list can have filters, multiple sliding
+ * windows, and maintains the index->room_id mapping.
  */
-export class SlidingSyncApi {
-    private currentSyncRequest: IRequestPromise<ISyncResponse> = null;
-    private syncState: SyncState = null;
-    private syncStateData: ISyncStateData = null; // additional data (eg. error object for failed sync)
-    private catchingUp = false;
-    private running = false;
-    private keepAliveTimer: number = null;
-    private connectionReturnedDefer: IDeferred<boolean> = null;
-    private notifEvents: MatrixEvent[] = []; // accumulator of sync events in the current sync response
-    private failedSyncCount = 0; // Number of consecutive failed /sync requests
-    private storeIsInvalid = false; // flag set if the store needs to be cleared before we can start
+ export class SlidingList {
+    list: MSC3575List;
+    defaultListRange: number[][];
 
-    constructor(private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
-        this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
-        this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
-        this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
-        this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
-        this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
+    roomIndexToRoomId: Record<number,string>;
+    joinedCount: number;
 
-        if (!opts.canResetEntireTimeline) {
-            opts.canResetEntireTimeline = (roomId: string) => {
-                return false;
+    /**
+     * Construct a new sliding list.
+     * @param {MSC3575List} list The default list values to apply for this list, including default
+     * ranges, required_state, timeline_limit, etc.
+     */
+    constructor(list: MSC3575List, defaultListRange: number[][]) {
+        defaultListRange = defaultListRange || [[0,20]];
+        list.filters = list.filters || {};
+        list.ranges = list.ranges || defaultListRange;
+        this.list = list;
+        this.defaultListRange = defaultListRange;
+        
+        // the constantly changing sliding window ranges. Not an array for performance reasons
+        // E.g tracking ranges 0-99, 500-599, we don't want to have a 600 element array
+        this.roomIndexToRoomId = {};
+        // the total number of joined rooms according to the server, always >= len(roomIndexToRoomId)
+        this.joinedCount = 0;
+    }
+
+    /**
+     * Return a copy of the list.
+     * @param {boolean} includeSticky If true, includes sticky params. Else skips them.
+     */
+    getList(includeSticky: boolean): MSC3575List {
+        if (!includeSticky) {
+            // only the ranges are non-sticky
+            return {
+                ranges: JSON.parse(JSON.stringify(this.list.ranges)),
             };
         }
-
-        if (client.getNotifTimelineSet()) {
-            client.reEmitter.reEmit(client.getNotifTimelineSet(), [
-                RoomEvent.Timeline,
-                RoomEvent.TimelineReset,
-            ]);
-        }
+        return JSON.parse(JSON.stringify(this.list));
     }
 
     /**
-     * @param {string} roomId
-     * @return {Room}
+     * Modify the filters on this list. The filters provided are copied.
+     * @param {object} filters The sliding sync filters to apply e.g { is_dm: true }.
      */
-    public createRoom(roomId: string): Room {
-        const client = this.client;
-        const {
-            timelineSupport,
-            unstableClientRelationAggregation,
-        } = client;
-        const room = new Room(roomId, client, client.getUserId(), {
-            lazyLoadMembers: this.opts.lazyLoadMembers,
-            pendingEventOrdering: this.opts.pendingEventOrdering,
-            timelineSupport,
-            unstableClientRelationAggregation,
+    setFilters(filters: object) {
+        this.list.filters = Object.assign({}, filters);
+        // if we are viewing a window at 100-120 and then we filter down to 5 total rooms,
+        // we'll end up showing nothing. Therefore, if the filters change (e.g room name filter)
+        // reset the range back to 0-20.
+        this.list.ranges = JSON.parse(JSON.stringify(this.defaultListRange));
+        // Wipe the index to room ID map as the filters have changed which will invalidate these.
+        this.roomIndexToRoomId = {};
+    }
+}
+
+/**
+ * SlidingSync is a high-level data structure which controls the majority of sliding sync.
+ * It has no hooks into JS SDK with the exception of needing a MatrixClient to perform the HTTP request.
+ * This means this class (and everything it uses) can be yanked somewhere else if need be.
+ */
+export class SlidingSync {
+    proxyBaseUrl: string;
+    lists: SlidingList[];
+    client: MatrixClient;
+    timeoutMS: number;
+    terminated: boolean;
+    roomSubscriptions: Set<string>;
+    roomSubscriptionInfo: MSC3575RoomSubscription;
+    roomDataCallbacks: Function[];
+    lifecycleCallbacks: Function[];
+
+    pendingReq?: IAbortablePromise<MSC3575SlidingSyncResponse>;
+
+    /**
+     * Create a new sliding sync instance
+     * @param {string} proxyBaseUrl The base URL of the sliding sync proxy
+     * @param {SlidingList[]} lists The lists to use for sliding sync.
+     * @param {MSC3575RoomSubscription} subInfo The params to use for room subscriptions.
+     * @param {MatrixClient} client The client to use for /sync calls.
+     * @param {number} timeoutMS The number of milliseconds to wait for a response.
+     */
+    constructor(proxyBaseUrl: string, lists: SlidingList[], subInfo: MSC3575RoomSubscription, client: MatrixClient, timeoutMS: number) {
+        this.proxyBaseUrl = proxyBaseUrl;
+        this.timeoutMS = timeoutMS;
+        this.lists = lists;
+        this.client = client;
+        this.roomSubscriptionInfo = subInfo;
+        this.terminated = false;
+        this.roomSubscriptions = new Set(); // the *desired* room subscriptions
+        this.roomDataCallbacks = [];
+        this.lifecycleCallbacks = [];
+        this.pendingReq = null;
+    }
+
+    /**
+     * Listen for high-level room events on the sync connection
+     * @param {function} callback The callback to invoke.
+     */
+    addRoomDataListener(callback) {
+        this.roomDataCallbacks.push(callback);
+    }
+
+    /**
+     * Listen for high-level lifecycle events on the sync connection
+     * @param {function} callback The callback to invoke.
+     */
+    addLifecycleListener(callback) {
+        this.lifecycleCallbacks.push(callback);
+    }
+
+    /**
+     * Invoke all attached room data listeners.
+     * @param {string} roomId The room which received some data.
+     * @param {object} roomData The raw sliding sync response JSON.
+     */
+    private _invokeRoomDataListeners(roomId: string, roomData: object) {
+        this.roomDataCallbacks.forEach((callback) => {
+            callback(roomId, roomData);
         });
-        client.reEmitter.reEmit(room, [
-            RoomEvent.Name,
-            RoomEvent.Redaction,
-            RoomEvent.RedactionCancelled,
-            RoomEvent.Receipt,
-            RoomEvent.Tags,
-            RoomEvent.LocalEchoUpdated,
-            RoomEvent.AccountData,
-            RoomEvent.MyMembership,
-            RoomEvent.Timeline,
-            RoomEvent.TimelineReset,
-        ]);
-        this.registerStateListeners(room);
-        return room;
     }
 
     /**
-     * @param {Room} room
-     * @private
+     * Invoke all attached lifecycle listeners.
+     * @param {SlidingSyncState} state The Lifecycle state
+     * @param {object} resp The raw sync response JSON
+     * @param {Error?} err Any error that occurred when making the request e.g network errors.
      */
-    private registerStateListeners(room: Room): void {
-        const client = this.client;
-        // we need to also re-emit room state and room member events, so hook it up
-        // to the client now. We need to add a listener for RoomState.members in
-        // order to hook them correctly.
-        client.reEmitter.reEmit(room.currentState, [
-            RoomStateEvent.Events,
-            RoomStateEvent.Members,
-            RoomStateEvent.NewMember,
-            RoomStateEvent.Update,
-        ]);
-        room.currentState.on(RoomStateEvent.NewMember, function(event, state, member) {
-            member.user = client.getUser(member.userId);
-            client.reEmitter.reEmit(member, [
-                RoomMemberEvent.Name,
-                RoomMemberEvent.Typing,
-                RoomMemberEvent.PowerLevel,
-                RoomMemberEvent.Membership,
-            ]);
+    private _invokeLifecycleListeners(state: SlidingSyncState, resp: object, err?: Error) {
+        this.lifecycleCallbacks.forEach((callback) => {
+            callback(state, resp, err);
         });
     }
 
     /**
-     * @param {Room} room
-     * @private
+     * Resend a Sliding Sync request. Used when something has changed in the request.
      */
-    private deregisterStateListeners(room: Room): void {
-        // could do with a better way of achieving this.
-        room.currentState.removeAllListeners(RoomStateEvent.Events);
-        room.currentState.removeAllListeners(RoomStateEvent.Members);
-        room.currentState.removeAllListeners(RoomStateEvent.NewMember);
-    }
-
-    /**
-     * Sync rooms the user has left.
-     * @return {Promise} Resolved when they've been added to the store.
-     */
-    public async syncLeftRooms() {
-        return []; // TODO
-    }
-
-    /**
-     * Peek into a room. This will result in the room in question being synced so it
-     * is accessible via getRooms(). Live updates for the room will be provided.
-     * @param {string} roomId The room ID to peek into.
-     * @return {Promise} A promise which resolves once the room has been added to the
-     * store.
-     */
-    public async peek(roomId: string): Promise<Room> {
-        return null; // TODO
-    }
-
-    /**
-     * Stop polling for updates in the peeked room. NOPs if there is no room being
-     * peeked.
-     */
-    public stopPeeking(): void {
-        // TODO
-    }
-
-    /**
-     * Returns the current state of this sync object
-     * @see module:client~MatrixClient#event:"sync"
-     * @return {?String}
-     */
-    public getSyncState(): SyncState {
-        return this.syncState;
-    }
-
-    /**
-     * Returns the additional data object associated with
-     * the current sync state, or null if there is no
-     * such data.
-     * Sync errors, if available, are put in the 'error' key of
-     * this object.
-     * @return {?Object}
-     */
-    public getSyncStateData(): ISyncStateData {
-        return this.syncStateData;
-    }
-
-    public async recoverFromSyncStartupError(savedSyncPromise: Promise<void>, err: MatrixError): Promise<void> {
-        // Wait for the saved sync to complete - we send the pushrules and filter requests
-        // before the saved sync has finished so they can run in parallel, but only process
-        // the results after the saved sync is done. Equivalently, we wait for it to finish
-        // before reporting failures from these functions.
-        await savedSyncPromise;
-        const keepaliveProm = this.startKeepAlives();
-        this.updateSyncState(SyncState.Error, { error: err });
-        await keepaliveProm;
-    }
-
-    /**
-     * Is the lazy loading option different than in previous session?
-     * @param {boolean} lazyLoadMembers current options for lazy loading
-     * @return {boolean} whether or not the option has changed compared to the previous session */
-    private async wasLazyLoadingToggled(lazyLoadMembers = false): Promise<boolean> {
-        // assume it was turned off before
-        // if we don't know any better
-        let lazyLoadMembersBefore = false;
-        const isStoreNewlyCreated = await this.client.store.isNewlyCreated();
-        if (!isStoreNewlyCreated) {
-            const prevClientOptions = await this.client.store.getClientOptions();
-            if (prevClientOptions) {
-                lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
-            }
-            return lazyLoadMembersBefore !== lazyLoadMembers;
+    resend() {
+        if (this.pendingReq) {
+            this.pendingReq.abort();
         }
-        return false;
-    }
-
-    private shouldAbortSync(error: MatrixError): boolean {
-        if (error.errcode === "M_UNKNOWN_TOKEN") {
-            // The logout already happened, we just need to stop.
-            logger.warn("Token no longer valid - assuming logout");
-            this.stop();
-            this.updateSyncState(SyncState.Error, { error });
-            return true;
-        }
-        return false;
     }
 
     /**
-     * Main entry point
+     * Stop syncing with the server.
      */
-    public sync(): void {
-        const client = this.client;
-
-        this.running = true;
-
-        if (global.window && global.window.addEventListener) {
-            global.window.addEventListener("online", this.onOnline, false);
+    stop() {
+        this.terminated = true;
+        if (this.pendingReq) {
+            this.pendingReq.abort();
         }
+    }
 
-        let savedSyncPromise = Promise.resolve();
-        let savedSyncToken = null;
-
-        // We need to do one-off checks before we can begin the /sync loop.
-        // These are:
-        //   1) We need to get push rules so we can check if events should bing as we get
-        //      them from /sync.
-        //   2) We need to get/create a filter which we can use for /sync.
-        //   3) We need to check the lazy loading option matches what was used in the
-        //       stored sync. If it doesn't, we can't use the stored sync.
-
-        const getPushRules = async () => {
+    /**
+     * Start syncing with the server. Blocks until stopped.
+     */
+    async start() {
+        let currentPos;
+        let confirmedSubscriptions: Set<string> = new Set(); // subs we've confirmed we're tracking from the server
+        while (!this.terminated) {
+            let resp;
             try {
-                debuglog("Getting push rules...");
-                const result = await client.getPushRules();
-                debuglog("Got push rules");
-
-                client.pushRules = result;
+                // these fields are always required
+                let reqBody: MSC3575SlidingSyncRequest = {
+                    lists: this.lists.map((l) => {
+                        // include sticky params if there is no current pos (first request)
+                        return l.getList(!currentPos);
+                    }),
+                    pos: currentPos,
+                    timeout: this.timeoutMS,
+                    clientTimeout: this.timeoutMS + BUFFER_PERIOD_MS,
+                };
+                // check if we are (un)subscribing to a room and modify request this one time for it
+                const newSubscriptions = difference(this.roomSubscriptions, confirmedSubscriptions);
+                const unsubscriptions = difference(confirmedSubscriptions, this.roomSubscriptions);
+                if (unsubscriptions.size > 0) {
+                    reqBody.unsubscribe_rooms = Array.from(unsubscriptions);
+                }
+                if (newSubscriptions.size > 0) {
+                    reqBody.room_subscriptions = {};
+                    for (let roomId of newSubscriptions) {
+                        reqBody.room_subscriptions[roomId] = this.roomSubscriptionInfo;
+                    }
+                }
+                this.pendingReq = this.client.slidingSync(reqBody, this.proxyBaseUrl);
+                let resp = await this.pendingReq;
+                currentPos = resp.pos;
+                // update what we think we're subscribed to.
+                for (let roomId of newSubscriptions) {
+                    confirmedSubscriptions.add(roomId);
+                }
+                for (let roomId of unsubscriptions) {
+                    confirmedSubscriptions.delete(roomId);
+                }
+                if (!resp.ops) {
+                    resp.ops = [];
+                }
+                if (resp.counts) {
+                    resp.counts.forEach((count, index) => {
+                        this.lists[index].joinedCount = count;
+                    });
+                }
+                this._invokeLifecycleListeners(
+                    SlidingSyncState.RequestFinished,
+                    resp
+                );
             } catch (err) {
-                logger.error("Getting push rules failed", err);
-                if (this.shouldAbortSync(err)) return;
-                // wait for saved sync to complete before doing anything else,
-                // otherwise the sync state will end up being incorrect
-                debuglog("Waiting for saved sync before retrying push rules...");
-                await this.recoverFromSyncStartupError(savedSyncPromise, err);
-                getPushRules();
-                return;
-            }
-            checkLazyLoadStatus(); // advance to the next stage
-        };
-
-        const checkLazyLoadStatus = async () => {
-            debuglog("Checking lazy load status...");
-            if (this.opts.lazyLoadMembers && client.isGuest()) {
-                this.opts.lazyLoadMembers = false;
-            }
-            if (this.opts.lazyLoadMembers) {
-                debuglog("Checking server lazy load support...");
-                const supported = await client.doesServerSupportLazyLoading();
-                if (supported) {
-                    debuglog("Enabling lazy load on sync filter...");
-                    this.opts.lazyLoadMembers = false; // TODO
-                } else {
-                    debuglog("LL: lazy loading requested but not supported " +
-                        "by server, so disabling");
-                    this.opts.lazyLoadMembers = false;
+                if (err.httpStatus) {
+                    this._invokeLifecycleListeners(
+                        SlidingSyncState.RequestFinished,
+                        null,
+                        err
+                    );
+                    await sleep(3000);
                 }
             }
-            // need to vape the store when enabling LL and wasn't enabled before
-            debuglog("Checking whether lazy loading has changed in store...");
-            const shouldClear = await this.wasLazyLoadingToggled(this.opts.lazyLoadMembers);
-            if (shouldClear) {
-                this.storeIsInvalid = true;
-                const reason = InvalidStoreError.TOGGLED_LAZY_LOADING;
-                const error = new InvalidStoreError(reason, !!this.opts.lazyLoadMembers);
-                this.updateSyncState(SyncState.Error, { error });
-                // bail out of the sync loop now: the app needs to respond to this error.
-                // we leave the state as 'ERROR' which isn't great since this normally means
-                // we're retrying. The client must be stopped before clearing the stores anyway
-                // so the app should stop the client, clear the store and start it again.
-                logger.warn("InvalidStoreError: store is not usable: stopping sync.");
-                return;
-            }
-            if (this.opts.lazyLoadMembers && this.opts.crypto) {
-                this.opts.crypto.enableLazyLoading();
-            }
-            try {
-                debuglog("Storing client options...");
-                await this.client.storeClientOptions();
-                debuglog("Stored client options");
-            } catch (err) {
-                logger.error("Storing client options failed", err);
-                throw err;
+            if (!resp) {
+                continue;
             }
 
-            getFilter(); // Now get the filter and start syncing
-        };
-
-        const getFilter = async () => {
-            debuglog("Getting filter...");
-            // reset the notifications timeline to prepare it to paginate from
-            // the current point in time.
-            // The right solution would be to tie /sync pagination tokens into
-            // /notifications API somehow.
-            client.resetNotifTimelineSet();
-
-            if (this.currentSyncRequest === null) {
-                // Send this first sync request here so we can then wait for the saved
-                // sync data to finish processing before we process the results of this one.
-                debuglog("Sending first sync request...");
-                this.currentSyncRequest = this.doSyncRequest({ }, savedSyncToken);
-            }
-
-            // Now wait for the saved sync to finish...
-            debuglog("Waiting for saved sync before starting sync processing...");
-            await savedSyncPromise;
-            this.doSync({ });
-        };
-
-        if (client.isGuest()) {
-            // no push rules for guests, no access to POST filter for guests.
-            this.doSync({});
-        } else {
-            // Pull the saved sync token out first, before the worker starts sending
-            // all the sync data which could take a while. This will let us send our
-            // first incremental sync request before we've processed our saved data.
-            debuglog("Getting saved sync token...");
-            savedSyncPromise = client.store.getSavedSyncToken().then((tok) => {
-                debuglog("Got saved sync token");
-                savedSyncToken = tok;
-                debuglog("Getting saved sync...");
-                return client.store.getSavedSync();
-            }).then((savedSync) => {
-                debuglog(`Got reply from saved sync, exists? ${!!savedSync}`);
-                if (savedSync) {
-                    return this.syncFromCache(savedSync);
-                }
-            }).catch(err => {
-                logger.error("Getting saved sync failed", err);
+            Object.keys(resp.room_subscriptions).forEach((roomId) => {
+                this._invokeRoomDataListeners(
+                    roomId,
+                    resp.room_subscriptions[roomId]
+                );
             });
-            // Now start the first incremental sync request: this can also
-            // take a while so if we set it going now, we can wait for it
-            // to finish while we process our saved sync data.
-            getPushRules();
-        }
-    }
 
-    /**
-     * Stops the sync object from syncing.
-     */
-    public stop(): void {
-        debuglog("SyncApi.stop");
-        // It is necessary to check for the existance of
-        // global.window AND global.window.removeEventListener.
-        // Some platforms (e.g. React Native) register global.window,
-        // but do not have global.window.removeEventListener.
-        if (global.window && global.window.removeEventListener) {
-            global.window.removeEventListener("online", this.onOnline, false);
-        }
-        this.running = false;
-        if (this.currentSyncRequest) {
-            this.currentSyncRequest.abort();
-        }
-        if (this.keepAliveTimer) {
-            clearTimeout(this.keepAliveTimer);
-            this.keepAliveTimer = null;
-        }
-    }
-
-    /**
-     * Retry a backed off syncing request immediately. This should only be used when
-     * the user <b>explicitly</b> attempts to retry their lost connection.
-     * @return {boolean} True if this resulted in a request being retried.
-     */
-    public retryImmediately(): boolean {
-        if (!this.connectionReturnedDefer) {
-            return false;
-        }
-        this.startKeepAlives(0);
-        return true;
-    }
-    /**
-     * Process a single set of cached sync data.
-     * @param {Object} savedSync a saved sync that was persisted by a store. This
-     * should have been acquired via client.store.getSavedSync().
-     */
-    private async syncFromCache(savedSync: ISavedSync): Promise<void> {
-        debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
-
-        const nextSyncToken = savedSync.nextBatch;
-
-        // Set sync token for future incremental syncing
-        this.client.store.setSyncToken(nextSyncToken);
-
-        // No previous sync, set old token to null
-        const syncEventData = {
-            oldSyncToken: null,
-            nextSyncToken,
-            catchingUp: false,
-            fromCache: true,
-        };
-
-        const data: ISyncResponse = {
-            next_batch: nextSyncToken,
-            rooms: savedSync.roomsData,
-            groups: savedSync.groupsData,
-            account_data: {
-                events: savedSync.accountData,
-            },
-        };
-
-        try {
-            await this.processSyncResponse(syncEventData, data);
-        } catch (e) {
-            logger.error("Error processing cached sync", e.stack || e);
-        }
-
-        // Don't emit a prepared if we've bailed because the store is invalid:
-        // in this case the client will not be usable until stopped & restarted
-        // so this would be useless and misleading.
-        if (!this.storeIsInvalid) {
-            this.updateSyncState(SyncState.Prepared, syncEventData);
-        }
-    }
-
-    /**
-     * Invoke me to do /sync calls
-     * @param {Object} syncOptions
-     * @param {string} syncOptions.filterId
-     * @param {boolean} syncOptions.hasSyncedBefore
-     */
-    private async doSync(syncOptions: ISyncOptions): Promise<void> {
-        const client = this.client;
-
-        if (!this.running) {
-            debuglog("Sync no longer running: exiting.");
-            if (this.connectionReturnedDefer) {
-                this.connectionReturnedDefer.reject();
-                this.connectionReturnedDefer = null;
-            }
-            this.updateSyncState(SyncState.Stopped);
-            return;
-        }
-
-        const syncToken = client.store.getSyncToken();
-
-        let data;
-        try {
-            //debuglog('Starting sync since=' + syncToken);
-            if (this.currentSyncRequest === null) {
-                this.currentSyncRequest = this.doSyncRequest(syncOptions, syncToken);
-            }
-            data = await this.currentSyncRequest;
-        } catch (e) {
-            this.onSyncError(e, syncOptions);
-            return;
-        } finally {
-            this.currentSyncRequest = null;
-        }
-
-        //debuglog('Completed sync, next_batch=' + data.next_batch);
-
-        // set the sync token NOW *before* processing the events. We do this so
-        // if something barfs on an event we can skip it rather than constantly
-        // polling with the same token.
-        client.store.setSyncToken(data.next_batch);
-
-        // Reset after a successful sync
-        this.failedSyncCount = 0;
-
-        await client.store.setSyncData(data);
-
-        const syncEventData = {
-            oldSyncToken: syncToken,
-            nextSyncToken: data.next_batch,
-            catchingUp: this.catchingUp,
-        };
-
-        if (this.opts.crypto) {
-            // tell the crypto module we're about to process a sync
-            // response
-            await this.opts.crypto.onSyncWillProcess(syncEventData);
-        }
-
-        try {
-            await this.processSyncResponse(syncEventData, data);
-        } catch (e) {
-            // log the exception with stack if we have it, else fall back
-            // to the plain description
-            logger.error("Caught /sync error", e.stack || e);
-
-            // Emit the exception for client handling
-            this.client.emit(ClientEvent.SyncUnexpectedError, e);
-        }
-
-        // update this as it may have changed
-        syncEventData.catchingUp = this.catchingUp;
-
-        // emit synced events
-        if (!syncOptions.hasSyncedBefore) {
-            this.updateSyncState(SyncState.Prepared, syncEventData);
-            syncOptions.hasSyncedBefore = true;
-        }
-
-        // tell the crypto module to do its processing. It may block (to do a
-        // /keys/changes request).
-        if (this.opts.crypto) {
-            await this.opts.crypto.onSyncCompleted(syncEventData);
-        }
-
-        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
-        this.updateSyncState(SyncState.Syncing, syncEventData);
-
-        if (client.store.wantsSave()) {
-            // We always save the device list (if it's dirty) before saving the sync data:
-            // this means we know the saved device list data is at least as fresh as the
-            // stored sync data which means we don't have to worry that we may have missed
-            // device changes. We can also skip the delay since we're not calling this very
-            // frequently (and we don't really want to delay the sync for it).
-            if (this.opts.crypto) {
-                await this.opts.crypto.saveDeviceList(0);
-            }
-
-            // tell databases that everything is now in a consistent state and can be saved.
-            client.store.save();
-        }
-
-        // Begin next sync
-        this.doSync(syncOptions);
-    }
-
-    private doSyncRequest(syncOptions: ISyncOptions, pos: string): IRequestPromise<ISyncResponse> {
-        const qps = this.getSyncQueryParams(syncOptions, pos);
-        return this.client.http.authedRequest(
-            undefined, Method.Get, "/sync", qps as any, undefined,
-            qps.timeout + BUFFER_PERIOD_MS,
-        );
-    }
-
-    private getSyncQueryParams(syncOptions: ISyncOptions, pos: string): ISyncQueryParams {
-        let pollTimeout = this.opts.pollTimeout;
-
-        if (this.getSyncState() !== 'SYNCING' || this.catchingUp) {
-            // unless we are happily syncing already, we want the server to return
-            // as quickly as possible, even if there are no events queued. This
-            // serves two purposes:
-            //
-            // * When the connection dies, we want to know asap when it comes back,
-            //   so that we can hide the error from the user. (We don't want to
-            //   have to wait for an event or a timeout).
-            //
-            // * We want to know if the server has any to_device messages queued up
-            //   for us. We do that by calling it with a zero timeout until it
-            //   doesn't give us any more to_device messages.
-            this.catchingUp = true;
-            pollTimeout = 0;
-        }
-
-        const qps: ISyncQueryParams = {
-            timeout: pollTimeout,
-        };
-
-        if (pos) {
-            qps.pos = pos;
-        } else {
-            // use a cachebuster for initialsyncs, to make sure that
-            // we don't get a stale sync
-            // (https://github.com/vector-im/vector-web/issues/1354)
-            qps._cacheBuster = Date.now();
-        }
-
-        if (this.getSyncState() == 'ERROR' || this.getSyncState() == 'RECONNECTING') {
-            // we think the connection is dead. If it comes back up, we won't know
-            // about it till /sync returns. If the timeout= is high, this could
-            // be a long time. Set it to 0 when doing retries so we don't have to wait
-            // for an event or a timeout before emiting the SYNCING event.
-            qps.timeout = 0;
-        }
-
-        return qps;
-    }
-
-    private onSyncError(err: MatrixError, syncOptions: ISyncOptions): void {
-        if (!this.running) {
-            debuglog("Sync no longer running: exiting");
-            if (this.connectionReturnedDefer) {
-                this.connectionReturnedDefer.reject();
-                this.connectionReturnedDefer = null;
-            }
-            this.updateSyncState(SyncState.Stopped);
-            return;
-        }
-
-        logger.error("/sync error %s", err);
-        logger.error(err);
-
-        if (this.shouldAbortSync(err)) {
-            return;
-        }
-
-        this.failedSyncCount++;
-        logger.log('Number of consecutive failed sync requests:', this.failedSyncCount);
-
-        debuglog("Starting keep-alive");
-        // Note that we do *not* mark the sync connection as
-        // lost yet: we only do this if a keepalive poke
-        // fails, since long lived HTTP connections will
-        // go away sometimes and we shouldn't treat this as
-        // erroneous. We set the state to 'reconnecting'
-        // instead, so that clients can observe this state
-        // if they wish.
-        this.startKeepAlives().then((connDidFail) => {
-            // Only emit CATCHUP if we detected a connectivity error: if we didn't,
-            // it's quite likely the sync will fail again for the same reason and we
-            // want to stay in ERROR rather than keep flip-flopping between ERROR
-            // and CATCHUP.
-            if (connDidFail && this.getSyncState() === SyncState.Error) {
-                this.updateSyncState(SyncState.Catchup, {
-                    oldSyncToken: null,
-                    nextSyncToken: null,
-                    catchingUp: true,
-                });
-            }
-            this.doSync(syncOptions);
-        });
-
-        this.currentSyncRequest = null;
-        // Transition from RECONNECTING to ERROR after a given number of failed syncs
-        this.updateSyncState(
-            this.failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
-                SyncState.Error : SyncState.Reconnecting,
-            { error: err },
-        );
-    }
-
-    /**
-     * Process data returned from a sync response and propagate it
-     * into the model objects
-     *
-     * @param {Object} syncEventData Object containing sync tokens associated with this sync
-     * @param {Object} data The response from /sync
-     */
-    private async processSyncResponse(syncEventData: ISyncStateData, data: ISyncResponse): Promise<void> {
-        const client = this.client;
-
-        // data looks like:
-        // {
-        // }
-
-        // handle presence events (User objects)
-        if (data.presence && Array.isArray(data.presence.events)) {
-            data.presence.events.map(client.getEventMapper()).forEach(
-                function(presenceEvent) {
-                    let user = client.store.getUser(presenceEvent.getSender());
-                    if (user) {
-                        user.setPresenceEvent(presenceEvent);
-                    } else {
-                        user = createNewUser(client, presenceEvent.getSender());
-                        user.setPresenceEvent(presenceEvent);
-                        client.store.storeUser(user);
-                    }
-                    client.emit(ClientEvent.Event, presenceEvent);
-                });
-        }
-
-        // handle non-room account_data
-        if (data.account_data && Array.isArray(data.account_data.events)) {
-            const events = data.account_data.events.map(client.getEventMapper());
-            const prevEventsMap = events.reduce((m, c) => {
-                m[c.getId()] = client.store.getAccountData(c.getType());
-                return m;
-            }, {});
-            client.store.storeAccountDataEvents(events);
-            events.forEach(
-                function(accountDataEvent) {
-                    // Honour push rules that come down the sync stream but also
-                    // honour push rules that were previously cached. Base rules
-                    // will be updated when we receive push rules via getPushRules
-                    // (see sync) before syncing over the network.
-                    if (accountDataEvent.getType() === EventType.PushRules) {
-                        const rules = accountDataEvent.getContent<IPushRules>();
-                        client.pushRules = PushProcessor.rewriteDefaultRules(rules);
-                    }
-                    const prevEvent = prevEventsMap[accountDataEvent.getId()];
-                    client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
-                    return accountDataEvent;
-                },
-            );
-        }
-
-        // handle to-device events
-        if (data.to_device && Array.isArray(data.to_device.events) &&
-            data.to_device.events.length > 0
-        ) {
-            const cancelledKeyVerificationTxns = [];
-            data.to_device.events
-                .map(client.getEventMapper())
-                .map((toDeviceEvent) => { // map is a cheap inline forEach
-                    // We want to flag m.key.verification.start events as cancelled
-                    // if there's an accompanying m.key.verification.cancel event, so
-                    // we pull out the transaction IDs from the cancellation events
-                    // so we can flag the verification events as cancelled in the loop
-                    // below.
-                    if (toDeviceEvent.getType() === "m.key.verification.cancel") {
-                        const txnId = toDeviceEvent.getContent()['transaction_id'];
-                        if (txnId) {
-                            cancelledKeyVerificationTxns.push(txnId);
-                        }
-                    }
-
-                    // as mentioned above, .map is a cheap inline forEach, so return
-                    // the unmodified event.
-                    return toDeviceEvent;
-                })
-                .forEach(
-                    function(toDeviceEvent) {
-                        const content = toDeviceEvent.getContent();
-                        if (
-                            toDeviceEvent.getType() == "m.room.message" &&
-                            content.msgtype == "m.bad.encrypted"
-                        ) {
-                            // the mapper already logged a warning.
-                            logger.log(
-                                'Ignoring undecryptable to-device event from ' +
-                                toDeviceEvent.getSender(),
+            // TODO: clear gapIndex immediately after next op to avoid a genuine DELETE shifting incorrectly e.g leaving a room
+            let gapIndexes = {};
+            resp.counts.forEach((count, index) => {
+                gapIndexes[index] = -1;
+            });
+            resp.ops.forEach((op) => {
+                if (op.op === "DELETE") {
+                    console.log("DELETE", op.list, op.index, ";");
+                    delete this.lists[op.list].roomIndexToRoomId[op.index];
+                    gapIndexes[op.list] = op.index;
+                } else if (op.op === "INSERT") {
+                    console.log(
+                        "INSERT",
+                        op.list,
+                        op.index,
+                        op.room.room_id,
+                        ";"
+                    );
+                    if (this.lists[op.list].roomIndexToRoomId[op.index]) {
+                        const gapIndex = gapIndexes[op.list];
+                        // something is in this space, shift items out of the way
+                        if (gapIndex < 0) {
+                            console.log(
+                                "cannot work out where gap is, INSERT without previous DELETE! List: ",
+                                op.list
                             );
                             return;
                         }
-
-                        if (toDeviceEvent.getType() === "m.key.verification.start"
-                            || toDeviceEvent.getType() === "m.key.verification.request") {
-                            const txnId = content['transaction_id'];
-                            if (cancelledKeyVerificationTxns.includes(txnId)) {
-                                toDeviceEvent.flagCancelled();
+                        //  0,1,2,3  index
+                        // [A,B,C,D]
+                        //   DEL 3
+                        // [A,B,C,_]
+                        //   INSERT E 0
+                        // [E,A,B,C]
+                        // gapIndex=3, op.index=0
+                        if (gapIndex > op.index) {
+                            // the gap is further down the list, shift every element to the right
+                            // starting at the gap so we can just shift each element in turn:
+                            // [A,B,C,_] gapIndex=3, op.index=0
+                            // [A,B,C,C] i=3
+                            // [A,B,B,C] i=2
+                            // [A,A,B,C] i=1
+                            // Terminate. We'll assign into op.index next.
+                            for (let i = gapIndex; i > op.index; i--) {
+                                if (indexInRange(this.lists[op.list].list.ranges, i)) {
+                                    this.lists[op.list].roomIndexToRoomId[i] =
+                                        this.lists[op.list].roomIndexToRoomId[
+                                            i - 1
+                                        ];
+                                }
+                            }
+                        } else if (gapIndex < op.index) {
+                            // the gap is further up the list, shift every element to the left
+                            // starting at the gap so we can just shift each element in turn
+                            for (let i = gapIndex; i < op.index; i++) {
+                                if (indexInRange(this.lists[op.list].list.ranges, i)) {
+                                    this.lists[op.list].roomIndexToRoomId[i] =
+                                        this.lists[op.list].roomIndexToRoomId[
+                                            i + 1
+                                        ];
+                                }
                             }
                         }
-
-                        client.emit(ClientEvent.ToDeviceEvent, toDeviceEvent);
-                    },
-                );
-        } else {
-            // no more to-device events: we can stop polling with a short timeout.
-            this.catchingUp = false;
-        }
-
-        // the returned json structure is a bit crap, so make it into a
-        // nicer form (array) after applying sanity to make sure we don't fail
-        // on missing keys (on the off chance)
-        let inviteRooms: WrappedRoom<IInvitedRoom>[] = [];
-        let joinRooms: WrappedRoom<IJoinedRoom>[] = [];
-        let leaveRooms: WrappedRoom<ILeftRoom>[] = [];
-
-        if (data.rooms) {
-            if (data.rooms.invite) {
-                inviteRooms = this.mapSyncResponseToRoomArray(data.rooms.invite);
-            }
-            if (data.rooms.join) {
-                joinRooms = this.mapSyncResponseToRoomArray(data.rooms.join);
-            }
-            if (data.rooms.leave) {
-                leaveRooms = this.mapSyncResponseToRoomArray(data.rooms.leave);
-            }
-        }
-
-        this.notifEvents = [];
-
-        // Handle invites
-        inviteRooms.forEach((inviteObj) => {
-            const room = inviteObj.room;
-            const stateEvents = this.mapSyncEventsFormat(inviteObj.invite_state, room);
-
-            this.processRoomEvents(room, stateEvents);
-            if (inviteObj.isBrandNewRoom) {
-                room.recalculate();
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-            stateEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            room.updateMyMembership("invite");
-        });
-
-        // Handle joins
-        await utils.promiseMapSeries(joinRooms, async (joinObj) => {
-            const room = joinObj.room;
-            const stateEvents = this.mapSyncEventsFormat(joinObj.state, room);
-            // Prevent events from being decrypted ahead of time
-            // this helps large account to speed up faster
-            // room::decryptCriticalEvent is in charge of decrypting all the events
-            // required for a client to function properly
-            const events = this.mapSyncEventsFormat(joinObj.timeline, room, false);
-            const ephemeralEvents = this.mapSyncEventsFormat(joinObj.ephemeral);
-            const accountDataEvents = this.mapSyncEventsFormat(joinObj.account_data);
-
-            const encrypted = client.isRoomEncrypted(room.roomId);
-            // we do this first so it's correct when any of the events fire
-            if (joinObj.unread_notifications) {
-                room.setUnreadNotificationCount(
-                    NotificationCountType.Total,
-                    joinObj.unread_notifications.notification_count,
-                );
-
-                // We track unread notifications ourselves in encrypted rooms, so don't
-                // bother setting it here. We trust our calculations better than the
-                // server's for this case, and therefore will assume that our non-zero
-                // count is accurate.
-                if (!encrypted
-                    || (encrypted && room.getUnreadNotificationCount(NotificationCountType.Highlight) <= 0)) {
-                    room.setUnreadNotificationCount(
-                        NotificationCountType.Highlight,
-                        joinObj.unread_notifications.highlight_count,
+                    }
+                    this.lists[op.list].roomIndexToRoomId[op.index] =
+                        op.room.room_id;
+                    this._invokeRoomDataListeners(op.room.room_id, op.room);
+                } else if (op.op === "UPDATE") {
+                    console.log(
+                        "UPDATE",
+                        op.list,
+                        op.index,
+                        op.room.room_id,
+                        ";"
+                    );
+                    this._invokeRoomDataListeners(op.room.room_id, op.room);
+                } else if (op.op === "SYNC") {
+                    let syncRooms = [];
+                    const startIndex = op.range[0];
+                    for (let i = startIndex; i <= op.range[1]; i++) {
+                        const r = op.rooms[i - startIndex];
+                        if (!r) {
+                            break; // we are at the end of list
+                        }
+                        this.lists[op.list].roomIndexToRoomId[i] = r.room_id;
+                        syncRooms.push(r.room_id);
+                        this._invokeRoomDataListeners(r.room_id, r);
+                    }
+                    console.log(
+                        "SYNC",
+                        op.list,
+                        op.range[0],
+                        op.range[1],
+                        syncRooms.join(" "),
+                        ";"
+                    );
+                } else if (op.op === "INVALIDATE") {
+                    let invalidRooms = [];
+                    const startIndex = op.range[0];
+                    for (let i = startIndex; i <= op.range[1]; i++) {
+                        invalidRooms.push(
+                            this.lists[op.list].roomIndexToRoomId[i]
+                        );
+                        delete this.lists[op.list].roomIndexToRoomId[i];
+                    }
+                    console.log(
+                        "INVALIDATE",
+                        op.list,
+                        op.range[0],
+                        op.range[1],
+                        ";"
                     );
                 }
-            }
-
-            joinObj.timeline = joinObj.timeline || {} as ITimeline;
-
-            if (joinObj.isBrandNewRoom) {
-                // set the back-pagination token. Do this *before* adding any
-                // events so that clients can start back-paginating.
-                room.getLiveTimeline().setPaginationToken(
-                    joinObj.timeline.prev_batch, EventTimeline.BACKWARDS);
-            } else if (joinObj.timeline.limited) {
-                let limited = true;
-
-                // we've got a limited sync, so we *probably* have a gap in the
-                // timeline, so should reset. But we might have been peeking or
-                // paginating and already have some of the events, in which
-                // case we just want to append any subsequent events to the end
-                // of the existing timeline.
-                //
-                // This is particularly important in the case that we already have
-                // *all* of the events in the timeline - in that case, if we reset
-                // the timeline, we'll end up with an entirely empty timeline,
-                // which we'll try to paginate but not get any new events (which
-                // will stop us linking the empty timeline into the chain).
-                //
-                for (let i = events.length - 1; i >= 0; i--) {
-                    const eventId = events[i].getId();
-                    if (room.getTimelineForEvent(eventId)) {
-                        debuglog("Already have event " + eventId + " in limited " +
-                            "sync - not resetting");
-                        limited = false;
-
-                        // we might still be missing some of the events before i;
-                        // we don't want to be adding them to the end of the
-                        // timeline because that would put them out of order.
-                        events.splice(0, i);
-
-                        // XXX: there's a problem here if the skipped part of the
-                        // timeline modifies the state set in stateEvents, because
-                        // we'll end up using the state from stateEvents rather
-                        // than the later state from timelineEvents. We probably
-                        // need to wind stateEvents forward over the events we're
-                        // skipping.
-
-                        break;
-                    }
-                }
-
-                if (limited) {
-                    this.deregisterStateListeners(room);
-                    room.resetLiveTimeline(
-                        joinObj.timeline.prev_batch,
-                        this.opts.canResetEntireTimeline(room.roomId) ?
-                            null : syncEventData.oldSyncToken,
-                    );
-
-                    // We have to assume any gap in any timeline is
-                    // reason to stop incrementally tracking notifications and
-                    // reset the timeline.
-                    client.resetNotifTimelineSet();
-
-                    this.registerStateListeners(room);
-                }
-            }
-
-            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
-
-            this.processRoomEvents(room, stateEvents, timelineEvents, syncEventData.fromCache);
-
-            // set summary after processing events,
-            // because it will trigger a name calculation
-            // which needs the room state to be up to date
-            if (joinObj.summary) {
-                room.setSummary(joinObj.summary);
-            }
-
-            // we deliberately don't add ephemeral events to the timeline
-            room.addEphemeralEvents(ephemeralEvents);
-
-            // we deliberately don't add accountData to the timeline
-            room.addAccountData(accountDataEvents);
-
-            room.recalculate();
-            if (joinObj.isBrandNewRoom) {
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-
-            this.processEventsForNotifs(room, events);
-
-            const processRoomEvent = async (e) => {
-                client.emit(ClientEvent.Event, e);
-                if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
-                    await this.opts.crypto.onCryptoEvent(e);
-                }
-                if (e.isState() && e.getType() === "im.vector.user_status") {
-                    let user = client.store.getUser(e.getStateKey());
-                    if (user) {
-                        user.unstable_updateStatusMessage(e);
-                    } else {
-                        user = createNewUser(client, e.getStateKey());
-                        user.unstable_updateStatusMessage(e);
-                        client.store.storeUser(user);
-                    }
-                }
-            };
-
-            await utils.promiseMapSeries(stateEvents, processRoomEvent);
-            await utils.promiseMapSeries(timelineEvents, processRoomEvent);
-            await utils.promiseMapSeries(threadedEvents, processRoomEvent);
-            ephemeralEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            accountDataEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
             });
 
-            room.updateMyMembership("join");
-
-            // Decrypt only the last message in all rooms to make sure we can generate a preview
-            // And decrypt all events after the recorded read receipt to ensure an accurate
-            // notification count
-            room.decryptCriticalEvents();
-        });
-
-        // Handle leaves (e.g. kicked rooms)
-        leaveRooms.forEach(async (leaveObj) => {
-            const room = leaveObj.room;
-            const stateEvents = this.mapSyncEventsFormat(leaveObj.state, room);
-            const events = this.mapSyncEventsFormat(leaveObj.timeline, room);
-            const accountDataEvents = this.mapSyncEventsFormat(leaveObj.account_data);
-
-            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
-
-            this.processRoomEvents(room, stateEvents, timelineEvents);
-            room.addAccountData(accountDataEvents);
-
-            room.recalculate();
-            if (leaveObj.isBrandNewRoom) {
-                client.store.storeRoom(room);
-                client.emit(ClientEvent.Room, room);
-            }
-
-            this.processEventsForNotifs(room, events);
-
-            stateEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            timelineEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            threadedEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            accountDataEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-
-            room.updateMyMembership("leave");
-        });
-
-        // update the notification timeline, if appropriate.
-        // we only do this for live events, as otherwise we can't order them sanely
-        // in the timeline relative to ones paginated in by /notifications.
-        // XXX: we could fix this by making EventTimeline support chronological
-        // ordering... but it doesn't, right now.
-        if (syncEventData.oldSyncToken && this.notifEvents.length) {
-            this.notifEvents.sort(function(a, b) {
-                return a.getTs() - b.getTs();
-            });
-            this.notifEvents.forEach(function(event) {
-                client.getNotifTimelineSet().addLiveEvent(event);
-            });
-        }
-
-        // Handle device list updates
-        if (data.device_lists) {
-            if (this.opts.crypto) {
-                await this.opts.crypto.handleDeviceListChanges(syncEventData, data.device_lists);
-            } else {
-                // FIXME if we *don't* have a crypto module, we still need to
-                // invalidate the device lists. But that would require a
-                // substantial bit of rework :/.
-            }
-        }
-
-        // Handle one_time_keys_count
-        if (this.opts.crypto && data.device_one_time_keys_count) {
-            const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
-            this.opts.crypto.updateOneTimeKeyCount(currentCount);
-        }
-        if (this.opts.crypto &&
-            (data["device_unused_fallback_key_types"] ||
-                data["org.matrix.msc2732.device_unused_fallback_key_types"])) {
-            // The presence of device_unused_fallback_key_types indicates that the
-            // server supports fallback keys. If there's no unused
-            // signed_curve25519 fallback key we need a new one.
-            const unusedFallbackKeys = data["device_unused_fallback_key_types"] ||
-                data["org.matrix.msc2732.device_unused_fallback_key_types"];
-            this.opts.crypto.setNeedsNewFallback(
-                unusedFallbackKeys instanceof Array &&
-                !unusedFallbackKeys.includes("signed_curve25519"),
-            );
+            this._invokeLifecycleListeners(SlidingSyncState.Complete, resp);
         }
     }
-
-    /**
-     * Starts polling the connectivity check endpoint
-     * @param {number} delay How long to delay until the first poll.
-     *        defaults to a short, randomised interval (to prevent
-     *        tightlooping if /versions succeeds but /sync etc. fail).
-     * @return {promise} which resolves once the connection returns
-     */
-    private startKeepAlives(delay?: number): Promise<boolean> {
-        if (delay === undefined) {
-            delay = 2000 + Math.floor(Math.random() * 5000);
-        }
-
-        if (this.keepAliveTimer !== null) {
-            clearTimeout(this.keepAliveTimer);
-        }
-        if (delay > 0) {
-            this.keepAliveTimer = setTimeout(this.pokeKeepAlive.bind(this), delay);
-        } else {
-            this.pokeKeepAlive();
-        }
-        if (!this.connectionReturnedDefer) {
-            this.connectionReturnedDefer = utils.defer();
-        }
-        return this.connectionReturnedDefer.promise;
-    }
-
-    /**
-     * Make a dummy call to /_matrix/client/versions, to see if the HS is
-     * reachable.
-     *
-     * On failure, schedules a call back to itself. On success, resolves
-     * this.connectionReturnedDefer.
-     *
-     * @param {boolean} connDidFail True if a connectivity failure has been detected. Optional.
-     */
-    private pokeKeepAlive(connDidFail = false): void {
-        const success = () => {
-            clearTimeout(this.keepAliveTimer);
-            if (this.connectionReturnedDefer) {
-                this.connectionReturnedDefer.resolve(connDidFail);
-                this.connectionReturnedDefer = null;
-            }
-        };
-
-        this.client.http.request(
-            undefined, // callback
-            Method.Get, "/_matrix/client/versions",
-            undefined, // queryParams
-            undefined, // data
-            {
-                prefix: '',
-                localTimeoutMs: 15 * 1000,
-            },
-        ).then(() => {
-            success();
-        }, (err) => {
-            if (err.httpStatus == 400 || err.httpStatus == 404) {
-                // treat this as a success because the server probably just doesn't
-                // support /versions: point is, we're getting a response.
-                // We wait a short time though, just in case somehow the server
-                // is in a mode where it 400s /versions responses and sync etc.
-                // responses fail, this will mean we don't hammer in a loop.
-                this.keepAliveTimer = setTimeout(success, 2000);
-            } else {
-                connDidFail = true;
-                this.keepAliveTimer = setTimeout(
-                    this.pokeKeepAlive.bind(this, connDidFail),
-                    5000 + Math.floor(Math.random() * 5000),
-                );
-                // A keepalive has failed, so we emit the
-                // error state (whether or not this is the
-                // first failure).
-                // Note we do this after setting the timer:
-                // this lets the unit tests advance the mock
-                // clock when they get the error.
-                this.updateSyncState(SyncState.Error, { error: err });
-            }
-        });
-    }
-
-    /**
-     * @param {Object} obj
-     * @return {Object[]}
-     */
-    private mapSyncResponseToRoomArray<T extends ILeftRoom | IJoinedRoom | IInvitedRoom>(
-        obj: Record<string, T>,
-    ): Array<WrappedRoom<T>> {
-        // Maps { roomid: {stuff}, roomid: {stuff} }
-        // to
-        // [{stuff+Room+isBrandNewRoom}, {stuff+Room+isBrandNewRoom}]
-        const client = this.client;
-        return Object.keys(obj).map((roomId) => {
-            const arrObj = obj[roomId] as T & { room: Room, isBrandNewRoom: boolean };
-            let room = client.store.getRoom(roomId);
-            let isBrandNewRoom = false;
-            if (!room) {
-                room = this.createRoom(roomId);
-                isBrandNewRoom = true;
-            }
-            arrObj.room = room;
-            arrObj.isBrandNewRoom = isBrandNewRoom;
-            return arrObj;
-        });
-    }
-
-    /**
-     * @param {Object} obj
-     * @param {Room} room
-     * @param {boolean} decrypt
-     * @return {MatrixEvent[]}
-     */
-    private mapSyncEventsFormat(
-        obj: IInviteState | ITimeline | IEphemeral,
-        room?: Room,
-        decrypt = true,
-    ): MatrixEvent[] {
-        if (!obj || !Array.isArray(obj.events)) {
-            return [];
-        }
-        const mapper = this.client.getEventMapper({ decrypt });
-        return (obj.events as Array<IStrippedState | IRoomEvent | IStateEvent | IMinimalEvent>).map(function(e) {
-            if (room) {
-                e["room_id"] = room.roomId;
-            }
-            return mapper(e);
-        });
-    }
-
-    /**
-     * @param {Room} room
-     */
-    private resolveInvites(room: Room): void {
-        if (!room || !this.opts.resolveInvitesToProfiles) {
-            return;
-        }
-        const client = this.client;
-        // For each invited room member we want to give them a displayname/avatar url
-        // if they have one (the m.room.member invites don't contain this).
-        room.getMembersWithMembership("invite").forEach(function(member) {
-            if (member._requestedProfileInfo) return;
-            member._requestedProfileInfo = true;
-            // try to get a cached copy first.
-            const user = client.getUser(member.userId);
-            let promise;
-            if (user) {
-                promise = Promise.resolve({
-                    avatar_url: user.avatarUrl,
-                    displayname: user.displayName,
-                });
-            } else {
-                promise = client.getProfileInfo(member.userId);
-            }
-            promise.then(function(info) {
-                // slightly naughty by doctoring the invite event but this means all
-                // the code paths remain the same between invite/join display name stuff
-                // which is a worthy trade-off for some minor pollution.
-                const inviteEvent = member.events.member;
-                if (inviteEvent.getContent().membership !== "invite") {
-                    // between resolving and now they have since joined, so don't clobber
-                    return;
-                }
-                inviteEvent.getContent().avatar_url = info.avatar_url;
-                inviteEvent.getContent().displayname = info.displayname;
-                // fire listeners
-                member.setMembershipEvent(inviteEvent, room.currentState);
-            }, function(err) {
-                // OH WELL.
-            });
-        });
-    }
-
-    /**
-     * @param {Room} room
-     * @param {MatrixEvent[]} stateEventList A list of state events. This is the state
-     * at the *START* of the timeline list if it is supplied.
-     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
-     * @param {boolean} fromCache whether the sync response came from cache
-     * is earlier in time. Higher index is later.
-     */
-    private processRoomEvents(
-        room: Room,
-        stateEventList: MatrixEvent[],
-        timelineEventList?: MatrixEvent[],
-        fromCache = false,
-    ): void {
-        // If there are no events in the timeline yet, initialise it with
-        // the given state events
-        const liveTimeline = room.getLiveTimeline();
-        const timelineWasEmpty = liveTimeline.getEvents().length == 0;
-        if (timelineWasEmpty) {
-            // Passing these events into initialiseState will freeze them, so we need
-            // to compute and cache the push actions for them now, otherwise sync dies
-            // with an attempt to assign to read only property.
-            // XXX: This is pretty horrible and is assuming all sorts of behaviour from
-            // these functions that it shouldn't be. We should probably either store the
-            // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise
-            // find some solution where MatrixEvents are immutable but allow for a cache
-            // field.
-            for (const ev of stateEventList) {
-                this.client.getPushActionsForEvent(ev);
-            }
-            liveTimeline.initialiseState(stateEventList);
-        }
-
-        this.resolveInvites(room);
-
-        // recalculate the room name at this point as adding events to the timeline
-        // may make notifications appear which should have the right name.
-        // XXX: This looks suspect: we'll end up recalculating the room once here
-        // and then again after adding events (processSyncResponse calls it after
-        // calling us) even if no state events were added. It also means that if
-        // one of the room events in timelineEventList is something that needs
-        // a recalculation (like m.room.name) we won't recalculate until we've
-        // finished adding all the events, which will cause the notification to have
-        // the old room name rather than the new one.
-        room.recalculate();
-
-        // If the timeline wasn't empty, we process the state events here: they're
-        // defined as updates to the state before the start of the timeline, so this
-        // starts to roll the state forward.
-        // XXX: That's what we *should* do, but this can happen if we were previously
-        // peeking in a room, in which case we obviously do *not* want to add the
-        // state events here onto the end of the timeline. Historically, the js-sdk
-        // has just set these new state events on the old and new state. This seems
-        // very wrong because there could be events in the timeline that diverge the
-        // state, in which case this is going to leave things out of sync. However,
-        // for now I think it;s best to behave the same as the code has done previously.
-        if (!timelineWasEmpty) {
-            // XXX: As above, don't do this...
-            //room.addLiveEvents(stateEventList || []);
-            // Do this instead...
-            room.oldState.setStateEvents(stateEventList || []);
-            room.currentState.setStateEvents(stateEventList || []);
-        }
-        // execute the timeline events. This will continue to diverge the current state
-        // if the timeline has any state events in it.
-        // This also needs to be done before running push rules on the events as they need
-        // to be decorated with sender etc.
-        room.addLiveEvents(timelineEventList || [], null, fromCache);
-    }
-
-    /**
-     * Takes a list of timelineEvents and adds and adds to notifEvents
-     * as appropriate.
-     * This must be called after the room the events belong to has been stored.
-     *
-     * @param {Room} room
-     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
-     * is earlier in time. Higher index is later.
-     */
-    private processEventsForNotifs(room: Room, timelineEventList: MatrixEvent[]): void {
-        // gather our notifications into this.notifEvents
-        if (this.client.getNotifTimelineSet()) {
-            for (let i = 0; i < timelineEventList.length; i++) {
-                const pushActions = this.client.getPushActionsForEvent(timelineEventList[i]);
-                if (pushActions && pushActions.notify &&
-                    pushActions.tweaks && pushActions.tweaks.highlight) {
-                    this.notifEvents.push(timelineEventList[i]);
-                }
-            }
-        }
-    }
-
-    /**
-     * Sets the sync state and emits an event to say so
-     * @param {String} newState The new state string
-     * @param {Object} data Object of additional data to emit in the event
-     */
-    private updateSyncState(newState: SyncState, data?: ISyncStateData): void {
-        const old = this.syncState;
-        this.syncState = newState;
-        this.syncStateData = data;
-        this.client.emit(ClientEvent.Sync, this.syncState, old, data);
-    }
-
-    /**
-     * Event handler for the 'online' event
-     * This event is generally unreliable and precise behaviour
-     * varies between browsers, so we poll for connectivity too,
-     * but this might help us reconnect a little faster.
-     */
-    private onOnline = (): void => {
-        debuglog("Browser thinks we are back online");
-        this.startKeepAlives(0);
-    };
 }
 
-function createNewUser(client: MatrixClient, userId: string): User {
-    const user = new User(userId);
-    client.reEmitter.reEmit(user, [
-        UserEvent.AvatarUrl,
-        UserEvent.DisplayName,
-        UserEvent.Presence,
-        UserEvent.CurrentlyActive,
-        UserEvent.LastPresenceTs,
-    ]);
-    return user;
+function difference(setA: Set<string>, setB: Set<string>): Set<string> {
+    let _difference = new Set(setA)
+    for (let elem of setB) {
+        _difference.delete(elem)
+    }
+    return _difference
 }
 
+const sleep = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+// SYNC 0 2 a b c; SYNC 6 8 d e f; DELETE 7; INSERT 0 e;
+// 0 1 2 3 4 5 6 7 8
+// a b c       d e f
+// a b c       d _ f
+// e a b c       d f  <--- c=3 is wrong as we are not tracking it, ergo we need to see if `i` is in range else drop it
+const indexInRange = (ranges, i) => {
+    let isInRange = false;
+    ranges.forEach((r) => {
+        if (r[0] <= i && i <= r[1]) {
+            isInRange = true;
+        }
+    });
+    return isInRange;
+};

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -1,0 +1,1466 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { User, UserEvent } from "./models/user";
+import { NotificationCountType, Room, RoomEvent } from "./models/room";
+import * as utils from "./utils";
+import { IDeferred } from "./utils";
+import { EventTimeline } from "./models/event-timeline";
+import { PushProcessor } from "./pushprocessor";
+import { logger } from './logger';
+import { InvalidStoreError } from './errors';
+import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
+import {
+    Category,
+    IEphemeral,
+    IInvitedRoom,
+    IInviteState,
+    IJoinedRoom,
+    ILeftRoom,
+    IMinimalEvent,
+    IRoomEvent,
+    IStateEvent,
+    IStrippedState,
+    ISyncResponse,
+    ITimeline,
+} from "./sync-accumulator";
+import { MatrixEvent } from "./models/event";
+import { MatrixError, Method } from "./http-api";
+import { ISavedSync } from "./store";
+import { EventType } from "./@types/event";
+import { IPushRules } from "./@types/PushRules";
+import { RoomStateEvent } from "./models/room-state";
+import { RoomMemberEvent } from "./models/room-member";
+import {SyncState } from "./sync";
+
+const DEBUG = true;
+
+// /sync requests allow you to set a timeout= but the request may continue
+// beyond that and wedge forever, so we need to track how long we are willing
+// to keep open the connection. This constant is *ADDED* to the timeout= value
+// to determine the max time we're willing to wait.
+const BUFFER_PERIOD_MS = 80 * 1000;
+
+// Number of consecutive failed syncs that will lead to a syncState of ERROR as opposed
+// to RECONNECTING. This is needed to inform the client of server issues when the
+// keepAlive is successful but the server /sync fails.
+const FAILED_SYNC_ERROR_THRESHOLD = 3;
+
+function debuglog(...params) {
+    if (!DEBUG) {
+        return;
+    }
+    logger.log(...params);
+}
+
+/**
+ * Represents a subscription to a room or set of rooms. Controls which events are returned.
+ */
+export interface MSC3575RoomSubscription {
+    required_state: string[][];
+    timeline_limit: number;
+};
+
+/**
+ * Controls which rooms are returned in a given list.
+ */
+export interface MSC3575Filter {
+    is_dm: boolean | undefined;
+    is_encrypted: boolean | undefined;
+    is_invite: boolean | undefined;
+    room_name_like: string | undefined;
+};
+
+/**
+ * Represents a list subscription.
+ */
+export interface MSC3575List extends MSC3575RoomSubscription {
+    ranges: number[][];
+    sort: string[];
+    filters: MSC3575Filter;
+};
+
+/**
+ * A complete Sliding Sync request.
+ */
+export interface MSC3575SlidingSyncRequest {
+    // json body params
+    lists: MSC3575List[];
+    unsubscribe_rooms: string[];
+    room_subscriptions: Record<string, MSC3575RoomSubscription>;
+    extensions: object;
+
+    // query params
+    pos: string | undefined;
+    timeout: number | undefined;
+};
+
+/**
+ * A complete Sliding Sync response
+ */
+export interface MSC3575SlidingSyncResponse {
+    pos: string;
+    ops: object[];
+    counts: number[];
+    room_subscriptions: Record<string, object>;
+    extensions: object;
+};
+
+interface ISyncOptions {
+    filterId?: string;
+    hasSyncedBefore?: boolean;
+}
+
+export interface ISyncStateData {
+    error?: MatrixError;
+    oldSyncToken?: string;
+    nextSyncToken?: string;
+    catchingUp?: boolean;
+    fromCache?: boolean;
+}
+
+interface ISyncQueryParams {
+    timeout: number;
+    pos?: string;
+    _cacheBuster?: string | number; // not part of the API itself
+}
+
+// http-api mangles an abort method onto its promises
+interface IRequestPromise<T> extends Promise<T> {
+    abort(): void;
+}
+
+type WrappedRoom<T> = T & {
+    room: Room;
+    isBrandNewRoom: boolean;
+};
+
+/**
+ * <b>Internal class - unstable.</b>
+ * Construct an entity which is able to sync with a homeserver.
+ * @constructor
+ * @param {MatrixClient} client The matrix client instance to use.
+ * @param {Object} opts Config options
+ * @param {module:crypto=} opts.crypto Crypto manager
+ * @param {Function=} opts.canResetEntireTimeline A function which is called
+ * with a room ID and returns a boolean. It should return 'true' if the SDK can
+ * SAFELY remove events from this room. It may not be safe to remove events if
+ * there are other references to the timelines for this room.
+ * Default: returns false.
+ * @param {Boolean=} opts.disablePresence True to perform syncing without automatically
+ * updating presence.
+ */
+export class SlidingSyncApi {
+    private currentSyncRequest: IRequestPromise<ISyncResponse> = null;
+    private syncState: SyncState = null;
+    private syncStateData: ISyncStateData = null; // additional data (eg. error object for failed sync)
+    private catchingUp = false;
+    private running = false;
+    private keepAliveTimer: number = null;
+    private connectionReturnedDefer: IDeferred<boolean> = null;
+    private notifEvents: MatrixEvent[] = []; // accumulator of sync events in the current sync response
+    private failedSyncCount = 0; // Number of consecutive failed /sync requests
+    private storeIsInvalid = false; // flag set if the store needs to be cleared before we can start
+
+    constructor(private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
+        this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
+        this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
+        this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
+        this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
+        this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
+
+        if (!opts.canResetEntireTimeline) {
+            opts.canResetEntireTimeline = (roomId: string) => {
+                return false;
+            };
+        }
+
+        if (client.getNotifTimelineSet()) {
+            client.reEmitter.reEmit(client.getNotifTimelineSet(), [
+                RoomEvent.Timeline,
+                RoomEvent.TimelineReset,
+            ]);
+        }
+    }
+
+    /**
+     * @param {string} roomId
+     * @return {Room}
+     */
+    public createRoom(roomId: string): Room {
+        const client = this.client;
+        const {
+            timelineSupport,
+            unstableClientRelationAggregation,
+        } = client;
+        const room = new Room(roomId, client, client.getUserId(), {
+            lazyLoadMembers: this.opts.lazyLoadMembers,
+            pendingEventOrdering: this.opts.pendingEventOrdering,
+            timelineSupport,
+            unstableClientRelationAggregation,
+        });
+        client.reEmitter.reEmit(room, [
+            RoomEvent.Name,
+            RoomEvent.Redaction,
+            RoomEvent.RedactionCancelled,
+            RoomEvent.Receipt,
+            RoomEvent.Tags,
+            RoomEvent.LocalEchoUpdated,
+            RoomEvent.AccountData,
+            RoomEvent.MyMembership,
+            RoomEvent.Timeline,
+            RoomEvent.TimelineReset,
+        ]);
+        this.registerStateListeners(room);
+        return room;
+    }
+
+    /**
+     * @param {Room} room
+     * @private
+     */
+    private registerStateListeners(room: Room): void {
+        const client = this.client;
+        // we need to also re-emit room state and room member events, so hook it up
+        // to the client now. We need to add a listener for RoomState.members in
+        // order to hook them correctly.
+        client.reEmitter.reEmit(room.currentState, [
+            RoomStateEvent.Events,
+            RoomStateEvent.Members,
+            RoomStateEvent.NewMember,
+            RoomStateEvent.Update,
+        ]);
+        room.currentState.on(RoomStateEvent.NewMember, function(event, state, member) {
+            member.user = client.getUser(member.userId);
+            client.reEmitter.reEmit(member, [
+                RoomMemberEvent.Name,
+                RoomMemberEvent.Typing,
+                RoomMemberEvent.PowerLevel,
+                RoomMemberEvent.Membership,
+            ]);
+        });
+    }
+
+    /**
+     * @param {Room} room
+     * @private
+     */
+    private deregisterStateListeners(room: Room): void {
+        // could do with a better way of achieving this.
+        room.currentState.removeAllListeners(RoomStateEvent.Events);
+        room.currentState.removeAllListeners(RoomStateEvent.Members);
+        room.currentState.removeAllListeners(RoomStateEvent.NewMember);
+    }
+
+    /**
+     * Sync rooms the user has left.
+     * @return {Promise} Resolved when they've been added to the store.
+     */
+    public async syncLeftRooms() {
+        return []; // TODO
+    }
+
+    /**
+     * Peek into a room. This will result in the room in question being synced so it
+     * is accessible via getRooms(). Live updates for the room will be provided.
+     * @param {string} roomId The room ID to peek into.
+     * @return {Promise} A promise which resolves once the room has been added to the
+     * store.
+     */
+    public async peek(roomId: string): Promise<Room> {
+        return null; // TODO
+    }
+
+    /**
+     * Stop polling for updates in the peeked room. NOPs if there is no room being
+     * peeked.
+     */
+    public stopPeeking(): void {
+        // TODO
+    }
+
+    /**
+     * Returns the current state of this sync object
+     * @see module:client~MatrixClient#event:"sync"
+     * @return {?String}
+     */
+    public getSyncState(): SyncState {
+        return this.syncState;
+    }
+
+    /**
+     * Returns the additional data object associated with
+     * the current sync state, or null if there is no
+     * such data.
+     * Sync errors, if available, are put in the 'error' key of
+     * this object.
+     * @return {?Object}
+     */
+    public getSyncStateData(): ISyncStateData {
+        return this.syncStateData;
+    }
+
+    public async recoverFromSyncStartupError(savedSyncPromise: Promise<void>, err: MatrixError): Promise<void> {
+        // Wait for the saved sync to complete - we send the pushrules and filter requests
+        // before the saved sync has finished so they can run in parallel, but only process
+        // the results after the saved sync is done. Equivalently, we wait for it to finish
+        // before reporting failures from these functions.
+        await savedSyncPromise;
+        const keepaliveProm = this.startKeepAlives();
+        this.updateSyncState(SyncState.Error, { error: err });
+        await keepaliveProm;
+    }
+
+    /**
+     * Is the lazy loading option different than in previous session?
+     * @param {boolean} lazyLoadMembers current options for lazy loading
+     * @return {boolean} whether or not the option has changed compared to the previous session */
+    private async wasLazyLoadingToggled(lazyLoadMembers = false): Promise<boolean> {
+        // assume it was turned off before
+        // if we don't know any better
+        let lazyLoadMembersBefore = false;
+        const isStoreNewlyCreated = await this.client.store.isNewlyCreated();
+        if (!isStoreNewlyCreated) {
+            const prevClientOptions = await this.client.store.getClientOptions();
+            if (prevClientOptions) {
+                lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
+            }
+            return lazyLoadMembersBefore !== lazyLoadMembers;
+        }
+        return false;
+    }
+
+    private shouldAbortSync(error: MatrixError): boolean {
+        if (error.errcode === "M_UNKNOWN_TOKEN") {
+            // The logout already happened, we just need to stop.
+            logger.warn("Token no longer valid - assuming logout");
+            this.stop();
+            this.updateSyncState(SyncState.Error, { error });
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Main entry point
+     */
+    public sync(): void {
+        const client = this.client;
+
+        this.running = true;
+
+        if (global.window && global.window.addEventListener) {
+            global.window.addEventListener("online", this.onOnline, false);
+        }
+
+        let savedSyncPromise = Promise.resolve();
+        let savedSyncToken = null;
+
+        // We need to do one-off checks before we can begin the /sync loop.
+        // These are:
+        //   1) We need to get push rules so we can check if events should bing as we get
+        //      them from /sync.
+        //   2) We need to get/create a filter which we can use for /sync.
+        //   3) We need to check the lazy loading option matches what was used in the
+        //       stored sync. If it doesn't, we can't use the stored sync.
+
+        const getPushRules = async () => {
+            try {
+                debuglog("Getting push rules...");
+                const result = await client.getPushRules();
+                debuglog("Got push rules");
+
+                client.pushRules = result;
+            } catch (err) {
+                logger.error("Getting push rules failed", err);
+                if (this.shouldAbortSync(err)) return;
+                // wait for saved sync to complete before doing anything else,
+                // otherwise the sync state will end up being incorrect
+                debuglog("Waiting for saved sync before retrying push rules...");
+                await this.recoverFromSyncStartupError(savedSyncPromise, err);
+                getPushRules();
+                return;
+            }
+            checkLazyLoadStatus(); // advance to the next stage
+        };
+
+        const checkLazyLoadStatus = async () => {
+            debuglog("Checking lazy load status...");
+            if (this.opts.lazyLoadMembers && client.isGuest()) {
+                this.opts.lazyLoadMembers = false;
+            }
+            if (this.opts.lazyLoadMembers) {
+                debuglog("Checking server lazy load support...");
+                const supported = await client.doesServerSupportLazyLoading();
+                if (supported) {
+                    debuglog("Enabling lazy load on sync filter...");
+                    this.opts.lazyLoadMembers = false; // TODO
+                } else {
+                    debuglog("LL: lazy loading requested but not supported " +
+                        "by server, so disabling");
+                    this.opts.lazyLoadMembers = false;
+                }
+            }
+            // need to vape the store when enabling LL and wasn't enabled before
+            debuglog("Checking whether lazy loading has changed in store...");
+            const shouldClear = await this.wasLazyLoadingToggled(this.opts.lazyLoadMembers);
+            if (shouldClear) {
+                this.storeIsInvalid = true;
+                const reason = InvalidStoreError.TOGGLED_LAZY_LOADING;
+                const error = new InvalidStoreError(reason, !!this.opts.lazyLoadMembers);
+                this.updateSyncState(SyncState.Error, { error });
+                // bail out of the sync loop now: the app needs to respond to this error.
+                // we leave the state as 'ERROR' which isn't great since this normally means
+                // we're retrying. The client must be stopped before clearing the stores anyway
+                // so the app should stop the client, clear the store and start it again.
+                logger.warn("InvalidStoreError: store is not usable: stopping sync.");
+                return;
+            }
+            if (this.opts.lazyLoadMembers && this.opts.crypto) {
+                this.opts.crypto.enableLazyLoading();
+            }
+            try {
+                debuglog("Storing client options...");
+                await this.client.storeClientOptions();
+                debuglog("Stored client options");
+            } catch (err) {
+                logger.error("Storing client options failed", err);
+                throw err;
+            }
+
+            getFilter(); // Now get the filter and start syncing
+        };
+
+        const getFilter = async () => {
+            debuglog("Getting filter...");
+            // reset the notifications timeline to prepare it to paginate from
+            // the current point in time.
+            // The right solution would be to tie /sync pagination tokens into
+            // /notifications API somehow.
+            client.resetNotifTimelineSet();
+
+            if (this.currentSyncRequest === null) {
+                // Send this first sync request here so we can then wait for the saved
+                // sync data to finish processing before we process the results of this one.
+                debuglog("Sending first sync request...");
+                this.currentSyncRequest = this.doSyncRequest({ }, savedSyncToken);
+            }
+
+            // Now wait for the saved sync to finish...
+            debuglog("Waiting for saved sync before starting sync processing...");
+            await savedSyncPromise;
+            this.doSync({ });
+        };
+
+        if (client.isGuest()) {
+            // no push rules for guests, no access to POST filter for guests.
+            this.doSync({});
+        } else {
+            // Pull the saved sync token out first, before the worker starts sending
+            // all the sync data which could take a while. This will let us send our
+            // first incremental sync request before we've processed our saved data.
+            debuglog("Getting saved sync token...");
+            savedSyncPromise = client.store.getSavedSyncToken().then((tok) => {
+                debuglog("Got saved sync token");
+                savedSyncToken = tok;
+                debuglog("Getting saved sync...");
+                return client.store.getSavedSync();
+            }).then((savedSync) => {
+                debuglog(`Got reply from saved sync, exists? ${!!savedSync}`);
+                if (savedSync) {
+                    return this.syncFromCache(savedSync);
+                }
+            }).catch(err => {
+                logger.error("Getting saved sync failed", err);
+            });
+            // Now start the first incremental sync request: this can also
+            // take a while so if we set it going now, we can wait for it
+            // to finish while we process our saved sync data.
+            getPushRules();
+        }
+    }
+
+    /**
+     * Stops the sync object from syncing.
+     */
+    public stop(): void {
+        debuglog("SyncApi.stop");
+        // It is necessary to check for the existance of
+        // global.window AND global.window.removeEventListener.
+        // Some platforms (e.g. React Native) register global.window,
+        // but do not have global.window.removeEventListener.
+        if (global.window && global.window.removeEventListener) {
+            global.window.removeEventListener("online", this.onOnline, false);
+        }
+        this.running = false;
+        if (this.currentSyncRequest) {
+            this.currentSyncRequest.abort();
+        }
+        if (this.keepAliveTimer) {
+            clearTimeout(this.keepAliveTimer);
+            this.keepAliveTimer = null;
+        }
+    }
+
+    /**
+     * Retry a backed off syncing request immediately. This should only be used when
+     * the user <b>explicitly</b> attempts to retry their lost connection.
+     * @return {boolean} True if this resulted in a request being retried.
+     */
+    public retryImmediately(): boolean {
+        if (!this.connectionReturnedDefer) {
+            return false;
+        }
+        this.startKeepAlives(0);
+        return true;
+    }
+    /**
+     * Process a single set of cached sync data.
+     * @param {Object} savedSync a saved sync that was persisted by a store. This
+     * should have been acquired via client.store.getSavedSync().
+     */
+    private async syncFromCache(savedSync: ISavedSync): Promise<void> {
+        debuglog("sync(): not doing HTTP hit, instead returning stored /sync data");
+
+        const nextSyncToken = savedSync.nextBatch;
+
+        // Set sync token for future incremental syncing
+        this.client.store.setSyncToken(nextSyncToken);
+
+        // No previous sync, set old token to null
+        const syncEventData = {
+            oldSyncToken: null,
+            nextSyncToken,
+            catchingUp: false,
+            fromCache: true,
+        };
+
+        const data: ISyncResponse = {
+            next_batch: nextSyncToken,
+            rooms: savedSync.roomsData,
+            groups: savedSync.groupsData,
+            account_data: {
+                events: savedSync.accountData,
+            },
+        };
+
+        try {
+            await this.processSyncResponse(syncEventData, data);
+        } catch (e) {
+            logger.error("Error processing cached sync", e.stack || e);
+        }
+
+        // Don't emit a prepared if we've bailed because the store is invalid:
+        // in this case the client will not be usable until stopped & restarted
+        // so this would be useless and misleading.
+        if (!this.storeIsInvalid) {
+            this.updateSyncState(SyncState.Prepared, syncEventData);
+        }
+    }
+
+    /**
+     * Invoke me to do /sync calls
+     * @param {Object} syncOptions
+     * @param {string} syncOptions.filterId
+     * @param {boolean} syncOptions.hasSyncedBefore
+     */
+    private async doSync(syncOptions: ISyncOptions): Promise<void> {
+        const client = this.client;
+
+        if (!this.running) {
+            debuglog("Sync no longer running: exiting.");
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.reject();
+                this.connectionReturnedDefer = null;
+            }
+            this.updateSyncState(SyncState.Stopped);
+            return;
+        }
+
+        const syncToken = client.store.getSyncToken();
+
+        let data;
+        try {
+            //debuglog('Starting sync since=' + syncToken);
+            if (this.currentSyncRequest === null) {
+                this.currentSyncRequest = this.doSyncRequest(syncOptions, syncToken);
+            }
+            data = await this.currentSyncRequest;
+        } catch (e) {
+            this.onSyncError(e, syncOptions);
+            return;
+        } finally {
+            this.currentSyncRequest = null;
+        }
+
+        //debuglog('Completed sync, next_batch=' + data.next_batch);
+
+        // set the sync token NOW *before* processing the events. We do this so
+        // if something barfs on an event we can skip it rather than constantly
+        // polling with the same token.
+        client.store.setSyncToken(data.next_batch);
+
+        // Reset after a successful sync
+        this.failedSyncCount = 0;
+
+        await client.store.setSyncData(data);
+
+        const syncEventData = {
+            oldSyncToken: syncToken,
+            nextSyncToken: data.next_batch,
+            catchingUp: this.catchingUp,
+        };
+
+        if (this.opts.crypto) {
+            // tell the crypto module we're about to process a sync
+            // response
+            await this.opts.crypto.onSyncWillProcess(syncEventData);
+        }
+
+        try {
+            await this.processSyncResponse(syncEventData, data);
+        } catch (e) {
+            // log the exception with stack if we have it, else fall back
+            // to the plain description
+            logger.error("Caught /sync error", e.stack || e);
+
+            // Emit the exception for client handling
+            this.client.emit(ClientEvent.SyncUnexpectedError, e);
+        }
+
+        // update this as it may have changed
+        syncEventData.catchingUp = this.catchingUp;
+
+        // emit synced events
+        if (!syncOptions.hasSyncedBefore) {
+            this.updateSyncState(SyncState.Prepared, syncEventData);
+            syncOptions.hasSyncedBefore = true;
+        }
+
+        // tell the crypto module to do its processing. It may block (to do a
+        // /keys/changes request).
+        if (this.opts.crypto) {
+            await this.opts.crypto.onSyncCompleted(syncEventData);
+        }
+
+        // keep emitting SYNCING -> SYNCING for clients who want to do bulk updates
+        this.updateSyncState(SyncState.Syncing, syncEventData);
+
+        if (client.store.wantsSave()) {
+            // We always save the device list (if it's dirty) before saving the sync data:
+            // this means we know the saved device list data is at least as fresh as the
+            // stored sync data which means we don't have to worry that we may have missed
+            // device changes. We can also skip the delay since we're not calling this very
+            // frequently (and we don't really want to delay the sync for it).
+            if (this.opts.crypto) {
+                await this.opts.crypto.saveDeviceList(0);
+            }
+
+            // tell databases that everything is now in a consistent state and can be saved.
+            client.store.save();
+        }
+
+        // Begin next sync
+        this.doSync(syncOptions);
+    }
+
+    private doSyncRequest(syncOptions: ISyncOptions, pos: string): IRequestPromise<ISyncResponse> {
+        const qps = this.getSyncQueryParams(syncOptions, pos);
+        return this.client.http.authedRequest(
+            undefined, Method.Get, "/sync", qps as any, undefined,
+            qps.timeout + BUFFER_PERIOD_MS,
+        );
+    }
+
+    private getSyncQueryParams(syncOptions: ISyncOptions, pos: string): ISyncQueryParams {
+        let pollTimeout = this.opts.pollTimeout;
+
+        if (this.getSyncState() !== 'SYNCING' || this.catchingUp) {
+            // unless we are happily syncing already, we want the server to return
+            // as quickly as possible, even if there are no events queued. This
+            // serves two purposes:
+            //
+            // * When the connection dies, we want to know asap when it comes back,
+            //   so that we can hide the error from the user. (We don't want to
+            //   have to wait for an event or a timeout).
+            //
+            // * We want to know if the server has any to_device messages queued up
+            //   for us. We do that by calling it with a zero timeout until it
+            //   doesn't give us any more to_device messages.
+            this.catchingUp = true;
+            pollTimeout = 0;
+        }
+
+        const qps: ISyncQueryParams = {
+            timeout: pollTimeout,
+        };
+
+        if (pos) {
+            qps.pos = pos;
+        } else {
+            // use a cachebuster for initialsyncs, to make sure that
+            // we don't get a stale sync
+            // (https://github.com/vector-im/vector-web/issues/1354)
+            qps._cacheBuster = Date.now();
+        }
+
+        if (this.getSyncState() == 'ERROR' || this.getSyncState() == 'RECONNECTING') {
+            // we think the connection is dead. If it comes back up, we won't know
+            // about it till /sync returns. If the timeout= is high, this could
+            // be a long time. Set it to 0 when doing retries so we don't have to wait
+            // for an event or a timeout before emiting the SYNCING event.
+            qps.timeout = 0;
+        }
+
+        return qps;
+    }
+
+    private onSyncError(err: MatrixError, syncOptions: ISyncOptions): void {
+        if (!this.running) {
+            debuglog("Sync no longer running: exiting");
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.reject();
+                this.connectionReturnedDefer = null;
+            }
+            this.updateSyncState(SyncState.Stopped);
+            return;
+        }
+
+        logger.error("/sync error %s", err);
+        logger.error(err);
+
+        if (this.shouldAbortSync(err)) {
+            return;
+        }
+
+        this.failedSyncCount++;
+        logger.log('Number of consecutive failed sync requests:', this.failedSyncCount);
+
+        debuglog("Starting keep-alive");
+        // Note that we do *not* mark the sync connection as
+        // lost yet: we only do this if a keepalive poke
+        // fails, since long lived HTTP connections will
+        // go away sometimes and we shouldn't treat this as
+        // erroneous. We set the state to 'reconnecting'
+        // instead, so that clients can observe this state
+        // if they wish.
+        this.startKeepAlives().then((connDidFail) => {
+            // Only emit CATCHUP if we detected a connectivity error: if we didn't,
+            // it's quite likely the sync will fail again for the same reason and we
+            // want to stay in ERROR rather than keep flip-flopping between ERROR
+            // and CATCHUP.
+            if (connDidFail && this.getSyncState() === SyncState.Error) {
+                this.updateSyncState(SyncState.Catchup, {
+                    oldSyncToken: null,
+                    nextSyncToken: null,
+                    catchingUp: true,
+                });
+            }
+            this.doSync(syncOptions);
+        });
+
+        this.currentSyncRequest = null;
+        // Transition from RECONNECTING to ERROR after a given number of failed syncs
+        this.updateSyncState(
+            this.failedSyncCount >= FAILED_SYNC_ERROR_THRESHOLD ?
+                SyncState.Error : SyncState.Reconnecting,
+            { error: err },
+        );
+    }
+
+    /**
+     * Process data returned from a sync response and propagate it
+     * into the model objects
+     *
+     * @param {Object} syncEventData Object containing sync tokens associated with this sync
+     * @param {Object} data The response from /sync
+     */
+    private async processSyncResponse(syncEventData: ISyncStateData, data: ISyncResponse): Promise<void> {
+        const client = this.client;
+
+        // data looks like:
+        // {
+        // }
+
+        // handle presence events (User objects)
+        if (data.presence && Array.isArray(data.presence.events)) {
+            data.presence.events.map(client.getEventMapper()).forEach(
+                function(presenceEvent) {
+                    let user = client.store.getUser(presenceEvent.getSender());
+                    if (user) {
+                        user.setPresenceEvent(presenceEvent);
+                    } else {
+                        user = createNewUser(client, presenceEvent.getSender());
+                        user.setPresenceEvent(presenceEvent);
+                        client.store.storeUser(user);
+                    }
+                    client.emit(ClientEvent.Event, presenceEvent);
+                });
+        }
+
+        // handle non-room account_data
+        if (data.account_data && Array.isArray(data.account_data.events)) {
+            const events = data.account_data.events.map(client.getEventMapper());
+            const prevEventsMap = events.reduce((m, c) => {
+                m[c.getId()] = client.store.getAccountData(c.getType());
+                return m;
+            }, {});
+            client.store.storeAccountDataEvents(events);
+            events.forEach(
+                function(accountDataEvent) {
+                    // Honour push rules that come down the sync stream but also
+                    // honour push rules that were previously cached. Base rules
+                    // will be updated when we receive push rules via getPushRules
+                    // (see sync) before syncing over the network.
+                    if (accountDataEvent.getType() === EventType.PushRules) {
+                        const rules = accountDataEvent.getContent<IPushRules>();
+                        client.pushRules = PushProcessor.rewriteDefaultRules(rules);
+                    }
+                    const prevEvent = prevEventsMap[accountDataEvent.getId()];
+                    client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
+                    return accountDataEvent;
+                },
+            );
+        }
+
+        // handle to-device events
+        if (data.to_device && Array.isArray(data.to_device.events) &&
+            data.to_device.events.length > 0
+        ) {
+            const cancelledKeyVerificationTxns = [];
+            data.to_device.events
+                .map(client.getEventMapper())
+                .map((toDeviceEvent) => { // map is a cheap inline forEach
+                    // We want to flag m.key.verification.start events as cancelled
+                    // if there's an accompanying m.key.verification.cancel event, so
+                    // we pull out the transaction IDs from the cancellation events
+                    // so we can flag the verification events as cancelled in the loop
+                    // below.
+                    if (toDeviceEvent.getType() === "m.key.verification.cancel") {
+                        const txnId = toDeviceEvent.getContent()['transaction_id'];
+                        if (txnId) {
+                            cancelledKeyVerificationTxns.push(txnId);
+                        }
+                    }
+
+                    // as mentioned above, .map is a cheap inline forEach, so return
+                    // the unmodified event.
+                    return toDeviceEvent;
+                })
+                .forEach(
+                    function(toDeviceEvent) {
+                        const content = toDeviceEvent.getContent();
+                        if (
+                            toDeviceEvent.getType() == "m.room.message" &&
+                            content.msgtype == "m.bad.encrypted"
+                        ) {
+                            // the mapper already logged a warning.
+                            logger.log(
+                                'Ignoring undecryptable to-device event from ' +
+                                toDeviceEvent.getSender(),
+                            );
+                            return;
+                        }
+
+                        if (toDeviceEvent.getType() === "m.key.verification.start"
+                            || toDeviceEvent.getType() === "m.key.verification.request") {
+                            const txnId = content['transaction_id'];
+                            if (cancelledKeyVerificationTxns.includes(txnId)) {
+                                toDeviceEvent.flagCancelled();
+                            }
+                        }
+
+                        client.emit(ClientEvent.ToDeviceEvent, toDeviceEvent);
+                    },
+                );
+        } else {
+            // no more to-device events: we can stop polling with a short timeout.
+            this.catchingUp = false;
+        }
+
+        // the returned json structure is a bit crap, so make it into a
+        // nicer form (array) after applying sanity to make sure we don't fail
+        // on missing keys (on the off chance)
+        let inviteRooms: WrappedRoom<IInvitedRoom>[] = [];
+        let joinRooms: WrappedRoom<IJoinedRoom>[] = [];
+        let leaveRooms: WrappedRoom<ILeftRoom>[] = [];
+
+        if (data.rooms) {
+            if (data.rooms.invite) {
+                inviteRooms = this.mapSyncResponseToRoomArray(data.rooms.invite);
+            }
+            if (data.rooms.join) {
+                joinRooms = this.mapSyncResponseToRoomArray(data.rooms.join);
+            }
+            if (data.rooms.leave) {
+                leaveRooms = this.mapSyncResponseToRoomArray(data.rooms.leave);
+            }
+        }
+
+        this.notifEvents = [];
+
+        // Handle invites
+        inviteRooms.forEach((inviteObj) => {
+            const room = inviteObj.room;
+            const stateEvents = this.mapSyncEventsFormat(inviteObj.invite_state, room);
+
+            this.processRoomEvents(room, stateEvents);
+            if (inviteObj.isBrandNewRoom) {
+                room.recalculate();
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+            stateEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            room.updateMyMembership("invite");
+        });
+
+        // Handle joins
+        await utils.promiseMapSeries(joinRooms, async (joinObj) => {
+            const room = joinObj.room;
+            const stateEvents = this.mapSyncEventsFormat(joinObj.state, room);
+            // Prevent events from being decrypted ahead of time
+            // this helps large account to speed up faster
+            // room::decryptCriticalEvent is in charge of decrypting all the events
+            // required for a client to function properly
+            const events = this.mapSyncEventsFormat(joinObj.timeline, room, false);
+            const ephemeralEvents = this.mapSyncEventsFormat(joinObj.ephemeral);
+            const accountDataEvents = this.mapSyncEventsFormat(joinObj.account_data);
+
+            const encrypted = client.isRoomEncrypted(room.roomId);
+            // we do this first so it's correct when any of the events fire
+            if (joinObj.unread_notifications) {
+                room.setUnreadNotificationCount(
+                    NotificationCountType.Total,
+                    joinObj.unread_notifications.notification_count,
+                );
+
+                // We track unread notifications ourselves in encrypted rooms, so don't
+                // bother setting it here. We trust our calculations better than the
+                // server's for this case, and therefore will assume that our non-zero
+                // count is accurate.
+                if (!encrypted
+                    || (encrypted && room.getUnreadNotificationCount(NotificationCountType.Highlight) <= 0)) {
+                    room.setUnreadNotificationCount(
+                        NotificationCountType.Highlight,
+                        joinObj.unread_notifications.highlight_count,
+                    );
+                }
+            }
+
+            joinObj.timeline = joinObj.timeline || {} as ITimeline;
+
+            if (joinObj.isBrandNewRoom) {
+                // set the back-pagination token. Do this *before* adding any
+                // events so that clients can start back-paginating.
+                room.getLiveTimeline().setPaginationToken(
+                    joinObj.timeline.prev_batch, EventTimeline.BACKWARDS);
+            } else if (joinObj.timeline.limited) {
+                let limited = true;
+
+                // we've got a limited sync, so we *probably* have a gap in the
+                // timeline, so should reset. But we might have been peeking or
+                // paginating and already have some of the events, in which
+                // case we just want to append any subsequent events to the end
+                // of the existing timeline.
+                //
+                // This is particularly important in the case that we already have
+                // *all* of the events in the timeline - in that case, if we reset
+                // the timeline, we'll end up with an entirely empty timeline,
+                // which we'll try to paginate but not get any new events (which
+                // will stop us linking the empty timeline into the chain).
+                //
+                for (let i = events.length - 1; i >= 0; i--) {
+                    const eventId = events[i].getId();
+                    if (room.getTimelineForEvent(eventId)) {
+                        debuglog("Already have event " + eventId + " in limited " +
+                            "sync - not resetting");
+                        limited = false;
+
+                        // we might still be missing some of the events before i;
+                        // we don't want to be adding them to the end of the
+                        // timeline because that would put them out of order.
+                        events.splice(0, i);
+
+                        // XXX: there's a problem here if the skipped part of the
+                        // timeline modifies the state set in stateEvents, because
+                        // we'll end up using the state from stateEvents rather
+                        // than the later state from timelineEvents. We probably
+                        // need to wind stateEvents forward over the events we're
+                        // skipping.
+
+                        break;
+                    }
+                }
+
+                if (limited) {
+                    this.deregisterStateListeners(room);
+                    room.resetLiveTimeline(
+                        joinObj.timeline.prev_batch,
+                        this.opts.canResetEntireTimeline(room.roomId) ?
+                            null : syncEventData.oldSyncToken,
+                    );
+
+                    // We have to assume any gap in any timeline is
+                    // reason to stop incrementally tracking notifications and
+                    // reset the timeline.
+                    client.resetNotifTimelineSet();
+
+                    this.registerStateListeners(room);
+                }
+            }
+
+            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
+
+            this.processRoomEvents(room, stateEvents, timelineEvents, syncEventData.fromCache);
+
+            // set summary after processing events,
+            // because it will trigger a name calculation
+            // which needs the room state to be up to date
+            if (joinObj.summary) {
+                room.setSummary(joinObj.summary);
+            }
+
+            // we deliberately don't add ephemeral events to the timeline
+            room.addEphemeralEvents(ephemeralEvents);
+
+            // we deliberately don't add accountData to the timeline
+            room.addAccountData(accountDataEvents);
+
+            room.recalculate();
+            if (joinObj.isBrandNewRoom) {
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+
+            this.processEventsForNotifs(room, events);
+
+            const processRoomEvent = async (e) => {
+                client.emit(ClientEvent.Event, e);
+                if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
+                    await this.opts.crypto.onCryptoEvent(e);
+                }
+                if (e.isState() && e.getType() === "im.vector.user_status") {
+                    let user = client.store.getUser(e.getStateKey());
+                    if (user) {
+                        user.unstable_updateStatusMessage(e);
+                    } else {
+                        user = createNewUser(client, e.getStateKey());
+                        user.unstable_updateStatusMessage(e);
+                        client.store.storeUser(user);
+                    }
+                }
+            };
+
+            await utils.promiseMapSeries(stateEvents, processRoomEvent);
+            await utils.promiseMapSeries(timelineEvents, processRoomEvent);
+            await utils.promiseMapSeries(threadedEvents, processRoomEvent);
+            ephemeralEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            accountDataEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+
+            room.updateMyMembership("join");
+
+            // Decrypt only the last message in all rooms to make sure we can generate a preview
+            // And decrypt all events after the recorded read receipt to ensure an accurate
+            // notification count
+            room.decryptCriticalEvents();
+        });
+
+        // Handle leaves (e.g. kicked rooms)
+        leaveRooms.forEach(async (leaveObj) => {
+            const room = leaveObj.room;
+            const stateEvents = this.mapSyncEventsFormat(leaveObj.state, room);
+            const events = this.mapSyncEventsFormat(leaveObj.timeline, room);
+            const accountDataEvents = this.mapSyncEventsFormat(leaveObj.account_data);
+
+            const [timelineEvents, threadedEvents] = this.client.partitionThreadedEvents(events);
+
+            this.processRoomEvents(room, stateEvents, timelineEvents);
+            room.addAccountData(accountDataEvents);
+
+            room.recalculate();
+            if (leaveObj.isBrandNewRoom) {
+                client.store.storeRoom(room);
+                client.emit(ClientEvent.Room, room);
+            }
+
+            this.processEventsForNotifs(room, events);
+
+            stateEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            timelineEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            threadedEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+            accountDataEvents.forEach(function(e) {
+                client.emit(ClientEvent.Event, e);
+            });
+
+            room.updateMyMembership("leave");
+        });
+
+        // update the notification timeline, if appropriate.
+        // we only do this for live events, as otherwise we can't order them sanely
+        // in the timeline relative to ones paginated in by /notifications.
+        // XXX: we could fix this by making EventTimeline support chronological
+        // ordering... but it doesn't, right now.
+        if (syncEventData.oldSyncToken && this.notifEvents.length) {
+            this.notifEvents.sort(function(a, b) {
+                return a.getTs() - b.getTs();
+            });
+            this.notifEvents.forEach(function(event) {
+                client.getNotifTimelineSet().addLiveEvent(event);
+            });
+        }
+
+        // Handle device list updates
+        if (data.device_lists) {
+            if (this.opts.crypto) {
+                await this.opts.crypto.handleDeviceListChanges(syncEventData, data.device_lists);
+            } else {
+                // FIXME if we *don't* have a crypto module, we still need to
+                // invalidate the device lists. But that would require a
+                // substantial bit of rework :/.
+            }
+        }
+
+        // Handle one_time_keys_count
+        if (this.opts.crypto && data.device_one_time_keys_count) {
+            const currentCount = data.device_one_time_keys_count.signed_curve25519 || 0;
+            this.opts.crypto.updateOneTimeKeyCount(currentCount);
+        }
+        if (this.opts.crypto &&
+            (data["device_unused_fallback_key_types"] ||
+                data["org.matrix.msc2732.device_unused_fallback_key_types"])) {
+            // The presence of device_unused_fallback_key_types indicates that the
+            // server supports fallback keys. If there's no unused
+            // signed_curve25519 fallback key we need a new one.
+            const unusedFallbackKeys = data["device_unused_fallback_key_types"] ||
+                data["org.matrix.msc2732.device_unused_fallback_key_types"];
+            this.opts.crypto.setNeedsNewFallback(
+                unusedFallbackKeys instanceof Array &&
+                !unusedFallbackKeys.includes("signed_curve25519"),
+            );
+        }
+    }
+
+    /**
+     * Starts polling the connectivity check endpoint
+     * @param {number} delay How long to delay until the first poll.
+     *        defaults to a short, randomised interval (to prevent
+     *        tightlooping if /versions succeeds but /sync etc. fail).
+     * @return {promise} which resolves once the connection returns
+     */
+    private startKeepAlives(delay?: number): Promise<boolean> {
+        if (delay === undefined) {
+            delay = 2000 + Math.floor(Math.random() * 5000);
+        }
+
+        if (this.keepAliveTimer !== null) {
+            clearTimeout(this.keepAliveTimer);
+        }
+        if (delay > 0) {
+            this.keepAliveTimer = setTimeout(this.pokeKeepAlive.bind(this), delay);
+        } else {
+            this.pokeKeepAlive();
+        }
+        if (!this.connectionReturnedDefer) {
+            this.connectionReturnedDefer = utils.defer();
+        }
+        return this.connectionReturnedDefer.promise;
+    }
+
+    /**
+     * Make a dummy call to /_matrix/client/versions, to see if the HS is
+     * reachable.
+     *
+     * On failure, schedules a call back to itself. On success, resolves
+     * this.connectionReturnedDefer.
+     *
+     * @param {boolean} connDidFail True if a connectivity failure has been detected. Optional.
+     */
+    private pokeKeepAlive(connDidFail = false): void {
+        const success = () => {
+            clearTimeout(this.keepAliveTimer);
+            if (this.connectionReturnedDefer) {
+                this.connectionReturnedDefer.resolve(connDidFail);
+                this.connectionReturnedDefer = null;
+            }
+        };
+
+        this.client.http.request(
+            undefined, // callback
+            Method.Get, "/_matrix/client/versions",
+            undefined, // queryParams
+            undefined, // data
+            {
+                prefix: '',
+                localTimeoutMs: 15 * 1000,
+            },
+        ).then(() => {
+            success();
+        }, (err) => {
+            if (err.httpStatus == 400 || err.httpStatus == 404) {
+                // treat this as a success because the server probably just doesn't
+                // support /versions: point is, we're getting a response.
+                // We wait a short time though, just in case somehow the server
+                // is in a mode where it 400s /versions responses and sync etc.
+                // responses fail, this will mean we don't hammer in a loop.
+                this.keepAliveTimer = setTimeout(success, 2000);
+            } else {
+                connDidFail = true;
+                this.keepAliveTimer = setTimeout(
+                    this.pokeKeepAlive.bind(this, connDidFail),
+                    5000 + Math.floor(Math.random() * 5000),
+                );
+                // A keepalive has failed, so we emit the
+                // error state (whether or not this is the
+                // first failure).
+                // Note we do this after setting the timer:
+                // this lets the unit tests advance the mock
+                // clock when they get the error.
+                this.updateSyncState(SyncState.Error, { error: err });
+            }
+        });
+    }
+
+    /**
+     * @param {Object} obj
+     * @return {Object[]}
+     */
+    private mapSyncResponseToRoomArray<T extends ILeftRoom | IJoinedRoom | IInvitedRoom>(
+        obj: Record<string, T>,
+    ): Array<WrappedRoom<T>> {
+        // Maps { roomid: {stuff}, roomid: {stuff} }
+        // to
+        // [{stuff+Room+isBrandNewRoom}, {stuff+Room+isBrandNewRoom}]
+        const client = this.client;
+        return Object.keys(obj).map((roomId) => {
+            const arrObj = obj[roomId] as T & { room: Room, isBrandNewRoom: boolean };
+            let room = client.store.getRoom(roomId);
+            let isBrandNewRoom = false;
+            if (!room) {
+                room = this.createRoom(roomId);
+                isBrandNewRoom = true;
+            }
+            arrObj.room = room;
+            arrObj.isBrandNewRoom = isBrandNewRoom;
+            return arrObj;
+        });
+    }
+
+    /**
+     * @param {Object} obj
+     * @param {Room} room
+     * @param {boolean} decrypt
+     * @return {MatrixEvent[]}
+     */
+    private mapSyncEventsFormat(
+        obj: IInviteState | ITimeline | IEphemeral,
+        room?: Room,
+        decrypt = true,
+    ): MatrixEvent[] {
+        if (!obj || !Array.isArray(obj.events)) {
+            return [];
+        }
+        const mapper = this.client.getEventMapper({ decrypt });
+        return (obj.events as Array<IStrippedState | IRoomEvent | IStateEvent | IMinimalEvent>).map(function(e) {
+            if (room) {
+                e["room_id"] = room.roomId;
+            }
+            return mapper(e);
+        });
+    }
+
+    /**
+     * @param {Room} room
+     */
+    private resolveInvites(room: Room): void {
+        if (!room || !this.opts.resolveInvitesToProfiles) {
+            return;
+        }
+        const client = this.client;
+        // For each invited room member we want to give them a displayname/avatar url
+        // if they have one (the m.room.member invites don't contain this).
+        room.getMembersWithMembership("invite").forEach(function(member) {
+            if (member._requestedProfileInfo) return;
+            member._requestedProfileInfo = true;
+            // try to get a cached copy first.
+            const user = client.getUser(member.userId);
+            let promise;
+            if (user) {
+                promise = Promise.resolve({
+                    avatar_url: user.avatarUrl,
+                    displayname: user.displayName,
+                });
+            } else {
+                promise = client.getProfileInfo(member.userId);
+            }
+            promise.then(function(info) {
+                // slightly naughty by doctoring the invite event but this means all
+                // the code paths remain the same between invite/join display name stuff
+                // which is a worthy trade-off for some minor pollution.
+                const inviteEvent = member.events.member;
+                if (inviteEvent.getContent().membership !== "invite") {
+                    // between resolving and now they have since joined, so don't clobber
+                    return;
+                }
+                inviteEvent.getContent().avatar_url = info.avatar_url;
+                inviteEvent.getContent().displayname = info.displayname;
+                // fire listeners
+                member.setMembershipEvent(inviteEvent, room.currentState);
+            }, function(err) {
+                // OH WELL.
+            });
+        });
+    }
+
+    /**
+     * @param {Room} room
+     * @param {MatrixEvent[]} stateEventList A list of state events. This is the state
+     * at the *START* of the timeline list if it is supplied.
+     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
+     * @param {boolean} fromCache whether the sync response came from cache
+     * is earlier in time. Higher index is later.
+     */
+    private processRoomEvents(
+        room: Room,
+        stateEventList: MatrixEvent[],
+        timelineEventList?: MatrixEvent[],
+        fromCache = false,
+    ): void {
+        // If there are no events in the timeline yet, initialise it with
+        // the given state events
+        const liveTimeline = room.getLiveTimeline();
+        const timelineWasEmpty = liveTimeline.getEvents().length == 0;
+        if (timelineWasEmpty) {
+            // Passing these events into initialiseState will freeze them, so we need
+            // to compute and cache the push actions for them now, otherwise sync dies
+            // with an attempt to assign to read only property.
+            // XXX: This is pretty horrible and is assuming all sorts of behaviour from
+            // these functions that it shouldn't be. We should probably either store the
+            // push actions cache elsewhere so we can freeze MatrixEvents, or otherwise
+            // find some solution where MatrixEvents are immutable but allow for a cache
+            // field.
+            for (const ev of stateEventList) {
+                this.client.getPushActionsForEvent(ev);
+            }
+            liveTimeline.initialiseState(stateEventList);
+        }
+
+        this.resolveInvites(room);
+
+        // recalculate the room name at this point as adding events to the timeline
+        // may make notifications appear which should have the right name.
+        // XXX: This looks suspect: we'll end up recalculating the room once here
+        // and then again after adding events (processSyncResponse calls it after
+        // calling us) even if no state events were added. It also means that if
+        // one of the room events in timelineEventList is something that needs
+        // a recalculation (like m.room.name) we won't recalculate until we've
+        // finished adding all the events, which will cause the notification to have
+        // the old room name rather than the new one.
+        room.recalculate();
+
+        // If the timeline wasn't empty, we process the state events here: they're
+        // defined as updates to the state before the start of the timeline, so this
+        // starts to roll the state forward.
+        // XXX: That's what we *should* do, but this can happen if we were previously
+        // peeking in a room, in which case we obviously do *not* want to add the
+        // state events here onto the end of the timeline. Historically, the js-sdk
+        // has just set these new state events on the old and new state. This seems
+        // very wrong because there could be events in the timeline that diverge the
+        // state, in which case this is going to leave things out of sync. However,
+        // for now I think it;s best to behave the same as the code has done previously.
+        if (!timelineWasEmpty) {
+            // XXX: As above, don't do this...
+            //room.addLiveEvents(stateEventList || []);
+            // Do this instead...
+            room.oldState.setStateEvents(stateEventList || []);
+            room.currentState.setStateEvents(stateEventList || []);
+        }
+        // execute the timeline events. This will continue to diverge the current state
+        // if the timeline has any state events in it.
+        // This also needs to be done before running push rules on the events as they need
+        // to be decorated with sender etc.
+        room.addLiveEvents(timelineEventList || [], null, fromCache);
+    }
+
+    /**
+     * Takes a list of timelineEvents and adds and adds to notifEvents
+     * as appropriate.
+     * This must be called after the room the events belong to has been stored.
+     *
+     * @param {Room} room
+     * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
+     * is earlier in time. Higher index is later.
+     */
+    private processEventsForNotifs(room: Room, timelineEventList: MatrixEvent[]): void {
+        // gather our notifications into this.notifEvents
+        if (this.client.getNotifTimelineSet()) {
+            for (let i = 0; i < timelineEventList.length; i++) {
+                const pushActions = this.client.getPushActionsForEvent(timelineEventList[i]);
+                if (pushActions && pushActions.notify &&
+                    pushActions.tweaks && pushActions.tweaks.highlight) {
+                    this.notifEvents.push(timelineEventList[i]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the sync state and emits an event to say so
+     * @param {String} newState The new state string
+     * @param {Object} data Object of additional data to emit in the event
+     */
+    private updateSyncState(newState: SyncState, data?: ISyncStateData): void {
+        const old = this.syncState;
+        this.syncState = newState;
+        this.syncStateData = data;
+        this.client.emit(ClientEvent.Sync, this.syncState, old, data);
+    }
+
+    /**
+     * Event handler for the 'online' event
+     * This event is generally unreliable and precise behaviour
+     * varies between browsers, so we poll for connectivity too,
+     * but this might help us reconnect a little faster.
+     */
+    private onOnline = (): void => {
+        debuglog("Browser thinks we are back online");
+        this.startKeepAlives(0);
+    };
+}
+
+function createNewUser(client: MatrixClient, userId: string): User {
+    const user = new User(userId);
+    client.reEmitter.reEmit(user, [
+        UserEvent.AvatarUrl,
+        UserEvent.DisplayName,
+        UserEvent.Presence,
+        UserEvent.CurrentlyActive,
+        UserEvent.LastPresenceTs,
+    ]);
+    return user;
+}
+


### PR DESCRIPTION
This PR adds API support for Sliding Sync. This is a big change and can be broken down into sliding sync specific changes and general JS SDK changes (which are inherently more risky and needs closer attention).

JS SDK changes:
 - `IRequestOpts` in `http-api.ts` now accepts an optional `baseUrl`. It already accepts a `prefix` but that isn't enough for sliding sync because we want to redirect `/sync` requests to a different server entirely (the proxy server), hence this was added.
 - `slidingSync` has been added as a function to `MatrixClient`. This function just makes a `/sync` request: it doesn't handle the loop or retries.
 - `IStartClientOpts` in `client.ts` now accepts an optional `slidingSync` object, which must be of type `SlidingSync`. If this is present, JS SDK operates in Sliding Sync mode.

Sliding Sync changes:
 - Added new files:
     * `sliding-sync.ts`: contains the core sliding sync API and event loop handling. Does not handle interactions with JS SDK innards. Exposes an event emitter for sliding sync data.
     * `siding-sync-sdk.ts`: contains JS SDK <--> sliding sync data mappings. Listens for events emitted by `SlidingSync`.
     * `conn-management.ts`: factored out keep-alive code. Same as sync v2 otherwise.

Limitations:
 - The data mappings in `sliding-sync-sdk.ts` are very bare bones currently - only state/timeline events are handled (not ephemeral/account/to-device/E2EE). This will be expanded upon in the future.

Contains integration tests for `SlidingSync`. No tests exist yet for `SlidingSyncSdk`.
