### PR TITLE
NodeURL isn't needed as Node exports the standard URL c'tor as global

### DIFF
--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -18,7 +18,6 @@ limitations under the License.
 /** @module auto-discovery */
 
 import {logger} from './logger';
-import {URL as NodeURL} from "url";
 
 // Dev note: Auto discovery is part of the spec.
 // See: https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery
@@ -451,16 +450,11 @@ export class AutoDiscovery {
         if (!url) return false;
 
         try {
-            // We have to try and parse the URL using the NodeJS URL
-            // library if we're on NodeJS and use the browser's URL
-            // library when we're in a browser. To accomplish this, we
-            // try the NodeJS version first and fall back to the browser.
             let parsed = null;
             try {
-                if (NodeURL) parsed = new NodeURL(url);
-                else parsed = new URL(url);
-            } catch (e) {
                 parsed = new URL(url);
+            } catch (e) {
+                logger.error("Could not parse url", e);
             }
 
             if (!parsed || !parsed.hostname) return false;


### PR DESCRIPTION
Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
