### PR TITLE
Draft: Refresh room timeline when we see a MSC2716 marker event

### DIFF
--- a/spec/unit/event-timeline.spec.js
+++ b/spec/unit/event-timeline.spec.js
@@ -49,10 +49,14 @@ describe("EventTimeline", function() {
             ];
             timeline.initialiseState(events);
             expect(timeline.startState.setStateEvents).toHaveBeenCalledWith(
-                events,
+                events, {
+                    fromInitialState: true,
+                },
             );
             expect(timeline.endState.setStateEvents).toHaveBeenCalledWith(
-                events,
+                events, {
+                    fromInitialState: true,
+                },
             );
         });
 
@@ -73,7 +77,7 @@ describe("EventTimeline", function() {
             expect(function() {
                 timeline.initialiseState(state);
             }).not.toThrow();
-            timeline.addEvent(event, false);
+            timeline.addEvent(event, { toStartOfTimeline: false });
             expect(function() {
                 timeline.initialiseState(state);
             }).toThrow();
@@ -149,9 +153,9 @@ describe("EventTimeline", function() {
         ];
 
         it("should be able to add events to the end", function() {
-            timeline.addEvent(events[0], false);
+            timeline.addEvent(events[0], { toStartOfTimeline: false });
             const initialIndex = timeline.getBaseIndex();
-            timeline.addEvent(events[1], false);
+            timeline.addEvent(events[1], { toStartOfTimeline: false });
             expect(timeline.getBaseIndex()).toEqual(initialIndex);
             expect(timeline.getEvents().length).toEqual(2);
             expect(timeline.getEvents()[0]).toEqual(events[0]);
@@ -159,9 +163,9 @@ describe("EventTimeline", function() {
         });
 
         it("should be able to add events to the start", function() {
-            timeline.addEvent(events[0], true);
+            timeline.addEvent(events[0], { toStartOfTimeline: true });
             const initialIndex = timeline.getBaseIndex();
-            timeline.addEvent(events[1], true);
+            timeline.addEvent(events[1], { toStartOfTimeline: true });
             expect(timeline.getBaseIndex()).toEqual(initialIndex + 1);
             expect(timeline.getEvents().length).toEqual(2);
             expect(timeline.getEvents()[0]).toEqual(events[1]);
@@ -203,9 +207,9 @@ describe("EventTimeline", function() {
                 content: { name: "Old Room Name" },
             });
 
-            timeline.addEvent(newEv, false);
+            timeline.addEvent(newEv, { toStartOfTimeline: false });
             expect(newEv.sender).toEqual(sentinel);
-            timeline.addEvent(oldEv, true);
+            timeline.addEvent(oldEv, { toStartOfTimeline: true });
             expect(oldEv.sender).toEqual(oldSentinel);
         });
 
@@ -242,9 +246,9 @@ describe("EventTimeline", function() {
             const oldEv = utils.mkMembership({
                 room: roomId, mship: "ban", user: userB, skey: userA, event: true,
             });
-            timeline.addEvent(newEv, false);
+            timeline.addEvent(newEv, { toStartOfTimeline: false });
             expect(newEv.target).toEqual(sentinel);
-            timeline.addEvent(oldEv, true);
+            timeline.addEvent(oldEv, { toStartOfTimeline: true });
             expect(oldEv.target).toEqual(oldSentinel);
         });
 
@@ -262,13 +266,17 @@ describe("EventTimeline", function() {
                 }),
             ];
 
-            timeline.addEvent(events[0], false);
-            timeline.addEvent(events[1], false);
+            timeline.addEvent(events[0], { toStartOfTimeline: false });
+            timeline.addEvent(events[1], { toStartOfTimeline: false });
 
             expect(timeline.getState(EventTimeline.FORWARDS).setStateEvents).
-                toHaveBeenCalledWith([events[0]]);
+                toHaveBeenCalledWith([events[0]], {
+                    fromInitialState: undefined,
+                });
             expect(timeline.getState(EventTimeline.FORWARDS).setStateEvents).
-                toHaveBeenCalledWith([events[1]]);
+                toHaveBeenCalledWith([events[1]], {
+                    fromInitialState: undefined,
+                });
 
             expect(events[0].forwardLooking).toBe(true);
             expect(events[1].forwardLooking).toBe(true);
@@ -291,13 +299,17 @@ describe("EventTimeline", function() {
                 }),
             ];
 
-            timeline.addEvent(events[0], true);
-            timeline.addEvent(events[1], true);
+            timeline.addEvent(events[0], { toStartOfTimeline: true });
+            timeline.addEvent(events[1], { toStartOfTimeline: true });
 
             expect(timeline.getState(EventTimeline.BACKWARDS).setStateEvents).
-                toHaveBeenCalledWith([events[0]]);
+                toHaveBeenCalledWith([events[0]], {
+                    fromInitialState: undefined,
+                });
             expect(timeline.getState(EventTimeline.BACKWARDS).setStateEvents).
-                toHaveBeenCalledWith([events[1]]);
+                toHaveBeenCalledWith([events[1]], {
+                    fromInitialState: undefined,
+                });
 
             expect(events[0].forwardLooking).toBe(false);
             expect(events[1].forwardLooking).toBe(false);
@@ -324,8 +336,8 @@ describe("EventTimeline", function() {
         ];
 
         it("should remove events", function() {
-            timeline.addEvent(events[0], false);
-            timeline.addEvent(events[1], false);
+            timeline.addEvent(events[0], { toStartOfTimeline: false });
+            timeline.addEvent(events[1], { toStartOfTimeline: false });
             expect(timeline.getEvents().length).toEqual(2);
 
             let ev = timeline.removeEvent(events[0].getId());
@@ -338,9 +350,9 @@ describe("EventTimeline", function() {
         });
 
         it("should update baseIndex", function() {
-            timeline.addEvent(events[0], false);
-            timeline.addEvent(events[1], true);
-            timeline.addEvent(events[2], false);
+            timeline.addEvent(events[0], { toStartOfTimeline: false });
+            timeline.addEvent(events[1], { toStartOfTimeline: true });
+            timeline.addEvent(events[2], { toStartOfTimeline: false });
             expect(timeline.getEvents().length).toEqual(3);
             expect(timeline.getBaseIndex()).toEqual(1);
 
@@ -358,11 +370,11 @@ describe("EventTimeline", function() {
         // further addEvent(ev, false) calls made the index increase.
         it("should not make baseIndex assplode when removing the last event",
            function() {
-               timeline.addEvent(events[0], true);
+               timeline.addEvent(events[0], { toStartOfTimeline: true });
                timeline.removeEvent(events[0].getId());
                const initialIndex = timeline.getBaseIndex();
-               timeline.addEvent(events[1], false);
-               timeline.addEvent(events[2], false);
+               timeline.addEvent(events[1], { toStartOfTimeline: false });
+               timeline.addEvent(events[2], { toStartOfTimeline: false });
                expect(timeline.getBaseIndex()).toEqual(initialIndex);
                expect(timeline.getEvents().length).toEqual(2);
            });

--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -3,6 +3,7 @@ import { makeBeaconEvent, makeBeaconInfoEvent } from "../test-utils/beacon";
 import { filterEmitCallsByEventType } from "../test-utils/emitter";
 import { RoomState, RoomStateEvent } from "../../src/models/room-state";
 import { BeaconEvent, getBeaconInfoIdentifier } from "../../src/models/beacon";
+import { EventType } from "../../src/@types/event";
 
 describe("RoomState", function() {
     const roomId = "!foo:bar";
@@ -250,6 +251,29 @@ describe("RoomState", function() {
             expect(state.members[userB].setMembershipEvent).toHaveBeenCalledWith(
                 memberEvent, state,
             );
+        });
+
+        it("should emit 'RoomStateEvent.Marker' for each marker event", function() {
+            const events = [
+                utils.mkEvent({
+                    event: true,
+                    type: EventType.Marker,
+                    room: roomId,
+                    user: userA,
+                    skey: "",
+                    content: {
+                        "m.insertion_id": "$abc",
+                    },
+                }),
+            ];
+            let emitCount = 0;
+            state.on("RoomStateEvent.Marker", function(markerEvent, setStateOptions) {
+                expect(markerEvent).toEqual(events[emitCount]);
+                expect(setStateOptions).toEqual({ fromInitialState: true });
+                emitCount += 1;
+            });
+            state.setStateEvents(events, { fromInitialState: true });
+            expect(emitCount).toEqual(1);
         });
 
         describe('beacon events', () => {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -209,7 +209,9 @@ describe("Room", function() {
 
         it("should throw if duplicateStrategy isn't 'replace' or 'ignore'", function() {
             expect(function() {
-                room.addLiveEvents(events, "foo");
+                room.addLiveEvents(events, {
+                    duplicateStrategy: "foo",
+                });
             }).toThrow();
         });
 
@@ -221,7 +223,9 @@ describe("Room", function() {
             dupe.event.event_id = events[0].getId();
             room.addLiveEvents(events);
             expect(room.timeline[0]).toEqual(events[0]);
-            room.addLiveEvents([dupe], DuplicateStrategy.Replace);
+            room.addLiveEvents([dupe], {
+                duplicateStrategy: DuplicateStrategy.Replace,
+            });
             expect(room.timeline[0]).toEqual(dupe);
         });
 
@@ -233,7 +237,9 @@ describe("Room", function() {
             dupe.event.event_id = events[0].getId();
             room.addLiveEvents(events);
             expect(room.timeline[0]).toEqual(events[0]);
-            room.addLiveEvents([dupe], "ignore");
+            room.addLiveEvents([dupe], {
+                duplicateStrategy: "ignore",
+            });
             expect(room.timeline[0]).toEqual(events[0]);
         });
 
@@ -266,9 +272,11 @@ describe("Room", function() {
                 room.addLiveEvents(events);
                 expect(room.currentState.setStateEvents).toHaveBeenCalledWith(
                     [events[0]],
+                    { fromInitialState: false },
                 );
                 expect(room.currentState.setStateEvents).toHaveBeenCalledWith(
                     [events[1]],
+                    { fromInitialState: false },
                 );
                 expect(events[0].forwardLooking).toBe(true);
                 expect(events[1].forwardLooking).toBe(true);
@@ -470,9 +478,11 @@ describe("Room", function() {
             room.addEventsToTimeline(events, true, room.getLiveTimeline());
             expect(room.oldState.setStateEvents).toHaveBeenCalledWith(
                 [events[0]],
+                { fromInitialState: false },
             );
             expect(room.oldState.setStateEvents).toHaveBeenCalledWith(
                 [events[1]],
+                { fromInitialState: false },
             );
             expect(events[0].forwardLooking).toBe(false);
             expect(events[1].forwardLooking).toBe(false);

--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -42,7 +42,7 @@ function addEventsToTimeline(timeline, numEvents, toStartOfTimeline) {
                 room: ROOM_ID, user: USER_ID,
                 event: true,
             }), {
-                toStartOfTimeline
+                toStartOfTimeline,
             },
         );
     }

--- a/spec/unit/timeline-window.spec.js
+++ b/spec/unit/timeline-window.spec.js
@@ -35,13 +35,15 @@ function createTimeline(numEvents, baseIndex) {
     return timeline;
 }
 
-function addEventsToTimeline(timeline, numEvents, atStart) {
+function addEventsToTimeline(timeline, numEvents, toStartOfTimeline) {
     for (let i = 0; i < numEvents; i++) {
         timeline.addEvent(
             utils.mkMessage({
                 room: ROOM_ID, user: USER_ID,
                 event: true,
-            }), atStart,
+            }), {
+                toStartOfTimeline
+            },
         );
     }
 }

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -87,6 +87,8 @@ export enum EventType {
     RoomKeyRequest = "m.room_key_request",
     ForwardedRoomKey = "m.forwarded_room_key",
     Dummy = "m.dummy",
+
+    Marker = "org.matrix.msc2716.marker", // MSC2716
 }
 
 export enum RelationType {

--- a/src/client.ts
+++ b/src/client.ts
@@ -790,6 +790,7 @@ type RoomEvents = RoomEvent.Name
     | RoomEvent.Receipt
     | RoomEvent.Tags
     | RoomEvent.LocalEchoUpdated
+    | RoomEvent.historyImportedWithinTimeline
     | RoomEvent.AccountData
     | RoomEvent.MyMembership
     | RoomEvent.Timeline

--- a/src/client.ts
+++ b/src/client.ts
@@ -799,6 +799,7 @@ type RoomStateEvents = RoomStateEvent.Events
     | RoomStateEvent.Members
     | RoomStateEvent.NewMember
     | RoomStateEvent.Update
+    | RoomStateEvent.Marker
     ;
 
 type CryptoEvents = CryptoEvent.KeySignatureUploadFailure

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3240,7 +3240,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     private onTimelineEvent = (
         event: MatrixEvent,
         room: Room,
-        atStart: boolean,
+        toStartOfTimeline: boolean,
         removed: boolean,
         { liveEvent = true } = {},
     ): void => {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3240,7 +3240,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     private onTimelineEvent = (
         event: MatrixEvent,
         room: Room,
-        toStartOfTimeline: boolean,
+        atStart: boolean,
         removed: boolean,
         { liveEvent = true } = {},
     ): void => {

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -639,7 +639,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
     ) {
         const eventId = event.getId();
         timeline.addEvent(event, {
-            atStart: toStartOfTimeline,
+            toStartOfTimeline,
             roomState,
             fromInitialState,
         });

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -641,7 +641,13 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
         timeline.addEvent(event, {
             toStartOfTimeline,
             roomState,
-            fromInitialState,
+            // We don't want to refresh the timeline:
+            //  1. If it's persons first time syncing the room, they won't have
+            //     any old events cached to refresh. This could be from initial
+            //     sync or just the first time syncing the room since joining.
+            //  2. If we're re-hydrating from `syncFromCache` because we already
+            //     processed any marker event state that was in the cache
+            fromInitialState: fromInitialState || fromCache,
         });
         this._eventIdToTimeline[eventId] = timeline;
 

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -640,7 +640,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
         const eventId = event.getId();
         timeline.addEvent(event, {
             atStart: toStartOfTimeline,
-            stateContext: roomState,
+            roomState,
             fromInitialState,
         });
         this._eventIdToTimeline[eventId] = timeline;

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -57,9 +57,22 @@ export interface IRoomTimelineData {
 }
 
 export interface IAddLiveEventOptions {
+    /** Applies to events in the timeline only. If this is 'replace' then if a
+     * duplicate is encountered, the event passed to this function will replace
+     * the existing event in the timeline. If this is not specified, or is
+     * 'ignore', then the event passed to this function will be ignored
+     * entirely, preserving the existing event in the timeline. Events are
+     * identical based on their event ID <b>only</b>. */
     duplicateStrategy?: DuplicateStrategy;
+    /** Whether the sync response came from cache */
     fromCache?: boolean;
+    /** The state events to reconcile metadata from */
     roomState?: RoomState;
+    /** Whether the state is part of the first state snapshot we're seeing in
+     *  the room. This could be happen in a variety of cases:
+     *  1. From the initial sync
+     *  2. It's the first state we're seeing after joining the room
+     *  3. Or whether it's coming from `syncFromCache` */
     fromInitialState?: boolean;
 }
 
@@ -67,6 +80,11 @@ export interface IAddEventToTimelineOptions {
     toStartOfTimeline: boolean;
     fromCache?: boolean;
     roomState?: RoomState;
+    /** Whether the state is part of the first state snapshot we're seeing in
+     *  the room. This could be happen in a variety of cases:
+     *  1. From the initial sync
+     *  2. It's the first state we're seeing after joining the room
+     *  3. Or whether it's coming from `syncFromCache` */
     fromInitialState?: boolean;
 }
 
@@ -539,9 +557,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
      * Add an event to the end of this live timeline.
      *
      * @param {MatrixEvent} event Event to be added
-     * @param {string?} duplicateStrategy 'ignore' or 'replace'
-     * @param {boolean} fromCache whether the sync response came from cache
-     * @param roomState the state events to reconcile metadata from
+     * @param {IAddLiveEventOptions} options addLiveEvent options
      */
     public addLiveEvent(
         event: MatrixEvent,
@@ -605,8 +621,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
      *
      * @param {MatrixEvent} event
      * @param {EventTimeline} timeline
-     * @param {boolean} toStartOfTimeline
-     * @param {boolean} fromCache whether the sync response came from cache
+     * @param {IAddEventToTimelineOptions} options addEventToTimeline options
      *
      * @fires module:client~MatrixClient#event:"Room.timeline"
      */

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -78,7 +78,9 @@ export interface IAddLiveEventOptions {
 
 export interface IAddEventToTimelineOptions {
     toStartOfTimeline: boolean;
+    /** Whether the sync response came from cache */
     fromCache?: boolean;
+    /** The state events to reconcile metadata from */
     roomState?: RoomState;
     /** Whether the state is part of the first state snapshot we're seeing in
      *  the room. This could be happen in a variety of cases:
@@ -464,7 +466,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             if (!existingTimeline) {
                 // we don't know about this event yet. Just add it to the timeline.
                 this.addEventToTimeline(event, timeline, {
-                    toStartOfTimeline
+                    toStartOfTimeline,
                 });
                 lastEventWasNew = true;
                 didUpdate = true;
@@ -565,8 +567,8 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             duplicateStrategy = DuplicateStrategy.Ignore,
             fromCache = false,
             roomState,
-            fromInitialState
-        }: IAddLiveEventOptions = {}
+            fromInitialState,
+        }: IAddLiveEventOptions = {},
     ): void {
         if (this.filter) {
             const events = this.filter.filterRoomTimeline([event]);
@@ -632,12 +634,12 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             toStartOfTimeline,
             fromCache = false,
             roomState,
-            fromInitialState = false
+            fromInitialState = false,
         }: IAddEventToTimelineOptions,
     ) {
         const eventId = event.getId();
         timeline.addEvent(event, {
-            atStart: toStartOfTimeline, 
+            atStart: toStartOfTimeline,
             stateContext: roomState,
             fromInitialState,
         });
@@ -677,12 +679,12 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             if (this.filter) {
                 if (this.filter.filterRoomTimeline([localEvent]).length) {
                     this.addEventToTimeline(localEvent, this.liveTimeline, {
-                        toStartOfTimeline: false
+                        toStartOfTimeline: false,
                     });
                 }
             } else {
                 this.addEventToTimeline(localEvent, this.liveTimeline, {
-                    toStartOfTimeline: false
+                    toStartOfTimeline: false,
                 });
             }
         }

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -160,7 +160,7 @@ export class EventTimeline {
         }
 
         const setStateOptions: ISetStateOptions = {
-            fromInitialState: true
+            fromInitialState: true,
         };
         this.startState.setStateEvents(stateEvents, setStateOptions);
         this.endState.setStateEvents(stateEvents, setStateOptions);
@@ -363,7 +363,7 @@ export class EventTimeline {
             atStart,
             stateContext,
             fromInitialState,
-        }: IAddEventOptions
+        }: IAddEventOptions,
     ): void {
         if (!stateContext) {
             stateContext = atStart ? this.startState : this.endState;
@@ -380,7 +380,7 @@ export class EventTimeline {
                 timelineSet.room.getUnfilteredTimelineSet() === timelineSet
             ) {
                 stateContext.setStateEvents([event], {
-                    fromInitialState
+                    fromInitialState,
                 });
                 // it is possible that the act of setting the state event means we
                 // can set more metadata (specifically sender/target props), so try

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -146,6 +146,7 @@ export class EventTimeline {
      * @throws {Error} if an attempt is made to call this after addEvent is called.
      */
     public initialiseState(stateEvents: MatrixEvent[]): void {
+        console.log('initialiseState', stateEvents.map((ev) => { return ev.getType(); }));
         if (this.events.length > 0) {
             throw new Error("Cannot initialise state after events are added");
         }
@@ -387,7 +388,7 @@ export class EventTimeline {
                 timelineSet.room.getUnfilteredTimelineSet() === timelineSet
             ) {
                 roomState.setStateEvents([event], {
-                    fromInitialState,
+                    fromInitialState: fromInitialState,
                 });
                 // it is possible that the act of setting the state event means we
                 // can set more metadata (specifically sender/target props), so try

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -32,7 +32,7 @@ export enum Direction {
 
 export interface IAddEventOptions {
     atStart: boolean;
-    stateContext?: RoomState;
+    roomState?: RoomState;
     fromInitialState?: boolean;
 }
 
@@ -361,25 +361,25 @@ export class EventTimeline {
         event: MatrixEvent,
         {
             atStart,
-            stateContext,
+            roomState,
             fromInitialState,
         }: IAddEventOptions,
     ): void {
-        if (!stateContext) {
-            stateContext = atStart ? this.startState : this.endState;
+        if (!roomState) {
+            roomState = atStart ? this.startState : this.endState;
         }
 
         const timelineSet = this.getTimelineSet();
 
         if (timelineSet.room) {
-            EventTimeline.setEventMetadata(event, stateContext, atStart);
+            EventTimeline.setEventMetadata(event, roomState, atStart);
 
             // modify state but only on unfiltered timelineSets
             if (
                 event.isState() &&
                 timelineSet.room.getUnfilteredTimelineSet() === timelineSet
             ) {
-                stateContext.setStateEvents([event], {
+                roomState.setStateEvents([event], {
                     fromInitialState,
                 });
                 // it is possible that the act of setting the state event means we
@@ -393,7 +393,7 @@ export class EventTimeline {
                 // member event, whereas we want to set the .sender value for the ACTUAL
                 // member event itself.
                 if (!event.sender || (event.getType() === "m.room.member" && !atStart)) {
-                    EventTimeline.setEventMetadata(event, stateContext, atStart);
+                    EventTimeline.setEventMetadata(event, roomState, atStart);
                 }
             }
         }

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -355,7 +355,7 @@ export class EventTimeline {
      * Add a new event to the timeline, and update the state
      *
      * @param {MatrixEvent} event   new event
-     * @param {boolean}  atStart     true to insert new event at the start
+     * @param {IAddEventOptions} options addEvent options
      */
     public addEvent(
         event: MatrixEvent,

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -326,13 +326,15 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * Add an array of one or more state MatrixEvents, overwriting any existing
      * state with the same {type, stateKey} tuple. Will fire "RoomState.events"
      * for every event added. May fire "RoomState.members" if there are
-     * <code>m.room.member</code> events.
+     * <code>m.room.member</code> events. May fire "RoomStateEvent.Marker" if there are
+     * <code>EventType.Marker</code> events.
      * @param {MatrixEvent[]} stateEvents a list of state events for this room.
      * @param {boolean} fromInitialState whether the stateEvents are from the first
      * sync in the room or a sync we already know about (syncFromCache)
      * @fires module:client~MatrixClient#event:"RoomState.members"
      * @fires module:client~MatrixClient#event:"RoomState.newMember"
      * @fires module:client~MatrixClient#event:"RoomState.events"
+     * @fires module:client~MatrixClient#event:"RoomStateEvent.Marker"
      */
     public setStateEvents(stateEvents: MatrixEvent[], setStateOptions?: ISetStateOptions) {
         this.updateModifiedTime();

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -37,6 +37,11 @@ enum OobStatus {
 }
 
 export interface ISetStateOptions {
+    /** Whether the state is part of the first state snapshot we're seeing in
+     *  the room. This could be happen in a variety of cases:
+     *  1. From the initial sync
+     *  2. It's the first state we're seeing after joining the room
+     *  3. Or whether it's coming from `syncFromCache` */
     fromInitialState?: boolean;
 }
 

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -42,6 +42,7 @@ export enum RoomStateEvent {
     NewMember = "RoomState.newMember",
     Update = "RoomState.update", // signals batches of updates without specificity
     BeaconLiveness = "RoomState.BeaconLiveness",
+    Marker = "RoomState.org.matrix.msc2716.marker",
 }
 
 export type RoomStateEventHandlerMap = {
@@ -51,6 +52,7 @@ export type RoomStateEventHandlerMap = {
     [RoomStateEvent.Update]: (state: RoomState) => void;
     [RoomStateEvent.BeaconLiveness]: (state: RoomState, hasLiveBeacons: boolean) => void;
     [BeaconEvent.New]: (event: MatrixEvent, beacon: Beacon) => void;
+    [RoomStateEvent.Marker]: (event: MatrixEvent, state: RoomState) => void;
 };
 
 type EmittedEvents = RoomStateEvent | BeaconEvent;
@@ -398,6 +400,8 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
 
                 // assume all our sentinels are now out-of-date
                 this.sentinels = {};
+            } else if (event.getType() === EventType.Marker) {
+                this.emit(RoomStateEvent.Marker, event, this);
             }
         });
 

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -320,7 +320,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * for every event added. May fire "RoomState.members" if there are
      * <code>m.room.member</code> events.
      * @param {MatrixEvent[]} stateEvents a list of state events for this room.
-     * @param {Bool} fromInitialState whether the stateEvents are from the first
+     * @param {boolean} fromInitialState whether the stateEvents are from the first
      * sync in the room or a sync we already know about (syncFromCache)
      * @fires module:client~MatrixClient#event:"RoomState.members"
      * @fires module:client~MatrixClient#event:"RoomState.newMember"

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -40,6 +40,8 @@ enum OobStatus {
 }
 
 export interface ISetStateOptions {
+    /** Whether the sync response came from cache */
+    fromCache?: boolean;
     /** Whether the state is part of the first state snapshot we're seeing in
      *  the room. This could be happen in a variety of cases:
      *  1. From the initial sync
@@ -337,6 +339,10 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * @fires module:client~MatrixClient#event:"RoomStateEvent.Marker"
      */
     public setStateEvents(stateEvents: MatrixEvent[], setStateOptions?: ISetStateOptions) {
+        Error.stackTraceLimit = Infinity;
+        console.log(`setStateEvents fromInitialState=${setStateOptions && setStateOptions.fromInitialState} stateEvents:\n`, stateEvents.map((ev) => {
+            return `\t${ev.getType()} ${ev.getId()}`;
+        }).join('\n'), new Error().stack);
         this.updateModifiedTime();
 
         // update the core event dict

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -210,7 +210,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
     private readonly filteredTimelineSets: Record<string, EventTimelineSet> = {}; // filter_id: timelineSet
-    private timelineNeedsRefresh: boolean = false;
+    private timelineNeedsRefresh = false;
     private lastMarkerEventIdProcessed: string = null;
     private readonly pendingEventList?: MatrixEvent[];
     // read by megolm via getter; boolean value - null indicates "use global value"
@@ -1030,7 +1030,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      * historical messages that were imported.
      * @param {Boolean} value The value to set
      */
-     public setTimelineNeedsRefresh(value: boolean): void {
+    public setTimelineNeedsRefresh(value: boolean): void {
         this.timelineNeedsRefresh = value;
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -204,6 +204,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
     private readonly filteredTimelineSets: Record<string, EventTimelineSet> = {}; // filter_id: timelineSet
+    private lastMarkerEventIdProcessed: string = null;
     private readonly pendingEventList?: MatrixEvent[];
     // read by megolm via getter; boolean value - null indicates "use global value"
     private blacklistUnverifiedDevices: boolean = null;
@@ -437,6 +438,19 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
             .map(event => event.attemptDecryption(this.client.crypto, { isRetry: true }));
 
         return Promise.allSettled(decryptionPromises) as unknown as Promise<void>;
+    }
+
+    /**
+     * Gets the creator of the room
+     * @returns {string} The creator of the room, or null if it could not be determined
+     */
+    public getRoomCreator(): string | null {
+        const createEvent = this.currentState.getStateEvents(EventType.RoomCreate, "");
+        if (!createEvent) {
+            return null;
+        }
+        const roomCreator = createEvent.getContent()['sender'];
+        return roomCreator;
     }
 
     /**
@@ -1002,6 +1016,25 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      */
     public addTimeline(): EventTimeline {
         return this.getUnfilteredTimelineSet().addTimeline();
+    }
+
+    /**
+     * Get the last marker event ID proccessed
+     *
+     * @return {String} the last marker event ID proccessed or null if none have
+     * been processed
+     */
+    public getLastMarkerEventIdProcessed(): string | null {
+        return this.lastMarkerEventIdProcessed;
+    }
+
+    /**
+     * Set the last marker event ID proccessed
+     *
+     * @param {String} eventId The marker event ID to set
+     */
+    public setLastMarkerEventIdProcessed(eventId: string): void {
+        this.lastMarkerEventIdProcessed = eventId;
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1519,7 +1519,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                     });
                     if (filterType !== ThreadFilterType.My || currentUserParticipated) {
                         timelineSet.getLiveTimeline().addEvent(thread.rootEvent, {
-                            atStart: false
+                            atStart: false,
                         });
                     }
                 });
@@ -1837,9 +1837,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      * "Room.timeline".
      *
      * @param {MatrixEvent} event Event to be added
-     * @param {string?} duplicateStrategy 'ignore' or 'replace'
-     * @param {boolean} fromCache whether the sync response came from cache
-     * @fires module:client~MatrixClient#event:"Room.timeline"
+     * @param {IAddLiveEventOptions} options addLiveEvent options
      * @private
      */
     private addLiveEvent(event: MatrixEvent, addLiveEventOptions: IAddLiveEventOptions = {}): void {
@@ -2199,15 +2197,8 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      * they will go to the end of the timeline.
      *
      * @param {MatrixEvent[]} events A list of events to add.
+     * @param {IAddLiveEventOptions} options addLiveEvent options
      *
-     * @param {string} duplicateStrategy Optional. Applies to events in the
-     * timeline only. If this is 'replace' then if a duplicate is encountered, the
-     * event passed to this function will replace the existing event in the
-     * timeline. If this is not specified, or is 'ignore', then the event passed to
-     * this function will be ignored entirely, preserving the existing event in the
-     * timeline. Events are identical based on their event ID <b>only</b>.
-     *
-     * @param {boolean} fromCache whether the sync response came from cache
      * @throws If <code>duplicateStrategy</code> is not falsey, 'replace' or 'ignore'.
      */
     public addLiveEvents(events: MatrixEvent[], addLiveEventOptions: IAddLiveEventOptions = {}): void {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1523,7 +1523,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                     });
                     if (filterType !== ThreadFilterType.My || currentUserParticipated) {
                         timelineSet.getLiveTimeline().addEvent(thread.rootEvent, {
-                            atStart: false,
+                            toStartOfTimeline: false,
                         });
                     }
                 });

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -212,7 +212,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
     private readonly filteredTimelineSets: Record<string, EventTimelineSet> = {}; // filter_id: timelineSet
-    private timelineNeedsRefresh: boolean = false;
+    private timelineNeedsRefresh = false;
     private lastMarkerEventIdProcessed: string = null;
     private readonly pendingEventList?: MatrixEvent[];
     // read by megolm via getter; boolean value - null indicates "use global value"
@@ -1815,7 +1815,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
                             timelineSet.addEventToTimeline(
                                 thread.rootEvent,
                                 timelineSet.getLiveTimeline(),
-                                {toStartOfTimeline},
+                                { toStartOfTimeline },
                             );
                         }
                     }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -460,7 +460,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
         if (!createEvent) {
             return null;
         }
-        const roomCreator = createEvent.getContent()['sender'];
+        const roomCreator = createEvent.getContent()['creator'];
         return roomCreator;
     }
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -138,9 +138,11 @@ export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
             this.timelineSet.addEventToTimeline(
                 event,
                 this.liveTimeline,
-                toStartOfTimeline,
-                false,
-                this.roomState,
+                {
+                    toStartOfTimeline,
+                    fromCache: false,
+                    roomState: this.roomState,
+                }
             );
         }
     }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -142,7 +142,7 @@ export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
                     toStartOfTimeline,
                     fromCache: false,
                     roomState: this.roomState,
-                }
+                },
             );
         }
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -257,8 +257,9 @@ export class SyncApi {
         ) {
             // We don't want to refresh the timeline:
             //  1. If it's persons first time syncing the room, they won't have
-            //     any old events cached to refresh.
-            //  1. If we're re-hydrating from `syncFromCache` because we already
+            //     any old events cached to refresh. This could be from initial
+            //     sync or just the first time syncing the room since joining.
+            //  2. If we're re-hydrating from `syncFromCache` because we already
             //     processed any marker event state that was in the cache
             if (fromInitialState) {
                 console.log('fromInitialState ignoring');
@@ -287,7 +288,9 @@ export class SyncApi {
                 // was imported and whether we have it locally? Because we only
                 // need to refresh the timeline if the timeline includes the
                 // prev_events of the base insertion event.
-                console.log('Saw new marker event', new Error().stack);
+                Error.stackTraceLimit = Infinity;
+                console.log(`Saw new marker event roomId=${room.roomId}`, new Error().stack);
+                room.setTimelineNeedsRefresh(true);
                 room.emit(RoomEvent.historyImportedWithinTimeline, markerEvent, room);
                 room.setLastMarkerEventIdProcessed(markerEvent.getId());
             }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -77,6 +77,13 @@ export enum SyncState {
     Reconnecting = "RECONNECTING",
 }
 
+// Room versions where "insertion", "batch", and "marker" events are controlled
+// by power-levels. MSC2716 is supported in existing room versions but they
+// should only have special meaning when the room creator sends them.
+const MSC2716_ROOM_VERSIONS = [
+    'org.matrix.msc2716v3'
+];
+
 function getFilterName(userId: string, suffix?: string): string {
     // scope this on the user ID because people may login on many accounts
     // and they all need to be stored!
@@ -239,6 +246,27 @@ export class SyncApi {
                 RoomMemberEvent.Membership,
             ]);
         });
+
+        room.currentState.on(RoomStateEvent.Marker, function(event, state) {
+            const isValidMsc2716Event =  MSC2716_ROOM_VERSIONS.includes(room.getVersion()) ||
+                // MSC2716 is supported in all existing room versions but special
+                // meaning should only be given to "insertion", "batch", and
+                // "marker" events when they come from the room creator
+                event.getSender() === room.getRoomCreator();
+            console.log(`On marker state isValidMsc2716Event=${isValidMsc2716Event}, event_id=${event.getId()} room.getLastMarkerEventIdProcessed()=${room.getLastMarkerEventIdProcessed()}`);
+            if(
+                isValidMsc2716Event &&
+                // We only need to throw the timeline away once when we see a
+                // marker. All of the historical content will be in the
+                // `/messsages` responses from here on out.
+                event.getId() !== room.getLastMarkerEventIdProcessed()
+            ) {
+                // Saw new marker event, refreshing the timeline
+                console.log('Saw new marker event, refreshing the timeline');
+                room.resetLiveTimeline(null, null);
+                room.setLastMarkerEventIdProcessed(event.getId())
+            }
+        });
     }
 
     /**
@@ -250,6 +278,7 @@ export class SyncApi {
         room.currentState.removeAllListeners(RoomStateEvent.Events);
         room.currentState.removeAllListeners(RoomStateEvent.Members);
         room.currentState.removeAllListeners(RoomStateEvent.NewMember);
+        room.currentState.removeAllListeners(RoomStateEvent.Marker);
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1738,6 +1738,7 @@ export class SyncApi {
 
         room.addLiveEvents(timelineEventList || [], {
             fromCache,
+            fromInitialState: timelineWasEmpty || fromCache
         });
         this.client.processBeaconEvents(room, timelineEventList);
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -250,86 +250,95 @@ export class SyncApi {
             ]);
         });
 
-        // When we see the marker state change in the room, we know there is
-        // some new historical messages imported by MSC2716 `/batch_send`
-        // somewhere in the room and we need to throw away the timeline to make
-        // sure the historical messages are shown when we paginate `/messages`
-        // again.
-        room.currentState.on(RoomStateEvent.Marker, async function(
-            markerEvent,
-            { fromInitialState }: ISetStateOptions = {},
-        ) {
-            // We don't want to refresh the timeline:
-            //  1. If it's persons first time syncing the room, they won't have
-            //     any old events cached to refresh. This could be from initial
-            //     sync or just the first time syncing the room since joining.
-            //  2. If we're re-hydrating from `syncFromCache` because we already
-            //     processed any marker event state that was in the cache
-            if (fromInitialState) {
-                logger.debug(
-                    `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} ` +
-                    `because it's from initial state.`,
-                );
-                return;
-            }
-
-            const isValidMsc2716Event =
-                // Check whether the room version directly supports MSC2716, in
-                // which case, "marker" events are already auth'ed by
-                // power_levels
-                MSC2716_ROOM_VERSIONS.includes(room.getVersion()) ||
-                // MSC2716 is also supported in all existing room versions but
-                // special meaning should only be given to "insertion", "batch",
-                // and "marker" events when they come from the room creator
-                markerEvent.getSender() === room.getRoomCreator();
-
-            if (!isValidMsc2716Event) {
-                logger.debug(
-                    `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} because ` +
-                    `MSC2716 is not supported in the room version or for any room version, the marker wasn't sent ` +
-                    `by the room creator.`,
-                );
-            }
-
-            // Don't process a marker event multiple times; we only need to
-            // throw the timeline away once, when we see a marker. All of the
-            // historical content will be in the `/messsages` responses from
-            // here on out.
-            const markerAlreadyProcessed = markerEvent.getId() === room.getLastMarkerEventIdProcessed();
-            if (markerAlreadyProcessed) {
-                logger.debug(
-                    `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} because ` +
-                    `it has already been processed.`,
-                );
-            }
-
-            // It would be nice if we could also specifically tell whether the
-            // historical messages actually affected the locally cached client
-            // timeline or not. The problem is we can't see the prev_events of
-            // the base insertion event that the marker was pointing to because
-            // prev_events aren't available in the client API's. In most cases,
-            // the history won't be in people's locally cached timelines in the
-            // client, so we don't need to bother everyone about refreshing
-            // their timeline. This works for a v1 though and there are use
-            // cases like initially bootstrapping your bridged room where people
-            // are likely to encounter the historical messages affecting their
-            // current timeline (think someone signing up for Beeper and
-            // importing their Whatsapp history).
-            if (
-                isValidMsc2716Event &&
-                !markerAlreadyProcessed
-            ) {
-                // Saw new marker event, let's let the clients know they should
-                // refresh the timeline.
-                logger.debug(
-                    `MarkerState: Timeline needs to be refreshed because ` +
-                    `a new markerEventId=${markerEvent.getId()} was sent in roomId=${room.roomId}`,
-                );
-                room.setTimelineNeedsRefresh(true);
-                room.emit(RoomEvent.historyImportedWithinTimeline, markerEvent, room);
-                room.setLastMarkerEventIdProcessed(markerEvent.getId());
-            }
+        room.currentState.on(RoomStateEvent.Marker, (markerEvent, setStateOptions) => {
+            this.onMarkerStateEvent(room, markerEvent, setStateOptions);
         });
+    }
+
+    /** When we see the marker state change in the room, we know there is some
+     * new historical messages imported by MSC2716 `/batch_send` somewhere in
+     * the room and we need to throw away the timeline to make sure the
+     * historical messages are shown when we paginate `/messages` again.
+     * @param {Room} room The room where the marker event was sent
+     * @param {MatrixEvent} markerEvent The new marker event
+     * @param {ISetStateOptions} setStateOptions When `fromInitialState` is set
+     * as `true`, the given marker event will be ignored
+    */
+    private onMarkerStateEvent(
+        room: Room,
+        markerEvent: MatrixEvent,
+        { fromInitialState }: ISetStateOptions = {},
+    ): void {
+        // We don't want to refresh the timeline:
+        //  1. If it's persons first time syncing the room, they won't have
+        //     any old events cached to refresh. This could be from initial
+        //     sync or just the first time syncing the room since joining.
+        //  2. If we're re-hydrating from `syncFromCache` because we already
+        //     processed any marker event state that was in the cache
+        if (fromInitialState) {
+            logger.debug(
+                `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} ` +
+                `because it's from initial state.`,
+            );
+            return;
+        }
+
+        const isValidMsc2716Event =
+            // Check whether the room version directly supports MSC2716, in
+            // which case, "marker" events are already auth'ed by
+            // power_levels
+            MSC2716_ROOM_VERSIONS.includes(room.getVersion()) ||
+            // MSC2716 is also supported in all existing room versions but
+            // special meaning should only be given to "insertion", "batch",
+            // and "marker" events when they come from the room creator
+            markerEvent.getSender() === room.getRoomCreator();
+
+        if (!isValidMsc2716Event) {
+            logger.debug(
+                `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} because ` +
+                `MSC2716 is not supported in the room version or for any room version, the marker wasn't sent ` +
+                `by the room creator.`,
+            );
+        }
+
+        // Don't process a marker event multiple times; we only need to
+        // throw the timeline away once, when we see a marker. All of the
+        // historical content will be in the `/messsages` responses from
+        // here on out.
+        const markerAlreadyProcessed = markerEvent.getId() === room.getLastMarkerEventIdProcessed();
+        if (markerAlreadyProcessed) {
+            logger.debug(
+                `MarkerState: Ignoring markerEventId=${markerEvent.getId()} in roomId=${room.roomId} because ` +
+                `it has already been processed.`,
+            );
+        }
+
+        // It would be nice if we could also specifically tell whether the
+        // historical messages actually affected the locally cached client
+        // timeline or not. The problem is we can't see the prev_events of
+        // the base insertion event that the marker was pointing to because
+        // prev_events aren't available in the client API's. In most cases,
+        // the history won't be in people's locally cached timelines in the
+        // client, so we don't need to bother everyone about refreshing
+        // their timeline. This works for a v1 though and there are use
+        // cases like initially bootstrapping your bridged room where people
+        // are likely to encounter the historical messages affecting their
+        // current timeline (think someone signing up for Beeper and
+        // importing their Whatsapp history).
+        if (
+            isValidMsc2716Event &&
+            !markerAlreadyProcessed
+        ) {
+            // Saw new marker event, let's let the clients know they should
+            // refresh the timeline.
+            logger.debug(
+                `MarkerState: Timeline needs to be refreshed because ` +
+                `a new markerEventId=${markerEvent.getId()} was sent in roomId=${room.roomId}`,
+            );
+            room.setTimelineNeedsRefresh(true);
+            room.emit(RoomEvent.historyImportedWithinTimeline, markerEvent, room);
+            room.setLastMarkerEventIdProcessed(markerEvent.getId());
+        }
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -305,20 +305,16 @@ export class SyncApi {
                 // Saw new marker event, let's let the clients know they should
                 // refresh the timeline.
                 //
-                // FIXME: Is there a way we could lookup
-                // `markerEvent.getContent()['m.insertion_id']` and get the
-                // prev_events of that event to see exactly where the history
-                // was imported and whether we have it locally? Because we only
+                // It would be nice if we could lookup the base insertion event
+                // that the marker event was pointing to because we really only
                 // need to refresh the timeline if the timeline includes the
-                // prev_events of the base insertion event.
-                const originalStackTraceLimit = Error.stackTraceLimit;
-                Error.stackTraceLimit = Infinity;
+                // prev_events of the base insertion event and won't re-request
+                // `/messages` over that range in the timeline. But the problem
+                // is we can't see prev_events from the client API.
                 logger.debug(
                     `MarkerState: Timeline needs to be refreshed because ` +
                     `a new markerEventId=${markerEvent.getId()} was sent in roomId=${room.roomId}`,
-                    new Error().stack,
                 );
-                Error.stackTraceLimit = originalStackTraceLimit;
                 room.setTimelineNeedsRefresh(true);
                 room.emit(RoomEvent.historyImportedWithinTimeline, markerEvent, room);
                 room.setLastMarkerEventIdProcessed(markerEvent.getId());

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -250,7 +250,6 @@ export class SyncApi {
             ]);
         });
 
-        // TODO: Should we just move this to `room.ts`?
         room.currentState.on(RoomStateEvent.Marker, async function(
             markerEvent,
             { fromInitialState }: ISetStateOptions = {},

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -253,7 +253,7 @@ export class SyncApi {
         // TODO: Should we just move this to `room.ts`?
         room.currentState.on(RoomStateEvent.Marker, async function(
             markerEvent,
-            {fromInitialState}: ISetStateOptions = {},
+            { fromInitialState }: ISetStateOptions = {},
         ) {
             // We don't want to refresh the timeline:
             //  1. If it's persons first time syncing the room, they won't have

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1639,7 +1639,6 @@ export class SyncApi {
         // the given state events
         const liveTimeline = room.getLiveTimeline();
         const timelineWasEmpty = liveTimeline.getEvents().length == 0;
-        console.log('timelineWasEmpty', timelineWasEmpty)
         if (timelineWasEmpty) {
             // Passing these events into initialiseState will freeze them, so we need
             // to compute and cache the push actions for them now, otherwise sync dies


### PR DESCRIPTION
Refresh room timeline when we see a MSC2716 marker event.

The "marker" events are being used as state now because this way they can't be lost in the timeline. Regardless of when they were sent, we will still have the latest version of the state to compare against. Any time we see our latest state value change for marker events, refresh the timeline.

> In a [sync meeting with @ara4n](https://docs.google.com/document/d/1KCEmpnGr4J-I8EeaVQ8QJZKBDu53ViI7V62y5BzfXr0/edit#bookmark=id.67nio1ka8znc), we came up with the idea to make the `marker` events as state events. When the client sees that the `m.room.marker` state changed to a different event ID, it can throw away all of the timeline and re-fetch as needed.
>
> For homeservers where the [same problem](https://github.com/matrix-org/matrix-doc/pull/2716#discussion_r782499674) can happen, we probably don't want to throw away the whole timeline but it can go up the `unsigned.replaces_state` chain of the `m.room.marker` state events to get them all.
>
> In terms of state performance, there could be thousands of `marker` events in a room but it's no different than room members joining and leaving over and over like an IRC room.
>
> *-- https://github.com/matrix-org/matrix-spec-proposals/pull/2716#discussion_r782629097*


<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


## Todo

 - [ ] Add tests
    - [x] When already joined to room, new `marker` event will cause `timelineNeedsRefresh`
    - [ ] `marker` event already sent in room, user joins room where the `/sync` `state` includes `marker` should *NOT* trigger `timelineNeedsRefresh`
    - [ ] When already joined to room, `marker` event already sent in room, initial `/sync` `state` includes `marker` should *NOT* trigger `timelineNeedsRefresh`
    - [ ] When `syncFromCache` where the state includes marker should *NOT* trigger `timelineNeedsRefresh`
    - [ ] In normal room version, `marker` from creator will cause `timelineNeedsRefresh`
    - [ ] In normal room version, `marker` not from creator  should *NOT* trigger `timelineNeedsRefresh`
 - [ ] Add method to refresh the timeline to use in https://github.com/matrix-org/matrix-react-sdk/pull/8303#discussion_r848999579


### Dev notes

```
yarn jest spec/integ/matrix-client-syncing.spec.js --silent=false --verbose=false
```

---

```js
        Error.stackTraceLimit = Infinity;
        console.log(`setStateEvents timelineWasEmpty=${markerFoundOptions && markerFoundOptions.timelineWasEmpty} stateEvents:\n`, stateEvents.map((ev) => {
            return `\t${ev.getType()} ${ev.getId()}`;
        }).join('\n'), new Error().stack);
```


---

```
room.resetLiveTimeline(null, null);
```

```
addEventsToTimeline
addEventToTimeline
addLiveEvent

resetLiveTimeline

resetAllTimelines

removeFilteredTimelineSet


syncFromCache
processSyncResponse
processRoomEvents
room.addLiveEvents


sessionStore


processSyncResponse
processRoomEvents
initialiseState
setStateEvents

load
getEventTimeline
initialiseState
setStateEvents
```




<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Draft: Refresh room timeline when we see a MSC2716 marker event ([\#2282](https://github.com/matrix-org/matrix-js-sdk/pull/2282)). Contributed by @MadLittleMods.<!-- CHANGELOG_PREVIEW_END -->