### PR TITLE
Add `id` to `sdp_stream_metadata`

### DIFF
--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -13,6 +13,7 @@ export enum SDPStreamMetadataPurpose {
 
 export interface SDPStreamMetadataObject {
     purpose: SDPStreamMetadataPurpose;
+    id: string;
     audio_muted: boolean;
     video_muted: boolean;
 }

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -28,6 +28,7 @@ export interface ICallFeedOpts {
     roomId: string;
     userId: string;
     stream: MediaStream;
+    id: string;
     purpose: SDPStreamMetadataPurpose;
     /**
      * Whether or not the remote SDPStreamMetadata says audio is muted
@@ -57,6 +58,7 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
     public stream: MediaStream;
     public userId: string;
     public purpose: SDPStreamMetadataPurpose;
+    public id: string;
     public speakingVolumeSamples: number[];
 
     private client: MatrixClient;
@@ -78,6 +80,7 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
         this.roomId = opts.roomId;
         this.userId = opts.userId;
         this.purpose = opts.purpose;
+        this.id = opts.id;
         this.audioMuted = opts.audioMuted;
         this.videoMuted = opts.videoMuted;
         this.speakingVolumeSamples = new Array(SPEAKING_SAMPLE_COUNT).fill(-Infinity);


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-spec-proposals/pull/3077#discussion_r611032820 and makes the implementation more future-proof

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add `id` to `sdp_stream_metadata` ([\#2493](https://github.com/matrix-org/matrix-js-sdk/pull/2493)).<!-- CHANGELOG_PREVIEW_END -->