### PR TITLE
add upsert function for updating beacon events

### DIFF
--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -59,6 +59,18 @@ describe('Beacon content helpers', () => {
             }));
         });
 
+        it('uses timestamp when provided', () => {
+            expect(makeBeaconInfoContent(
+                1234,
+                true,
+                'nice beacon_info',
+                LocationAssetType.Pin,
+                99999,
+            )).toEqual(expect.objectContaining({
+                [M_TIMESTAMP.name]: 99999,
+            }));
+        });
+
         it('defaults asset type to self when not set', () => {
             expect(makeBeaconInfoContent(
                 1234,

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -122,6 +122,7 @@ describe('Beacon', () => {
             expect(beacon.roomId).toEqual(roomId);
             expect(beacon.isLive).toEqual(true);
             expect(beacon.beaconInfoOwner).toEqual(userId);
+            expect(beacon.beaconInfoEventType).toEqual(liveBeaconEvent.getType());
         });
 
         describe('isLive()', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3686,14 +3686,32 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns {ISendEventResponse}
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    unstable_createLiveBeacon(
+    public async unstable_createLiveBeacon(
         roomId: Room["roomId"],
         beaconInfoContent: MBeaconInfoEventContent,
         eventTypeSuffix: string,
     ) {
         const userId = this.getUserId();
         const eventType = M_BEACON_INFO_VARIABLE.name.replace('*', `${userId}.${eventTypeSuffix}`);
-        return this.sendStateEvent(roomId, eventType, beaconInfoContent, userId);
+        return this.unstable_setLiveBeacon(roomId, eventType, beaconInfoContent);
+    }
+
+    /**
+     * Upsert a live beacon event
+     * using a specific m.beacon_info.* event variable type
+     * @param {string} roomId string
+     * @param {string} beaconInfoEventType event type including variable suffix
+     * @param {MBeaconInfoEventContent} beaconInfoContent
+     * @returns {ISendEventResponse}
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public async unstable_setLiveBeacon(
+        roomId: string,
+        beaconInfoEventType: string,
+        beaconInfoContent: MBeaconInfoEventContent,
+    ) {
+        const userId = this.getUserId();
+        return this.sendStateEvent(roomId, beaconInfoEventType, beaconInfoContent, userId);
     }
 
     /**

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -198,6 +198,7 @@ export type MakeBeaconInfoContent = (
     isLive?: boolean,
     description?: string,
     assetType?: LocationAssetType,
+    timestamp?: number
 ) => MBeaconInfoEventContent;
 
 export const makeBeaconInfoContent: MakeBeaconInfoContent = (
@@ -205,13 +206,14 @@ export const makeBeaconInfoContent: MakeBeaconInfoContent = (
     isLive,
     description,
     assetType,
+    timestamp,
 ) => ({
     [M_BEACON_INFO.name]: {
         description,
         timeout,
         live: isLive,
     },
-    [M_TIMESTAMP.name]: Date.now(),
+    [M_TIMESTAMP.name]: timestamp || Date.now(),
     [M_ASSET.name]: {
         type: assetType ?? LocationAssetType.Self,
     },

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -44,7 +44,7 @@ export const isBeaconInfoEventType = (type: string) =>
 // https://github.com/matrix-org/matrix-spec-proposals/pull/3489
 export class Beacon extends TypedEventEmitter<BeaconEvent, BeaconEventHandlerMap> {
     public readonly roomId: string;
-    private beaconInfo: BeaconInfoState;
+    private _beaconInfo: BeaconInfoState;
     private _isLive: boolean;
     private livenessWatchInterval: number;
 
@@ -73,6 +73,10 @@ export class Beacon extends TypedEventEmitter<BeaconEvent, BeaconEventHandlerMap
         return this.rootEvent.getType();
     }
 
+    public get beaconInfo(): BeaconInfoState {
+        return this._beaconInfo;
+    }
+
     public update(beaconInfoEvent: MatrixEvent): void {
         if (beaconInfoEvent.getId() !== this.beaconInfoId) {
             throw new Error('Invalid updating event');
@@ -99,7 +103,7 @@ export class Beacon extends TypedEventEmitter<BeaconEvent, BeaconEventHandlerMap
         }
 
         if (this.isLive) {
-            const expiryInMs = (this.beaconInfo?.timestamp + this.beaconInfo?.timeout + 1) - Date.now();
+            const expiryInMs = (this._beaconInfo?.timestamp + this._beaconInfo?.timeout + 1) - Date.now();
             if (expiryInMs > 1) {
                 this.livenessWatchInterval = setInterval(this.checkLiveness.bind(this), expiryInMs);
             }
@@ -107,14 +111,14 @@ export class Beacon extends TypedEventEmitter<BeaconEvent, BeaconEventHandlerMap
     }
 
     private setBeaconInfo(event: MatrixEvent): void {
-        this.beaconInfo = parseBeaconInfoContent(event.getContent());
+        this._beaconInfo = parseBeaconInfoContent(event.getContent());
         this.checkLiveness();
     }
 
     private checkLiveness(): void {
         const prevLiveness = this.isLive;
-        this._isLive = this.beaconInfo?.live &&
-            isTimestampInDuration(this.beaconInfo?.timestamp, this.beaconInfo?.timeout, Date.now());
+        this._isLive = this._beaconInfo?.live &&
+            isTimestampInDuration(this._beaconInfo?.timestamp, this._beaconInfo?.timeout, Date.now());
 
         if (prevLiveness !== this.isLive) {
             this.emit(BeaconEvent.LivenessChange, this.isLive, this);

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -69,6 +69,10 @@ export class Beacon extends TypedEventEmitter<BeaconEvent, BeaconEventHandlerMap
         return this.rootEvent.getStateKey();
     }
 
+    public get beaconInfoEventType(): string {
+        return this.rootEvent.getType();
+    }
+
     public update(beaconInfoEvent: MatrixEvent): void {
         if (beaconInfoEvent.getId() !== this.beaconInfoId) {
             throw new Error('Invalid updating event');


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

- Adds a function to allow updating beacon_info events using suffixed m.beacon_info.* event types.
- expose event type on beacon model
- allow setting timestamp on beacon info content helper

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
