### PR TITLE
Fix coverage diffs for PRs that aren't up to date, take 3

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           fail_ci_if_error: false
           verbose: true
+          override_commit: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}


### PR DESCRIPTION
The checkout action correctly gets the pull request's HEAD, but then the Codecov uploader still thought that the coverage output was for the HEAD+develop merge commit, rather than HEAD.

Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->