### PR TITLE
Require confirmation when doing proper release when intending to make an RC

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -121,6 +121,8 @@ echo $release | grep -q '-' && prerelease=1
 
 if [ $prerelease -eq 1 ]; then
     echo Making a PRE-RELEASE
+else
+    read -p "Making a FINAL RELEASE, press enter to continue " REPLY
 fi
 
 # We might already be on the release branch, in which case, yay


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->