### PR TITLE
Export KNOWN_SAFE_ROOM_VERSION

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -57,7 +57,7 @@ import { RelationsContainer } from "./relations-container";
 // room versions which are considered okay for people to run without being asked
 // to upgrade (ie: "stable"). Eventually, we should remove these when all homeservers
 // return an m.room_versions capability.
-const KNOWN_SAFE_ROOM_VERSION = '9';
+export const KNOWN_SAFE_ROOM_VERSION = '9';
 const SAFE_ROOM_VERSIONS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
 function synthesizeReceipt(userId: string, event: MatrixEvent, receiptType: ReceiptType): MatrixEvent {


### PR DESCRIPTION
The plan is to use this for the local rooms when creating a DM.

Notes: `room` now exports `KNOWN_SAFE_ROOM_VERSION`

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * `room` now exports `KNOWN_SAFE_ROOM_VERSION` ([\#2474](https://github.com/matrix-org/matrix-js-sdk/pull/2474)). Contributed by @weeman1337.<!-- CHANGELOG_PREVIEW_END -->