### PR TITLE
Prevent exception 'Unable to set up secret storage'

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -920,7 +920,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             // secrets using it, in theory. We could move them to the new key but a)
             // that would mean we'd need to prompt for the old passphrase, and b)
             // it's not clear that would be the right thing to do anyway.
-            const { keyInfo, privateKey } = await createSecretStorageKey();
+            const { keyInfo = {} as IAddSecretStorageKeyOpts, privateKey } = await createSecretStorageKey();
             newKeyId = await createSSSS(keyInfo, privateKey);
         } else if (!storageExists && keyBackupInfo) {
             // we have an existing backup, but no SSSS


### PR DESCRIPTION
Some of the code in `createSSSS()` assumed that keyInfo was not undefined, so default it to `{}`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent exception 'Unable to set up secret storage' ([\#2260](https://github.com/matrix-org/matrix-js-sdk/pull/2260)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->