### PR TITLE
Update relations after every decryption attempt

### DIFF
--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -6,7 +6,7 @@ import '../olm-loader';
 
 import { logger } from '../../src/logger';
 import { IContent, IEvent, IUnsigned, MatrixEvent, MatrixEventEvent } from "../../src/models/event";
-import { ClientEvent, EventType, MatrixClient } from "../../src";
+import { ClientEvent, EventType, MatrixClient, RelationType } from "../../src";
 import { SyncState } from "../../src/sync";
 import { eventMapperFor } from "../../src/event-mapper";
 
@@ -227,6 +227,45 @@ export function mkMessage(opts: IMessageOpts, client?: MatrixClient): object | M
         content: {
             msgtype: "m.text",
             body: opts.msg,
+        },
+    };
+
+    if (!eventOpts.content.body) {
+        eventOpts.content.body = "Random->" + Math.random();
+    }
+    return mkEvent(eventOpts, client);
+}
+
+interface IReplyMessageOpts extends IMessageOpts {
+    replyToMessage: MatrixEvent;
+}
+
+/**
+ * Create a reply message.
+ *
+ * @param {Object} opts Values for the message
+ * @param {string} opts.room The room ID for the event.
+ * @param {string} opts.user The user ID for the event.
+ * @param {string} opts.msg Optional. The content.body for the event.
+ * @param {MatrixEvent} opts.replyToMessage The replied message
+ * @param {boolean} opts.event True to make a MatrixEvent.
+ * @param {MatrixClient} client If passed along with opts.event=true will be used to set up re-emitters.
+ * @return {Object|MatrixEvent} The event
+ */
+export function mkReplyMessage(opts: IReplyMessageOpts, client?: MatrixClient): object | MatrixEvent {
+    const eventOpts: IEventOpts = {
+        ...opts,
+        type: EventType.RoomMessage,
+        content: {
+            "msgtype": "m.text",
+            "body": opts.msg,
+            "m.relates_to": {
+                "rel_type": RelationType.Reply,
+                "event_id": opts.replyToMessage.getId(),
+                [RelationType.Reply]: {
+                    "event_id": opts.replyToMessage.getId(),
+                },
+            },
         },
     };
 

--- a/spec/unit/event-timeline-set.spec.ts
+++ b/spec/unit/event-timeline-set.spec.ts
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as utils from "../test-utils/test-utils";
+import {
+    EventTimeline,
+    EventTimelineSet,
+    EventType,
+    MatrixClient,
+    MatrixEvent,
+    MatrixEventEvent,
+    RelationType,
+    Room,
+} from '../../src';
+
+describe('EventTimelineSet', () => {
+    const roomId = '!foo:bar';
+    const userA = "@alice:bar";
+
+    let room: Room;
+    let eventTimeline: EventTimeline;
+    let eventTimelineSet: EventTimelineSet;
+    let client: MatrixClient;
+
+    let messageEvent: MatrixEvent;
+    let replyEvent: MatrixEvent;
+
+    const itShouldReturnTheRelatedEvents = () => {
+        it('should return the related events', () => {
+            eventTimelineSet.aggregateRelations(messageEvent);
+            const relations = eventTimelineSet.getRelationsForEvent(
+                messageEvent.getId(),
+                RelationType.Reply,
+                EventType.RoomMessage,
+            );
+            expect(relations).toBeDefined();
+            expect(relations.getRelations().length).toBe(1);
+            expect(relations.getRelations()[0].getId()).toBe(replyEvent.getId());
+        });
+    };
+
+    beforeEach(() => {
+        client = utils.mock(MatrixClient, 'MatrixClient');
+        room = new Room(roomId, client, userA);
+        eventTimelineSet = new EventTimelineSet(room, {
+            unstableClientRelationAggregation: true,
+        });
+        eventTimeline = new EventTimeline(eventTimelineSet);
+        messageEvent = utils.mkMessage({
+            room: roomId,
+            user: userA,
+            msg: 'Hi!',
+            event: true,
+        }) as MatrixEvent;
+        replyEvent = utils.mkReplyMessage({
+            room: roomId,
+            user: userA,
+            msg: 'Hoo!',
+            event: true,
+            replyToMessage: messageEvent,
+        }) as MatrixEvent;
+    });
+
+    describe('aggregateRelations', () => {
+        describe('with unencrypted events', () => {
+            beforeEach(() => {
+                eventTimelineSet.addEventsToTimeline(
+                    [
+                        messageEvent,
+                        replyEvent,
+                    ],
+                    true,
+                    eventTimeline,
+                    'foo',
+                );
+            });
+
+            itShouldReturnTheRelatedEvents();
+        });
+
+        describe('with events to be decrypted', () => {
+            let messageEventShouldAttemptDecryptionSpy: jest.SpyInstance;
+            let replyEventShouldAttemptDecryptionSpy: jest.SpyInstance;
+
+            beforeEach(() => {
+                messageEventShouldAttemptDecryptionSpy = jest.spyOn(messageEvent, 'shouldAttemptDecryption');
+                messageEventShouldAttemptDecryptionSpy.mockReturnValue(true);
+
+                replyEventShouldAttemptDecryptionSpy = jest.spyOn(replyEvent, 'shouldAttemptDecryption');
+                replyEventShouldAttemptDecryptionSpy.mockReturnValue(true);
+
+                eventTimelineSet.addEventsToTimeline(
+                    [
+                        messageEvent,
+                        replyEvent,
+                    ],
+                    true,
+                    eventTimeline,
+                    'foo',
+                );
+            });
+
+            it('should not return the related events', () => {
+                eventTimelineSet.aggregateRelations(messageEvent);
+                const relations = eventTimelineSet.getRelationsForEvent(
+                    messageEvent.getId(),
+                    RelationType.Reply,
+                    EventType.RoomMessage,
+                );
+                expect(relations).toBeUndefined();
+            });
+
+            describe('after decryption', () => {
+                beforeEach(() => {
+                    messageEventShouldAttemptDecryptionSpy.mockReturnValue(false);
+                    replyEventShouldAttemptDecryptionSpy.mockReturnValue(false);
+
+                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent);
+                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent);
+                });
+
+                itShouldReturnTheRelatedEvents();
+            });
+        });
+    });
+});

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -94,6 +94,7 @@ export enum RelationType {
     Replace = "m.replace",
     Reference = "m.reference",
     Thread = "m.thread",
+    Reply = "m.in_reply_to",
 }
 
 export enum MsgType {


### PR DESCRIPTION
If an event is encrypted the aggregation cannot pick up the relation types.
Before this change there was exactly one aggregation retry after decryption.
If the events are being decrypted afterwards (for example on restore
from key backup) the aggregation was not aware of that.
This change adds relation updates after every decryption event if there
has been a decryption error.

Closes vector-im/element-web#22258