### PR TITLE
Live location sharing - monitor liveness of beacons yet to start

### DIFF
--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -224,7 +224,7 @@ describe('Beacon', () => {
                 beacon.monitorLiveness();
 
                 // @ts-ignore
-                expect(beacon.livenessWatchInterval).toBeFalsy();
+                expect(beacon.livenessWatchTimeout).toBeFalsy();
                 advanceDateAndTime(HOUR_MS * 2 + 1);
 
                 // no emit
@@ -289,12 +289,12 @@ describe('Beacon', () => {
 
                 beacon.monitorLiveness();
                 // @ts-ignore
-                const oldMonitor = beacon.livenessWatchInterval;
+                const oldMonitor = beacon.livenessWatchTimeout;
 
                 beacon.monitorLiveness();
 
                 // @ts-ignore
-                expect(beacon.livenessWatchInterval).not.toEqual(oldMonitor);
+                expect(beacon.livenessWatchTimeout).not.toEqual(oldMonitor);
             });
 
             it('destroy kills liveness monitor and emits', () => {

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -135,6 +135,13 @@ export class Beacon extends TypedEventEmitter<Exclude<BeaconEvent, BeaconEvent.N
                     expiryInMs,
                 );
             }
+        } else if (this._beaconInfo?.timestamp > Date.now()) {
+            // beacon start timestamp is in the future
+            // check liveness again then
+            this.livenessWatchInterval = setInterval(
+                () => { this.monitorLiveness(); },
+                this.beaconInfo?.timestamp - Date.now(),
+            );
         }
     }
 


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

https://github.com/vector-im/element-web/issues/22437

- When a beacon's start timestamp is in the future, add a timeout to refresh the beacon's state after it becomes live

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->
