### PR TITLE
Remove default push rule override for MSC1930

### DIFF
--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -57,31 +57,6 @@ const RULEKINDS_IN_ORDER = [
 //      and so we can put them here.
 const DEFAULT_OVERRIDE_RULES: IPushRule[] = [
     {
-        // For homeservers which don't support MSC1930 yet
-        rule_id: ".m.rule.tombstone",
-        default: true,
-        enabled: true,
-        conditions: [
-            {
-                kind: ConditionKind.EventMatch,
-                key: "type",
-                pattern: "m.room.tombstone",
-            },
-            {
-                kind: ConditionKind.EventMatch,
-                key: "state_key",
-                pattern: "",
-            },
-        ],
-        actions: [
-            PushRuleActionName.Notify,
-            {
-                set_tweak: TweakName.Highlight,
-                value: true,
-            },
-        ],
-    },
-    {
         // For homeservers which don't support MSC2153 yet
         rule_id: ".m.rule.reaction",
         default: true,


### PR DESCRIPTION
Folks have had since Matrix 1.0 (June 2019) to upgrade to a compatible server

Fixes https://github.com/vector-im/element-web/issues/15439

**Note**: there's almost certainly a bug with the UI handling for these default rules, however since the other two aren't exposed in the UI I am less concerned after this fix.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove default push rule override for MSC1930 ([\#2376](https://github.com/matrix-org/matrix-js-sdk/pull/2376)). Fixes vector-im/element-web#15439.<!-- CHANGELOG_PREVIEW_END -->