### PR TITLE
Add missing events from reemitter to GroupCall

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -1,7 +1,14 @@
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 import { CallFeed, SPEAKING_THRESHOLD } from "./callFeed";
 import { MatrixClient } from "../client";
-import { CallErrorCode, CallEvent, CallState, genCallID, MatrixCall, setTracksEnabled } from "./call";
+import { CallErrorCode,
+    CallEvent,
+    CallEventHandlerMap,
+    CallState,
+    genCallID,
+    MatrixCall,
+    setTracksEnabled,
+} from "./call";
 import { RoomMember } from "../models/room-member";
 import { Room } from "../models/room";
 import { logger } from "../logger";
@@ -146,7 +153,10 @@ function getCallUserId(call: MatrixCall): string | null {
     return call.getOpponentMember()?.userId || call.invitee || null;
 }
 
-export class GroupCall extends TypedEventEmitter<GroupCallEvent, GroupCallEventHandlerMap> {
+export class GroupCall extends TypedEventEmitter<
+    GroupCallEvent | CallEvent,
+    GroupCallEventHandlerMap & CallEventHandlerMap
+> {
     // Config
     public activeSpeakerInterval = 1000;
     public retryCallInterval = 5000;


### PR DESCRIPTION
The `GroupCall` class uses a reemitter to also emit all the `CallEvent`'s from the calls that are part of the group call (in addition to the `GroupCallEvent`'s). This PR adds the missing events that are coming from the reemitter.
## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add missing events from reemitter to GroupCall ([\#2527](https://github.com/matrix-org/matrix-js-sdk/pull/2527)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->