### PR TITLE
Don't mute the remote side immediately in PTT calls

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1971,7 +1971,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         // the peer, since we don't want to block the line if they're not saying anything.
         // Experimenting in Chrome, this happens after 5 or 6 seconds, which is probably
         // fast enough.
-        if (this.isPtt && !["connected", "completed"].includes(this.peerConn.iceConnectionState)) {
+        if (this.isPtt && ["failed", "disconnected"].includes(this.peerConn.iceConnectionState)) {
             for (const feed of this.getRemoteFeeds()) {
                 feed.setAudioMuted(true);
                 feed.setVideoMuted(true);


### PR DESCRIPTION
This clause was causing all PTT calls to mute the remote side immediately upon ICE connection status changing to 'checking'.

Closes https://github.com/vector-im/element-call/issues/425

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't mute the remote side immediately in PTT calls ([\#2487](https://github.com/matrix-org/matrix-js-sdk/pull/2487)). Fixes vector-im/element-call#425.<!-- CHANGELOG_PREVIEW_END -->