### PR TITLE
Make self membership less prone to races

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2228,22 +2228,27 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
         // set fake stripped state events if this is an invite room so logic remains
         // consistent elsewhere.
         const membershipEvent = this.currentState.getStateEvents(EventType.RoomMember, this.myUserId);
-        if (membershipEvent && membershipEvent.getContent().membership === "invite") {
-            const strippedStateEvents = membershipEvent.getUnsigned().invite_room_state || [];
-            strippedStateEvents.forEach((strippedEvent) => {
-                const existingEvent = this.currentState.getStateEvents(strippedEvent.type, strippedEvent.state_key);
-                if (!existingEvent) {
-                    // set the fake stripped event instead
-                    this.currentState.setStateEvents([new MatrixEvent({
-                        type: strippedEvent.type,
-                        state_key: strippedEvent.state_key,
-                        content: strippedEvent.content,
-                        event_id: "$fake" + Date.now(),
-                        room_id: this.roomId,
-                        user_id: this.myUserId, // technically a lie
-                    })]);
-                }
-            });
+        if (membershipEvent) {
+            const membership = membershipEvent.getContent().membership;
+            this.updateMyMembership(membership);
+
+            if (membership === "invite") {
+                const strippedStateEvents = membershipEvent.getUnsigned().invite_room_state || [];
+                strippedStateEvents.forEach((strippedEvent) => {
+                    const existingEvent = this.currentState.getStateEvents(strippedEvent.type, strippedEvent.state_key);
+                    if (!existingEvent) {
+                        // set the fake stripped event instead
+                        this.currentState.setStateEvents([new MatrixEvent({
+                            type: strippedEvent.type,
+                            state_key: strippedEvent.state_key,
+                            content: strippedEvent.content,
+                            event_id: "$fake" + Date.now(),
+                            room_id: this.roomId,
+                            user_id: this.myUserId, // technically a lie
+                        })]);
+                    }
+                });
+            }
         }
 
         const oldName = this.name;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1170,7 +1170,6 @@ export class SyncApi {
             stateEvents.forEach(function(e) {
                 client.emit(ClientEvent.Event, e);
             });
-            room.updateMyMembership("invite");
         });
 
         // Handle joins
@@ -1317,8 +1316,6 @@ export class SyncApi {
                 client.emit(ClientEvent.Event, e);
             });
 
-            room.updateMyMembership("join");
-
             // Decrypt only the last message in all rooms to make sure we can generate a preview
             // And decrypt all events after the recorded read receipt to ensure an accurate
             // notification count
@@ -1352,8 +1349,6 @@ export class SyncApi {
             accountDataEvents.forEach(function(e) {
                 client.emit(ClientEvent.Event, e);
             });
-
-            room.updateMyMembership("leave");
         });
 
         // update the notification timeline, if appropriate.


### PR DESCRIPTION
Previously, if you tried to peek a room while the sync loop was still pulling in your own join event for that room, the peek could end up overwriting the synced membership with `null`, causing the room to get stuck in a 'peeking' state. By bundling the call to `updateMyMembership` with `recalculate`, we ensure that it the actual latest membership value gets set.

Type: defect

Closes https://github.com/vector-im/element-web/issues/21661.