### PR TITLE
Convert `getLocalAliases` to a stable API call

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,8 @@ module.exports = {
             "@typescript-eslint/no-explicit-any": "off",
             // We'd rather not do this but we do
             "@typescript-eslint/ban-ts-comment": "off",
+            // We're okay with assertion errors when we ask for them
+            "@typescript-eslint/no-non-null-assertion": "off",
 
             "quotes": "off",
             // We use a `logger` intermediary module

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1207,8 +1207,9 @@ describe("MatrixClient", function() {
             const result = await client.getLocalAliases(roomId);
 
             // Current version of the endpoint we support is v3
-            const [callback, method, path, queryParams, _, opts] = client.http.authedRequest.mock.calls[0];
+            const [callback, method, path, queryParams, data, opts] = client.http.authedRequest.mock.calls[0];
             expect(callback).toBeFalsy();
+            expect(data).toBeFalsy();
             expect(method).toBe('GET');
             expect(path).toEqual(`/rooms/${encodeURIComponent(roomId)}/aliases`);
             expect(opts).toMatchObject({ prefix: "/_matrix/client/v3" });

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,6 +61,7 @@ import {
     PREFIX_R0,
     PREFIX_UNSTABLE,
     PREFIX_V1,
+    PREFIX_V3,
     retryNetworkOperation,
     UploadContentResponseType,
 } from "./http-api";
@@ -7531,16 +7532,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * @param {string} roomId
-     * @param {module:client.callback} callback Optional.
+     * Gets the local aliases for the room. Note: this includes all local aliases, unlike the
+     * curated list from the m.room.canonical_alias state event.
+     * @param {string} roomId The room ID to get local aliases for.
      * @return {Promise} Resolves: an object with an `aliases` property, containing an array of local aliases
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public unstableGetLocalAliases(roomId: string, callback?: Callback): Promise<{ aliases: string[] }> {
-        const path = utils.encodeUri("/rooms/$roomId/aliases",
-            { $roomId: roomId });
-        const prefix = PREFIX_UNSTABLE + "/org.matrix.msc2432";
-        return this.http.authedRequest(callback, Method.Get, path, null, null, { prefix });
+    public getLocalAliases(roomId: string): Promise<{ aliases: string[] }> {
+        const path = utils.encodeUri("/rooms/$roomId/aliases", { $roomId: roomId });
+        const prefix = PREFIX_V3;
+        return this.http.authedRequest(undefined, Method.Get, path, null, null, { prefix });
     }
 
     /**

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -48,9 +48,14 @@ TODO:
 export const PREFIX_R0 = "/_matrix/client/r0";
 
 /**
- * A constant representing the URI path for release v1 of the Client-Server HTTP API.
+ * A constant representing the URI path for the legacy release v1 of the Client-Server HTTP API.
  */
 export const PREFIX_V1 = "/_matrix/client/v1";
+
+/**
+ * A constant representing the URI path for Client-Server API endpoints versioned at v3.
+ */
+export const PREFIX_V3 = "/_matrix/client/v3";
 
 /**
  * A constant representing the URI path for as-yet unspecified Client-Server HTTP APIs.


### PR DESCRIPTION
This should be fine to do as non-breaking given the function was previously unstable.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Convert `getLocalAliases` to a stable API call ([\#2402](https://github.com/matrix-org/matrix-js-sdk/pull/2402)).<!-- CHANGELOG_PREVIEW_END -->