### PR TITLE
Prevent double mute status changed events

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1262,7 +1262,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             await this.upgradeCall(false, true);
             return this.isLocalVideoMuted();
         }
-        this.localUsermediaFeed?.setVideoMuted(muted);
+        this.localUsermediaFeed?.setAudioVideoMuted(null, muted);
         this.updateMuteStatus();
         await this.sendMetadataUpdate();
         return this.isLocalVideoMuted();
@@ -1296,7 +1296,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             await this.upgradeCall(true, false);
             return this.isMicrophoneMuted();
         }
-        this.localUsermediaFeed?.setAudioMuted(muted);
+        this.localUsermediaFeed?.setAudioVideoMuted(muted, null);
         this.updateMuteStatus();
         await this.sendMetadataUpdate();
         return this.isMicrophoneMuted();
@@ -1801,8 +1801,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             const streamId = feed.stream.id;
             const metadata = this.remoteSDPStreamMetadata[streamId];
 
-            feed.setAudioMuted(metadata?.audio_muted);
-            feed.setVideoMuted(metadata?.video_muted);
+            feed.setAudioVideoMuted(metadata?.audio_muted, metadata?.video_muted);
             feed.purpose = this.remoteSDPStreamMetadata[streamId]?.purpose;
         }
     }
@@ -2027,8 +2026,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         // fast enough.
         if (this.isPtt && ["failed", "disconnected"].includes(this.peerConn.iceConnectionState)) {
             for (const feed of this.getRemoteFeeds()) {
-                feed.setAudioMuted(true);
-                feed.setVideoMuted(true);
+                feed.setAudioVideoMuted(true, true);
             }
         }
     };

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -186,21 +186,18 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
     }
 
     /**
-     * Set feed's internal audio mute state
-     * @param muted is the feed's audio muted?
-     */
-    public setAudioMuted(muted: boolean): void {
-        this.audioMuted = muted;
-        this.speakingVolumeSamples.fill(-Infinity);
-        this.emit(CallFeedEvent.MuteStateChanged, this.audioMuted, this.videoMuted);
-    }
-
-    /**
-     * Set feed's internal video mute state
+     * Set one or both of feed's internal audio and video video mute state
+     * Either value may be null to leave it as-is
      * @param muted is the feed's video muted?
      */
-    public setVideoMuted(muted: boolean): void {
-        this.videoMuted = muted;
+    public setAudioVideoMuted(audioMuted: boolean, videoMuted: boolean): void {
+        if (audioMuted !== null) {
+            if (this.audioMuted !== audioMuted) {
+                this.speakingVolumeSamples.fill(-Infinity);
+            }
+            this.audioMuted = audioMuted;
+        }
+        if (videoMuted !== null) this.videoMuted = videoMuted;
         this.emit(CallFeedEvent.MuteStateChanged, this.audioMuted, this.videoMuted);
     }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -460,7 +460,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         }
 
         for (const call of this.calls) {
-            call.localUsermediaFeed.setAudioMuted(muted);
+            call.localUsermediaFeed.setAudioVideoMuted(muted, null);
         }
 
         if (sendUpdatesBefore) {
@@ -474,7 +474,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         if (this.localCallFeed) {
             logger.log(`groupCall ${this.groupCallId} setMicrophoneMuted stream ${
                 this.localCallFeed.stream.id} muted ${muted}`);
-            this.localCallFeed.setAudioMuted(muted);
+            this.localCallFeed.setAudioVideoMuted(muted, null);
             // I don't believe its actually necessary to enable these tracks: they
             // are the one on the groupcall's own CallFeed and are cloned before being
             // given to any of the actual calls, so these tracks don't actually go
@@ -514,7 +514,7 @@ export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventH
         if (this.localCallFeed) {
             logger.log(`groupCall ${this.groupCallId} setLocalVideoMuted stream ${
                 this.localCallFeed.stream.id} muted ${muted}`);
-            this.localCallFeed.setVideoMuted(muted);
+            this.localCallFeed.setAudioVideoMuted(null, muted);
             setTracksEnabled(this.localCallFeed.stream.getVideoTracks(), !muted);
         }
 


### PR DESCRIPTION
Audio & video mute status were set in separate calls but share a
mute status changed event, so you'd always get two mute status
changed events emitted. We could suppress events where the mute
status didn't change, but this would still get two events saying
the same thing when they both changed. Instead, merge setAudioMuted
& setVideoMuted into a single call that sets either or both.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Prevent double mute status changed events ([\#2502](https://github.com/matrix-org/matrix-js-sdk/pull/2502)).<!-- CHANGELOG_PREVIEW_END -->