### PR TITLE
Live location sharing - expose room liveBeaconIds

### DIFF
--- a/spec/unit/room-state.spec.js
+++ b/spec/unit/room-state.spec.js
@@ -334,7 +334,7 @@ describe("RoomState", function() {
                 state.setStateEvents([updatedLiveBeaconEvent]);
 
                 expect(state.hasLiveBeacons).toBe(false);
-                expect(filterEmitCallsByEventType(RoomStateEvent.BeaconLiveness, emitSpy).length).toBe(2);
+                expect(filterEmitCallsByEventType(RoomStateEvent.BeaconLiveness, emitSpy).length).toBe(3);
                 expect(emitSpy).toHaveBeenCalledWith(RoomStateEvent.BeaconLiveness, state, false);
             });
         });

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -518,15 +518,11 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      * roomstate.hasLiveBeacons has changed
      */
     private onBeaconLivenessChange(): void {
-        const prevHasLiveBeacons = !!this.liveBeaconIds?.length;
         this._liveBeaconIds = Array.from(this.beacons.values())
             .filter(beacon => beacon.isLive)
             .map(beacon => beacon.identifier);
 
-        const hasLiveBeacons = !!this.liveBeaconIds.length;
-        if (prevHasLiveBeacons !== hasLiveBeacons) {
-            this.emit(RoomStateEvent.BeaconLiveness, this, hasLiveBeacons);
-        }
+            this.emit(RoomStateEvent.BeaconLiveness, this, this.hasLiveBeacons);
     }
 
     private getStateEventMatching(event: MatrixEvent): MatrixEvent | null {

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -84,7 +84,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
     public paginationToken: string = null;
 
     public readonly beacons = new Map<BeaconIdentifier, Beacon>();
-    private liveBeaconIds: BeaconIdentifier[] = [];
+    private _liveBeaconIds: BeaconIdentifier[] = [];
 
     /**
      * Construct room state.
@@ -249,6 +249,10 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
 
     public get hasLiveBeacons(): boolean {
         return !!this.liveBeaconIds?.length;
+    }
+
+    public get liveBeaconIds(): BeaconIdentifier[] {
+        return this._liveBeaconIds;
     }
 
     /**
@@ -515,7 +519,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
      */
     private onBeaconLivenessChange(): void {
         const prevHasLiveBeacons = !!this.liveBeaconIds?.length;
-        this.liveBeaconIds = Array.from(this.beacons.values())
+        this._liveBeaconIds = Array.from(this.beacons.values())
             .filter(beacon => beacon.isLive)
             .map(beacon => beacon.identifier);
 

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -514,15 +514,14 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
     /**
      * @experimental
      * Check liveness of room beacons
-     * emit RoomStateEvent.BeaconLiveness when
-     * roomstate.hasLiveBeacons has changed
+     * emit RoomStateEvent.BeaconLiveness event
      */
     private onBeaconLivenessChange(): void {
         this._liveBeaconIds = Array.from(this.beacons.values())
             .filter(beacon => beacon.isLive)
             .map(beacon => beacon.identifier);
 
-            this.emit(RoomStateEvent.BeaconLiveness, this, this.hasLiveBeacons);
+        this.emit(RoomStateEvent.BeaconLiveness, this, this.hasLiveBeacons);
     }
 
     private getStateEventMatching(event: MatrixEvent): MatrixEvent | null {

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -502,6 +502,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
 
         this.emit(BeaconEvent.New, event, beacon);
         beacon.on(BeaconEvent.LivenessChange, this.onBeaconLivenessChange.bind(this));
+        beacon.on(BeaconEvent.Destroy, this.onBeaconLivenessChange.bind(this));
 
         this.beacons.set(beacon.identifier, beacon);
     }


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

- exposes `liveBeaconIds` on room state
- updates liveBeaconIds on beacon destroy
- emits `RoomStateEvent.BeaconLiveness` whenever liveBeaconIds changes (not just when overall liveness of a room changes)

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location sharing - expose room liveBeaconIds ([\#2296](https://github.com/matrix-org/matrix-js-sdk/pull/2296)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->