### PR TITLE
Set PTT mode on call correctly

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -611,7 +611,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         logger.log(`GroupCall: incoming call from: ${opponentMemberId}`);
 
         // we are handlng this call as a PTT call, so enable PTT semantics
-        newCall.isPtt = true;
+        newCall.isPtt = this.isPtt;
 
         // Check if the user calling has an existing call and use this call instead.
         if (existingCall) {
@@ -778,7 +778,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
             },
         );
 
-        newCall.isPtt = true;
+        newCall.isPtt = this.isPtt;
 
         const requestScreenshareFeed = opponentDevice.feeds.some(
             (feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);


### PR DESCRIPTION
And not always to true. This was causing audio & video to start muted
sometimes on normal calls because the ICE connection state would change
to 'checking', causing the feeds to be muted.

Fixes https://github.com/vector-im/element-call/issues/382

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Set PTT mode on call correctly ([\#2445](https://github.com/matrix-org/matrix-js-sdk/pull/2445)). Fixes vector-im/element-call#382.<!-- CHANGELOG_PREVIEW_END -->