### PR TITLE
Add support for sending encrypted to-device events with OLM

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3036,7 +3036,7 @@ export class Crypto extends EventEmitter {
      * set of devices.  Factored out from encryptAndSendKeysToDevices in
      * megolm.ts.
      *
-     * @param {object<userId, deviceInfo>} userDeviceMap
+     * @param {object[]} userDeviceInfoArr
      *   mapping from userId to deviceInfo
      *
      * @param {object} payload fields to include in the encrypted payload
@@ -3047,20 +3047,20 @@ export class Crypto extends EventEmitter {
      *     of the successfully sent messages.
      */
     public encryptAndSendToDevices(
-        userDeviceMap: IOlmDevice<DeviceInfo>[],
+        userDeviceInfoArr: IOlmDevice<DeviceInfo>[],
         payload: object,
     ): Promise<{contentMap, deviceInfoByDeviceId}> {
         const contentMap = {};
         const deviceInfoByDeviceId = new Map<string, DeviceInfo>();
 
         const promises = [];
-        for (let i = 0; i < userDeviceMap.length; i++) {
+        for (let i = 0; i < userDeviceInfoArr.length; i++) {
             const encryptedContent = {
                 algorithm: olmlib.OLM_ALGORITHM,
                 sender_key: this.olmDevice.deviceCurve25519Key,
                 ciphertext: {},
             };
-            const val = userDeviceMap[i];
+            const val = userDeviceInfoArr[i];
             const userId = val.userId;
             const deviceInfo = val.deviceInfo;
             const deviceId = deviceInfo.deviceId;

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2005,7 +2005,7 @@ export class MatrixCall extends EventEmitter {
      * @param {Object} content
      * @return {Promise}
      */
-    private sendVoipEvent(eventType: string, content: object): Promise<ISendEventResponse | {}> {
+    private async sendVoipEvent(eventType: string, content: object): Promise<ISendEventResponse | {}> {
         const realContent = Object.assign({}, content, {
             version: VOIP_PROTO_VERSION,
             call_id: this.callId,
@@ -2030,17 +2030,20 @@ export class MatrixCall extends EventEmitter {
                 },
             });
 
-            return this.client.sendToDevice(eventType, {
-                [this.invitee || this.getOpponentMember().userId]: {
-                    [this.opponentDeviceId]: {
-                        ...realContent,
-                        device_id: this.client.deviceId,
-                        sender_session_id: this.client.getSessionId(),
-                        dest_session_id: this.opponentSessionId,
-                        seq: toDeviceSeq,
-                    },
+            const payload = {
+                type: eventType,
+                content: {
+                    ...realContent,
+                    device_id: this.client.deviceId,
+                    sender_session_id: this.client.getSessionId(),
+                    dest_session_id: this.opponentSessionId,
+                    seq: toDeviceSeq,
                 },
-            });
+            };
+            const userId = this.invitee || this.getOpponentMember().userId;
+            const deviceInfoMap = await this.client.crypto.deviceList.downloadKeys([userId], false);
+            const deviceInfo = deviceInfoMap[userId][this.opponentDeviceId];
+            return this.client.crypto.encryptAndSendToDevices([{ userId, deviceInfo }], payload);
         } else {
             this.emit(CallEvent.SendVoipEvent, {
                 type: "sendEvent",


### PR DESCRIPTION
This PR encrypts to-device events used in GroupCall signalling.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add support for sending encrypted to-device events with OLM ([\#2322](https://github.com/matrix-org/matrix-js-sdk/pull/2322)). Contributed by @robertlong.<!-- CHANGELOG_PREVIEW_END -->