### PR TITLE
Ignore m.replace relations on state events, they're invalid

### DIFF
--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -130,4 +130,53 @@ describe("Relations", function() {
             await relationsCreated;
         }
     });
+
+    it("edits shouldn't apply to state events", async () => {
+        const userId = "@bob:example.com";
+        const room = new Room("room123", null, userId);
+        const relations = new Relations("m.replace", "m.room.topic", room);
+
+        // Create an instance of a state event with rel_type m.replace
+        const originalTopic = new MatrixEvent({
+            "sender": userId,
+            "type": "m.room.topic",
+            "event_id": "$orig",
+            "room_id": room.roomId,
+            "content": {
+                "topic": "orig",
+            },
+        });
+        const badlyEditedTopic = new MatrixEvent({
+            "sender": userId,
+            "type": "m.room.topic",
+            "event_id": "$orig",
+            "room_id": room.roomId,
+            "content": {
+                "topic": "topic",
+                "m.new_content": {
+                    "topic": "edit",
+                },
+                "m.relates_to": {
+                    "event_id": "$orig",
+                    "rel_type": "m.replace",
+                },
+            },
+        });
+
+        // Add the original topic and check results
+        {
+            relations.addEvent(originalTopic);
+            expect(originalTopic.replacingEvent()).toBe(null);
+            expect(originalTopic.getContent().topic).toBe("orig");
+        }
+
+        // Add the badly edited topic and check results
+        {
+            relations.addEvent(badlyEditedTopic);
+            expect(originalTopic.replacingEvent()).toBe(null);
+            expect(originalTopic.getContent().topic).toBe("orig");
+            expect(badlyEditedTopic.replacingEvent()).toBe(null);
+            expect(badlyEditedTopic.getContent().topic).toBe("topic");
+        }
+    });
 });

--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -131,7 +131,7 @@ describe("Relations", function() {
         }
     });
 
-    it("edits shouldn't apply to state events", async () => {
+    it("should ignore m.replace for state events", async () => {
         const userId = "@bob:example.com";
         const room = new Room("room123", null, userId);
         const relations = new Relations("m.replace", "m.room.topic", room);
@@ -145,6 +145,7 @@ describe("Relations", function() {
             "content": {
                 "topic": "orig",
             },
+            "state_key": "",
         });
         const badlyEditedTopic = new MatrixEvent({
             "sender": userId,
@@ -161,22 +162,17 @@ describe("Relations", function() {
                     "rel_type": "m.replace",
                 },
             },
+            "state_key": "",
         });
 
-        // Add the original topic and check results
-        {
-            relations.addEvent(originalTopic);
-            expect(originalTopic.replacingEvent()).toBe(null);
-            expect(originalTopic.getContent().topic).toBe("orig");
-        }
+        await relations.setTargetEvent(originalTopic);
+        expect(originalTopic.replacingEvent()).toBe(null);
+        expect(originalTopic.getContent().topic).toBe("orig");
 
-        // Add the badly edited topic and check results
-        {
-            relations.addEvent(badlyEditedTopic);
-            expect(originalTopic.replacingEvent()).toBe(null);
-            expect(originalTopic.getContent().topic).toBe("orig");
-            expect(badlyEditedTopic.replacingEvent()).toBe(null);
-            expect(badlyEditedTopic.getContent().topic).toBe("topic");
-        }
+        await relations.addEvent(badlyEditedTopic);
+        expect(originalTopic.replacingEvent()).toBe(null);
+        expect(originalTopic.getContent().topic).toBe("orig");
+        expect(badlyEditedTopic.replacingEvent()).toBe(null);
+        expect(badlyEditedTopic.getContent().topic).toBe("topic");
     });
 });

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1336,6 +1336,10 @@ export class MatrixEvent extends TypedEventEmitter<EmittedEvents, MatrixEventHan
         if (this.isRedacted() && newEvent) {
             return;
         }
+        // don't allow state events to be replaced using this mechanism as per MSC2676
+        if (this.isState()) {
+            return;
+        }
         if (this._replacingEvent !== newEvent) {
             this._replacingEvent = newEvent;
             this.emit(MatrixEventEvent.Replaced, this);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/21851

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ignore m.replace relations on state events, they're invalid ([\#2306](https://github.com/matrix-org/matrix-js-sdk/pull/2306)). Fixes vector-im/element-web#21851.<!-- CHANGELOG_PREVIEW_END -->