### PR TITLE
Update threads handling for replies-to-thread-responses as per MSC update

### DIFF
--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -797,7 +797,7 @@ describe("MatrixClient", function() {
             ]);
         });
 
-        it("sends reply to thread responses to thread timeline only", () => {
+        it("sends reply to thread responses to main timeline only", () => {
             client.clientOpts = { experimentalThreadSupport: true };
 
             const threadRootEvent = buildEventPollStartThreadRoot();
@@ -814,12 +814,12 @@ describe("MatrixClient", function() {
 
             expect(timeline).toEqual([
                 threadRootEvent,
+                replyToThreadResponse,
             ]);
 
             expect(threaded).toEqual([
                 threadRootEvent,
                 eventMessageInThread,
-                replyToThreadResponse,
             ]);
         });
     });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2154,36 +2154,32 @@ describe("Room", function() {
             expect(room.eventShouldLiveIn(threadReaction2Redaction, events, roots).threadId).toBe(threadRoot.getId());
         });
 
-        it("reply to thread response and its relations&redactions should be only in thread timeline", () => {
+        it("reply to thread response and its relations&redactions should be only in main timeline", () => {
             const threadRoot = mkMessage();
             const threadResponse1 = mkThreadResponse(threadRoot);
             const reply1 = mkReply(threadResponse1);
-            const threadReaction1 = mkReaction(reply1);
-            const threadReaction2 = mkReaction(reply1);
-            const threadReaction2Redaction = mkRedaction(reply1);
+            const reaction1 = mkReaction(reply1);
+            const reaction2 = mkReaction(reply1);
+            const reaction2Redaction = mkRedaction(reply1);
 
             const roots = new Set([threadRoot.getId()]);
             const events = [
                 threadRoot,
                 threadResponse1,
                 reply1,
-                threadReaction1,
-                threadReaction2,
-                threadReaction2Redaction,
+                reaction1,
+                reaction2,
+                reaction2Redaction,
             ];
 
-            expect(room.eventShouldLiveIn(reply1, events, roots).shouldLiveInRoom).toBeFalsy();
-            expect(room.eventShouldLiveIn(reply1, events, roots).shouldLiveInThread).toBeTruthy();
-            expect(room.eventShouldLiveIn(reply1, events, roots).threadId).toBe(threadRoot.getId());
-            expect(room.eventShouldLiveIn(threadReaction1, events, roots).shouldLiveInRoom).toBeFalsy();
-            expect(room.eventShouldLiveIn(threadReaction1, events, roots).shouldLiveInThread).toBeTruthy();
-            expect(room.eventShouldLiveIn(threadReaction1, events, roots).threadId).toBe(threadRoot.getId());
-            expect(room.eventShouldLiveIn(threadReaction2, events, roots).shouldLiveInRoom).toBeFalsy();
-            expect(room.eventShouldLiveIn(threadReaction2, events, roots).shouldLiveInThread).toBeTruthy();
-            expect(room.eventShouldLiveIn(threadReaction2, events, roots).threadId).toBe(threadRoot.getId());
-            expect(room.eventShouldLiveIn(threadReaction2Redaction, events, roots).shouldLiveInRoom).toBeFalsy();
-            expect(room.eventShouldLiveIn(threadReaction2Redaction, events, roots).shouldLiveInThread).toBeTruthy();
-            expect(room.eventShouldLiveIn(threadReaction2Redaction, events, roots).threadId).toBe(threadRoot.getId());
+            expect(room.eventShouldLiveIn(reply1, events, roots).shouldLiveInRoom).toBeTruthy();
+            expect(room.eventShouldLiveIn(reply1, events, roots).shouldLiveInThread).toBeFalsy();
+            expect(room.eventShouldLiveIn(reaction1, events, roots).shouldLiveInRoom).toBeTruthy();
+            expect(room.eventShouldLiveIn(reaction1, events, roots).shouldLiveInThread).toBeFalsy();
+            expect(room.eventShouldLiveIn(reaction2, events, roots).shouldLiveInRoom).toBeTruthy();
+            expect(room.eventShouldLiveIn(reaction2, events, roots).shouldLiveInThread).toBeFalsy();
+            expect(room.eventShouldLiveIn(reaction2Redaction, events, roots).shouldLiveInRoom).toBeTruthy();
+            expect(room.eventShouldLiveIn(reaction2Redaction, events, roots).shouldLiveInThread).toBeFalsy();
         });
 
         it("reply to reply to thread root should only be in the main timeline", () => {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1612,16 +1612,6 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
             };
         }
 
-        // A reply directly to a thread response is shown as part of the thread only, this is to provide a better
-        // experience when communicating with users using clients without full threads support
-        if (parentEvent?.isThreadRelation) {
-            return {
-                shouldLiveInRoom: false,
-                shouldLiveInThread: true,
-                threadId: parentEvent.threadRootId,
-            };
-        }
-
         // We've exhausted all scenarios, can safely assume that this event should live in the room timeline only
         return {
             shouldLiveInRoom: true,


### PR DESCRIPTION
Verified matches Element Android behaviour

Fixes https://github.com/vector-im/element-web/issues/19678

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Update threads handling for replies-to-thread-responses as per MSC update ([\#2305](https://github.com/matrix-org/matrix-js-sdk/pull/2305)). Fixes vector-im/element-web#19678.<!-- CHANGELOG_PREVIEW_END -->