### PR TITLE
Implement MSC3827: Filtering of `/publicRooms` by room type

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -113,7 +113,7 @@ export interface IRoomDirectoryOptions {
     since?: string;
     filter?: {
         generic_search_term?: string;
-        room_type?: Set<RoomType | null>;
+        room_types?: Set<RoomType | null>;
     };
     include_all_networks?: boolean;
     third_party_instance_id?: string;

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -113,7 +113,7 @@ export interface IRoomDirectoryOptions {
     since?: string;
     filter?: {
         generic_search_term?: string;
-        room_type?: Set<RoomType>;
+        room_type?: Set<RoomType | null>;
     };
     include_all_networks?: boolean;
     third_party_instance_id?: string;

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -22,6 +22,7 @@ import { IRoomEventFilter } from "../filter";
 import { Direction } from "../models/event-timeline";
 import { PushRuleAction } from "./PushRules";
 import { IRoomEvent } from "../sync-accumulator";
+import { RoomType } from "./event";
 
 // allow camelcase as these are things that go onto the wire
 /* eslint-disable camelcase */
@@ -111,7 +112,8 @@ export interface IRoomDirectoryOptions {
     limit?: number;
     since?: string;
     filter?: {
-        generic_search_term: string;
+        generic_search_term?: string;
+        room_type?: Set<RoomType>;
     };
     include_all_networks?: boolean;
     third_party_instance_id?: string;

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -113,7 +113,7 @@ export interface IRoomDirectoryOptions {
     since?: string;
     filter?: {
         generic_search_term?: string;
-        room_types?: Set<RoomType | null>;
+        "org.matrix.msc3827.room_types"?: Set<RoomType | null>;
     };
     include_all_networks?: boolean;
     third_party_instance_id?: string;

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -113,7 +113,7 @@ export interface IRoomDirectoryOptions {
     since?: string;
     filter?: {
         generic_search_term?: string;
-        "org.matrix.msc3827.room_types"?: Set<RoomType | null>;
+        "org.matrix.msc3827.room_types"?: Array<RoomType | null>;
     };
     include_all_networks?: boolean;
     third_party_instance_id?: string;


### PR DESCRIPTION
Implement [MSC3827: Filtering of `/publicRooms` by room type](https://github.com/matrix-org/matrix-spec-proposals/pull/3827)
Towards https://github.com/vector-im/element-meta/issues/338
For https://github.com/matrix-org/matrix-react-sdk/pull/8866

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement MSC3827: Filtering of `/publicRooms` by room type ([\#2469](https://github.com/matrix-org/matrix-js-sdk/pull/2469)).<!-- CHANGELOG_PREVIEW_END -->