### PR TITLE
webrtc: add advanced audio settings

### DIFF
--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -79,6 +79,23 @@ describe('Media Handler', function() {
         }));
     });
 
+    it("sets audio settings", async () => {
+        await mediaHandler.setAudioSettings({
+            autoGainControl: false,
+            echoCancellation: true,
+            noiseSuppression: false,
+        });
+
+        await mediaHandler.getUserMediaStream(true, false);
+        expect(mockMediaDevices.getUserMedia).toHaveBeenCalledWith(expect.objectContaining({
+            audio: expect.objectContaining({
+                autoGainControl: { ideal: false },
+                echoCancellation: { ideal: true },
+                noiseSuppression: { ideal: false },
+            }),
+        }));
+    });
+
     it("sets video device ID", async () => {
         await mediaHandler.setVideoInput(FAKE_VIDEO_INPUT_ID);
 

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -40,10 +40,17 @@ export interface IScreensharingOpts {
     throwOnFail?: boolean;
 }
 
+export interface AudioSettings {
+    autoGainControl: boolean;
+    echoCancellation: boolean;
+    noiseSuppression: boolean;
+}
+
 export class MediaHandler extends TypedEventEmitter<
     MediaHandlerEvent.LocalStreamsChanged, MediaHandlerEventHandlerMap
 > {
     private audioInput?: string;
+    private audioSettings?: AudioSettings;
     private videoInput?: string;
     private localUserMediaStream?: MediaStream;
     public userMediaStreams: MediaStream[] = [];
@@ -69,6 +76,17 @@ export class MediaHandler extends TypedEventEmitter<
         if (this.audioInput === deviceId) return;
 
         this.audioInput = deviceId;
+        await this.updateLocalUsermediaStreams();
+    }
+
+    /**
+     * Set audio settings for MatrixCalls
+     * @param {AudioSettings} opts audio options to set
+     */
+    public async setAudioSettings(opts: AudioSettings): Promise<void> {
+        logger.info("LOG setting audio settings to", opts);
+
+        this.audioSettings = Object.assign({}, opts) as AudioSettings;
         await this.updateLocalUsermediaStreams();
     }
 
@@ -362,6 +380,9 @@ export class MediaHandler extends TypedEventEmitter<
             audio: audio
                 ? {
                     deviceId: this.audioInput ? { ideal: this.audioInput } : undefined,
+                    autoGainControl: this.audioSettings ? { ideal: this.audioSettings.autoGainControl } : undefined,
+                    echoCancellation: this.audioSettings ? { ideal: this.audioSettings.echoCancellation } : undefined,
+                    noiseSuppression: this.audioSettings ? { ideal: this.audioSettings.noiseSuppression } : undefined,
                 }
                 : false,
             video: video

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -71,7 +71,7 @@ export class MediaHandler extends TypedEventEmitter<
      * undefined treated as unset
      */
     public async setAudioInput(deviceId: string): Promise<void> {
-        logger.info("LOG setting audio input to", deviceId);
+        logger.info("Setting audio input to", deviceId);
 
         if (this.audioInput === deviceId) return;
 
@@ -84,7 +84,7 @@ export class MediaHandler extends TypedEventEmitter<
      * @param {AudioSettings} opts audio options to set
      */
     public async setAudioSettings(opts: AudioSettings): Promise<void> {
-        logger.info("LOG setting audio settings to", opts);
+        logger.info("Setting audio settings to", opts);
 
         this.audioSettings = Object.assign({}, opts) as AudioSettings;
         await this.updateLocalUsermediaStreams();
@@ -96,7 +96,7 @@ export class MediaHandler extends TypedEventEmitter<
      * undefined treated as unset
      */
     public async setVideoInput(deviceId: string): Promise<void> {
-        logger.info("LOG setting video input to", deviceId);
+        logger.info("Setting video input to", deviceId);
 
         if (this.videoInput === deviceId) return;
 


### PR DESCRIPTION
autoGainControl, echoCancellation, and noiseSuppression are audio
processing options that are usually enabled by default on WebRTC input
tracks.

This PR adds the possibility to enable/disable them, as they can be
undesirable in some cases (audiophile use cases). For example, one might
want to stream electronic dance music, which is basically noise, so it
should not be suppressed in that specific case.

Note that these are not exact settings, they are set as "ideal" in order
not to break anything on devices where those constraints are not
implemented.

Related to matrix-org/matrix-react-sdk#8759

Type: task

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * webrtc: add advanced audio settings ([\#2434](https://github.com/matrix-org/matrix-js-sdk/pull/2434)). Contributed by @MrAnno.<!-- CHANGELOG_PREVIEW_END -->