### PR TITLE
Prevent overlapping sync accumulator persists

### DIFF
--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -412,13 +412,15 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             this.isPersisting = true;
         }
 
-        await Promise.all([
-            this.persistUserPresenceEvents(userTuples),
-            this.persistAccountData(syncData.accountData),
-            this.persistSyncData(syncData.nextBatch, syncData.roomsData),
-        ]).finally(() => {
+        try {
+            await Promise.all([
+                this.persistUserPresenceEvents(userTuples),
+                this.persistAccountData(syncData.accountData),
+                this.persistSyncData(syncData.nextBatch, syncData.roomsData),
+            ]);
+        } finally {
             this.isPersisting = false;
-        });
+        }
     }
 
     /**

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -127,6 +127,8 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     private db: IDBDatabase = null;
     private disconnected = true;
     private _isNewlyCreated = false;
+    private _isPersisting = false;
+    private _pendingUserPresenceData: UserTuple[] = [];
 
     /**
      * Does the actual reading from and writing to the indexeddb
@@ -401,11 +403,22 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     public async syncToDatabase(userTuples: UserTuple[]): Promise<void> {
         const syncData = this.syncAccumulator.getJSON(true);
 
+        if (this._isPersisting) {
+            logger.warn("Skipping syncToDatabase() as persist already in flight");
+            this._pendingUserPresenceData.push(...userTuples);
+            return;
+        } else {
+            userTuples.unshift(...this._pendingUserPresenceData);
+            this._isPersisting = true;
+        }
+
         await Promise.all([
             this.persistUserPresenceEvents(userTuples),
             this.persistAccountData(syncData.accountData),
             this.persistSyncData(syncData.nextBatch, syncData.roomsData),
-        ]);
+        ]).finally(() => {
+            this._isPersisting = false;
+        });
     }
 
     /**
@@ -427,7 +440,9 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
                 nextBatch,
                 roomsData,
             }); // put == UPSERT
-            return txnAsPromise(txn).then();
+            return txnAsPromise(txn).then(() => {
+                logger.log("Persisted sync data up to", nextBatch);
+            });
         });
     }
 

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -127,8 +127,8 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     private db: IDBDatabase = null;
     private disconnected = true;
     private _isNewlyCreated = false;
-    private _isPersisting = false;
-    private _pendingUserPresenceData: UserTuple[] = [];
+    private isPersisting = false;
+    private pendingUserPresenceData: UserTuple[] = [];
 
     /**
      * Does the actual reading from and writing to the indexeddb
@@ -403,13 +403,13 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     public async syncToDatabase(userTuples: UserTuple[]): Promise<void> {
         const syncData = this.syncAccumulator.getJSON(true);
 
-        if (this._isPersisting) {
+        if (this.isPersisting) {
             logger.warn("Skipping syncToDatabase() as persist already in flight");
-            this._pendingUserPresenceData.push(...userTuples);
+            this.pendingUserPresenceData.push(...userTuples);
             return;
         } else {
-            userTuples.unshift(...this._pendingUserPresenceData);
-            this._isPersisting = true;
+            userTuples.unshift(...this.pendingUserPresenceData);
+            this.isPersisting = true;
         }
 
         await Promise.all([
@@ -417,7 +417,7 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             this.persistAccountData(syncData.accountData),
             this.persistSyncData(syncData.nextBatch, syncData.roomsData),
         ]).finally(() => {
-            this._isPersisting = false;
+            this.isPersisting = false;
         });
     }
 


### PR DESCRIPTION
Adds a flag to stop the sync worker trying to persist to indexeddb if there is already a persist in flight.  This means that if indexeddb is being very slow (e.g. due to the browser running for a few seconds every ~10 mins while a macbook is asleep), you won't end up with overlapping write operations to indexeddb which could consume heap and cause an OOM.  It's okay to do this in the sync worker rather than the main thread, as it turns out that all the accumulation happens inside the worker, so we never pass large accumulated sync responses over postmessage to the worker.

If the persist is skipped, we accumulate user presence updates in RAM to stop them being lost (given the sync accumulator doesn't handle them itself for some reason).

Hopefully fixes https://github.com/vector-im/element-web/issues/21541

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent overlapping sync accumulator persists ([\#2392](https://github.com/matrix-org/matrix-js-sdk/pull/2392)). Fixes vector-im/element-web#21541.<!-- CHANGELOG_PREVIEW_END -->