### PR TITLE
Remove PTT 'other user speaking' logic

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -431,11 +431,6 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
 
         // set a timer for the maximum transmit time on PTT calls
         if (this.isPtt) {
-            // if anoher user is currently unmuted, we can't unmute
-            if (!muted && this.userMediaFeeds.some(f => !f.isAudioMuted())) {
-                throw new OtherUserSpeakingError();
-            }
-
             // Set or clear the max transmit timer
             if (!muted && this.isMicrophoneMuted()) {
                 this.transmitTimer = setTimeout(() => {


### PR DESCRIPTION
This was also in Element Call, and whilst js-=sdk might be a more
sensible place, EC has all the information to do it properly (this
impl didn't take admin talk-over into account).

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
