### PR TITLE
Read receipts for threads proof of concept (MSC3771) 

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -32,13 +32,14 @@ import {
     RoomEvent,
 } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
-import { IWrappedReceipt, Room } from "../../src/models/room";
+import { Room } from "../../src/models/room";
 import { RoomState } from "../../src/models/room-state";
 import { UNSTABLE_ELEMENT_FUNCTIONAL_USERS } from "../../src/@types/event";
 import { TestClient } from "../TestClient";
 import { emitPromise } from "../test-utils/test-utils";
 import { ReceiptType } from "../../src/@types/read_receipts";
 import { Thread, ThreadEvent } from "../../src/models/thread";
+import { WrappedReceipt } from "../../src/models/timeline-receipts";
 
 describe("Room", function() {
     const roomId = "!foo:bar";
@@ -2429,7 +2430,7 @@ describe("Room", function() {
 
         it("handles missing receipt type", () => {
             room.getReadReceiptForUserId = (userId, ignore, receiptType) => {
-                return receiptType === ReceiptType.ReadPrivate ? { eventId: "eventId" } as IWrappedReceipt : null;
+                return receiptType === ReceiptType.ReadPrivate ? { eventId: "eventId" } as WrappedReceipt : null;
             };
 
             expect(room.getEventReadUpTo(userA)).toEqual("eventId");
@@ -2440,7 +2441,7 @@ describe("Room", function() {
                 return (receiptType === ReceiptType.Read
                     ? { eventId: "eventId1" }
                     : { eventId: "eventId2" }
-                    ) as IWrappedReceipt;
+                    ) as WrappedReceipt;
             };
             room.getUnfilteredTimelineSet = () => ({ compareEventOrdering: (event1, event2) => 1 } as EventTimelineSet);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -4535,11 +4535,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             return Promise.resolve({}); // guests cannot send receipts so don't bother.
         }
 
-        const path = utils.encodeUri("/rooms/$roomId/receipt/$receiptType/$eventId", {
+        let path = utils.encodeUri("/rooms/$roomId/receipt/$receiptType/$eventId", {
             $roomId: event.getRoomId(),
             $receiptType: receiptType,
             $eventId: event.getId(),
         });
+
+        if (event.threadRootId) {
+            path += utils.encodeUri("/$threadId", {
+                $threadId: event.threadRootId,
+            });
+        }
+
         const promise = this.http.authedRequest(callback, Method.Post, path, undefined, body || {});
 
         const room = this.getRoom(event.getRoomId());

--- a/src/client.ts
+++ b/src/client.ts
@@ -4614,6 +4614,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
     public async sendReadReceipt(event: MatrixEvent, receiptType = ReceiptType.Read, callback?: Callback): Promise<{}> {
+        if (!event) return;
         const eventId = event.getId();
         const room = this.getRoom(event.getRoomId());
         if (room && room.hasPendingEvent(eventId)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4584,7 +4584,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             return Promise.resolve({}); // guests cannot send receipts so don't bother.
         }
 
-        let path = utils.encodeUri("/rooms/$roomId/receipt/$receiptType/$eventId", {
+        const path = utils.encodeUri("/rooms/$roomId/receipt/$receiptType/$eventId", {
             $roomId: event.getRoomId(),
             $receiptType: receiptType,
             $eventId: event.getId(),
@@ -4592,9 +4592,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const isThread = !!event.threadRootId;
         if (isThread) {
-            path += utils.encodeUri("/$threadId", {
-                $threadId: event.threadRootId,
-            });
+            body.thread_id = event.threadRootId;
         }
 
         const promise = this.http.authedRequest(callback, Method.Post, path, undefined, body || {});

--- a/src/client.ts
+++ b/src/client.ts
@@ -4590,7 +4590,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             $eventId: event.getId(),
         });
 
-        if (event.threadRootId) {
+        const isThread = !!event.threadRootId;
+        if (isThread) {
             path += utils.encodeUri("/$threadId", {
                 $threadId: event.threadRootId,
             });

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -390,7 +390,7 @@ export class MatrixHttpApi {
             };
 
             // set an initial timeout of 30s; we'll advance it each time we get a progress notification
-            let timeoutTimer = callbacks.setTimeout(timeoutFn, 30000);
+            let timeoutTimer = callbacks.setTimeout(timeoutFn, 60000);
 
             xhr.onreadystatechange = function() {
                 let resp: string;
@@ -421,7 +421,7 @@ export class MatrixHttpApi {
                 callbacks.clearTimeout(timeoutTimer);
                 upload.loaded = ev.loaded;
                 upload.total = ev.total;
-                timeoutTimer = callbacks.setTimeout(timeoutFn, 30000);
+                timeoutTimer = callbacks.setTimeout(timeoutFn, 60000);
                 if (opts.progressHandler) {
                     opts.progressHandler({
                         loaded: ev.loaded,

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -221,7 +221,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
      * @fires module:client~MatrixClient#event:"RoomMember.typing"
      */
     public setTypingEvent(event: MatrixEvent): void {
-        if (event.getType() !== "m.typing") {
+        if (event.getType() !== EventType.Typing) {
             return;
         }
         const oldTyping = this.typing;

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -72,7 +72,7 @@ function synthesizeReceipt(userId: string, event: MatrixEvent, receiptType: Rece
                 },
             },
         },
-        type: "m.receipt",
+        type: EventType.Receipt,
         room_id: event.getRoomId(),
     });
 }
@@ -2423,9 +2423,9 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      */
     public addEphemeralEvents(events: MatrixEvent[]): void {
         for (const event of events) {
-            if (event.getType() === 'm.typing') {
+            if (event.getType() === EventType.Typing) {
                 this.currentState.setTypingEvent(event);
-            } else if (event.getType() === 'm.receipt') {
+            } else if (event.getType() === EventType.Receipt) {
                 this.addReceipt(event);
             } // else ignore - life is too short for us to care about these events
         }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2460,9 +2460,10 @@ export class Room extends TimelineReceipts<EmittedEvents, RoomEventHandlerMap> {
         Object.keys(content).forEach((eventId: string) => {
             Object.keys(content[eventId]).forEach((receiptType: ReceiptType) => {
                 Object.keys(content[eventId][receiptType]).forEach((userId: string) => {
-                    const receipt = content[eventId][receiptType][userId];
+                    // hack, threadId should be thread_id
+                    const receipt = content[eventId][receiptType][userId] as any;
 
-                    const receiptDestination = this.threads.get(event.threadRootId) ?? this;
+                    const receiptDestination = this.threads.get(receipt.threadId) ?? this;
                     receiptDestination.addReceiptToStructure(
                         eventId,
                         receiptType,

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2463,7 +2463,7 @@ export class Room extends TimelineReceipts<EmittedEvents, RoomEventHandlerMap> {
                     // hack, threadId should be thread_id
                     const receipt = content[eventId][receiptType][userId] as any;
 
-                    const receiptDestination = this.threads.get(receipt.threadId) ?? this;
+                    const receiptDestination = this.threads.get(receipt.thread_id) ?? this;
                     receiptDestination.addReceiptToStructure(
                         eventId,
                         receiptType,

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -23,10 +23,10 @@ import { IThreadBundledRelationship, MatrixEvent } from "./event";
 import { Direction, EventTimeline } from "./event-timeline";
 import { EventTimelineSet, EventTimelineSetHandlerMap } from './event-timeline-set';
 import { Room } from './room';
-import { TypedEventEmitter } from "./typed-event-emitter";
 import { RoomState } from "./room-state";
 import { ServerControlledNamespacedValue } from "../NamespacedValue";
 import { logger } from "../logger";
+import { TimelineReceipts } from "./timeline-receipts";
 
 export enum ThreadEvent {
     New = "Thread.new",
@@ -54,7 +54,7 @@ interface IThreadOpts {
 /**
  * @experimental
  */
-export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
+export class Thread extends TimelineReceipts<EmittedEvents, EventHandlerMap> {
     public static hasServerSideSupport: boolean;
 
     /**
@@ -428,6 +428,18 @@ export class Thread extends TypedEventEmitter<EmittedEvents, EventHandlerMap> {
             prevBatch,
             nextBatch,
         };
+    }
+
+    public getUnfilteredTimelineSet(): EventTimelineSet {
+        return this.timelineSet;
+    }
+
+    public get timeline(): MatrixEvent[] {
+        return this.events;
+    }
+
+    public addReceipt(event: MatrixEvent, synthetic: boolean): void {
+        throw new Error("Unsupported function on the thread model");
     }
 }
 

--- a/src/models/timeline-receipts.ts
+++ b/src/models/timeline-receipts.ts
@@ -1,0 +1,332 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ReceiptType } from "../@types/read_receipts";
+import { EventType } from "../matrix";
+import { MatrixEvent, MatrixEventEvent } from "./event";
+import { EventTimelineSet } from "./event-timeline-set";
+import { RoomEvent } from "./room";
+import { ThreadEvent } from "./thread";
+import { ListenerMap, TypedEventEmitter } from "./typed-event-emitter";
+
+export function synthesizeReceipt(userId: string, event: MatrixEvent, receiptType: ReceiptType): MatrixEvent {
+    // console.log("synthesizing receipt for "+event.getId());
+    return new MatrixEvent({
+        content: {
+            [event.getId()]: {
+                [receiptType]: {
+                    [userId]: {
+                        ts: event.getTs(),
+                        threadId: event.threadRootId ?? undefined,
+                    },
+                },
+            },
+        },
+        type: EventType.Receipt,
+        room_id: event.getRoomId(),
+    });
+}
+
+interface Receipt {
+    ts: number;
+    thread_id?: string;
+}
+
+export interface WrappedReceipt {
+    eventId: string;
+    data: Receipt;
+}
+
+interface CachedReceipt {
+    type: ReceiptType;
+    userId: string;
+    data: Receipt;
+}
+
+type ReceiptCache = {[eventId: string]: CachedReceipt[]};
+
+interface ReceiptContent {
+    [eventId: string]: {
+        [key in ReceiptType]: {
+            [userId: string]: Receipt;
+        };
+    };
+}
+
+const ReceiptPairRealIndex = 0;
+const ReceiptPairSyntheticIndex = 1;
+// We will only hold a synthetic receipt if we do not have a real receipt or the synthetic is newer.
+type Receipts = {
+    [receiptType: string]: {
+        [userId: string]: [WrappedReceipt, WrappedReceipt]; // Pair<real receipt, synthetic receipt> (both nullable)
+    };
+};
+
+export type EmittedEvents = RoomEvent
+    | ThreadEvent.New
+    | ThreadEvent.Update
+    | ThreadEvent.NewReply
+    | RoomEvent.Timeline
+    | RoomEvent.TimelineReset
+    | RoomEvent.TimelineRefresh
+    | RoomEvent.HistoryImportedWithinTimeline
+    | RoomEvent.OldStateUpdated
+    | RoomEvent.CurrentStateUpdated
+    | MatrixEventEvent.BeforeRedaction;
+
+export abstract class TimelineReceipts<
+    Events extends string,
+    Arguments extends ListenerMap<Events>,
+    SuperclassArguments extends ListenerMap<any> = Arguments,
+> extends TypedEventEmitter<Events, Arguments, SuperclassArguments> {
+    // receipts should clobber based on receipt_type and user_id pairs hence
+    // the form of this structure. This is sub-optimal for the exposed APIs
+    // which pass in an event ID and get back some receipts, so we also store
+    // a pre-cached list for this purpose.
+    private receipts: Receipts = {}; // { receipt_type: { user_id: IReceipt } }
+    private receiptCacheByEventId: ReceiptCache = {}; // { event_id: ICachedReceipt[] }
+
+    public abstract getUnfilteredTimelineSet(): EventTimelineSet;
+    public abstract timeline: MatrixEvent[];
+
+    /**
+     * Gets the latest receipt for a given user in the room
+     * @param userId The id of the user for which we want the receipt
+     * @param ignoreSynthesized Whether to ignore synthesized receipts or not
+     * @param receiptType Optional. The type of the receipt we want to get
+     * @returns the latest receipts of the chosen type for the chosen user
+     */
+    public getReadReceiptForUserId(
+        userId: string, ignoreSynthesized = false, receiptType = ReceiptType.Read,
+    ): WrappedReceipt | null {
+        const [realReceipt, syntheticReceipt] = this.receipts[receiptType]?.[userId] ?? [];
+        if (ignoreSynthesized) {
+            return realReceipt;
+        }
+
+        return syntheticReceipt ?? realReceipt;
+    }
+
+    /**
+     * Get the ID of the event that a given user has read up to, or null if we
+     * have received no read receipts from them.
+     * @param {String} userId The user ID to get read receipt event ID for
+     * @param {Boolean} ignoreSynthesized If true, return only receipts that have been
+     *                                    sent by the server, not implicit ones generated
+     *                                    by the JS SDK.
+     * @return {String} ID of the latest event that the given user has read, or null.
+     */
+    public getEventReadUpTo(userId: string, ignoreSynthesized = false): string | null {
+        const timelineSet = this.getUnfilteredTimelineSet();
+        const publicReadReceipt = this.getReadReceiptForUserId(userId, ignoreSynthesized, ReceiptType.Read);
+        const privateReadReceipt = this.getReadReceiptForUserId(userId, ignoreSynthesized, ReceiptType.ReadPrivate);
+
+        // If we have both, compare them
+        let comparison: number | undefined;
+        if (publicReadReceipt?.eventId && privateReadReceipt?.eventId) {
+            comparison = timelineSet.compareEventOrdering(publicReadReceipt?.eventId, privateReadReceipt?.eventId);
+        }
+
+        // If we didn't get a comparison try to compare the ts of the receipts
+        if (!comparison) comparison = publicReadReceipt?.data?.ts - privateReadReceipt?.data?.ts;
+
+        // The public receipt is more likely to drift out of date so the private
+        // one has precedence
+        if (!comparison) return privateReadReceipt?.eventId ?? publicReadReceipt?.eventId ?? null;
+
+        // If public read receipt is older, return the private one
+        return (comparison < 0) ? privateReadReceipt?.eventId : publicReadReceipt?.eventId;
+    }
+
+    /**
+     * Add a receipt event to the room.
+     * @param {MatrixEvent} event The m.receipt event.
+     * @param {Boolean} synthetic True if this event is implicit.
+     */
+    private addReceiptsToStructure(event: MatrixEvent, synthetic: boolean): void {
+        const content = event.getContent<ReceiptContent>();
+        Object.keys(content).forEach((eventId) => {
+            Object.keys(content[eventId]).forEach((receiptType) => {
+                Object.keys(content[eventId][receiptType]).forEach((userId) => {
+                    const receipt = content[eventId][receiptType][userId];
+
+                    if (!this.receipts[receiptType]) {
+                        this.receipts[receiptType] = {};
+                    }
+                    if (!this.receipts[receiptType][userId]) {
+                        this.receipts[receiptType][userId] = [null, null];
+                    }
+
+                    const pair = this.receipts[receiptType][userId];
+
+                    let existingReceipt = pair[ReceiptPairRealIndex];
+                    if (synthetic) {
+                        existingReceipt = pair[ReceiptPairSyntheticIndex] ?? pair[ReceiptPairRealIndex];
+                    }
+
+                    if (existingReceipt) {
+                        // we only want to add this receipt if we think it is later than the one we already have.
+                        // This is managed server-side, but because we synthesize RRs locally we have to do it here too.
+                        const ordering = this.getUnfilteredTimelineSet().compareEventOrdering(
+                            existingReceipt.eventId,
+                            eventId,
+                        );
+                        if (ordering !== null && ordering >= 0) {
+                            return;
+                        }
+                    }
+
+                    const wrappedReceipt: WrappedReceipt = {
+                        eventId,
+                        data: receipt,
+                    };
+
+                    const realReceipt = synthetic ? pair[ReceiptPairRealIndex] : wrappedReceipt;
+                    const syntheticReceipt = synthetic ? wrappedReceipt : pair[ReceiptPairSyntheticIndex];
+
+                    let ordering: number | null = null;
+                    if (realReceipt && syntheticReceipt) {
+                        ordering = this.getUnfilteredTimelineSet().compareEventOrdering(
+                            realReceipt.eventId,
+                            syntheticReceipt.eventId,
+                        );
+                    }
+
+                    const preferSynthetic = ordering === null || ordering < 0;
+
+                    // we don't bother caching just real receipts by event ID as there's nothing that would read it.
+                    // Take the current cached receipt before we overwrite the pair elements.
+                    const cachedReceipt = pair[ReceiptPairSyntheticIndex] ?? pair[ReceiptPairRealIndex];
+
+                    if (synthetic && preferSynthetic) {
+                        pair[ReceiptPairSyntheticIndex] = wrappedReceipt;
+                    } else if (!synthetic) {
+                        pair[ReceiptPairRealIndex] = wrappedReceipt;
+
+                        if (!preferSynthetic) {
+                            pair[ReceiptPairSyntheticIndex] = null;
+                        }
+                    }
+
+                    const newCachedReceipt = pair[ReceiptPairSyntheticIndex] ?? pair[ReceiptPairRealIndex];
+                    if (cachedReceipt === newCachedReceipt) return;
+
+                    // clean up any previous cache entry
+                    if (cachedReceipt && this.receiptCacheByEventId[cachedReceipt.eventId]) {
+                        const previousEventId = cachedReceipt.eventId;
+                        // Remove the receipt we're about to clobber out of existence from the cache
+                        this.receiptCacheByEventId[previousEventId] = (
+                            this.receiptCacheByEventId[previousEventId].filter(r => {
+                                return r.type !== receiptType || r.userId !== userId;
+                            })
+                        );
+
+                        if (this.receiptCacheByEventId[previousEventId].length < 1) {
+                            delete this.receiptCacheByEventId[previousEventId]; // clean up the cache keys
+                        }
+                    }
+
+                    // cache the new one
+                    if (!this.receiptCacheByEventId[eventId]) {
+                        this.receiptCacheByEventId[eventId] = [];
+                    }
+                    this.receiptCacheByEventId[eventId].push({
+                        userId: userId,
+                        type: receiptType as ReceiptType,
+                        data: receipt,
+                    });
+                });
+            });
+        });
+    }
+
+    /**
+     * Get a list of receipts for the given event.
+     * @param {MatrixEvent} event the event to get receipts for
+     * @return {Object[]} A list of receipts with a userId, type and data keys or
+     * an empty list.
+     */
+    public getReceiptsForEvent(event: MatrixEvent): CachedReceipt[] {
+        return this.receiptCacheByEventId[event.getId()] || [];
+    }
+
+    /**
+     * Add a receipt event to the room.
+     * @param {MatrixEvent} event The m.receipt event.
+     * @param {Boolean} synthetic True if this event is implicit.
+     */
+    public addReceipt(event: MatrixEvent, synthetic = false): void {
+        this.addReceiptsToStructure(event, synthetic);
+    }
+
+    /**
+     * Add a temporary local-echo receipt to the room to reflect in the
+     * client the fact that we've sent one.
+     * @param {string} userId The user ID if the receipt sender
+     * @param {MatrixEvent} e The event that is to be acknowledged
+     * @param {ReceiptType} receiptType The type of receipt
+     */
+    public addLocalEchoReceipt(userId: string, e: MatrixEvent, receiptType: ReceiptType): void {
+        this.addReceipt(synthesizeReceipt(userId, e, receiptType), true);
+    }
+
+    /**
+     * Get a list of user IDs who have <b>read up to</b> the given event.
+     * @param {MatrixEvent} event the event to get read receipts for.
+     * @return {String[]} A list of user IDs.
+     */
+    public getUsersReadUpTo(event: MatrixEvent): string[] {
+        return this.getReceiptsForEvent(event).filter(function(receipt) {
+            return [ReceiptType.Read, ReceiptType.ReadPrivate].includes(receipt.type);
+        }).map(function(receipt) {
+            return receipt.userId;
+        });
+    }
+
+    /**
+     * Determines if the given user has read a particular event ID with the known
+     * history of the room. This is not a definitive check as it relies only on
+     * what is available to the room at the time of execution.
+     * @param {String} userId The user ID to check the read state of.
+     * @param {String} eventId The event ID to check if the user read.
+     * @returns {Boolean} True if the user has read the event, false otherwise.
+     */
+    public hasUserReadEvent(userId: string, eventId: string): boolean {
+        const readUpToId = this.getEventReadUpTo(userId, false);
+        if (readUpToId === eventId) return true;
+
+        if (this.timeline.length
+            && this.timeline[this.timeline.length - 1].getSender()
+            && this.timeline[this.timeline.length - 1].getSender() === userId) {
+            // It doesn't matter where the event is in the timeline, the user has read
+            // it because they've sent the latest event.
+            return true;
+        }
+
+        for (let i = this.timeline.length - 1; i >= 0; --i) {
+            const ev = this.timeline[i];
+
+            // If we encounter the target event first, the user hasn't read it
+            // however if we encounter the readUpToId first then the user has read
+            // it. These rules apply because we're iterating bottom-up.
+            if (ev.getId() === eventId) return false;
+            if (ev.getId() === readUpToId) return true;
+        }
+
+        // We don't know if the user has read it, so assume not.
+        return false;
+    }
+}

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -250,7 +250,7 @@ export class SlidingSyncSdk {
     ) {
         this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
         this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
-        this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
+        this.opts.pollTimeout = this.opts.pollTimeout || (60 * 1000);
         this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
         this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
 

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -401,7 +401,7 @@ export class SyncAccumulator {
                 // typing forever until someone really does start typing (which
                 // will prompt Synapse to send down an actual m.typing event to
                 // clobber the one we persisted).
-                if (e.type !== "m.receipt" || !e.content) {
+                if (e.type !== EventType.Receipt || !e.content) {
                     // This means we'll drop unknown ephemeral events but that
                     // seems okay.
                     return;
@@ -559,7 +559,7 @@ export class SyncAccumulator {
 
             // Add receipt data
             const receiptEvent = {
-                type: "m.receipt",
+                type: EventType.Receipt,
                 room_id: roomId,
                 content: {
                     // $event_id: { "m.read": { $user_id: $json } }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -176,7 +176,7 @@ export class SyncApi {
     constructor(private readonly client: MatrixClient, private readonly opts: Partial<IStoredClientOpts> = {}) {
         this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
         this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
-        this.opts.pollTimeout = this.opts.pollTimeout || (30 * 1000);
+        this.opts.pollTimeout = this.opts.pollTimeout || (60 * 1000);
         this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
         this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
 
@@ -505,7 +505,7 @@ export class SyncApi {
         // FIXME: gut wrenching; hard-coded timeout values
         this.client.http.authedRequest<IEventsResponse>(undefined, Method.Get, "/events", {
             room_id: peekRoom.roomId,
-            timeout: String(30 * 1000),
+            timeout: String(60 * 1000),
             from: token,
         }, undefined, 50 * 1000).then((res) => {
             if (this._peekRoom !== peekRoom) {


### PR DESCRIPTION
Related to https://github.com/matrix-org/matrix-spec-proposals/pull/3771
Fixes https://github.com/vector-im/element-web/issues/22980

Update the `sendReceipt` function to include the `threadId` in the read receipt tuple. Also duplicates the read receipts room structure to all threads model


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Read receipts for threads proof of concept (MSC3771)  ([\#2559](https://github.com/matrix-org/matrix-js-sdk/pull/2559)). Fixes vector-im/element-web#22980.<!-- CHANGELOG_PREVIEW_END -->