### PR TITLE
Thread list ordering by last reply

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -93,14 +93,7 @@ export enum RelationType {
     Annotation = "m.annotation",
     Replace = "m.replace",
     Reference = "m.reference",
-    /**
-     * Note, "io.element.thread" is hardcoded
-     * Should be replaced with "m.thread" once MSC3440 lands
-     * Can not use `UnstableValue` as TypeScript does not
-     * allow computed values in enums
-     * https://github.com/microsoft/TypeScript/issues/27976
-     */
-    Thread = "io.element.thread",
+    Thread = "m.thread",
 }
 
 export enum MsgType {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -86,9 +86,17 @@ export interface IEvent {
     unsigned: IUnsigned;
     redacts?: string;
 
-    // v1 legacy fields
+    /**
+     * @deprecated
+     */
     user_id?: string;
+    /**
+     * @deprecated
+     */
     prev_content?: IContent;
+    /**
+     * @deprecated
+     */
     age?: number;
 }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1500,11 +1500,22 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
             return threadRelationship.current_user_participated;
         });
 
+        const roomState = this.getLiveTimeline().getState(EventTimeline.FORWARDS);
         for (const event of orderedByLastReplyEvents) {
-            this.threadsTimelineSets[0].addLiveEvent(event);
+            this.threadsTimelineSets[0].addLiveEvent(
+                event,
+                DuplicateStrategy.Ignore,
+                false,
+                roomState,
+            );
         }
         for (const event of myThreads) {
-            this.threadsTimelineSets[1].addLiveEvent(event);
+            this.threadsTimelineSets[1].addLiveEvent(
+                event,
+                DuplicateStrategy.Ignore,
+                false,
+                roomState,
+            );
         }
 
         this.client.decryptEventIfNeeded(orderedByLastReplyEvents[orderedByLastReplyEvents.length -1]);


### PR DESCRIPTION
Currently trying to get a relevant set of tests coming. Watch this space

- Initial thread list fetch in correct ordering
- re-order thread list on new reply
- Add state to thread list event

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
