### PR TITLE
Fix gha concurrency conditions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     types: [ opened, edited, labeled, unlabeled, synchronize ]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 jobs:
   changelog:


### PR DESCRIPTION
`pull_request_target` always run with ref = develop

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->