### PR TITLE
Don't block muting on determining whether the device exists

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -458,8 +458,11 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         return true;
     }
 
-    public async setMicrophoneMuted(muted) {
-        if (!await this.client.getMediaHandler().hasAudioDevice()) {
+    public async setMicrophoneMuted(muted: boolean): Promise<boolean | null> {
+        // hasAudioDevice can block indefinitely if the window has lost focus,
+        // and it doesn't make much sense to keep a device from being muted, so
+        // we always allow muted = true changes to go through
+        if (!muted && !await this.client.getMediaHandler().hasAudioDevice()) {
             return false;
         }
 
@@ -516,8 +519,8 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         this.emit(GroupCallEvent.LocalMuteStateChanged, muted, this.isLocalVideoMuted());
     }
 
-    public async setLocalVideoMuted(muted) {
-        if (!await this.client.getMediaHandler().hasVideoDevice()) {
+    public async setLocalVideoMuted(muted: boolean): Promise<boolean | null> {
+        if (!muted && !await this.client.getMediaHandler().hasVideoDevice()) {
             return false;
         }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -458,7 +458,12 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         return true;
     }
 
-    public async setMicrophoneMuted(muted: boolean): Promise<boolean | null> {
+    /**
+     * Sets the mute state of the local participants's microphone.
+     * @param {boolean} muted Whether to mute the microphone
+     * @returns {Promise<boolean>} Whether muting/unmuting was successful
+     */
+    public async setMicrophoneMuted(muted: boolean): Promise<boolean> {
         // hasAudioDevice can block indefinitely if the window has lost focus,
         // and it doesn't make much sense to keep a device from being muted, so
         // we always allow muted = true changes to go through
@@ -517,9 +522,18 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         }
 
         this.emit(GroupCallEvent.LocalMuteStateChanged, muted, this.isLocalVideoMuted());
+        return true;
     }
 
-    public async setLocalVideoMuted(muted: boolean): Promise<boolean | null> {
+    /**
+     * Sets the mute state of the local participants's video.
+     * @param {boolean} muted Whether to mute the video
+     * @returns {Promise<boolean>} Whether muting/unmuting was successful
+     */
+    public async setLocalVideoMuted(muted: boolean): Promise<boolean> {
+        // hasAudioDevice can block indefinitely if the window has lost focus,
+        // and it doesn't make much sense to keep a device from being muted, so
+        // we always allow muted = true changes to go through
         if (!muted && !await this.client.getMediaHandler().hasVideoDevice()) {
             return false;
         }
@@ -536,6 +550,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         }
 
         this.emit(GroupCallEvent.LocalMuteStateChanged, this.isMicrophoneMuted(), muted);
+        return true;
     }
 
     public async setScreensharingEnabled(


### PR DESCRIPTION
This was one thing that could allow you to keep transmitting past 20 seconds in PTT mode on Firefox.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't block muting on determining whether the device exists ([\#2461](https://github.com/matrix-org/matrix-js-sdk/pull/2461)).<!-- CHANGELOG_PREVIEW_END -->