### PR TITLE
Change `_unstable_getSharedRooms` to `_unstable_getMutualRooms`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6408,11 +6408,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {Promise<string[]>} Resolves to a set of rooms
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public async _unstable_getSharedRooms(userId: string): Promise<string[]> { // eslint-disable-line
+    public async _unstable_getMutualRooms(userId: string): Promise<string[]> { // eslint-disable-line
         if (!(await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666"))) {
-            throw Error('Server does not support shared_rooms API');
+            throw Error('Server does not support mutual_rooms API');
         }
-        const path = utils.encodeUri("/uk.half-shot.msc2666/user/shared_rooms/$userId", {
+        const path = utils.encodeUri("/uk.half-shot.msc2666/user/mutual_rooms/$userId", {
             $userId: userId,
         });
         const res = await this.http.authedRequest<{ joined: string[] }>(

--- a/src/client.ts
+++ b/src/client.ts
@@ -6408,7 +6408,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {Promise<string[]>} Resolves to a set of rooms
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public async _unstable_getMutualRooms(userId: string): Promise<string[]> { // eslint-disable-line
+    public async _unstable_getSharedRooms(userId: string): Promise<string[]> { // eslint-disable-line
         if (!(await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666"))) {
             throw Error('Server does not support mutual_rooms API');
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -6409,7 +6409,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
     public async _unstable_getSharedRooms(userId: string): Promise<string[]> { // eslint-disable-line
-        if (!(await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666"))) {
+        if (!(await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666.mutual_rooms"))) {
             throw Error('Server does not support mutual_rooms API');
         }
         const path = utils.encodeUri("/uk.half-shot.msc2666/user/mutual_rooms/$userId", {

--- a/src/client.ts
+++ b/src/client.ts
@@ -6409,12 +6409,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
     public async _unstable_getSharedRooms(userId: string): Promise<string[]> { // eslint-disable-line
-        if (!(await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666.mutual_rooms"))) {
+        const sharedRoomsSupport = await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666");
+        const mutualRoomsSupport = await this.doesServerSupportUnstableFeature("uk.half-shot.msc2666.mutual_rooms");
+
+        if (!sharedRoomsSupport && !mutualRoomsSupport) {
             throw Error('Server does not support mutual_rooms API');
         }
-        const path = utils.encodeUri("/uk.half-shot.msc2666/user/mutual_rooms/$userId", {
-            $userId: userId,
-        });
+
+        const path = utils.encodeUri(
+            `/uk.half-shot.msc2666/user/${mutualRoomsSupport ? 'mutual_rooms' : 'shared_rooms'}/$userId`,
+            { $userId: userId },
+        );
+
         const res = await this.http.authedRequest<{ joined: string[] }>(
             undefined, Method.Get, path, undefined, undefined,
             { prefix: PREFIX_UNSTABLE },


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

In accordance with changes to https://github.com/matrix-org/matrix-spec-proposals/pull/2666, renaming from "shared" to "mutual".

This updates https://github.com/matrix-org/matrix-js-sdk/pull/1417
This blocks https://github.com/matrix-org/matrix-react-sdk/pull/4897

Notes: Change `_unstable_getSharedRooms` to `_unstable_getMutualRooms` and update unstable URL.
Type: task

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->