### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/examples/node/app.js
+++ b/examples/node/app.js
@@ -341,7 +341,7 @@ function printLine(event) {
 
     var maxNameWidth = 15;
     if (name.length > maxNameWidth) {
-        name = name.substr(0, maxNameWidth-1) + "\u2026";
+        name = name.slice(0, maxNameWidth-1) + "\u2026";
     }
 
     if (event.getType() === "m.room.message") {
@@ -398,7 +398,7 @@ function print(str, formatter) {
 
 function fixWidth(str, len) {
     if (str.length > len) {
-        return str.substr(0, len-2) + "\u2026";
+        return str.substring(0, len-2) + "\u2026";
     }
     else if (str.length < len) {
         return str + new Array(len - str.length).join(" ");

--- a/src/content-repo.ts
+++ b/src/content-repo.ts
@@ -73,8 +73,8 @@ export function getHttpUriForMxc(
     const fragmentOffset = serverAndMediaId.indexOf("#");
     let fragment = "";
     if (fragmentOffset >= 0) {
-        fragment = serverAndMediaId.substr(fragmentOffset);
-        serverAndMediaId = serverAndMediaId.substr(0, fragmentOffset);
+        fragment = serverAndMediaId.slice(fragmentOffset);
+        serverAndMediaId = serverAndMediaId.slice(0, fragmentOffset);
     }
 
     const urlParams = (Object.keys(params).length === 0 ? "" : ("?" + utils.encodeParams(params)));

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -228,8 +228,8 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
                 // (hence 43 characters long).
 
                 func({
-                    senderKey: key.substr(KEY_INBOUND_SESSION_PREFIX.length, 43),
-                    sessionId: key.substr(KEY_INBOUND_SESSION_PREFIX.length + 44),
+                    senderKey: key.slice(KEY_INBOUND_SESSION_PREFIX.length, KEY_INBOUND_SESSION_PREFIX.length + 43),
+                    sessionId: key.slice(KEY_INBOUND_SESSION_PREFIX.length + 44),
                     sessionData: getJsonItem(this.store, key),
                 });
             }
@@ -299,7 +299,7 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
         for (let i = 0; i < this.store.length; ++i) {
             const key = this.store.key(i);
             if (key.startsWith(prefix)) {
-                const roomId = key.substr(prefix.length);
+                const roomId = key.slice(prefix.length);
                 result[roomId] = getJsonItem(this.store, key);
             }
         }
@@ -313,8 +313,8 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
         for (const session in sessionsNeedingBackup) {
             if (Object.prototype.hasOwnProperty.call(sessionsNeedingBackup, session)) {
                 // see getAllEndToEndInboundGroupSessions for the magic number explanations
-                const senderKey = session.substr(0, 43);
-                const sessionId = session.substr(44);
+                const senderKey = session.slice(0, 43);
+                const sessionId = session.slice(44);
                 this.getEndToEndInboundGroupSession(
                     senderKey, sessionId, null,
                     (sessionData) => {

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -418,8 +418,8 @@ export class MemoryCryptoStore implements CryptoStore {
             // (hence 43 characters long).
 
             func({
-                senderKey: key.substr(0, 43),
-                sessionId: key.substr(44),
+                senderKey: key.slice(0, 43),
+                sessionId: key.slice(44),
                 sessionData: this.inboundGroupSessions[key],
             });
         }
@@ -482,8 +482,8 @@ export class MemoryCryptoStore implements CryptoStore {
         for (const session in this.sessionsNeedingBackup) {
             if (this.inboundGroupSessions[session]) {
                 sessions.push({
-                    senderKey: session.substr(0, 43),
-                    sessionId: session.substr(44),
+                    senderKey: session.slice(0, 43),
+                    sessionId: session.slice(44),
                     sessionData: this.inboundGroupSessions[session],
                 });
                 if (limit && session.length >= limit) {

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -36,7 +36,7 @@ import {
 function matchesWildcard(actualValue: string, filterValue: string): boolean {
     if (filterValue.endsWith("*")) {
         const typePrefix = filterValue.slice(0, -1);
-        return actualValue.substr(0, typePrefix.length) === typePrefix;
+        return actualValue.slice(0, typePrefix.length) === typePrefix;
     } else {
         return actualValue === filterValue;
     }

--- a/src/store/session/webstorage.js
+++ b/src/store/session/webstorage.js
@@ -78,7 +78,7 @@ WebStorageSessionStore.prototype = {
         const devices = {};
         for (let i = 0; i < this.store.length; ++i) {
             const key = this.store.key(i);
-            const userId = key.substr(prefix.length);
+            const userId = key.slice(prefix.length);
             if (key.startsWith(prefix)) devices[userId] = getJsonItem(this.store, key);
         }
         return devices;
@@ -125,7 +125,7 @@ WebStorageSessionStore.prototype = {
         const deviceKeys = getKeysWithPrefix(this.store, keyEndToEndSessions(''));
         const results = {};
         for (const k of deviceKeys) {
-            const unprefixedKey = k.substr(keyEndToEndSessions('').length);
+            const unprefixedKey = k.slice(keyEndToEndSessions('').length);
             results[unprefixedKey] = getJsonItem(this.store, k);
         }
         return results;
@@ -158,8 +158,8 @@ WebStorageSessionStore.prototype = {
             // (hence 43 characters long).
 
             result.push({
-                senderKey: key.substr(prefix.length, 43),
-                sessionId: key.substr(prefix.length + 44),
+                senderKey: key.slice(prefix.length, prefix.length + 43),
+                sessionId: key.slice(prefix.length + 44),
             });
         }
         return result;
@@ -182,7 +182,7 @@ WebStorageSessionStore.prototype = {
         const roomKeys = getKeysWithPrefix(this.store, keyEndToEndRoom(''));
         const results = {};
         for (const k of roomKeys) {
-            const unprefixedKey = k.substr(keyEndToEndRoom('').length);
+            const unprefixedKey = k.slice(keyEndToEndRoom('').length);
             results[unprefixedKey] = getJsonItem(this.store, k);
         }
         return results;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -427,7 +427,7 @@ export function globToRegexp(glob: string, extended?: any): string {
 
 export function ensureNoTrailingSlash(url: string): string {
     if (url && url.endsWith("/")) {
-        return url.substr(0, url.length - 1);
+        return url.slice(0, -1);
     } else {
         return url;
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->