### PR TITLE
Correctly specify minimum Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ attached to ``window`` through which you can access the SDK. See below for how t
 include libolm to enable end-to-end-encryption.
 
 The browser bundle supports recent versions of browsers. Typically this is ES2015
-or `> 0.5%, last 2 versions, Firefox ESR, not dead` if using 
+or `> 0.5%, last 2 versions, Firefox ESR, not dead` if using
 [browserlists](https://github.com/browserslist/browserslist).
 
 Please check [the working browser example](examples/browser) for more information.
@@ -26,11 +26,11 @@ In Node.js
 
 Ensure you have the latest LTS version of Node.js installed.
 
-This SDK targets Node 10 for compatibility, which translates to ES6. If you're using
+This SDK targets Node 12 for compatibility, which translates to ES6. If you're using
 a bundler like webpack you'll likely have to transpile dependencies, including this
 SDK, to match your target browsers.
 
-Using `yarn` instead of `npm` is recommended. Please see the Yarn [install guide](https://classic.yarnpkg.com/en/docs/install) 
+Using `yarn` instead of `npm` is recommended. Please see the Yarn [install guide](https://classic.yarnpkg.com/en/docs/install)
 if you do not have it already.
 
 ``yarn add matrix-js-sdk``

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "matrix-js-sdk",
   "version": "17.1.0",
   "description": "Matrix Client-Server SDK for Javascript",
+  "engines": {
+      "node": ">=12.9.0"
+  },
   "scripts": {
     "prepublishOnly": "yarn build",
     "start": "echo THIS IS FOR LEGACY PURPOSES ONLY. && babel src -w -s -d lib --verbose --extensions \".ts,.js\"",


### PR DESCRIPTION
We use `Promise::allSettled` which was added in Node 12.9.0

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled

Node 12 is still in Maintenance status

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->