### PR TITLE
Run the changelog action regardless of trigger phase

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,7 +16,6 @@ concurrency: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
 jobs:
   changelog:
     name: Preview Changelog
-    if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     steps:
       - uses: matrix-org/allchange@main


### PR DESCRIPTION
As it is now used as a blocking stage due to validating required labels

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->