### PR TITLE
Remove the feature to disable audio from muted members

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1701,12 +1701,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             feed.setAudioMuted(metadata?.audio_muted);
             feed.setVideoMuted(metadata?.video_muted);
             feed.purpose = this.remoteSDPStreamMetadata[streamId]?.purpose;
-
-            if (this.isPtt) {
-                // In PTT mode, it's more important that only one person is speaking at a time, so we
-                // actively disable the output of any streams where we believe the user is muted.
-                feed.stream.getAudioTracks().forEach(t => t.enabled = metadata ? !metadata.audio_muted : true);
-            }
         }
     }
 


### PR DESCRIPTION
At the moment it looks like its more valuable to get the audio from
people even if they're not actually shown as speaking. We can always
re-introduce it later.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->