### PR TITLE
Don't ignore call member events with a distant future expiration date

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -139,8 +139,7 @@ const callMemberStateIsExpired = (event: MatrixEvent): boolean => {
     const now = Date.now();
     const content = event?.getContent<IGroupCallRoomMemberState>() ?? {};
     const expiresAt = typeof content["m.expires_ts"] === "number" ? content["m.expires_ts"] : -Infinity;
-    // The event is expired if the expiration date has passed, or if it's unreasonably far in the future
-    return expiresAt <= now || expiresAt > now + CALL_MEMBER_STATE_TIMEOUT * 5 / 4;
+    return expiresAt <= now;
 };
 
 function getCallUserId(call: MatrixCall): string | null {


### PR DESCRIPTION
to match recent updates to MSC3401

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->