### PR TITLE
Make SDP munging media type specific

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -93,10 +93,20 @@ interface AssertedIdentity {
     displayName: string;
 }
 
+enum MediaType {
+    AUDIO = "audio",
+    VIDEO = "video",
+}
+
+enum CodecName {
+    OPUS = "opus",
+    // add more as needed
+}
+
 // Used internally to specify modifications to codec parameters in SDP
 interface CodecParamsMod {
-    mediaType: string;
-    codec: string;
+    mediaType: MediaType;
+    codec: CodecName;
     enableDtx?: boolean; // true to enable discontinuous transmission, false to disable, undefined to leave as-is
     maxAverageBitrate?: number; // sets the max average bitrate, or undefined to leave as-is
 }

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -94,12 +94,12 @@ interface AssertedIdentity {
 }
 
 // Used internally to specify modifications to codec parameters in SDP
-interface CodecParams {
+interface CodecParamsMod {
+    mediaType: string;
+    codec: string;
     enableDtx?: boolean; // true to enable discontinuous transmission, false to disable, undefined to leave as-is
     maxAverageBitrate?: number; // sets the max average bitrate, or undefined to leave as-is
 }
-
-type CodecParamMods = Record<string, CodecParams>;
 
 export enum CallState {
     Fledgling = 'fledgling',
@@ -269,14 +269,15 @@ export function genCallID(): string {
     return Date.now().toString() + randomString(16);
 }
 
-function getCodecParamMods(isPtt: boolean): CodecParamMods {
-    const mods = {
-        'opus': {
+function getCodecParamMods(isPtt: boolean): CodecParamsMod[] {
+    const mods = [
+        {
+            mediaType: "audio",
+            codec: "opus",
             enableDtx: true,
+            maxAverageBitrate: isPtt ? 12000 : undefined,
         },
-    } as CodecParamMods;
-
-    if (isPtt) mods.opus.maxAverageBitrate = 12000;
+    ] as CodecParamsMod[];
 
     return mods;
 }
@@ -1476,7 +1477,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
     // Enables DTX (discontinuous transmission) on the given session to reduce
     // bandwidth when transmitting silence
-    private mungeSdp(description: RTCSessionDescriptionInit, mods: CodecParamMods): void {
+    private mungeSdp(description: RTCSessionDescriptionInit, mods: CodecParamsMod[]): void {
         // The only way to enable DTX at this time is through SDP munging
         const sdp = parseSdp(description.sdp);
 
@@ -1488,30 +1489,32 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 codecToPayloadTypeMap.set(rtp.codec, rtp.payload);
             }
 
-            for (const [codec, params] of Object.entries(mods)) {
-                if (!codecToPayloadTypeMap.has(codec)) {
-                    logger.info(`Ignoring SDP modifications for ${codec} as it's not present.`);
+            for (const mod of mods) {
+                if (mod.mediaType !== media.type) continue;
+
+                if (!codecToPayloadTypeMap.has(mod.codec)) {
+                    logger.info(`Ignoring SDP modifications for ${mod.codec} as it's not present.`);
                     continue;
                 }
 
                 const extraconfig: string[] = [];
-                if (params.enableDtx !== undefined) {
-                    extraconfig.push(`usedtx=${params.enableDtx ? '1' : '0'}`);
+                if (mod.enableDtx !== undefined) {
+                    extraconfig.push(`usedtx=${mod.enableDtx ? '1' : '0'}`);
                 }
-                if (params.maxAverageBitrate !== undefined) {
-                    extraconfig.push(`maxaveragebitrate=${params.maxAverageBitrate}`);
+                if (mod.maxAverageBitrate !== undefined) {
+                    extraconfig.push(`maxaveragebitrate=${mod.maxAverageBitrate}`);
                 }
 
                 let found = false;
                 for (const fmtp of media.fmtp) {
-                    if (payloadTypeToCodecMap.get(fmtp.payload) === codec) {
+                    if (payloadTypeToCodecMap.get(fmtp.payload) === mod.codec) {
                         found = true;
                         fmtp.config += ";" + extraconfig.join(";");
                     }
                 }
                 if (!found) {
                     media.fmtp.push({
-                        payload: codecToPayloadTypeMap.get(codec),
+                        payload: codecToPayloadTypeMap.get(mod.codec),
                         config: extraconfig.join(";"),
                     });
                 }


### PR DESCRIPTION
We were trying to apply modifications to all media types which led
to confusing warning messages saying opus wasn't present (when it
was for the video stream). Make the modifications media-type specific
to avoid this.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->