### PR TITLE
Actually store the identity server in the client when given as an option

### DIFF
--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -1001,7 +1001,7 @@ describe("MatrixClient", function() {
             };
 
             httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
-                versions: ["r0.5.0"],
+                versions: ["r0.6.0"],
             });
 
             const prom = client.requestRegisterEmailToken("bob@email", "secret", 1);

--- a/spec/integ/matrix-client-methods.spec.js
+++ b/spec/integ/matrix-client-methods.spec.js
@@ -27,11 +27,19 @@ describe("MatrixClient", function() {
     let store = null;
     const userId = "@alice:localhost";
     const accessToken = "aseukfgwef";
+    const idServerDomain = "identity.localhost"; // not a real server
+    const identityAccessToken = "woop-i-am-a-secret";
 
     beforeEach(function() {
         store = new MemoryStore();
 
-        const testClient = new TestClient(userId, "aliceDevice", accessToken, undefined, { store });
+        const testClient = new TestClient(userId, "aliceDevice", accessToken, undefined, {
+            store,
+            identityServer: {
+                getAccessToken: () => Promise.resolve(identityAccessToken),
+            },
+            idBaseUrl: `https://${idServerDomain}`,
+        });
         httpBackend = testClient.httpBackend;
         client = testClient.client;
     });
@@ -1004,6 +1012,64 @@ describe("MatrixClient", function() {
                     send_attempt: 1,
                 });
             }).respond(200, response);
+            await httpBackend.flush();
+            expect(await prom).toStrictEqual(response);
+        });
+    });
+
+    describe("inviteByThreePid", () => {
+        it("should supply an id_access_token", async () => {
+            const targetEmail = "gerald@example.org";
+
+            httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
+                versions: ["r0.6.0"],
+            });
+
+            httpBackend.when("POST", "/invite").check(req => {
+                expect(req.data).toStrictEqual({
+                    id_server: idServerDomain,
+                    id_access_token: identityAccessToken,
+                    medium: "email",
+                    address: targetEmail,
+                });
+            }).respond(200, {});
+
+            const prom = client.inviteByThreePid("!room:example.org", "email", targetEmail);
+            await httpBackend.flush();
+            await prom; // returns empty object, so no validation needed
+        });
+    });
+
+    describe("createRoom", () => {
+        it("should populate id_access_token on 3pid invites", async () => {
+            const targetEmail = "gerald@example.org";
+            const response = {
+                room_id: "!room:localhost",
+            };
+            const input = {
+                invite_3pid: [{
+                    // we intentionally exclude the access token here, so it can be populated for us
+                    id_server: idServerDomain,
+                    medium: "email",
+                    address: targetEmail,
+                }],
+            };
+
+            httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
+                versions: ["r0.6.0"],
+            });
+
+            httpBackend.when("POST", "/createRoom").check(req => {
+                expect(req.data).toMatchObject({
+                    invite_3pid: expect.arrayContaining([{
+                        ...input.invite_3pid[0],
+                        id_access_token: identityAccessToken,
+                    }]),
+                });
+                expect(req.data.invite_3pid.length).toBe(1);
+            }).respond(200, response);
+
+            const prom = client.createRoom(input);
             await httpBackend.flush();
             expect(await prom).toStrictEqual(response);
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -946,6 +946,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.baseUrl = opts.baseUrl;
         this.idBaseUrl = opts.idBaseUrl;
+        this.identityServer = opts.identityServer;
 
         this.usingExternalCrypto = opts.usingExternalCrypto;
         this.store = opts.store || new StubStore();
@@ -4814,8 +4815,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         };
 
         if (
-            this.identityServer &&
-            this.identityServer.getAccessToken &&
+            this.identityServer?.getAccessToken &&
             await this.doesServerAcceptIdentityAccessToken()
         ) {
             const identityAccessToken = await this.identityServer.getAccessToken();
@@ -7202,8 +7202,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             .filter(i => !i.id_access_token);
         if (
             invitesNeedingToken.length > 0 &&
-            this.identityServer &&
-            this.identityServer.getAccessToken &&
+            this.identityServer?.getAccessToken &&
             await this.doesServerAcceptIdentityAccessToken()
         ) {
             const identityAccessToken = await this.identityServer.getAccessToken();


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22757

Also add tests for specifically the functionality described in the issue - I'm very surprised we don't have `createRoom` tests, but that's a future PR's problem.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Actually store the identity server in the client when given as an option ([\#2503](https://github.com/matrix-org/matrix-js-sdk/pull/2503)). Fixes vector-im/element-web#22757.<!-- CHANGELOG_PREVIEW_END -->