### PR TITLE
Prevent infinite loop in getPushRules

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -604,7 +604,10 @@ export class SyncApi {
     }
 
     private shouldAbortSync(error: MatrixError): boolean {
-        if (error.errcode === "M_UNKNOWN_TOKEN") {
+        if (!this.running) {
+            logger.info("No longer running - assuming logout");
+            return true;
+        } else if (error.errcode === "M_UNKNOWN_TOKEN") {
             // The logout already happened, we just need to stop.
             logger.warn("Token no longer valid - assuming logout");
             this.stop();


### PR DESCRIPTION
During integration tests that start and stop the client quickly, getPushRules fails and doesn't exit cleanly. 

getPushRules fails with `Getting push rules failed M_MISSING_TOKEN: missing access token`, but shouldAbortSync only checks for `M_UNKNOWN_TOKEN`

Tests: pulled down project locally and ran all tests.

Signed-off-by: Austin Ellis <austin@hntlabs.com>



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent infinite loop in getPushRules ([\#2470](https://github.com/matrix-org/matrix-js-sdk/pull/2470)). Contributed by @texuf.<!-- CHANGELOG_PREVIEW_END -->