### PR TITLE
Remove unstable support for `m.room_key.withheld`

### DIFF
--- a/spec/integ/megolm-integ.spec.js
+++ b/spec/integ/megolm-integ.spec.js
@@ -616,9 +616,6 @@ describe("megolm", function() {
                 event_id: '$event_id',
             });
             aliceTestClient.httpBackend.when(
-                'PUT', '/sendToDevice/org.matrix.room_key.withheld/',
-            ).respond(200, {});
-            aliceTestClient.httpBackend.when(
                 'PUT', '/sendToDevice/m.room_key.withheld/',
             ).respond(200, {});
 
@@ -718,9 +715,6 @@ describe("megolm", function() {
                     event_id: '$event_id',
                 };
             });
-            aliceTestClient.httpBackend.when(
-                'PUT', '/sendToDevice/org.matrix.room_key.withheld/',
-            ).respond(200, {});
             aliceTestClient.httpBackend.when(
                 'PUT', '/sendToDevice/m.room_key.withheld/',
             ).respond(200, {});

--- a/spec/unit/crypto/algorithms/megolm.spec.js
+++ b/spec/unit/crypto/algorithms/megolm.spec.js
@@ -643,7 +643,7 @@ describe("MegolmDecryption", function() {
         const roomId = "!someroom";
 
         aliceClient.crypto.onToDeviceEvent(new MatrixEvent({
-            type: "org.matrix.room_key.withheld",
+            type: "m.room_key.withheld",
             sender: "@bob:example.com",
             content: {
                 algorithm: "m.megolm.v1.aes-sha2",
@@ -718,7 +718,7 @@ describe("MegolmDecryption", function() {
         const now = Date.now();
 
         aliceClient.crypto.onToDeviceEvent(new MatrixEvent({
-            type: "org.matrix.room_key.withheld",
+            type: "m.room_key.withheld",
             sender: "@bob:example.com",
             content: {
                 algorithm: "m.megolm.v1.aes-sha2",

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -738,7 +738,6 @@ class MegolmEncryption extends EncryptionAlgorithm {
             contentMap[userId][deviceId] = message;
         }
 
-        await this.baseApis.sendToDevice("org.matrix.room_key.withheld", contentMap);
         await this.baseApis.sendToDevice("m.room_key.withheld", contentMap);
 
         // record the fact that we notified these blocked devices

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3119,8 +3119,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
                 this.secretStorage.onRequestReceived(event);
             } else if (event.getType() === "m.secret.send") {
                 this.secretStorage.onSecretReceived(event);
-            } else if (event.getType() === "m.room_key.withheld"
-                || event.getType() === "org.matrix.room_key.withheld") {
+            } else if (event.getType() === "m.room_key.withheld") {
                 this.onRoomKeyWithheldEvent(event);
             } else if (event.getContent().transaction_id) {
                 this.onKeyVerificationMessage(event);


### PR DESCRIPTION
We no longer send or receive the unstable type.

The [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/2399) was *merged* to the spec about 2 years ago, so we should be more than safe to remove this sort of support. It was formally released in v1.1 of the spec in November of 2021, well beyond the 2 month window the spec requests of implementation for a grace period.

The only implementation I can see which hasn't changed over is Element Android: https://github.com/matrix-org/matrix-android-sdk2/blob/3adfe4d01c8ff5189ada1373015501256e2a2d57/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt#L90

Given the massive time scale and spec process here, I'm keen to land this without waiting for Android to fix their event type usage. Otherwise, we risk having to put `org.matrix.room_key.withheld` into the spec, which I am absolutely not going to be happy about :)

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/2233

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Remove unstable support for `m.room_key.withheld` ([\#2512](https://github.com/matrix-org/matrix-js-sdk/pull/2512)). Fixes #2233.<!-- CHANGELOG_PREVIEW_END -->