### PR TITLE
Remove MSC3244 support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -423,15 +423,9 @@ export enum RoomVersionStability {
     Unstable = "unstable",
 }
 
-export interface IRoomCapability { // MSC3244
-    preferred: string | null;
-    support: string[];
-}
-
 export interface IRoomVersionsCapability {
     default: string;
     available: Record<string, RoomVersionStability>;
-    "org.matrix.msc3244.room_capabilities"?: Record<string, IRoomCapability>; // MSC3244
 }
 
 export interface ICapability {


### PR DESCRIPTION
As of writing, the MSC is in FCP for **rejection**: https://github.com/matrix-org/matrix-spec-proposals/pull/3244

We probably should have named `IRoomCapability` something more unstable-looking, or added jsdoc to say it's unstable, so it feels less dangerous to remove, however considering how people use this I'm not overly concerned enough to call this a breaking change myself.

Paired with https://github.com/matrix-org/matrix-react-sdk/pull/9018

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Remove MSC3244 support ([\#2504](https://github.com/matrix-org/matrix-js-sdk/pull/2504)).<!-- CHANGELOG_PREVIEW_END -->