### PR TITLE
Live location sharing - update beacon_info implementation to latest MSC

### DIFF
--- a/spec/test-utils/beacon.ts
+++ b/spec/test-utils/beacon.ts
@@ -42,7 +42,6 @@ export const makeBeaconInfoEvent = (
     roomId: string,
     contentProps: Partial<InfoContentProps> = {},
     eventId?: string,
-    eventTypeSuffix?: string,
 ): MatrixEvent => {
     const {
         timeout, isLive, description, assetType,
@@ -56,6 +55,8 @@ export const makeBeaconInfoEvent = (
         state_key: sender,
         content: makeBeaconInfoContent(timeout, isLive, description, assetType),
     });
+
+    event.event.origin_server_ts = Date.now();
 
     // live beacons use the beacon_info event id
     // set or default this

--- a/spec/test-utils/beacon.ts
+++ b/spec/test-utils/beacon.ts
@@ -51,7 +51,7 @@ export const makeBeaconInfoEvent = (
         ...contentProps,
     };
     const event = new MatrixEvent({
-        type: `${M_BEACON_INFO.name}.${sender}.${eventTypeSuffix || Date.now()}`,
+        type: M_BEACON_INFO.name,
         room_id: roomId,
         state_key: sender,
         content: makeBeaconInfoContent(timeout, isLive, description, assetType),

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { REFERENCE_RELATION } from "matrix-events-sdk";
 
-import { M_BEACON_INFO } from "../../src/@types/beacon";
 import { LocationAssetType, M_ASSET, M_LOCATION, M_TIMESTAMP } from "../../src/@types/location";
 import { makeBeaconContent, makeBeaconInfoContent } from "../../src/content-helpers";
 

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -36,11 +36,9 @@ describe('Beacon content helpers', () => {
                 'nice beacon_info',
                 LocationAssetType.Pin,
             )).toEqual({
-                [M_BEACON_INFO.name]: {
-                    description: 'nice beacon_info',
-                    timeout: 1234,
-                    live: true,
-                },
+                description: 'nice beacon_info',
+                timeout: 1234,
+                live: true,
                 [M_TIMESTAMP.name]: mockDateNow,
                 [M_ASSET.name]: {
                     type: LocationAssetType.Pin,

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -999,7 +999,7 @@ describe("MatrixClient", function() {
         });
 
         it("creates new beacon info", async () => {
-            await client.unstable_createLiveBeacon(roomId, content, '123');
+            await client.unstable_createLiveBeacon(roomId, content);
 
             // event type combined
             const expectedEventType = M_BEACON_INFO.name;
@@ -1015,15 +1015,13 @@ describe("MatrixClient", function() {
         });
 
         it("updates beacon info with specific event type", async () => {
-            const eventType = M_BEACON_INFO.name;
-
-            await client.unstable_setLiveBeacon(roomId, eventType, content);
+            await client.unstable_setLiveBeacon(roomId, content);
 
             // event type combined
             const [, , path, , requestContent] = client.http.authedRequest.mock.calls[0];
             expect(path).toEqual(
                 `/rooms/${encodeURIComponent(roomId)}/state/` +
-                `${encodeURIComponent(eventType)}/${encodeURIComponent(userId)}`,
+                `${encodeURIComponent(M_BEACON_INFO.name)}/${encodeURIComponent(userId)}`,
             );
             expect(requestContent).toEqual(content);
         });

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1002,7 +1002,7 @@ describe("MatrixClient", function() {
             await client.unstable_createLiveBeacon(roomId, content, '123');
 
             // event type combined
-            const expectedEventType = `${M_BEACON_INFO.name}.${userId}.123`;
+            const expectedEventType = M_BEACON_INFO.name;
             const [callback, method, path, queryParams, requestContent] = client.http.authedRequest.mock.calls[0];
             expect(callback).toBeFalsy();
             expect(method).toBe('PUT');
@@ -1015,7 +1015,7 @@ describe("MatrixClient", function() {
         });
 
         it("updates beacon info with specific event type", async () => {
-            const eventType = `${M_BEACON_INFO.name}.${userId}.456`;
+            const eventType = M_BEACON_INFO.name;
 
             await client.unstable_setLiveBeacon(roomId, eventType, content);
 

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -58,6 +58,7 @@ describe('Beacon', () => {
 
     describe('Beacon', () => {
         const userId = '@user:server.org';
+        const userId2 = '@user2:server.org';
         const roomId = '$room:server.org';
         // 14.03.2022 16:15
         const now = 1647270879403;
@@ -68,6 +69,7 @@ describe('Beacon', () => {
         // without timeout of 3 hours
         let liveBeaconEvent;
         let notLiveBeaconEvent;
+        let user2BeaconEvent;
 
         const advanceDateAndTime = (ms: number) => {
             // bc liveness check uses Date.now we have to advance this mock
@@ -94,6 +96,15 @@ describe('Beacon', () => {
                 { timeout: HOUR_MS * 3, isLive: false },
                 '$dead123',
             );
+            user2BeaconEvent = makeBeaconInfoEvent(
+                userId2,
+                roomId,
+                {
+                    timeout: HOUR_MS * 3,
+                    isLive: true,
+                },
+                '$user2live123',
+            );
 
             // back to now
             jest.spyOn(global.Date, 'now').mockReturnValue(now);
@@ -111,7 +122,7 @@ describe('Beacon', () => {
             expect(beacon.isLive).toEqual(true);
             expect(beacon.beaconInfoOwner).toEqual(userId);
             expect(beacon.beaconInfoEventType).toEqual(liveBeaconEvent.getType());
-            expect(beacon.identifier).toEqual(liveBeaconEvent.getType());
+            expect(beacon.identifier).toEqual(liveBeaconEvent.getStateKey());
             expect(beacon.beaconInfo).toBeTruthy();
         });
 
@@ -149,8 +160,9 @@ describe('Beacon', () => {
 
                 expect(beacon.beaconInfoId).toEqual(liveBeaconEvent.getId());
 
-                expect(() => beacon.update(notLiveBeaconEvent)).toThrow();
-                expect(beacon.isLive).toEqual(true);
+                expect(() => beacon.update(user2BeaconEvent)).toThrow();
+                // didnt update
+                expect(beacon.identifier).toEqual(liveBeaconEvent.getStateKey());
             });
 
             it('updates event', () => {

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -18,7 +18,6 @@ import { EventType } from "../../../src";
 import { M_BEACON_INFO } from "../../../src/@types/beacon";
 import {
     isTimestampInDuration,
-    isBeaconInfoEventType,
     Beacon,
     BeaconEvent,
 } from "../../../src/models/beacon";
@@ -54,25 +53,6 @@ describe('Beacon', () => {
             const twoHourDuration = HOUR_MS * 2;
             const now = startTs + HOUR_MS;
             expect(isTimestampInDuration(startTs, twoHourDuration, now)).toBe(true);
-        });
-    });
-
-    describe('isBeaconInfoEventType', () => {
-        it.each([
-            EventType.CallAnswer,
-            `prefix.${M_BEACON_INFO.name}`,
-            `prefix.${M_BEACON_INFO.altName}`,
-        ])('returns false for %s', (type) => {
-            expect(isBeaconInfoEventType(type)).toBe(false);
-        });
-
-        it.each([
-            M_BEACON_INFO.name,
-            M_BEACON_INFO.altName,
-            `${M_BEACON_INFO.name}.@test:server.org.12345`,
-            `${M_BEACON_INFO.altName}.@test:server.org.12345`,
-        ])('returns true for %s', (type) => {
-            expect(isBeaconInfoEventType(type)).toBe(true);
         });
     });
 

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType } from "../../../src";
-import { M_BEACON_INFO } from "../../../src/@types/beacon";
 import {
     isTimestampInDuration,
     Beacon,
@@ -122,7 +120,7 @@ describe('Beacon', () => {
             expect(beacon.isLive).toEqual(true);
             expect(beacon.beaconInfoOwner).toEqual(userId);
             expect(beacon.beaconInfoEventType).toEqual(liveBeaconEvent.getType());
-            expect(beacon.identifier).toEqual(liveBeaconEvent.getStateKey());
+            expect(beacon.identifier).toEqual(`${roomId}_${userId}`);
             expect(beacon.beaconInfo).toBeTruthy();
         });
 
@@ -162,7 +160,7 @@ describe('Beacon', () => {
 
                 expect(() => beacon.update(user2BeaconEvent)).toThrow();
                 // didnt update
-                expect(beacon.identifier).toEqual(liveBeaconEvent.getStateKey());
+                expect(beacon.identifier).toEqual(`${roomId}_${userId}`);
             });
 
             it('updates event', () => {

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -163,6 +163,24 @@ describe('Beacon', () => {
                 expect(beacon.identifier).toEqual(`${roomId}_${userId}`);
             });
 
+            it('does not update with an older event', () => {
+                const beacon = new Beacon(liveBeaconEvent);
+                const emitSpy = jest.spyOn(beacon, 'emit').mockClear();
+                expect(beacon.beaconInfoId).toEqual(liveBeaconEvent.getId());
+
+                const oldUpdateEvent = makeBeaconInfoEvent(
+                    userId,
+                    roomId,
+                );
+                // less than the original event
+                oldUpdateEvent.event.origin_server_ts = liveBeaconEvent.event.origin_server_ts - 1000;
+
+                beacon.update(oldUpdateEvent);
+                // didnt update
+                expect(emitSpy).not.toHaveBeenCalled();
+                expect(beacon.beaconInfoId).toEqual(liveBeaconEvent.getId());
+            });
+
             it('updates event', () => {
                 const beacon = new Beacon(liveBeaconEvent);
                 const emitSpy = jest.spyOn(beacon, 'emit');

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -87,13 +87,11 @@ describe('Beacon', () => {
                     isLive: true,
                 },
                 '$live123',
-                '$live123',
             );
             notLiveBeaconEvent = makeBeaconInfoEvent(
                 userId,
                 roomId,
                 { timeout: HOUR_MS * 3, isLive: false },
-                '$dead123',
                 '$dead123',
             );
 
@@ -162,7 +160,7 @@ describe('Beacon', () => {
                 expect(beacon.isLive).toEqual(true);
 
                 const updatedBeaconEvent = makeBeaconInfoEvent(
-                    userId, roomId, { timeout: HOUR_MS * 3, isLive: false }, '$live123', '$live123');
+                    userId, roomId, { timeout: HOUR_MS * 3, isLive: false }, '$live123');
 
                 beacon.update(updatedBeaconEvent);
                 expect(beacon.isLive).toEqual(false);
@@ -180,7 +178,6 @@ describe('Beacon', () => {
                     roomId,
                     { timeout: HOUR_MS * 3, isLive: false },
                     beacon.beaconInfoId,
-                    '$live123',
                 );
 
                 beacon.update(updatedBeaconEvent);

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -282,8 +282,8 @@ describe("RoomState", function() {
 
             it('updates existing beacon info events in state', () => {
                 const beaconId = '$beacon1';
-                const beaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId, beaconId);
-                const updatedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, beaconId, beaconId);
+                const beaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId);
+                const updatedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, beaconId);
 
                 state.setStateEvents([beaconEvent]);
                 const beaconInstance = state.beacons.get(beaconEvent.getType());
@@ -299,8 +299,8 @@ describe("RoomState", function() {
 
             it('destroys and removes redacted beacon events', () => {
                 const beaconId = '$beacon1';
-                const beaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId, beaconId);
-                const redactedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId, beaconId);
+                const beaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId);
+                const redactedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId);
                 const redactionEvent = { event: { type: 'm.room.redaction' } };
                 redactedBeaconEvent.makeRedacted(redactionEvent);
 
@@ -316,8 +316,8 @@ describe("RoomState", function() {
             });
 
             it('updates live beacon ids once after setting state events', () => {
-                const liveBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, '$beacon1', '$beacon1');
-                const deadBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, '$beacon2', '$beacon2');
+                const liveBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, '$beacon1');
+                const deadBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, '$beacon2');
 
                 const emitSpy = jest.spyOn(state, 'emit');
 

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -301,7 +301,7 @@ describe("RoomState", function() {
                 const beaconId = '$beacon1';
                 const beaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId);
                 const redactedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, beaconId);
-                const redactionEvent = { event: { type: 'm.room.redaction' } };
+                const redactionEvent = { event: { type: 'm.room.redaction', redacts: beaconEvent.getId() } };
                 redactedBeaconEvent.makeRedacted(redactionEvent);
 
                 state.setStateEvents([beaconEvent]);

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -260,7 +260,7 @@ describe("RoomState", function() {
                 state.setStateEvents([beaconEvent]);
 
                 expect(state.beacons.size).toEqual(1);
-                const beaconInstance = state.beacons.get(beaconEvent.getType());
+                const beaconInstance = state.beacons.get(beaconEvent.getStateKey());
                 expect(beaconInstance).toBeTruthy();
                 expect(emitSpy).toHaveBeenCalledWith(BeaconEvent.New, beaconEvent, beaconInstance);
             });
@@ -286,15 +286,15 @@ describe("RoomState", function() {
                 const updatedBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, beaconId);
 
                 state.setStateEvents([beaconEvent]);
-                const beaconInstance = state.beacons.get(beaconEvent.getType());
+                const beaconInstance = state.beacons.get(beaconEvent.getStateKey());
                 expect(beaconInstance.isLive).toEqual(true);
 
                 state.setStateEvents([updatedBeaconEvent]);
 
                 // same Beacon
-                expect(state.beacons.get(beaconEvent.getType())).toBe(beaconInstance);
+                expect(state.beacons.get(beaconEvent.getStateKey())).toBe(beaconInstance);
                 // updated liveness
-                expect(state.beacons.get(beaconEvent.getType()).isLive).toEqual(false);
+                expect(state.beacons.get(beaconEvent.getStateKey()).isLive).toEqual(false);
             });
 
             it('destroys and removes redacted beacon events', () => {
@@ -305,19 +305,19 @@ describe("RoomState", function() {
                 redactedBeaconEvent.makeRedacted(redactionEvent);
 
                 state.setStateEvents([beaconEvent]);
-                const beaconInstance = state.beacons.get(beaconEvent.getType());
+                const beaconInstance = state.beacons.get(beaconEvent.getStateKey());
                 const destroySpy = jest.spyOn(beaconInstance, 'destroy');
                 expect(beaconInstance.isLive).toEqual(true);
 
                 state.setStateEvents([redactedBeaconEvent]);
 
                 expect(destroySpy).toHaveBeenCalled();
-                expect(state.beacons.get(beaconEvent.getType())).toBe(undefined);
+                expect(state.beacons.get(beaconEvent.getStateKey())).toBe(undefined);
             });
 
             it('updates live beacon ids once after setting state events', () => {
                 const liveBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: true }, '$beacon1');
-                const deadBeaconEvent = makeBeaconInfoEvent(userA, roomId, { isLive: false }, '$beacon2');
+                const deadBeaconEvent = makeBeaconInfoEvent(userB, roomId, { isLive: false }, '$beacon2');
 
                 const emitSpy = jest.spyOn(state, 'emit');
 

--- a/src/@types/beacon.ts
+++ b/src/@types/beacon.ts
@@ -61,11 +61,6 @@ import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location";
  */
 
 /**
- * Variable event type for m.beacon_info
- */
-export const M_BEACON_INFO_VARIABLE = new UnstableValue("m.beacon_info.*", "org.matrix.msc3489.beacon_info.*");
-
-/**
  * Non-variable type for m.beacon_info event content
  */
 export const M_BEACON_INFO = new UnstableValue("m.beacon_info", "org.matrix.msc3489.beacon_info");

--- a/src/@types/beacon.ts
+++ b/src/@types/beacon.ts
@@ -20,8 +20,8 @@ import { UnstableValue } from "../NamespacedValue";
 import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location";
 
 /**
- * Beacon info and beacon event types as described in MSC3489
- * https://github.com/matrix-org/matrix-spec-proposals/pull/3489
+ * Beacon info and beacon event types as described in MSC3672
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/3672
  */
 
 /**
@@ -63,8 +63,8 @@ import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location";
 /**
  * Non-variable type for m.beacon_info event content
  */
-export const M_BEACON_INFO = new UnstableValue("m.beacon_info", "org.matrix.msc3489.beacon_info");
-export const M_BEACON = new UnstableValue("m.beacon", "org.matrix.msc3489.beacon");
+export const M_BEACON_INFO = new UnstableValue("m.beacon_info", "org.matrix.msc3672.beacon_info");
+export const M_BEACON = new UnstableValue("m.beacon", "org.matrix.msc3672.beacon");
 
 export type MBeaconInfoContent = {
     description?: string;
@@ -82,9 +82,9 @@ export type MBeaconInfoEvent = EitherAnd<
 
 /**
  * m.beacon_info Event example from the spec
- * https://github.com/matrix-org/matrix-spec-proposals/pull/3489
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/3672
  * {
-    "type": "m.beacon_info.@matthew:matrix.org.1",
+    "type": "m.beacon_info",
     "state_key": "@matthew:matrix.org",
     "content": {
         "m.beacon_info": {
@@ -111,7 +111,7 @@ export type MBeaconInfoEventContent = &
 
 /**
  * m.beacon event example
- * https://github.com/matrix-org/matrix-spec-proposals/pull/3489
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/3672
  *
  * {
     "type": "m.beacon",

--- a/src/@types/beacon.ts
+++ b/src/@types/beacon.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd, RELATES_TO_RELATIONSHIP, REFERENCE_RELATION } from "matrix-events-sdk";
+import { RELATES_TO_RELATIONSHIP, REFERENCE_RELATION } from "matrix-events-sdk";
 
 import { UnstableValue } from "../NamespacedValue";
 import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location";
@@ -75,11 +75,6 @@ export type MBeaconInfoContent = {
     live?: boolean;
 };
 
-export type MBeaconInfoEvent = EitherAnd<
-    { [M_BEACON_INFO.name]: MBeaconInfoContent },
-    { [M_BEACON_INFO.altName]: MBeaconInfoContent }
->;
-
 /**
  * m.beacon_info Event example from the spec
  * https://github.com/matrix-org/matrix-spec-proposals/pull/3672
@@ -103,7 +98,7 @@ export type MBeaconInfoEvent = EitherAnd<
  * m.beacon_info.* event content
  */
 export type MBeaconInfoEventContent = &
-    MBeaconInfoEvent &
+    MBeaconInfoContent &
     // creation timestamp of the beacon on the client
     MTimestampEvent &
     // the type of asset being tracked as per MSC3488

--- a/src/client.ts
+++ b/src/client.ts
@@ -3651,8 +3651,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param {MBeaconInfoEventContent} beaconInfoContent
      * @param {string} eventTypeSuffix - string to suffix event type
      *  to make event type unique.
-     *  See MSC3489 for more context
-     *  https://github.com/matrix-org/matrix-spec-proposals/pull/3489
+     *  See MSC3672 for more context
+     *  https://github.com/matrix-org/matrix-spec-proposals/pull/3672
      * @returns {ISendEventResponse}
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/client.ts
+++ b/src/client.ts
@@ -180,7 +180,7 @@ import { MediaHandler } from "./webrtc/mediaHandler";
 import { IRefreshTokenResponse } from "./@types/auth";
 import { TypedEventEmitter } from "./models/typed-event-emitter";
 import { Thread, THREAD_RELATION_TYPE } from "./models/thread";
-import { MBeaconInfoEventContent, M_BEACON_INFO_VARIABLE } from "./@types/beacon";
+import { MBeaconInfoEventContent, M_BEACON_INFO } from "./@types/beacon";
 
 export type Store = IStore;
 export type SessionStore = WebStorageSessionStore;
@@ -3661,8 +3661,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         beaconInfoContent: MBeaconInfoEventContent,
         eventTypeSuffix: string,
     ) {
-        const userId = this.getUserId();
-        const eventType = M_BEACON_INFO_VARIABLE.name.replace('*', `${userId}.${eventTypeSuffix}`);
+        const eventType = M_BEACON_INFO.name;
         return this.unstable_setLiveBeacon(roomId, eventType, beaconInfoContent);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3649,38 +3649,30 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * Create an m.beacon_info event
      * @param {string} roomId
      * @param {MBeaconInfoEventContent} beaconInfoContent
-     * @param {string} eventTypeSuffix - string to suffix event type
-     *  to make event type unique.
-     *  See MSC3672 for more context
-     *  https://github.com/matrix-org/matrix-spec-proposals/pull/3672
      * @returns {ISendEventResponse}
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public async unstable_createLiveBeacon(
         roomId: Room["roomId"],
         beaconInfoContent: MBeaconInfoEventContent,
-        eventTypeSuffix: string,
     ) {
-        const eventType = M_BEACON_INFO.name;
-        return this.unstable_setLiveBeacon(roomId, eventType, beaconInfoContent);
+        return this.unstable_setLiveBeacon(roomId, beaconInfoContent);
     }
 
     /**
      * Upsert a live beacon event
      * using a specific m.beacon_info.* event variable type
      * @param {string} roomId string
-     * @param {string} beaconInfoEventType event type including variable suffix
      * @param {MBeaconInfoEventContent} beaconInfoContent
      * @returns {ISendEventResponse}
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public async unstable_setLiveBeacon(
         roomId: string,
-        beaconInfoEventType: string,
         beaconInfoContent: MBeaconInfoEventContent,
     ) {
         const userId = this.getUserId();
-        return this.sendStateEvent(roomId, beaconInfoEventType, beaconInfoContent, userId);
+        return this.sendStateEvent(roomId, M_BEACON_INFO.name, beaconInfoContent, userId);
     }
 
     /**

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import { REFERENCE_RELATION } from "matrix-events-sdk";
 
-import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent, M_BEACON_INFO } from "./@types/beacon";
+import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon";
 import { MsgType } from "./@types/event";
 import { TEXT_NODE_TYPE } from "./@types/extensible_events";
 import {
@@ -208,11 +208,9 @@ export const makeBeaconInfoContent: MakeBeaconInfoContent = (
     assetType,
     timestamp,
 ) => ({
-    [M_BEACON_INFO.name]: {
-        description,
-        timeout,
-        live: isLive,
-    },
+    description,
+    timeout,
+    live: isLive,
     [M_TIMESTAMP.name]: timestamp || Date.now(),
     [M_ASSET.name]: {
         type: assetType ?? LocationAssetType.Self,
@@ -227,7 +225,7 @@ export type BeaconInfoState = MBeaconInfoContent & {
  * Flatten beacon info event content
  */
 export const parseBeaconInfoContent = (content: MBeaconInfoEventContent): BeaconInfoState => {
-    const { description, timeout, live } = M_BEACON_INFO.findIn<MBeaconInfoContent>(content);
+    const { description, timeout, live } = content;
     const { type: assetType } = M_ASSET.findIn<MAssetContent>(content);
     const timestamp = M_TIMESTAMP.findIn<number>(content);
 

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -243,14 +243,14 @@ export const parseBeaconInfoContent = (content: MBeaconInfoEventContent): Beacon
 export type MakeBeaconContent = (
     uri: string,
     timestamp: number,
-    beaconInfoId: string,
+    beaconInfoEventId: string,
     description?: string,
 ) => MBeaconEventContent;
 
 export const makeBeaconContent: MakeBeaconContent = (
     uri,
     timestamp,
-    beaconInfoId,
+    beaconInfoEventId,
     description,
 ) => ({
     [M_LOCATION.name]: {
@@ -260,6 +260,6 @@ export const makeBeaconContent: MakeBeaconContent = (
     [M_TIMESTAMP.name]: timestamp,
     "m.relates_to": {
         rel_type: REFERENCE_RELATION.name,
-        event_id: beaconInfoId,
+        event_id: beaconInfoEventId,
     },
 });

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -58,7 +58,7 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
     }
 
     public get identifier(): string {
-        return this.beaconInfoEventType;
+        return this.rootEvent.getStateKey();
     }
 
     public get beaconInfoId(): string {

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -62,7 +62,7 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
         return this._isLive;
     }
 
-    public get identifier(): string {
+    public get identifier(): BeaconIdentifier {
         return getBeaconInfoIdentifier(this.rootEvent);
     }
 
@@ -85,6 +85,10 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
     public update(beaconInfoEvent: MatrixEvent): void {
         if (getBeaconInfoIdentifier(beaconInfoEvent) !== this.identifier) {
             throw new Error('Invalid updating event');
+        }
+        // don't update beacon with an older event
+        if (beaconInfoEvent.event.origin_server_ts < this.rootEvent.event.origin_server_ts) {
+            return;
         }
         this.rootEvent = beaconInfoEvent;
         this.setBeaconInfo(this.rootEvent);

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { M_BEACON_INFO } from "../@types/beacon";
 import { BeaconInfoState, parseBeaconInfoContent } from "../content-helpers";
 import { MatrixEvent } from "../matrix";
 import { TypedEventEmitter } from "./typed-event-emitter";
@@ -38,6 +37,12 @@ export const isTimestampInDuration = (
     timestamp: number,
 ): boolean => timestamp >= startTimestamp && startTimestamp + durationMs >= timestamp;
 
+// beacon info events are uniquely identified by
+// `<roomId>_<state_key>`
+export type BeaconIdentifier = string;
+export const getBeaconInfoIdentifier = (event: MatrixEvent): BeaconIdentifier =>
+    `${event.getRoomId()}_${event.getStateKey()}`;
+
 // https://github.com/matrix-org/matrix-spec-proposals/pull/3672
 export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.New>, BeaconEventHandlerMap> {
     public readonly roomId: string;
@@ -58,7 +63,7 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
     }
 
     public get identifier(): string {
-        return this.rootEvent.getStateKey();
+        return getBeaconInfoIdentifier(this.rootEvent);
     }
 
     public get beaconInfoId(): string {
@@ -78,7 +83,7 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
     }
 
     public update(beaconInfoEvent: MatrixEvent): void {
-        if (beaconInfoEvent.getStateKey() !== this.identifier) {
+        if (getBeaconInfoIdentifier(beaconInfoEvent) !== this.identifier) {
             throw new Error('Invalid updating event');
         }
         this.rootEvent = beaconInfoEvent;

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -78,7 +78,7 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
     }
 
     public update(beaconInfoEvent: MatrixEvent): void {
-        if (beaconInfoEvent.getType() !== this.beaconInfoEventType) {
+        if (beaconInfoEvent.getStateKey() !== this.identifier) {
             throw new Error('Invalid updating event');
         }
         this.rootEvent = beaconInfoEvent;

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -38,7 +38,7 @@ export const isTimestampInDuration = (
     timestamp: number,
 ): boolean => timestamp >= startTimestamp && startTimestamp + durationMs >= timestamp;
 
-// https://github.com/matrix-org/matrix-spec-proposals/pull/3489
+// https://github.com/matrix-org/matrix-spec-proposals/pull/3672
 export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.New>, BeaconEventHandlerMap> {
     public readonly roomId: string;
     private _beaconInfo: BeaconInfoState;

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -38,10 +38,6 @@ export const isTimestampInDuration = (
     timestamp: number,
 ): boolean => timestamp >= startTimestamp && startTimestamp + durationMs >= timestamp;
 
-export const isBeaconInfoEventType = (type: string) =>
-    type.startsWith(M_BEACON_INFO.name) ||
-    type.startsWith(M_BEACON_INFO.altName);
-
 // https://github.com/matrix-org/matrix-spec-proposals/pull/3489
 export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.New>, BeaconEventHandlerMap> {
     public readonly roomId: string;

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -438,12 +438,13 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * @experimental
      */
     private setBeacon(event: MatrixEvent): void {
-        if (this.beacons.has(event.getType())) {
-            const beacon = this.beacons.get(event.getType());
+        const beaconIdentifier = event.getStateKey();
+        if (this.beacons.has(beaconIdentifier)) {
+            const beacon = this.beacons.get(beaconIdentifier);
 
             if (event.isRedacted()) {
                 beacon.destroy();
-                this.beacons.delete(event.getType());
+                this.beacons.delete(beaconIdentifier);
                 return;
             }
 
@@ -465,7 +466,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
 
         this.emit(BeaconEvent.New, event, beacon);
         beacon.on(BeaconEvent.LivenessChange, this.onBeaconLivenessChange.bind(this));
-        this.beacons.set(beacon.beaconInfoEventType, beacon);
+        this.beacons.set(beacon.identifier, beacon);
     }
 
     /**
@@ -478,7 +479,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         const prevHasLiveBeacons = !!this.liveBeaconIds?.length;
         this.liveBeaconIds = Array.from(this.beacons.values())
             .filter(beacon => beacon.isLive)
-            .map(beacon => beacon.beaconInfoId);
+            .map(beacon => beacon.identifier);
 
         const hasLiveBeacons = !!this.liveBeaconIds.length;
         if (prevHasLiveBeacons !== hasLiveBeacons) {

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -30,6 +30,7 @@ import { Beacon, BeaconEvent, BeaconEventHandlerMap } from "./beacon";
 import { TypedReEmitter } from "../ReEmitter";
 import { M_BEACON_INFO } from "../@types/beacon";
 import { getBeaconInfoIdentifier } from "./beacon";
+import { BeaconIdentifier } from "..";
 
 // possible statuses for out-of-band member loading
 enum OobStatus {
@@ -82,8 +83,8 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
     public events = new Map<string, Map<string, MatrixEvent>>(); // Map<eventType, Map<stateKey, MatrixEvent>>
     public paginationToken: string = null;
 
-    public readonly beacons = new Map<string, Beacon>();
-    private liveBeaconIds: string[] = [];
+    public readonly beacons = new Map<BeaconIdentifier, Beacon>();
+    private liveBeaconIds: BeaconIdentifier[] = [];
 
     /**
      * Construct room state.
@@ -443,6 +444,8 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         if (this.beacons.has(beaconIdentifier)) {
             const beacon = this.beacons.get(beaconIdentifier);
 
+
+            // TODO is it redacting exactly the beacon we have, or a previous version?
             if (event.isRedacted()) {
                 beacon.destroy();
                 this.beacons.delete(beaconIdentifier);

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -29,6 +29,7 @@ import { TypedEventEmitter } from "./typed-event-emitter";
 import { Beacon, BeaconEvent, BeaconEventHandlerMap } from "./beacon";
 import { TypedReEmitter } from "../ReEmitter";
 import { M_BEACON_INFO } from "../@types/beacon";
+import { getBeaconInfoIdentifier } from "./beacon";
 
 // possible statuses for out-of-band member loading
 enum OobStatus {
@@ -438,7 +439,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * @experimental
      */
     private setBeacon(event: MatrixEvent): void {
-        const beaconIdentifier = event.getStateKey();
+        const beaconIdentifier = getBeaconInfoIdentifier(event);
         if (this.beacons.has(beaconIdentifier)) {
             const beacon = this.beacons.get(beaconIdentifier);
 

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -444,7 +444,6 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         if (this.beacons.has(beaconIdentifier)) {
             const beacon = this.beacons.get(beaconIdentifier);
 
-
             // TODO is it redacting exactly the beacon we have, or a previous version?
             if (event.isRedacted()) {
                 beacon.destroy();

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -444,10 +444,11 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         if (this.beacons.has(beaconIdentifier)) {
             const beacon = this.beacons.get(beaconIdentifier);
 
-            // TODO is it redacting exactly the beacon we have, or a previous version?
             if (event.isRedacted()) {
-                beacon.destroy();
-                this.beacons.delete(beaconIdentifier);
+                if (beacon.beaconInfoId === event.getRedactionEvent()?.['redacts']) {
+                    beacon.destroy();
+                    this.beacons.delete(beaconIdentifier);
+                }
                 return;
             }
 

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -26,8 +26,9 @@ import { MatrixEvent } from "./event";
 import { MatrixClient } from "../client";
 import { GuestAccess, HistoryVisibility, IJoinRuleEventContent, JoinRule } from "../@types/partials";
 import { TypedEventEmitter } from "./typed-event-emitter";
-import { Beacon, BeaconEvent, isBeaconInfoEventType, BeaconEventHandlerMap } from "./beacon";
+import { Beacon, BeaconEvent, BeaconEventHandlerMap } from "./beacon";
 import { TypedReEmitter } from "../ReEmitter";
+import { M_BEACON_INFO } from "../@types/beacon";
 
 // possible statuses for out-of-band member loading
 enum OobStatus {
@@ -330,7 +331,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
                 return;
             }
 
-            if (isBeaconInfoEventType(event.getType())) {
+            if (M_BEACON_INFO.matches(event.getType())) {
                 this.setBeacon(event);
             }
 


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

https://github.com/matrix-org/matrix-spec-proposals/pull/3672

- changes unstable event prefixes to use `msc3672`
- changes beacon identifier logic. Previously beacons used unique event types to enable multiple state events per user per room so event type could be used as an identifier. According to msc3672 plain event types and state_key are used for beacons, identifier is now `<roomId>_<state_key>`. 
- add extra logic about beacon update

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->