### PR TITLE
Correct the units in TURN servers expiry documentation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6292,9 +6292,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Get the unix timestamp (in seconds) at which the current
+     * Get the unix timestamp (in milliseconds) at which the current
      * TURN credentials (from getTurnServers) expire
-     * @return {number} The expiry timestamp, in seconds, or null if no credentials
+     * @return {number} The expiry timestamp, in milliseconds, or null if no credentials
      */
     public getTurnServersExpiry(): number | null {
         return this.turnServersExpiry;


### PR DESCRIPTION
As shown elsewhere in client.ts, `turnServersExpiry` really is in milliseconds rather than seconds. It seems that other libraries like matrix-react-sdk were already expecting it to be in milliseconds anyways, so it's just the documentation that was wrong.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Linter and other CI checks pass

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add super cool feature ([\#2520](https://github.com/matrix-org/matrix-js-sdk/pull/2520)).<!-- CHANGELOG_PREVIEW_END -->