### PR TITLE
Prevent duplicated re-emitter setups in event-mapper

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3779,6 +3779,15 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             localEvent.setThreadId(thread.id);
         }
 
+        // set up re-emitter for this new event - this is normally the job of EventMapper but we don't use it here
+        this.reEmitter.reEmit(localEvent, [
+            MatrixEventEvent.Replaced,
+            MatrixEventEvent.VisibilityChange,
+        ]);
+        room?.reEmitter.reEmit(localEvent, [
+            MatrixEventEvent.BeforeRedaction,
+        ]);
+
         // if this is a relation or redaction of an event
         // that hasn't been sent yet (e.g. with a local id starting with a ~)
         // then listen for the remote echo of that event so that by the time

--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -25,7 +25,7 @@ export interface MapperOpts {
 }
 
 export function eventMapperFor(client: MatrixClient, options: MapperOpts): EventMapper {
-    const preventReEmit = Boolean(options.preventReEmit);
+    let preventReEmit = Boolean(options.preventReEmit);
     const decrypt = options.decrypt !== false;
 
     function mapper(plainOldJsObject: Partial<IEvent>) {
@@ -43,6 +43,8 @@ export function eventMapperFor(client: MatrixClient, options: MapperOpts): Event
         } else {
             // merge the latest unsigned data from the server
             event.setUnsigned({ ...event.getUnsigned(), ...plainOldJsObject.unsigned });
+            // prevent doubling up re-emitters
+            preventReEmit = true;
         }
 
         const thread = room?.findThreadForEvent(event);


### PR DESCRIPTION
Fix redactions of own events not correctly updating thread summaries