### PR TITLE
Add a catastrophic throw to thread constructor

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Thread } from "../../../src/models/thread";
+
+describe('Thread', () => {
+    describe("constructor", () => {
+        it("should explode for element-web#22141 logging", () => {
+            // Logging/debugging for https://github.com/vector-im/element-web/issues/22141
+            expect(() => {
+                new Thread("$event", undefined, {} as any); // deliberate cast to test error case
+            }).toThrow("element-web#22141: A thread requires a room in order to function");
+        });
+    });
+});

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -79,6 +79,12 @@ export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
     ) {
         super();
 
+        if (!opts?.room) {
+            // Logging/debugging for https://github.com/vector-im/element-web/issues/22141
+            // Hope is that we end up with a more obvious stack trace.
+            throw new Error("element-web#22141: A thread requires a room in order to function");
+        }
+
         this.room = opts.room;
         this.client = opts.client;
         this.timelineSet = new EventTimelineSet(this.room, {


### PR DESCRIPTION
This is an attempt to narrow down https://github.com/vector-im/element-web/issues/22141

----

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->