### PR TITLE
Add support for sending user-defined encrypted to-device messages

### DIFF
--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -65,6 +65,10 @@ describe("Crypto", function() {
         return Olm.init();
     });
 
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     it("Crypto exposes the correct olm library version", function() {
         expect(Crypto.getOlmVersion()[0]).toEqual(3);
     });
@@ -456,8 +460,6 @@ describe("Crypto", function() {
             // the second call to sendToDevice will be the key request
             expect(aliceSendToDevice).toBeCalledTimes(3);
             expect(aliceSendToDevice.mock.calls[2][2]).not.toBe(txnId);
-
-            jest.useRealTimers();
         });
     });
 

--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -456,6 +456,8 @@ describe("Crypto", function() {
             // the second call to sendToDevice will be the key request
             expect(aliceSendToDevice).toBeCalledTimes(3);
             expect(aliceSendToDevice.mock.calls[2][2]).not.toBe(txnId);
+
+            jest.useRealTimers();
         });
     });
 

--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -360,8 +360,11 @@ describe("MegolmDecryption", function() {
 
                 // Splice the real method onto the mock object as megolm uses this method
                 // on the crypto class in order to encrypt / start sessions
+                // @ts-ignore Mock
                 mockCrypto.encryptAndSendToDevices = Crypto.prototype.encryptAndSendToDevices;
+                // @ts-ignore Mock
                 mockCrypto.olmDevice = olmDevice;
+                // @ts-ignore Mock
                 mockCrypto.baseApis = mockBaseApis;
 
                 mockRoom = {

--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -357,6 +357,13 @@ describe("MegolmDecryption", function() {
                         rotation_period_ms: rotationPeriodMs,
                     },
                 });
+
+                // Splice the real method onto the mock object as megolm uses this method
+                // on the crypto class in order to encrypt / start sessions
+                mockCrypto.encryptAndSendToDevices = Crypto.prototype.encryptAndSendToDevices;
+                mockCrypto.olmDevice = olmDevice;
+                mockCrypto.baseApis = mockBaseApis;
+
                 mockRoom = {
                     getEncryptionTargetMembers: jest.fn().mockReturnValue(
                         [{ userId: "@alice:home.server" }],

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -27,6 +27,7 @@ import {
     UNSTABLE_MSC3089_TREE_SUBTYPE,
 } from "../../src/@types/event";
 import { MEGOLM_ALGORITHM } from "../../src/crypto/olmlib";
+import { Crypto } from "../../src/crypto";
 import { EventStatus, MatrixEvent } from "../../src/models/event";
 import { Preset } from "../../src/@types/partials";
 import { ReceiptType } from "../../src/@types/read_receipts";
@@ -1295,6 +1296,21 @@ describe("MatrixClient", function() {
             expect(opts).toMatchObject({ prefix: "/_matrix/client/v3" });
             expect(queryParams).toBeFalsy();
             expect(result!.aliases).toEqual(response.aliases);
+        });
+    });
+
+    describe("encryptAndSendToDevices", () => {
+        it("throws an error if crypto is unavailable", () => {
+            client.crypto = undefined;
+            expect(() => client.encryptAndSendToDevices([], {})).toThrow();
+        });
+
+        it("is an alias for the crypto method", async () => {
+            client.crypto = testUtils.mock(Crypto, "Crypto");
+            const deviceInfos = [];
+            const payload = {};
+            await client.encryptAndSendToDevices(deviceInfos, payload);
+            expect(client.crypto.encryptAndSendToDevices).toHaveBeenLastCalledWith(deviceInfos, payload);
         });
     });
 });

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -609,93 +609,24 @@ class MegolmEncryption extends EncryptionAlgorithm {
         userDeviceMap: IOlmDevice[],
         payload: IPayload,
     ): Promise<void> {
-        const contentMap: Record<string, Record<string, IEncryptedContent>> = {};
-        // Map from userId to a map of deviceId to deviceInfo
-        const deviceInfoByUserIdAndDeviceId = new Map<string, Map<string, DeviceInfo>>();
-
-        const promises: Promise<unknown>[] = [];
-        for (let i = 0; i < userDeviceMap.length; i++) {
-            const encryptedContent: IEncryptedContent = {
-                algorithm: olmlib.OLM_ALGORITHM,
-                sender_key: this.olmDevice.deviceCurve25519Key,
-                ciphertext: {},
-            };
-            const val = userDeviceMap[i];
-            const userId = val.userId;
-            const deviceInfo = val.deviceInfo;
-            const deviceId = deviceInfo.deviceId;
-
-            // Assign to temp value to make type-checking happy
-            let userIdDeviceInfo = deviceInfoByUserIdAndDeviceId.get(userId);
-
-            if (userIdDeviceInfo === undefined) {
-                userIdDeviceInfo = new Map<string, DeviceInfo>();
-
-                deviceInfoByUserIdAndDeviceId.set(userId, userIdDeviceInfo);
-            }
-
-            // We hold by reference, this updates deviceInfoByUserIdAndDeviceId[userId]
-            userIdDeviceInfo.set(deviceId, deviceInfo);
-
-            if (!contentMap[userId]) {
-                contentMap[userId] = {};
-            }
-            contentMap[userId][deviceId] = encryptedContent;
-
-            promises.push(
-                olmlib.encryptMessageForDevice(
-                    encryptedContent.ciphertext,
-                    this.userId,
-                    this.deviceId,
-                    this.olmDevice,
-                    userId,
-                    deviceInfo,
-                    payload,
-                ),
-            );
-        }
-
-        return Promise.all(promises).then(() => {
-            // prune out any devices that encryptMessageForDevice could not encrypt for,
-            // in which case it will have just not added anything to the ciphertext object.
-            // There's no point sending messages to devices if we couldn't encrypt to them,
-            // since that's effectively a blank message.
+        return this.crypto.encryptAndSendToDevices(
+            userDeviceMap,
+            payload,
+        ).then(({ contentMap, deviceInfoByUserIdAndDeviceId }) => {
+            // store that we successfully uploaded the keys of the current slice
             for (const userId of Object.keys(contentMap)) {
                 for (const deviceId of Object.keys(contentMap[userId])) {
-                    if (Object.keys(contentMap[userId][deviceId].ciphertext).length === 0) {
-                        logger.log(
-                            "No ciphertext for device " +
-                            userId + ":" + deviceId + ": pruning",
-                        );
-                        delete contentMap[userId][deviceId];
-                    }
-                }
-                // No devices left for that user? Strip that too.
-                if (Object.keys(contentMap[userId]).length === 0) {
-                    logger.log("Pruned all devices for user " + userId);
-                    delete contentMap[userId];
+                    session.markSharedWithDevice(
+                        userId,
+                        deviceId,
+                        deviceInfoByUserIdAndDeviceId.get(userId).get(deviceId).getIdentityKey(),
+                        chainIndex,
+                    );
                 }
             }
-
-            // Is there anything left?
-            if (Object.keys(contentMap).length === 0) {
-                logger.log("No users left to send to: aborting");
-                return;
-            }
-
-            return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(() => {
-                // store that we successfully uploaded the keys of the current slice
-                for (const userId of Object.keys(contentMap)) {
-                    for (const deviceId of Object.keys(contentMap[userId])) {
-                        session.markSharedWithDevice(
-                            userId,
-                            deviceId,
-                            deviceInfoByUserIdAndDeviceId.get(userId).get(deviceId).getIdentityKey(),
-                            chainIndex,
-                        );
-                    }
-                }
-            });
+        }).catch((error) => {
+            logger.error("failed to encryptAndSendToDevices", error);
+            throw error;
         });
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3206,7 +3206,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             }
 
             return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
-                (response) => ({ contentMap, deviceInfoByUserIdAndDeviceId }),
+                () => ({ contentMap, deviceInfoByUserIdAndDeviceId }),
             ).catch(error => {
                 logger.error("sendToDevice failed", error);
                 throw error;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -210,7 +210,7 @@ export interface IEncryptedContent {
 }
 /* eslint-enable camelcase */
 
-interface IEncryptAndSendToDevicesResult {
+export interface IEncryptAndSendToDevicesResult {
     contentMap: Record<string, Record<string, IEncryptedContent>>;
     deviceInfoByUserIdAndDeviceId: Map<string, Map<string, DeviceInfo>>;
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -26,6 +26,7 @@ import anotherjson from "another-json";
 import { TypedReEmitter } from '../ReEmitter';
 import { logger } from '../logger';
 import { IExportedDevice, OlmDevice } from "./OlmDevice";
+import { IOlmDevice } from "./algorithms/megolm";
 import * as olmlib from "./olmlib";
 import { DeviceInfoMap, DeviceList } from "./DeviceList";
 import { DeviceInfo, IDevice } from "./deviceinfo";
@@ -199,6 +200,19 @@ export interface IRequestsMap {
     getRequestByChannel(channel: IVerificationChannel): VerificationRequest;
     setRequest(event: MatrixEvent, request: VerificationRequest): void;
     setRequestByChannel(channel: IVerificationChannel, request: VerificationRequest): void;
+}
+
+/* eslint-disable camelcase */
+export interface IEncryptedContent {
+    algorithm: string;
+    sender_key: string;
+    ciphertext: Record<string, string>;
+}
+/* eslint-enable camelcase */
+
+interface IEncryptAndSendToDevicesResult {
+    contentMap: Record<string, Record<string, IEncryptedContent>>;
+    deviceInfoByUserIdAndDeviceId: Map<string, Map<string, DeviceInfo>>;
 }
 
 export enum CryptoEvent {
@@ -3097,6 +3111,109 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             // ignore any rooms which we have left
             const myMembership = room.getMyMembership();
             return myMembership === "join" || myMembership === "invite";
+        });
+    }
+
+    /**
+     * Encrypts and sends a given object via Olm to-device messages to a given
+     * set of devices. Factored out from encryptAndSendKeysToDevices in
+     * megolm.ts.
+     *
+     * @param {object[]} userDeviceInfoArr
+     *   mapping from userId to deviceInfo
+     *
+     * @param {object} payload fields to include in the encrypted payload
+     *      *
+     * @return {Promise<{contentMap, deviceInfoByDeviceId}>} Promise which
+     *     resolves once the message has been encrypted and sent to the given
+     *     userDeviceMap, and returns the { contentMap, deviceInfoByDeviceId }
+     *     of the successfully sent messages.
+     */
+    public encryptAndSendToDevices(
+        userDeviceInfoArr: IOlmDevice<DeviceInfo>[],
+        payload: object,
+    ): Promise<IEncryptAndSendToDevicesResult> {
+        const contentMap: Record<string, Record<string, IEncryptedContent>> = {};
+        const deviceInfoByUserIdAndDeviceId = new Map<string, Map<string, DeviceInfo>>();
+
+        const promises: Promise<unknown>[] = [];
+        for (const { userId, deviceInfo } of userDeviceInfoArr) {
+            const deviceId = deviceInfo.deviceId;
+            const encryptedContent: IEncryptedContent = {
+                algorithm: olmlib.OLM_ALGORITHM,
+                sender_key: this.olmDevice.deviceCurve25519Key,
+                ciphertext: {},
+            };
+
+            // Assign to temp value to make type-checking happy
+            let userIdDeviceInfo = deviceInfoByUserIdAndDeviceId.get(userId);
+
+            if (userIdDeviceInfo === undefined) {
+                userIdDeviceInfo = new Map<string, DeviceInfo>();
+                deviceInfoByUserIdAndDeviceId.set(userId, userIdDeviceInfo);
+            }
+
+            // We hold by reference, this updates deviceInfoByUserIdAndDeviceId[userId]
+            userIdDeviceInfo.set(deviceId, deviceInfo);
+
+            if (!contentMap[userId]) {
+                contentMap[userId] = {};
+            }
+            contentMap[userId][deviceId] = encryptedContent;
+
+            promises.push(
+                olmlib.ensureOlmSessionsForDevices(
+                    this.olmDevice,
+                    this.baseApis,
+                    { [userId]: [deviceInfo] },
+                ).then(() =>
+                    olmlib.encryptMessageForDevice(
+                        encryptedContent.ciphertext,
+                        this.userId,
+                        this.deviceId,
+                        this.olmDevice,
+                        userId,
+                        deviceInfo,
+                        payload,
+                    ),
+                ),
+            );
+        }
+
+        return Promise.all(promises).then(() => {
+            // prune out any devices that encryptMessageForDevice could not encrypt for,
+            // in which case it will have just not added anything to the ciphertext object.
+            // There's no point sending messages to devices if we couldn't encrypt to them,
+            // since that's effectively a blank message.
+            for (const userId of Object.keys(contentMap)) {
+                for (const deviceId of Object.keys(contentMap[userId])) {
+                    if (Object.keys(contentMap[userId][deviceId].ciphertext).length === 0) {
+                        logger.log(`No ciphertext for device ${userId}:${deviceId}: pruning`);
+                        delete contentMap[userId][deviceId];
+                    }
+                }
+                // No devices left for that user? Strip that too.
+                if (Object.keys(contentMap[userId]).length === 0) {
+                    logger.log(`Pruned all devices for user ${userId}`);
+                    delete contentMap[userId];
+                }
+            }
+
+            // Is there anything left?
+            if (Object.keys(contentMap).length === 0) {
+                logger.log("No users left to send to: aborting");
+                return;
+            }
+
+            return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
+                (response) => ({ contentMap, deviceInfoByUserIdAndDeviceId }),
+            ).catch(error => {
+                logger.error("sendToDevice failed", error);
+                throw error;
+            });
+        }).catch(error => {
+            logger.error("encryptAndSendToDevices promises failed", error);
+            throw error;
         });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,7 +1307,6 @@
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz":
   version "3.2.12"
-  uid "0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
   resolved "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz#0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
@@ -1438,9 +1437,9 @@
     "@octokit/openapi-types" "^12.10.0"
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.20"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.20.tgz#11a657875de6008622d53f56e063a6347c51a6dd"
-  integrity sha512-kVaO5aEFZb33nPMTZBxiPEkY+slxiPtqC7QX8f9B3eGOMBvEfuMfxp9DSTTCsRJPumPKjrge4yagyssO4q6qzQ==
+  version "0.24.26"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.26.tgz#84f9e8c1d93154e734a7947609a1dc7c7a81cc22"
+  integrity sha512-1ZVIyyS1NXDRVT8GjWD5jULjhDyM3IsIHef2VGUMdnWOlX2tkPjyEX/7K0TGSH2S8EaPhp1ylFdjSjUGQ+gecg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1581,9 +1580,9 @@
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/node@*":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
-  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
+  version "18.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
+  integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
 "@types/node@16":
   version "16.11.45"
@@ -4803,9 +4802,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
 matrix-mock-request@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/matrix-mock-request/-/matrix-mock-request-2.1.0.tgz#86f5b0ef846865d0767d3a8e64f5bcd6ca94c178"
-  integrity sha512-Cjpl3yP6h0yu5GKG89m1XZXZlm69Kg/qHV41N/t6SrQsgcfM3Bfavqx9YrtG0UnuXGy4bBSZIe1QiWVeFPZw1A==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/matrix-mock-request/-/matrix-mock-request-2.1.2.tgz#11e38ed1233dced88a6f2bfba1684d5c5b3aa2c2"
+  integrity sha512-/OXCIzDGSLPJ3fs+uzDrtaOHI/Sqp4iEuniRn31U8S06mPXbvAnXknHqJ4c6A/KVwJj/nPFbGXpK4wPM038I6A==
   dependencies:
     expect "^28.1.0"
 


### PR DESCRIPTION
This is a port of the same changes from the robertlong/group-call branch.

Depends on https://github.com/matrix-org/matrix-mock-request/pull/18

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add support for sending user-defined encrypted to-device messages ([\#2528](https://github.com/matrix-org/matrix-js-sdk/pull/2528)).<!-- CHANGELOG_PREVIEW_END -->