### PR TITLE
fix getUrlPreview typeError

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4604,7 +4604,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         ts = Math.floor(ts / 60000) * 60000;
 
         const parsed = new URL(url);
-        parsed.hash = ""; // strip the hash as it won't affect the preview
         url = parsed.toString();
 
         const key = ts + "_" + url;


### PR DESCRIPTION
When using a strict mod, this line causes a typeError

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->