### PR TITLE
Mute disconnected peers in PTT mode

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -610,6 +610,9 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
 
         logger.log(`GroupCall: incoming call from: ${opponentMemberId}`);
 
+        // we are handlng this call as a PTT call, so enable PTT semantics
+        newCall.isPtt = true;
+
         // Check if the user calling has an existing call and use this call instead.
         if (existingCall) {
             this.replaceCall(existingCall, newCall);
@@ -774,6 +777,8 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
                 groupCallId: this.groupCallId,
             },
         );
+
+        newCall.isPtt = true;
 
         const requestScreenshareFeed = opponentDevice.feeds.some(
             (feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);


### PR DESCRIPTION
When we lose ICE connection to peers, set the status of their feeds
to muted so to end their talking session.

For https://github.com/vector-im/element-call/issues/331

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Mute disconnected peers in PTT mode ([\#2421](https://github.com/matrix-org/matrix-js-sdk/pull/2421)).<!-- CHANGELOG_PREVIEW_END -->