### PR TITLE
Add method for checking whether our other devices are cross-signed, even when this device isn't

### DIFF
--- a/spec/unit/crypto/cross-signing.spec.js
+++ b/spec/unit/crypto/cross-signing.spec.js
@@ -883,4 +883,138 @@ describe("Cross Signing", function() {
         expect(bobTrust3.isCrossSigningVerified()).toBeTruthy();
         expect(bobTrust3.isTofu()).toBeTruthy();
     });
+
+    it(
+        "should observe that our own device is cross-signed, even if this device doesn't trust the key",
+        async function() {
+            const { client: alice } = await makeTestClient(
+                { userId: "@alice:example.com", deviceId: "Osborne2" },
+            );
+            alice.uploadDeviceSigningKeys = async () => {};
+            alice.uploadKeySignatures = async () => {};
+
+            // Generate Alice's SSK etc
+            const aliceMasterSigning = new global.Olm.PkSigning();
+            const aliceMasterPrivkey = aliceMasterSigning.generate_seed();
+            const aliceMasterPubkey = aliceMasterSigning.init_with_seed(aliceMasterPrivkey);
+            const aliceSigning = new global.Olm.PkSigning();
+            const alicePrivkey = aliceSigning.generate_seed();
+            const alicePubkey = aliceSigning.init_with_seed(alicePrivkey);
+            const aliceSSK = {
+                user_id: "@alice:example.com",
+                usage: ["self_signing"],
+                keys: {
+                    ["ed25519:" + alicePubkey]: alicePubkey,
+                },
+            };
+            const sskSig = aliceMasterSigning.sign(anotherjson.stringify(aliceSSK));
+            aliceSSK.signatures = {
+                "@alice:example.com": {
+                    ["ed25519:" + aliceMasterPubkey]: sskSig,
+                },
+            };
+
+            // Alice's device downloads the keys, but doesn't trust them yet
+            alice.crypto.deviceList.storeCrossSigningForUser("@alice:example.com", {
+                keys: {
+                    master: {
+                        user_id: "@alice:example.com",
+                        usage: ["master"],
+                        keys: {
+                            ["ed25519:" + aliceMasterPubkey]: aliceMasterPubkey,
+                        },
+                    },
+                    self_signing: aliceSSK,
+                },
+                firstUse: 1,
+                unsigned: {},
+            });
+
+            // Alice has a second device that's cross-signed
+            const aliceCrossSignedDevice = {
+                user_id: "@alice:example.com",
+                device_id: "Dynabook",
+                algorithms: ["m.olm.curve25519-aes-sha256", "m.megolm.v1.aes-sha"],
+                keys: {
+                    "curve25519:Dynabook": "somePubkey",
+                    "ed25519:Dynabook": "someOtherPubkey",
+                },
+            };
+            const sig = aliceSigning.sign(anotherjson.stringify(aliceCrossSignedDevice));
+            aliceCrossSignedDevice.signatures = {
+                "@alice:example.com": {
+                    ["ed25519:" + alicePubkey]: sig,
+                },
+            };
+            alice.crypto.deviceList.storeDevicesForUser("@alice:example.com", {
+                Dynabook: aliceCrossSignedDevice,
+            });
+
+            // We don't trust the cross-signing keys yet...
+            expect(alice.checkDeviceTrust(aliceCrossSignedDevice.device_id).isCrossSigningVerified()).toBeFalsy();
+            // ... but we do acknowledge that the device is signed by them
+            expect(alice.checkIfOwnDeviceCrossSigned(aliceCrossSignedDevice.device_id)).toBeTruthy();
+        },
+    );
+
+    it("should observe that our own device isn't cross-signed", async function() {
+        const { client: alice } = await makeTestClient(
+            { userId: "@alice:example.com", deviceId: "Osborne2" },
+        );
+        alice.uploadDeviceSigningKeys = async () => {};
+        alice.uploadKeySignatures = async () => {};
+
+        // Generate Alice's SSK etc
+        const aliceMasterSigning = new global.Olm.PkSigning();
+        const aliceMasterPrivkey = aliceMasterSigning.generate_seed();
+        const aliceMasterPubkey = aliceMasterSigning.init_with_seed(aliceMasterPrivkey);
+        const aliceSigning = new global.Olm.PkSigning();
+        const alicePrivkey = aliceSigning.generate_seed();
+        const alicePubkey = aliceSigning.init_with_seed(alicePrivkey);
+        const aliceSSK = {
+            user_id: "@alice:example.com",
+            usage: ["self_signing"],
+            keys: {
+                ["ed25519:" + alicePubkey]: alicePubkey,
+            },
+        };
+        const sskSig = aliceMasterSigning.sign(anotherjson.stringify(aliceSSK));
+        aliceSSK.signatures = {
+            "@alice:example.com": {
+                ["ed25519:" + aliceMasterPubkey]: sskSig,
+            },
+        };
+
+        // Alice's device downloads the keys
+        alice.crypto.deviceList.storeCrossSigningForUser("@alice:example.com", {
+            keys: {
+                master: {
+                    user_id: "@alice:example.com",
+                    usage: ["master"],
+                    keys: {
+                        ["ed25519:" + aliceMasterPubkey]: aliceMasterPubkey,
+                    },
+                },
+                self_signing: aliceSSK,
+            },
+            firstUse: 1,
+            unsigned: {},
+        });
+
+        // Alice has a second device that's also not cross-signed
+        const aliceNotCrossSignedDevice = {
+            user_id: "@alice:example.com",
+            device_id: "Dynabook",
+            algorithms: ["m.olm.curve25519-aes-sha256", "m.megolm.v1.aes-sha"],
+            keys: {
+                "curve25519:Dynabook": "somePubkey",
+                "ed25519:Dynabook": "someOtherPubkey",
+            },
+        };
+        alice.crypto.deviceList.storeDevicesForUser("@alice:example.com", {
+            Dynabook: aliceNotCrossSignedDevice,
+        });
+
+        expect(alice.checkIfOwnDeviceCrossSigned(aliceNotCrossSignedDevice.device_id)).toBeFalsy();
+    });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -2073,6 +2073,21 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
+     * Check whether one of our own devices is cross-signed by our
+     * user's stored keys, regardless of whether we trust those keys yet.
+     *
+     * @param {string} deviceId The ID of the device to check
+     *
+     * @returns {boolean} true if the device is cross-signed
+     */
+    public checkIfOwnDeviceCrossSigned(deviceId: string): boolean {
+        if (!this.crypto) {
+            throw new Error("End-to-end encryption disabled");
+        }
+        return this.crypto.checkIfOwnDeviceCrossSigned(deviceId);
+    }
+
+    /**
      * Check the copy of our cross-signing key that we have in the device list and
      * see if we can get the private key. If so, mark it as trusted.
      * @param {Object} opts ICheckOwnCrossSigningTrustOpts object

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1423,6 +1423,25 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         }
     }
 
+    /**
+     * Check whether one of our own devices is cross-signed by our
+     * user's stored keys, regardless of whether we trust those keys yet.
+     *
+     * @param {string} deviceId The ID of the device to check
+     *
+     * @returns {boolean} true if the device is cross-signed
+     */
+    public checkIfOwnDeviceCrossSigned(deviceId: string): boolean {
+        const device = this.deviceList.getStoredDevice(this.userId, deviceId);
+        const userCrossSigning = this.deviceList.getStoredCrossSigningForUser(this.userId);
+        return userCrossSigning.checkDeviceTrust(
+            userCrossSigning,
+            device,
+            false,
+            true,
+        ).isCrossSigningVerified();
+    }
+
     /*
      * Event handler for DeviceList's userNewDevices event
      */


### PR DESCRIPTION
This is something I'm now doing multiple different places in matrix-react-sdk, so I figured it was worth adding as a method on MatrixClient.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
Notes: Add `MatrixClient.checkIfOwnDeviceCrossSigned` method, for checking if another of our devices is cross-signed regardless of whether this device trusts the MSK.


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->