### PR TITLE
Emit unknown device errors for group call participants without e2e

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -48,6 +48,7 @@ import { MatrixClient } from "../client";
 import { ISendEventResponse } from "../@types/requests";
 import { EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter";
 import { DeviceInfo } from '../crypto/deviceinfo';
+import { GroupCallUnknownDeviceError } from './groupCall';
 
 // events: hangup, error(err), replaced(call), state(state, oldState)
 
@@ -521,7 +522,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         const deviceInfoMap = await this.client.crypto.deviceList.downloadKeys([userId], false);
         this.opponentDeviceInfo = deviceInfoMap[userId][this.opponentDeviceId];
         if (this.opponentDeviceInfo === undefined) {
-            throw new Error(`No keys found for opponent device ${this.opponentDeviceId}!`);
+            throw new GroupCallUnknownDeviceError(userId);
         }
     }
 

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -20,7 +20,7 @@ import { CallDirection, CallErrorCode, CallState, createNewMatrixCall, MatrixCal
 import { EventType } from '../@types/event';
 import { ClientEvent, MatrixClient } from '../client';
 import { MCallAnswer, MCallHangupReject } from "./callEventTypes";
-import { GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from './groupCall';
+import { GroupCall, GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from './groupCall';
 import { RoomEvent } from "../models/room";
 
 // Don't ring unless we'd be ringing for at least 3 seconds: the user needs some
@@ -210,7 +210,7 @@ export class CallEventHandler {
 
         let opponentDeviceId: string | undefined;
 
-        let groupCall;
+        let groupCall: GroupCall;
         if (groupCallId) {
             groupCall = this.client.groupCallEventHandler.getGroupCallById(groupCallId);
 

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -20,7 +20,7 @@ import { CallDirection, CallErrorCode, CallState, createNewMatrixCall, MatrixCal
 import { EventType } from '../@types/event';
 import { ClientEvent, MatrixClient } from '../client';
 import { MCallAnswer, MCallHangupReject } from "./callEventTypes";
-import { GroupCallError, GroupCallErrorCode, GroupCallEvent } from './groupCall';
+import { GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from './groupCall';
 import { RoomEvent } from "../models/room";
 
 // Don't ring unless we'd be ringing for at least 3 seconds: the user needs some
@@ -210,8 +210,9 @@ export class CallEventHandler {
 
         let opponentDeviceId: string | undefined;
 
+        let groupCall;
         if (groupCallId) {
-            const groupCall = this.client.groupCallEventHandler.getGroupCallById(groupCallId);
+            groupCall = this.client.groupCallEventHandler.getGroupCallById(groupCallId);
 
             if (!groupCall) {
                 logger.warn(`Cannot find a group call ${groupCallId} for event ${type}. Ignoring event.`);
@@ -224,10 +225,7 @@ export class CallEventHandler {
                 logger.warn(`Cannot find a device id for ${senderId}. Ignoring event.`);
                 groupCall.emit(
                     GroupCallEvent.Error,
-                    new GroupCallError(
-                        GroupCallErrorCode.UnknownDevice,
-                        `Incoming Call: No opponent device found for ${senderId}, ignoring.`,
-                    ),
+                    new GroupCallUnknownDeviceError(senderId),
                 );
                 return;
             }
@@ -282,7 +280,13 @@ export class CallEventHandler {
             }
 
             call.callId = content.call_id;
-            await call.initWithInvite(event);
+            try {
+                await call.initWithInvite(event);
+            } catch (e) {
+                if (e.code === GroupCallErrorCode.UnknownDevice) {
+                    groupCall?.emit(GroupCallEvent.Error, e);
+                }
+            }
             this.calls.set(call.callId, call);
 
             // if we stashed candidate events for that call ID, play them back now


### PR DESCRIPTION
There are a number of different cases here: there were some before
when dealing with versions that didn't send deviceId. This catches
all of them and makes all these cases emit the same error.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Emit unknown device errors for group call participants without e2e ([\#2447](https://github.com/matrix-org/matrix-js-sdk/pull/2447)).<!-- CHANGELOG_PREVIEW_END -->