### PR TITLE
Live location share - add start time leniency (PSF-1081)

### DIFF
--- a/spec/test-utils/beacon.ts
+++ b/spec/test-utils/beacon.ts
@@ -27,6 +27,7 @@ type InfoContentProps = {
     isLive?: boolean;
     assetType?: LocationAssetType;
     description?: string;
+    timestamp?: number;
 };
 const DEFAULT_INFO_CONTENT_PROPS: InfoContentProps = {
     timeout: 3600000,
@@ -44,7 +45,11 @@ export const makeBeaconInfoEvent = (
     eventId?: string,
 ): MatrixEvent => {
     const {
-        timeout, isLive, description, assetType,
+        timeout,
+        isLive,
+        description,
+        assetType,
+        timestamp,
     } = {
         ...DEFAULT_INFO_CONTENT_PROPS,
         ...contentProps,
@@ -53,10 +58,10 @@ export const makeBeaconInfoEvent = (
         type: M_BEACON_INFO.name,
         room_id: roomId,
         state_key: sender,
-        content: makeBeaconInfoContent(timeout, isLive, description, assetType),
+        content: makeBeaconInfoContent(timeout, isLive, description, assetType, timestamp),
     });
 
-    event.event.origin_server_ts = Date.now();
+    event.event.origin_server_ts = timestamp || Date.now();
 
     // live beacons use the beacon_info event id
     // set or default this

--- a/spec/unit/models/beacon.spec.ts
+++ b/spec/unit/models/beacon.spec.ts
@@ -421,7 +421,7 @@ describe('Beacon', () => {
                         { isLive: true, timeout: 60000, timestamp: startTimestamp },
                     ));
                     const emitSpy = jest.spyOn(beacon, 'emit');
-    
+
                     beacon.addLocations([
                         // beacon has now + 60000 live period
                         makeBeaconEvent(
@@ -433,7 +433,7 @@ describe('Beacon', () => {
                             },
                         ),
                     ]);
-    
+
                     expect(beacon.latestLocationState).toBeFalsy();
                     expect(emitSpy).not.toHaveBeenCalled();
                 });
@@ -442,12 +442,12 @@ describe('Beacon', () => {
                     const beacon = new Beacon(makeBeaconInfoEvent(
                         userId,
                         roomId,
-                        { isLive: true, timeout: 60000, timestamp: startTimestamp },
+                        { isLive: true, timeout: 600000, timestamp: startTimestamp },
                     ));
                     const emitSpy = jest.spyOn(beacon, 'emit');
-    
+
                     beacon.addLocations([
-                        // beacon has now + 60000 live period
+                        // beacon has now + 600000 live period
                         makeBeaconEvent(
                             userId,
                             {
@@ -457,12 +457,11 @@ describe('Beacon', () => {
                             },
                         ),
                     ]);
-    
+
                     expect(beacon.latestLocationState).toBeTruthy();
                     expect(emitSpy).toHaveBeenCalled();
                 });
             });
-
 
             it('sets latest location state to most recent location', () => {
                 const beacon = new Beacon(makeBeaconInfoEvent(userId, roomId, { isLive: true, timeout: 60000 }));


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

Adds leniency so start timestamps that are slightly in the future are still considered live.

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: Live location share - add start time leniency
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Live location share - add start time leniency ([\#2465](https://github.com/matrix-org/matrix-js-sdk/pull/2465)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->