### PR TITLE
Support for MSC2457 logout_devices param for setPassword()

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1026,4 +1026,57 @@ describe("MatrixClient", function() {
             expect(requestContent).toEqual(content);
         });
     });
+
+    describe("setPassword", () => {
+        const auth = { session: 'abcdef', type: 'foo' };
+        const newPassword = 'newpassword';
+        const callback = () => {};
+
+        const passwordTest = (expectedRequestContent: any, expectedCallback?: Function) => {
+            const [callback, method, path, queryParams, requestContent] = client.http.authedRequest.mock.calls[0];
+            if (expectedCallback) {
+                expect(callback).toBe(expectedCallback);
+            } else {
+                expect(callback).toBeFalsy();
+            }
+            expect(method).toBe('POST');
+            expect(path).toEqual('/account/password');
+            expect(queryParams).toBeFalsy();
+            expect(requestContent).toEqual(expectedRequestContent);
+        };
+
+        beforeEach(() => {
+            client.http.authedRequest.mockClear().mockResolvedValue({});
+        });
+
+        it("no logout_devices specified", async () => {
+            await client.setPassword(auth, newPassword);
+            passwordTest({ auth, new_password: newPassword });
+        });
+
+        it("no logout_devices specified + callback", async () => {
+            await client.setPassword(auth, newPassword, callback);
+            passwordTest({ auth, new_password: newPassword }, callback);
+        });
+
+        it("overload logoutDevices=true", async () => {
+            await client.setPassword(auth, newPassword, true);
+            passwordTest({ auth, new_password: newPassword, logout_devices: true });
+        });
+
+        it("overload logoutDevices=true + callback", async () => {
+            await client.setPassword(auth, newPassword, true, callback);
+            passwordTest({ auth, new_password: newPassword, logout_devices: true }, callback);
+        });
+
+        it("overload logoutDevices=false", async () => {
+            await client.setPassword(auth, newPassword, false);
+            passwordTest({ auth, new_password: newPassword, logout_devices: false });
+        });
+
+        it("overload logoutDevices=false + callback", async () => {
+            await client.setPassword(auth, newPassword, false, callback);
+            passwordTest({ auth, new_password: newPassword, logout_devices: false }, callback);
+        });
+    });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -7815,15 +7815,35 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * Make a request to change your password.
      * @param {Object} authDict
      * @param {string} newPassword The new desired password.
+     * @param {boolean} logoutDevices Should all sessions be logged out after the password change. Defaults to true.
      * @param {module:client.callback} callback Optional.
      * @return {Promise} Resolves: TODO
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public setPassword(authDict: any, newPassword: string, callback?: Callback): Promise<any> { // TODO: Types
+    public setPassword(
+        authDict: any,
+        newPassword: string,
+        logoutDevices: boolean,
+        callback?: Callback
+        ): Promise<any>;
+    public setPassword(
+        authDict: any,
+        newPassword: string,
+        logoutDevices?: Callback | boolean,
+        callback?: Callback,
+    ): Promise<any> { // TODO: Types
+        if (typeof logoutDevices !== 'boolean') {
+            logoutDevices = true;
+        }
+        if (typeof logoutDevices === 'function') {
+            callback = logoutDevices;
+        }
+
         const path = "/account/password";
         const data = {
             'auth': authDict,
             'new_password': newPassword,
+            'logout_devices': logoutDevices,
         };
 
         return this.http.authedRequest(

--- a/src/client.ts
+++ b/src/client.ts
@@ -7823,6 +7823,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public setPassword(
         authDict: any,
         newPassword: string,
+        callback?: Callback
+    ): Promise<any>;
+    public setPassword(
+        authDict: any,
+        newPassword: string,
         logoutDevices: boolean,
         callback?: Callback
         ): Promise<any>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -7841,7 +7841,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             callback = logoutDevices;
         }
         if (typeof logoutDevices !== 'boolean') {
-            logoutDevices = true;
+            // Use backwards compatible behaviour of not specifying logout_devices
+            // This way it is left up to the server:
+            logoutDevices = undefined;
         }
 
         const path = "/account/password";

--- a/src/client.ts
+++ b/src/client.ts
@@ -7824,19 +7824,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         authDict: any,
         newPassword: string,
         callback?: Callback,
-    ): Promise<any>;
+    ): Promise<{}>;
     public setPassword(
         authDict: any,
         newPassword: string,
         logoutDevices: boolean,
         callback?: Callback,
-    ): Promise<any>;
+    ): Promise<{}>;
     public setPassword(
         authDict: any,
         newPassword: string,
         logoutDevices?: Callback | boolean,
         callback?: Callback,
-    ): Promise<any> { // TODO: Types
+    ): Promise<{}> {
         if (typeof logoutDevices === 'function') {
             callback = logoutDevices;
         }
@@ -7851,7 +7851,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             'logout_devices': logoutDevices,
         };
 
-        return this.http.authedRequest(
+        return this.http.authedRequest<{}>(
             callback, Method.Post, path, null, data,
         );
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -7823,14 +7823,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public setPassword(
         authDict: any,
         newPassword: string,
-        callback?: Callback
+        callback?: Callback,
     ): Promise<any>;
     public setPassword(
         authDict: any,
         newPassword: string,
         logoutDevices: boolean,
-        callback?: Callback
-        ): Promise<any>;
+        callback?: Callback,
+    ): Promise<any>;
     public setPassword(
         authDict: any,
         newPassword: string,

--- a/src/client.ts
+++ b/src/client.ts
@@ -7832,11 +7832,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         logoutDevices?: Callback | boolean,
         callback?: Callback,
     ): Promise<any> { // TODO: Types
-        if (typeof logoutDevices !== 'boolean') {
-            logoutDevices = true;
-        }
         if (typeof logoutDevices === 'function') {
             callback = logoutDevices;
+        }
+        if (typeof logoutDevices !== 'boolean') {
+            logoutDevices = true;
         }
 
         const path = "/account/password";


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Support for MSC2457 logout_devices param for setPassword() ([\#2285](https://github.com/matrix-org/matrix-js-sdk/pull/2285)). Contributed by @hughns.<!-- CHANGELOG_PREVIEW_END -->