### PR TITLE
Merge changes from develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Changes in [19.2.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.2.0) (2022-08-02)
+==================================================================================================
+
+## 🦖 Deprecations
+ * Remove unstable support for `m.room_key.withheld` ([\#2512](https://github.com/matrix-org/matrix-js-sdk/pull/2512)). Fixes #2233.
+
+## ✨ Features
+ * Sliding sync: add missing filters from latest MSC ([\#2555](https://github.com/matrix-org/matrix-js-sdk/pull/2555)).
+ * Use stable prefixes for MSC3827 ([\#2537](https://github.com/matrix-org/matrix-js-sdk/pull/2537)).
+ * Add support for MSC3575: Sliding Sync ([\#2242](https://github.com/matrix-org/matrix-js-sdk/pull/2242)).
+
+## 🐛 Bug Fixes
+ * Correct the units in TURN servers expiry documentation ([\#2520](https://github.com/matrix-org/matrix-js-sdk/pull/2520)).
+ * Re-insert room IDs when decrypting bundled redaction events returned by `/sync` ([\#2531](https://github.com/matrix-org/matrix-js-sdk/pull/2531)). Contributed by @duxovni.
+
 Changes in [19.1.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v19.1.0) (2022-07-26)
 ==================================================================================================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-js-sdk",
-  "version": "19.1.0",
+  "version": "19.2.0",
   "description": "Matrix Client-Server SDK for Javascript",
   "engines": {
     "node": ">=12.9.0"
@@ -104,7 +104,7 @@
     "jest-localstorage-mock": "^2.4.6",
     "jest-sonar-reporter": "^2.0.0",
     "jsdoc": "^3.6.6",
-    "matrix-mock-request": "^2.1.0",
+    "matrix-mock-request": "^2.1.2",
     "rimraf": "^3.0.2",
     "terser": "^5.5.1",
     "tsify": "^5.0.2",

--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -59,6 +59,7 @@ describe("MegolmDecryption", function() {
         mockBaseApis = {
             claimOneTimeKeys: jest.fn(),
             sendToDevice: jest.fn(),
+            queueToDevice: jest.fn(),
         } as unknown as MockedObject<MatrixClient>;
 
         const cryptoStore = new MemoryCryptoStore();
@@ -179,6 +180,7 @@ describe("MegolmDecryption", function() {
                 });
 
                 mockBaseApis.sendToDevice.mockReset();
+                mockBaseApis.queueToDevice.mockReset();
 
                 // do the share
                 megolmDecryption.shareKeysWithDevice(keyRequest);
@@ -324,6 +326,7 @@ describe("MegolmDecryption", function() {
                     },
                 });
                 mockBaseApis.sendToDevice.mockResolvedValue(undefined);
+                mockBaseApis.queueToDevice.mockResolvedValue(undefined);
 
                 aliceDeviceInfo = {
                     deviceId: 'aliceDevice',
@@ -413,7 +416,7 @@ describe("MegolmDecryption", function() {
                 expect(mockCrypto.downloadKeys).toHaveBeenCalledWith(
                     ['@alice:home.server'], false,
                 );
-                expect(mockBaseApis.sendToDevice).toHaveBeenCalled();
+                expect(mockBaseApis.queueToDevice).toHaveBeenCalled();
                 expect(mockBaseApis.claimOneTimeKeys).toHaveBeenCalledWith(
                     [['@alice:home.server', 'aliceDevice']], 'signed_curve25519', 2000,
                 );
@@ -456,7 +459,7 @@ describe("MegolmDecryption", function() {
                     'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWI',
                 );
 
-                mockBaseApis.sendToDevice.mockClear();
+                mockBaseApis.queueToDevice.mockClear();
                 await megolmEncryption.reshareKeyWithDevice(
                     olmDevice.deviceCurve25519Key,
                     ct1.session_id,
@@ -464,7 +467,7 @@ describe("MegolmDecryption", function() {
                     aliceDeviceInfo,
                 );
 
-                expect(mockBaseApis.sendToDevice).not.toHaveBeenCalled();
+                expect(mockBaseApis.queueToDevice).not.toHaveBeenCalled();
             });
         });
     });

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -27,6 +27,7 @@ import {
     UNSTABLE_MSC3089_TREE_SUBTYPE,
 } from "../../src/@types/event";
 import { MEGOLM_ALGORITHM } from "../../src/crypto/olmlib";
+import { Crypto } from "../../src/crypto";
 import { EventStatus, MatrixEvent } from "../../src/models/event";
 import { Preset } from "../../src/@types/partials";
 import { ReceiptType } from "../../src/@types/read_receipts";
@@ -1295,6 +1296,21 @@ describe("MatrixClient", function() {
             expect(opts).toMatchObject({ prefix: "/_matrix/client/v3" });
             expect(queryParams).toBeFalsy();
             expect(result!.aliases).toEqual(response.aliases);
+        });
+    });
+
+    describe("encryptAndSendToDevices", () => {
+        it("throws an error if crypto is unavailable", () => {
+            client.crypto = undefined;
+            expect(() => client.encryptAndSendToDevices([], {})).toThrow();
+        });
+
+        it("is an alias for the crypto method", async () => {
+            client.crypto = testUtils.mock(Crypto, "Crypto");
+            const deviceInfos = [];
+            const payload = {};
+            await client.encryptAndSendToDevices(deviceInfos, payload);
+            expect(client.crypto.encryptAndSendToDevices).toHaveBeenLastCalledWith(deviceInfos, payload);
         });
     });
 });

--- a/spec/unit/queueToDevice.spec.ts
+++ b/spec/unit/queueToDevice.spec.ts
@@ -1,0 +1,338 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import MockHttpBackend from 'matrix-mock-request';
+import { indexedDB as fakeIndexedDB } from 'fake-indexeddb';
+
+import { IHttpOpts, IndexedDBStore, MatrixEvent, MemoryStore, Room } from "../../src";
+import { MatrixClient } from "../../src/client";
+import { ToDeviceBatch } from '../../src/models/ToDeviceMessage';
+import { logger } from '../../src/logger';
+import { IStore } from '../../src/store';
+
+const FAKE_USER = "@alice:example.org";
+const FAKE_DEVICE_ID = "AAAAAAAA";
+const FAKE_PAYLOAD = {
+    "foo": 42,
+};
+const EXPECTED_BODY = {
+    messages: {
+        [FAKE_USER]: {
+            [FAKE_DEVICE_ID]: FAKE_PAYLOAD,
+        },
+    },
+};
+
+const FAKE_MSG = {
+    userId: FAKE_USER,
+    deviceId: FAKE_DEVICE_ID,
+    payload: FAKE_PAYLOAD,
+};
+
+enum StoreType {
+    Memory = 'Memory',
+    IndexedDB = 'IndexedDB',
+}
+
+// Jest now uses @sinonjs/fake-timers which exposes tickAsync() and a number of
+// other async methods which break the event loop, letting scheduled promise
+// callbacks run. Unfortunately, Jest doesn't expose these, so we have to do
+// it manually (this is what sinon does under the hood). We do both in a loop
+// until the thing we expect happens: hopefully this is the least flakey way
+// and avoids assuming anything about the app's behaviour.
+const realSetTimeout = setTimeout;
+function flushPromises() {
+    return new Promise(r => {
+        realSetTimeout(r, 1);
+    });
+}
+
+async function flushAndRunTimersUntil(cond: () => boolean) {
+    while (!cond()) {
+        await flushPromises();
+        if (cond()) break;
+        jest.advanceTimersToNextTimer();
+    }
+}
+
+describe.each([
+    [StoreType.Memory], [StoreType.IndexedDB],
+])("queueToDevice (%s store)", function(storeType) {
+    let httpBackend: MockHttpBackend;
+    let client: MatrixClient;
+
+    beforeEach(async function() {
+        httpBackend = new MockHttpBackend();
+
+        let store: IStore;
+        if (storeType === StoreType.IndexedDB) {
+            const idbStore = new IndexedDBStore({ indexedDB: fakeIndexedDB });
+            await idbStore.startup();
+            store = idbStore;
+        } else {
+            store = new MemoryStore();
+        }
+
+        client = new MatrixClient({
+            baseUrl: "https://my.home.server",
+            accessToken: "my.access.token",
+            request: httpBackend.requestFn as IHttpOpts["request"],
+            store,
+        });
+    });
+
+    afterEach(function() {
+        jest.useRealTimers();
+        client.stopClient();
+    });
+
+    it("sends a to-device message", async function() {
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).check((request) => {
+            expect(request.data).toEqual(EXPECTED_BODY);
+        }).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+
+        await httpBackend.flushAllExpected();
+    });
+
+    it("retries on error", async function() {
+        jest.useFakeTimers();
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(500);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).check((request) => {
+            expect(request.data).toEqual(EXPECTED_BODY);
+        }).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+        await flushAndRunTimersUntil(() => httpBackend.requests.length > 0);
+        expect(httpBackend.flushSync(null, 1)).toEqual(1);
+
+        await flushAndRunTimersUntil(() => httpBackend.requests.length > 0);
+
+        expect(httpBackend.flushSync(null, 1)).toEqual(1);
+    });
+
+    it("stops retrying on 4xx errors", async function() {
+        jest.useFakeTimers();
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(400);
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+        await flushAndRunTimersUntil(() => httpBackend.requests.length > 0);
+        expect(httpBackend.flushSync(null, 1)).toEqual(1);
+
+        // Asserting that another request is never made is obviously
+        // a bit tricky - we just flush the queue what should hopefully
+        // be plenty of times and assert that nothing comes through.
+        let tries = 0;
+        await flushAndRunTimersUntil(() => ++tries === 10);
+
+        expect(httpBackend.requests.length).toEqual(0);
+    });
+
+    it("honours ratelimiting", async function() {
+        jest.useFakeTimers();
+
+        // pick something obscure enough it's unlikley to clash with a
+        // retry delay the algorithm uses anyway
+        const retryDelay = 279 * 1000;
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(429, {
+            errcode: "M_LIMIT_EXCEEDED",
+            retry_after_ms: retryDelay,
+        });
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+        await flushAndRunTimersUntil(() => httpBackend.requests.length > 0);
+        expect(httpBackend.flushSync(null, 1)).toEqual(1);
+        await flushPromises();
+
+        logger.info("Advancing clock to just before expected retry time...");
+
+        jest.advanceTimersByTime(retryDelay - 1000);
+        await flushPromises();
+
+        expect(httpBackend.requests.length).toEqual(0);
+
+        logger.info("Advancing clock past expected retry time...");
+
+        jest.advanceTimersByTime(2000);
+        await flushPromises();
+
+        expect(httpBackend.flushSync(null, 1)).toEqual(1);
+    });
+
+    it("retries on retryImmediately()", async function() {
+        httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
+            versions: ["r0.0.1"],
+        });
+
+        await Promise.all([client.startClient(), httpBackend.flush(null, 1, 20)]);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(500);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+        expect(await httpBackend.flush(null, 1, 1)).toEqual(1);
+        await flushPromises();
+
+        client.retryImmediately();
+
+        expect(await httpBackend.flush(null, 1, 20)).toEqual(1);
+    });
+
+    it("retries on when client is started", async function() {
+        httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
+            versions: ["r0.0.1"],
+        });
+
+        await Promise.all([client.startClient(), httpBackend.flush("/_matrix/client/versions", 1, 20)]);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(500);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+        expect(await httpBackend.flush(null, 1, 1)).toEqual(1);
+        await flushPromises();
+
+        client.stopClient();
+        await Promise.all([client.startClient(), httpBackend.flush("/_matrix/client/versions", 1, 20)]);
+
+        expect(await httpBackend.flush(null, 1, 20)).toEqual(1);
+    });
+
+    it("retries when a message is retried", async function() {
+        httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
+            versions: ["r0.0.1"],
+        });
+
+        await Promise.all([client.startClient(), httpBackend.flush(null, 1, 20)]);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(500);
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).respond(200, {});
+
+        await client.queueToDevice({
+            eventType: "org.example.foo",
+            batch: [
+                FAKE_MSG,
+            ],
+        });
+
+        expect(await httpBackend.flush(null, 1, 1)).toEqual(1);
+        await flushPromises();
+
+        const dummyEvent = new MatrixEvent({
+            event_id: "!fake:example.org",
+        });
+        const mockRoom = {
+            updatePendingEvent: jest.fn(),
+        } as unknown as Room;
+        client.resendEvent(dummyEvent, mockRoom);
+
+        expect(await httpBackend.flush(null, 1, 20)).toEqual(1);
+    });
+
+    it("splits many messages into multiple HTTP requests", async function() {
+        const batch: ToDeviceBatch = {
+            eventType: "org.example.foo",
+            batch: [],
+        };
+
+        for (let i = 0; i <= 20; ++i) {
+            batch.batch.push({
+                userId: `@user${i}:example.org`,
+                deviceId: FAKE_DEVICE_ID,
+                payload: FAKE_PAYLOAD,
+            });
+        }
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).check((request) => {
+            expect(Object.keys(request.data.messages).length).toEqual(20);
+        }).respond(200, {});
+
+        httpBackend.when(
+            "PUT", "/sendToDevice/org.example.foo/",
+        ).check((request) => {
+            expect(Object.keys(request.data.messages).length).toEqual(1);
+        }).respond(200, {});
+
+        await client.queueToDevice(batch);
+        await httpBackend.flushAllExpected();
+    });
+});

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -761,6 +761,7 @@ describe('Call', function() {
                         },
                     };
                 },
+                getSender: () => "@test:foo",
             });
 
             call.pushRemoteFeed(new MockMediaStream(STREAM_ID));

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -415,71 +415,6 @@ describe('Call', function() {
         }).track.id).toBe("video_track");
     });
 
-    describe("should handle stream replacement", () => {
-        it("with both purpose and id", async () => {
-            await startVoiceCall(client, call);
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream1": {
-                    purpose: SDPStreamMetadataPurpose.Usermedia,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream1", []));
-            const feed = call.getFeeds().find((feed) => feed.stream.id === "remote_stream1");
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream2": {
-                    purpose: SDPStreamMetadataPurpose.Usermedia,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream2", []));
-
-            expect(feed?.stream?.id).toBe("remote_stream2");
-        });
-
-        it("with just purpose", async () => {
-            await startVoiceCall(client, call);
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream1": {
-                    purpose: SDPStreamMetadataPurpose.Usermedia,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream1", []));
-            const feed = call.getFeeds().find((feed) => feed.stream.id === "remote_stream1");
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream2": {
-                    purpose: SDPStreamMetadataPurpose.Usermedia,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream2", []));
-
-            expect(feed?.stream?.id).toBe("remote_stream2");
-        });
-
-        it("should not replace purpose is different", async () => {
-            await startVoiceCall(client, call);
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream1": {
-                    purpose: SDPStreamMetadataPurpose.Usermedia,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream1", []));
-            const feed = call.getFeeds().find((feed) => feed.stream.id === "remote_stream1");
-
-            call.updateRemoteSDPStreamMetadata({
-                "remote_stream2": {
-                    purpose: SDPStreamMetadataPurpose.Screenshare,
-                },
-            });
-            call.pushRemoteFeed(new MockMediaStream("remote_stream2", []));
-
-            expect(feed?.stream?.id).toBe("remote_stream1");
-        });
-    });
-
     it("should handle SDPStreamMetadata changes", async () => {
         await startVoiceCall(client, call);
 
@@ -792,6 +727,65 @@ describe('Call', function() {
             // @ts-ignore - writing to a read-only property as we are simulating faulty browsers
             global.navigator.mediaDevices = undefined;
             expect(supportsMatrixCall()).toBe(false);
+        });
+    });
+
+    describe("ignoring streams with ids for which we already have a feed", () => {
+        const STREAM_ID = "stream_id";
+        const FEEDS_CHANGED_CALLBACK = jest.fn();
+
+        beforeEach(async () => {
+            await startVoiceCall(client, call);
+            call.on(CallEvent.FeedsChanged, FEEDS_CHANGED_CALLBACK);
+            jest.spyOn(call, "pushLocalFeed");
+        });
+
+        afterEach(() => {
+            FEEDS_CHANGED_CALLBACK.mockReset();
+        });
+
+        it("should ignore stream passed to pushRemoteFeed()", async () => {
+            await call.onAnswerReceived({
+                getContent: () => {
+                    return {
+                        version: 1,
+                        call_id: call.callId,
+                        party_id: 'party_id',
+                        answer: {
+                            sdp: DUMMY_SDP,
+                        },
+                        [SDPStreamMetadataKey]: {
+                            [STREAM_ID]: {
+                                purpose: SDPStreamMetadataPurpose.Usermedia,
+                            },
+                        },
+                    };
+                },
+            });
+
+            call.pushRemoteFeed(new MockMediaStream(STREAM_ID));
+            call.pushRemoteFeed(new MockMediaStream(STREAM_ID));
+
+            expect(call.getRemoteFeeds().length).toBe(1);
+            expect(FEEDS_CHANGED_CALLBACK).toHaveBeenCalledTimes(1);
+        });
+
+        it("should ignore stream passed to pushRemoteFeedWithoutMetadata()", async () => {
+            call.pushRemoteFeedWithoutMetadata(new MockMediaStream(STREAM_ID));
+            call.pushRemoteFeedWithoutMetadata(new MockMediaStream(STREAM_ID));
+
+            expect(call.getRemoteFeeds().length).toBe(1);
+            expect(FEEDS_CHANGED_CALLBACK).toHaveBeenCalledTimes(1);
+        });
+
+        it("should ignore stream passed to pushNewLocalFeed()", async () => {
+            call.pushNewLocalFeed(new MockMediaStream(STREAM_ID), SDPStreamMetadataPurpose.Screenshare);
+            call.pushNewLocalFeed(new MockMediaStream(STREAM_ID), SDPStreamMetadataPurpose.Screenshare);
+
+            // We already have one local feed from placeVoiceCall()
+            expect(call.getLocalFeeds().length).toBe(2);
+            expect(FEEDS_CHANGED_CALLBACK).toHaveBeenCalledTimes(1);
+            expect(call.pushLocalFeed).toHaveBeenCalled();
         });
     });
 });

--- a/src/ToDeviceMessageQueue.ts
+++ b/src/ToDeviceMessageQueue.ts
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "./logger";
+import { MatrixClient } from "./matrix";
+import { IndexedToDeviceBatch, ToDeviceBatch, ToDeviceBatchWithTxnId, ToDevicePayload } from "./models/ToDeviceMessage";
+import { MatrixScheduler } from "./scheduler";
+
+const MAX_BATCH_SIZE = 20;
+
+/**
+ * Maintains a queue of outgoing to-device messages, sending them
+ * as soon as the homeserver is reachable.
+ */
+export class ToDeviceMessageQueue {
+    private sending = false;
+    private running = true;
+    private retryTimeout: number = null;
+    private retryAttempts = 0;
+
+    constructor(private client: MatrixClient) {
+    }
+
+    public start(): void {
+        this.running = true;
+        this.sendQueue();
+    }
+
+    public stop(): void {
+        this.running = false;
+        if (this.retryTimeout !== null) clearTimeout(this.retryTimeout);
+        this.retryTimeout = null;
+    }
+
+    public async queueBatch(batch: ToDeviceBatch): Promise<void> {
+        const batches: ToDeviceBatchWithTxnId[] = [];
+        for (let i = 0; i < batch.batch.length; i += MAX_BATCH_SIZE) {
+            batches.push({
+                eventType: batch.eventType,
+                batch: batch.batch.slice(i, i + MAX_BATCH_SIZE),
+                txnId: this.client.makeTxnId(),
+            });
+        }
+
+        await this.client.store.saveToDeviceBatches(batches);
+        this.sendQueue();
+    }
+
+    public sendQueue = async (): Promise<void> => {
+        if (this.retryTimeout !== null) clearTimeout(this.retryTimeout);
+        this.retryTimeout = null;
+
+        if (this.sending || !this.running) return;
+
+        logger.debug("Attempting to send queued to-device messages");
+
+        this.sending = true;
+        let headBatch;
+        try {
+            while (this.running) {
+                headBatch = await this.client.store.getOldestToDeviceBatch();
+                if (headBatch === null) break;
+                await this.sendBatch(headBatch);
+                await this.client.store.removeToDeviceBatch(headBatch.id);
+                this.retryAttempts = 0;
+            }
+
+            // Make sure we're still running after the async tasks: if not, stop.
+            if (!this.running) return;
+
+            logger.debug("All queued to-device messages sent");
+        } catch (e) {
+            ++this.retryAttempts;
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            // eslint-disable-next-line new-cap
+            const retryDelay = MatrixScheduler.RETRY_BACKOFF_RATELIMIT(null, this.retryAttempts, e);
+            if (retryDelay === -1) {
+                // the scheduler function doesn't differentiate between fatal errors and just getting
+                // bored and giving up for now
+                if (Math.floor(e.httpStatus / 100) === 4) {
+                    logger.error("Fatal error when sending to-device message - dropping to-device batch!", e);
+                    await this.client.store.removeToDeviceBatch(headBatch.id);
+                } else {
+                    logger.info("Automatic retry limit reached for to-device messages.");
+                }
+                return;
+            }
+
+            logger.info(`Failed to send batch of to-device messages. Will retry in ${retryDelay}ms`, e);
+            this.retryTimeout = setTimeout(this.sendQueue, retryDelay);
+        } finally {
+            this.sending = false;
+        }
+    };
+
+    /**
+     * Attempts to send a batch of to-device messages.
+     */
+    private async sendBatch(batch: IndexedToDeviceBatch): Promise<void> {
+        const contentMap: Record<string, Record<string, ToDevicePayload>> = {};
+        for (const item of batch.batch) {
+            if (!contentMap[item.userId]) {
+                contentMap[item.userId] = {};
+            }
+            contentMap[item.userId][item.deviceId] = item.payload;
+        }
+
+        logger.info(`Sending batch of ${batch.batch.length} to-device messages with ID ${batch.id}`);
+
+        await this.client.sendToDevice(batch.eventType, contentMap, batch.txnId);
+    }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,9 +41,11 @@ import { sleep } from './utils';
 import { Direction, EventTimeline } from "./models/event-timeline";
 import { IActionsObject, PushProcessor } from "./pushprocessor";
 import { AutoDiscovery, AutoDiscoveryAction } from "./autodiscovery";
+import { IEncryptAndSendToDevicesResult } from "./crypto";
 import * as olmlib from "./crypto/olmlib";
 import { decodeBase64, encodeBase64 } from "./crypto/olmlib";
-import { IExportedDevice as IOlmDevice } from "./crypto/OlmDevice";
+import { IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice";
+import { IOlmDevice } from "./crypto/algorithms/megolm";
 import { TypedReEmitter } from './ReEmitter';
 import { IRoomEncryption, RoomList } from './crypto/RoomList';
 import { logger } from './logger';
@@ -202,6 +204,8 @@ import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse, SlidingSync } fr
 import { SlidingSyncSdk } from "./sliding-sync-sdk";
 import { Thread, THREAD_RELATION_TYPE } from "./models/thread";
 import { MBeaconInfoEventContent, M_BEACON_INFO } from "./@types/beacon";
+import { ToDeviceMessageQueue } from "./ToDeviceMessageQueue";
+import { ToDeviceBatch } from "./models/ToDeviceMessage";
 
 export type Store = IStore;
 
@@ -214,7 +218,7 @@ const CAPABILITIES_CACHE_MS = 21600000; // 6 hours - an arbitrary value
 const TURN_CHECK_INTERVAL = 10 * 60 * 1000; // poll for turn credentials every 10 minutes
 
 interface IExportedDevice {
-    olmDevice: IOlmDevice;
+    olmDevice: IExportedOlmDevice;
     userId: string;
     deviceId: string;
 }
@@ -955,13 +959,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected turnServers: ITurnServer[] = [];
     protected turnServersExpiry = 0;
     protected checkTurnServersIntervalID: ReturnType<typeof setInterval>;
-    protected exportedOlmDeviceToImport: IOlmDevice;
+    protected exportedOlmDeviceToImport: IExportedOlmDevice;
     protected txnCtr = 0;
     protected mediaHandler = new MediaHandler(this);
     protected sessionId: string;
     protected pendingEventEncryption = new Map<string, Promise<void>>();
 
     private useE2eForGroupCall = true;
+    private toDeviceMessageQueue: ToDeviceMessageQueue;
 
     constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -1060,6 +1065,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // we still want to know which rooms are encrypted even if crypto is disabled:
         // we don't want to start sending unencrypted events to them.
         this.roomList = new RoomList(this.cryptoStore);
+
+        this.toDeviceMessageQueue = new ToDeviceMessageQueue(this);
 
         // The SDK doesn't really provide a clean way for events to recalculate the push
         // actions for themselves, so we have to kinda help them out when they are encrypted.
@@ -1224,6 +1231,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }, 1000 * this.clientOpts.clientWellKnownPollPeriod);
             this.fetchClientWellKnown();
         }
+
+        this.toDeviceMessageQueue.start();
     }
 
     /**
@@ -1251,6 +1260,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (this.clientWellKnownIntervalID !== undefined) {
             global.clearInterval(this.clientWellKnownIntervalID);
         }
+
+        this.toDeviceMessageQueue.stop();
     }
 
     /**
@@ -1652,9 +1663,13 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * Retry a backed off syncing request immediately. This should only be used when
      * the user <b>explicitly</b> attempts to retry their lost connection.
+     * Will also retry any outbound to-device messages currently in the queue to be sent
+     * (retries of regular outgoing events are handled separately, per-event).
      * @return {boolean} True if this resulted in a request being retried.
      */
     public retryImmediately(): boolean {
+        // don't await for this promise: we just want to kick it off
+        this.toDeviceMessageQueue.sendQueue();
         return this.syncApi.retryImmediately();
     }
 
@@ -2636,6 +2651,30 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
+     * Encrypts and sends a given object via Olm to-device messages to a given
+     * set of devices.
+     *
+     * @param {object[]} userDeviceInfoArr
+     *   mapping from userId to deviceInfo
+     *
+     * @param {object} payload fields to include in the encrypted payload
+     *      *
+     * @return {Promise<{contentMap, deviceInfoByDeviceId}>} Promise which
+     *     resolves once the message has been encrypted and sent to the given
+     *     userDeviceMap, and returns the { contentMap, deviceInfoByDeviceId }
+     *     of the successfully sent messages.
+     */
+    public encryptAndSendToDevices(
+        userDeviceInfoArr: IOlmDevice<DeviceInfo>[],
+        payload: object,
+    ): Promise<IEncryptAndSendToDevicesResult> {
+        if (!this.crypto) {
+            throw new Error("End-to-End encryption disabled");
+        }
+        return this.crypto.encryptAndSendToDevices(userDeviceInfoArr, payload);
+    }
+
+    /**
      * Forces the current outbound group session to be discarded such
      * that another one will be created next time an event is sent.
      *
@@ -3591,7 +3630,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Resend an event.
+     * Resend an event. Will also retry any to-device messages waiting to be sent.
      * @param {MatrixEvent} event The event to resend.
      * @param {Room} room Optional. The room the event is in. Will update the
      * timeline entry if provided.
@@ -3599,6 +3638,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
     public resendEvent(event: MatrixEvent, room: Room): Promise<ISendEventResponse> {
+        // also kick the to-device queue to retry
+        this.toDeviceMessageQueue.sendQueue();
+
         this.updatePendingEventStatus(room, event, EventStatus.SENDING);
         return this.encryptAndSendEvent(room, event);
     }
@@ -8786,7 +8828,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Send an event to a specific list of devices
+     * Send an event to a specific list of devices.
+     * This is a low-level API that simply wraps the HTTP API
+     * call to send to-device messages. We recommend using
+     * queueToDevice() which is a higher level API.
      *
      * @param {string} eventType  type of event to send
      * @param {Object.<string, Object<string, Object>>} contentMap
@@ -8816,6 +8861,17 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         logger.log(`PUT ${path}`, targets);
 
         return this.http.authedRequest(undefined, Method.Put, path, undefined, body);
+    }
+
+    /**
+     * Sends events directly to specific devices using Matrix's to-device
+     * messaging system. The batch will be split up into appropriately sized
+     * batches for sending and stored in the store so they can be retried
+     * later if they fail to send. Retries will happen automatically.
+     * @param batch The to-device messages to send
+     */
+    public queueToDevice(batch: ToDeviceBatch): Promise<void> {
+        return this.toDeviceMessageQueue.queueBatch(batch);
     }
 
     /**

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -606,17 +606,15 @@ class MegolmEncryption extends EncryptionAlgorithm {
         return this.crypto.encryptAndSendToDevices(
             userDeviceMap,
             payload,
-        ).then(({ contentMap, deviceInfoByUserIdAndDeviceId }) => {
+        ).then(({ toDeviceBatch, deviceInfoByUserIdAndDeviceId }) => {
             // store that we successfully uploaded the keys of the current slice
-            for (const userId of Object.keys(contentMap)) {
-                for (const deviceId of Object.keys(contentMap[userId])) {
-                    session.markSharedWithDevice(
-                        userId,
-                        deviceId,
-                        deviceInfoByUserIdAndDeviceId.get(userId).get(deviceId).getIdentityKey(),
-                        chainIndex,
-                    );
-                }
+            for (const msg of toDeviceBatch.batch) {
+                session.markSharedWithDevice(
+                    msg.userId,
+                    msg.deviceId,
+                    deviceInfoByUserIdAndDeviceId.get(msg.userId).get(msg.deviceId).getIdentityKey(),
+                    chainIndex,
+                );
             }
         }).catch((error) => {
             logger.error("failed to encryptAndSendToDevices", error);

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -23,6 +23,7 @@ limitations under the License.
 
 import anotherjson from "another-json";
 
+import { EventType } from "../@types/event";
 import { TypedReEmitter } from '../ReEmitter';
 import { logger } from '../logger';
 import { IExportedDevice, OlmDevice } from "./OlmDevice";
@@ -69,6 +70,7 @@ import { IStore } from "../store";
 import { Room, RoomEvent } from "../models/room";
 import { RoomMember, RoomMemberEvent } from "../models/room-member";
 import { EventStatus, IClearEvent, IEvent, MatrixEvent, MatrixEventEvent } from "../models/event";
+import { ToDeviceBatch } from "../models/ToDeviceMessage";
 import {
     ClientEvent,
     ICrossSigningKey,
@@ -210,8 +212,8 @@ export interface IEncryptedContent {
 }
 /* eslint-enable camelcase */
 
-interface IEncryptAndSendToDevicesResult {
-    contentMap: Record<string, Record<string, IEncryptedContent>>;
+export interface IEncryptAndSendToDevicesResult {
+    toDeviceBatch: ToDeviceBatch;
     deviceInfoByUserIdAndDeviceId: Map<string, Map<string, DeviceInfo>>;
 }
 
@@ -3115,106 +3117,91 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Encrypts and sends a given object via Olm to-device message to a given
-     * set of devices.  Factored out from encryptAndSendKeysToDevices in
-     * megolm.ts.
-     *
-     * @param {object[]} userDeviceInfoArr
-     *   mapping from userId to deviceInfo
-     *
+     * Encrypts and sends a given object via Olm to-device messages to a given
+     * set of devices.
+     * @param {object[]} userDeviceInfoArr the devices to send to
      * @param {object} payload fields to include in the encrypted payload
-     *      *
      * @return {Promise<{contentMap, deviceInfoByDeviceId}>} Promise which
      *     resolves once the message has been encrypted and sent to the given
      *     userDeviceMap, and returns the { contentMap, deviceInfoByDeviceId }
      *     of the successfully sent messages.
      */
-    public encryptAndSendToDevices(
+    public async encryptAndSendToDevices(
         userDeviceInfoArr: IOlmDevice<DeviceInfo>[],
         payload: object,
     ): Promise<IEncryptAndSendToDevicesResult> {
-        const contentMap: Record<string, Record<string, IEncryptedContent>> = {};
+        const toDeviceBatch: ToDeviceBatch = {
+            eventType: EventType.RoomMessageEncrypted,
+            batch: [],
+        };
         const deviceInfoByUserIdAndDeviceId = new Map<string, Map<string, DeviceInfo>>();
 
-        const promises: Promise<unknown>[] = [];
-        for (const { userId, deviceInfo } of userDeviceInfoArr) {
-            const deviceId = deviceInfo.deviceId;
-            const encryptedContent: IEncryptedContent = {
-                algorithm: olmlib.OLM_ALGORITHM,
-                sender_key: this.olmDevice.deviceCurve25519Key,
-                ciphertext: {},
-            };
+        try {
+            await Promise.all(userDeviceInfoArr.map(async ({ userId, deviceInfo }) => {
+                const deviceId = deviceInfo.deviceId;
+                const encryptedContent: IEncryptedContent = {
+                    algorithm: olmlib.OLM_ALGORITHM,
+                    sender_key: this.olmDevice.deviceCurve25519Key,
+                    ciphertext: {},
+                };
 
-            // Assign to temp value to make type-checking happy
-            let userIdDeviceInfo = deviceInfoByUserIdAndDeviceId.get(userId);
+                // Assign to temp value to make type-checking happy
+                let userIdDeviceInfo = deviceInfoByUserIdAndDeviceId.get(userId);
 
-            if (userIdDeviceInfo === undefined) {
-                userIdDeviceInfo = new Map<string, DeviceInfo>();
-                deviceInfoByUserIdAndDeviceId.set(userId, userIdDeviceInfo);
-            }
+                if (userIdDeviceInfo === undefined) {
+                    userIdDeviceInfo = new Map<string, DeviceInfo>();
+                    deviceInfoByUserIdAndDeviceId.set(userId, userIdDeviceInfo);
+                }
 
-            // We hold by reference, this updates deviceInfoByUserIdAndDeviceId[userId]
-            userIdDeviceInfo.set(deviceId, deviceInfo);
+                // We hold by reference, this updates deviceInfoByUserIdAndDeviceId[userId]
+                userIdDeviceInfo.set(deviceId, deviceInfo);
 
-            if (!contentMap[userId]) {
-                contentMap[userId] = {};
-            }
-            contentMap[userId][deviceId] = encryptedContent;
+                toDeviceBatch.batch.push({
+                    userId,
+                    deviceId,
+                    payload: encryptedContent,
+                });
 
-            promises.push(
-                olmlib.ensureOlmSessionsForDevices(
+                await olmlib.ensureOlmSessionsForDevices(
                     this.olmDevice,
                     this.baseApis,
                     { [userId]: [deviceInfo] },
-                ).then(() =>
-                    olmlib.encryptMessageForDevice(
-                        encryptedContent.ciphertext,
-                        this.userId,
-                        this.deviceId,
-                        this.olmDevice,
-                        userId,
-                        deviceInfo,
-                        payload,
-                    ),
-                ),
-            );
-        }
+                );
+                await olmlib.encryptMessageForDevice(
+                    encryptedContent.ciphertext,
+                    this.userId,
+                    this.deviceId,
+                    this.olmDevice,
+                    userId,
+                    deviceInfo,
+                    payload,
+                );
+            }));
 
-        return Promise.all(promises).then(() => {
             // prune out any devices that encryptMessageForDevice could not encrypt for,
             // in which case it will have just not added anything to the ciphertext object.
             // There's no point sending messages to devices if we couldn't encrypt to them,
             // since that's effectively a blank message.
-            for (const userId of Object.keys(contentMap)) {
-                for (const deviceId of Object.keys(contentMap[userId])) {
-                    if (Object.keys(contentMap[userId][deviceId].ciphertext).length === 0) {
-                        logger.log(`No ciphertext for device ${userId}:${deviceId}: pruning`);
-                        delete contentMap[userId][deviceId];
-                    }
+            toDeviceBatch.batch = toDeviceBatch.batch.filter(msg => {
+                if (Object.keys(msg.payload.ciphertext).length > 0) {
+                    return true;
+                } else {
+                    logger.log(`No ciphertext for device ${msg.userId}:${msg.deviceId}: pruning`);
+                    return false;
                 }
-                // No devices left for that user? Strip that too.
-                if (Object.keys(contentMap[userId]).length === 0) {
-                    logger.log(`Pruned all devices for user ${userId}`);
-                    delete contentMap[userId];
-                }
-            }
-
-            // Is there anything left?
-            if (Object.keys(contentMap).length === 0) {
-                logger.log("No users left to send to: aborting");
-                return;
-            }
-
-            return this.baseApis.sendToDevice("m.room.encrypted", contentMap).then(
-                (response) => ({ contentMap, deviceInfoByUserIdAndDeviceId }),
-            ).catch(error => {
-                logger.error("sendToDevice failed", error);
-                throw error;
             });
-        }).catch(error => {
-            logger.error("encryptAndSendToDevices promises failed", error);
-            throw error;
-        });
+
+            try {
+                await this.baseApis.queueToDevice(toDeviceBatch);
+                return { toDeviceBatch, deviceInfoByUserIdAndDeviceId };
+            } catch (e) {
+                logger.error("sendToDevice failed", e);
+                throw e;
+            }
+        } catch (e) {
+            logger.error("encryptAndSendToDevices promises failed", e);
+            throw e;
+        }
     }
 
     private onMembership = (event: MatrixEvent, member: RoomMember, oldMembership?: string) => {

--- a/src/models/ToDeviceMessage.ts
+++ b/src/models/ToDeviceMessage.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type ToDevicePayload = Record<string, any>;
+
+export interface ToDeviceMessage {
+    userId: string;
+    deviceId: string;
+    payload: ToDevicePayload;
+}
+
+export interface ToDeviceBatch {
+    eventType: string;
+    batch: ToDeviceMessage[];
+}
+
+// Only used internally
+export interface ToDeviceBatchWithTxnId extends ToDeviceBatch {
+    txnId: string;
+}
+
+// Only used internally
+export interface IndexedToDeviceBatch extends ToDeviceBatchWithTxnId {
+    id: number;
+}

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -72,7 +72,7 @@ function synthesizeReceipt(userId: string, event: MatrixEvent, receiptType: Rece
                 },
             },
         },
-        type: "m.receipt",
+        type: EventType.Receipt,
         room_id: event.getRoomId(),
     });
 }
@@ -2423,9 +2423,9 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
      */
     public addEphemeralEvents(events: MatrixEvent[]): void {
         for (const event of events) {
-            if (event.getType() === 'm.typing') {
+            if (event.getType() === EventType.Typing) {
                 this.currentState.setTypingEvent(event);
-            } else if (event.getType() === 'm.receipt') {
+            } else if (event.getType() === EventType.Receipt) {
                 this.addReceipt(event);
             } // else ignore - life is too short for us to care about these events
         }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -57,7 +57,7 @@ export class MatrixScheduler<T = ISendEventResponse> {
      * failure was due to a rate limited request, the time specified in the error is
      * waited before being retried.
      * @param {MatrixEvent} event
-     * @param {Number} attempts
+     * @param {Number} attempts Number of attempts that have been made, including the one that just failed (ie. starting at 1)
      * @param {MatrixError} err
      * @return {Number}
      * @see module:scheduler~retryAlgorithm

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -44,6 +44,9 @@ export interface MSC3575Filter {
     is_invite?: boolean;
     is_tombstoned?: boolean;
     room_name_like?: string;
+    room_types?: string[];
+    not_room_types?: string[];
+    spaces?: string[];
 }
 
 /**
@@ -602,7 +605,7 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
                         listIndex,
                         op.range[0],
                         op.range[1],
-                        op.room_ids.join(" "),
+                        (op.room_ids || []).join(" "),
                         ";",
                     );
                     break;

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { ISavedSync } from "./index";
 import { IEvent, IStartClientOpts, IStateEventWithRoomId, ISyncResponse } from "..";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
 
 export interface IIndexedDBBackend {
     connect(): Promise<void>;
@@ -31,6 +32,9 @@ export interface IIndexedDBBackend {
     getUserPresenceEvents(): Promise<UserTuple[]>;
     getClientOptions(): Promise<IStartClientOpts>;
     storeClientOptions(options: IStartClientOpts): Promise<void>;
+    saveToDeviceBatches(batches: ToDeviceBatchWithTxnId[]): Promise<void>;
+    getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch>;
+    removeToDeviceBatch(id: number): Promise<void>;
 }
 
 export type UserTuple = [userId: string, presenceEvent: Partial<IEvent>];

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -21,8 +21,9 @@ import { logger } from '../logger';
 import { IStartClientOpts, IStateEventWithRoomId } from "..";
 import { ISavedSync } from "./index";
 import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
 
-const VERSION = 3;
+const VERSION = 4;
 
 function createDatabase(db: IDBDatabase): void {
     // Make user store, clobber based on user ID. (userId property of User objects)
@@ -47,6 +48,10 @@ function upgradeSchemaV2(db: IDBDatabase): void {
 function upgradeSchemaV3(db: IDBDatabase): void {
     db.createObjectStore("client_options",
         { keyPath: ["clobber"] });
+}
+
+function upgradeSchemaV4(db: IDBDatabase): void {
+    db.createObjectStore("to_device_queue", { autoIncrement: true });
 }
 
 /**
@@ -112,7 +117,7 @@ function reqAsPromise(req: IDBRequest): Promise<IDBRequest> {
     });
 }
 
-function reqAsCursorPromise(req: IDBRequest<IDBCursor | null>): Promise<IDBCursor> {
+function reqAsCursorPromise<T>(req: IDBRequest<T>): Promise<T> {
     return reqAsEventPromise(req).then((event) => req.result);
 }
 
@@ -176,6 +181,9 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             }
             if (oldVersion < 3) {
                 upgradeSchemaV3(db);
+            }
+            if (oldVersion < 4) {
+                upgradeSchemaV4(db);
             }
             // Expand as needed.
         };
@@ -559,6 +567,38 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             clobber: "-", // constant key so will always clobber
             options: options,
         }); // put == UPSERT
+        await txnAsPromise(txn);
+    }
+
+    public async saveToDeviceBatches(batches: ToDeviceBatchWithTxnId[]): Promise<void> {
+        const txn = this.db.transaction(["to_device_queue"], "readwrite");
+        const store = txn.objectStore("to_device_queue");
+        for (const batch of batches) {
+            store.add(batch);
+        }
+        await txnAsPromise(txn);
+    }
+
+    public async getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch | null> {
+        const txn = this.db.transaction(["to_device_queue"], "readonly");
+        const store = txn.objectStore("to_device_queue");
+        const cursor = await reqAsCursorPromise(store.openCursor());
+        if (!cursor) return null;
+
+        const resultBatch = cursor.value as ToDeviceBatchWithTxnId;
+
+        return {
+            id: cursor.key as number,
+            txnId: resultBatch.txnId,
+            eventType: resultBatch.eventType,
+            batch: resultBatch.batch,
+        };
+    }
+
+    public async removeToDeviceBatch(id: number): Promise<void> {
+        const txn = this.db.transaction(["to_device_queue"], "readwrite");
+        const store = txn.objectStore("to_device_queue");
+        store.delete(id);
         await txnAsPromise(txn);
     }
 }

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -20,6 +20,7 @@ import { ISavedSync } from "./index";
 import { IStartClientOpts } from "../client";
 import { IStateEventWithRoomId, ISyncResponse } from "..";
 import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     private worker: Worker;
@@ -131,6 +132,18 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
      */
     public getUserPresenceEvents(): Promise<UserTuple[]> {
         return this.doCmd('getUserPresenceEvents');
+    }
+
+    public async saveToDeviceBatches(batches: ToDeviceBatchWithTxnId[]): Promise<void> {
+        return this.doCmd('saveToDeviceBatches', [batches]);
+    }
+
+    public async getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch> {
+        return this.doCmd('getOldestToDeviceBatch');
+    }
+
+    public async removeToDeviceBatch(id: number): Promise<void> {
+        return this.doCmd('removeToDeviceBatch', [id]);
     }
 
     private ensureStarted(): Promise<void> {

--- a/src/store/indexeddb-store-worker.ts
+++ b/src/store/indexeddb-store-worker.ts
@@ -103,6 +103,15 @@ export class IndexedDBStoreWorker {
             case 'storeClientOptions':
                 prom = this.backend.storeClientOptions(msg.args[0]);
                 break;
+            case 'saveToDeviceBatches':
+                prom = this.backend.saveToDeviceBatches(msg.args[0]);
+                break;
+            case 'getOldestToDeviceBatch':
+                prom = this.backend.getOldestToDeviceBatch();
+                break;
+            case 'removeToDeviceBatch':
+                prom = this.backend.removeToDeviceBatch(msg.args[0]);
+                break;
         }
 
         if (prom === undefined) {

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -27,6 +27,7 @@ import { IIndexedDBBackend } from "./indexeddb-backend";
 import { ISyncResponse } from "../sync-accumulator";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 import { IStateEventWithRoomId } from "../@types/search";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
 
 /**
  * This is an internal module. See {@link IndexedDBStore} for the public class.
@@ -350,6 +351,18 @@ export class IndexedDBStore extends MemoryStore {
         } else {
             this.localStorage.removeItem(pendingEventsKey(roomId));
         }
+    }
+
+    public saveToDeviceBatches(batches: ToDeviceBatchWithTxnId[]): Promise<void> {
+        return this.backend.saveToDeviceBatches(batches);
+    }
+
+    public getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch> {
+        return this.backend.getOldestToDeviceBatch();
+    }
+
+    public removeToDeviceBatch(id: number): Promise<void> {
+        return this.backend.removeToDeviceBatch(id);
     }
 }
 

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -28,6 +28,7 @@ import { ISavedSync, IStore } from "./index";
 import { RoomSummary } from "../models/room-summary";
 import { ISyncResponse } from "../sync-accumulator";
 import { IStateEventWithRoomId } from "../@types/search";
+import { IndexedToDeviceBatch, ToDeviceBatch } from "../models/ToDeviceMessage";
 
 /**
  * Construct a stub store. This does no-ops on most store methods.
@@ -268,6 +269,18 @@ export class StubStore implements IStore {
     }
 
     public setPendingEvents(roomId: string, events: Partial<IEvent>[]): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public async saveToDeviceBatches(batch: ToDeviceBatch[]): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch | null> {
+        return Promise.resolve(null);
+    }
+
+    public async removeToDeviceBatch(id: number): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -614,26 +614,26 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             return;
         }
 
-        // Try to find a feed with the same purpose as the new stream,
-        // if we find it replace the old stream with the new one
-        const existingFeed = this.getRemoteFeeds().find((feed) => feed.purpose === purpose);
-        if (existingFeed) {
-            existingFeed.setNewStream(stream);
-        } else {
-            this.feeds.push(new CallFeed({
-                client: this.client,
-                roomId: this.roomId,
-                userId,
-                stream,
-                purpose,
-                audioMuted,
-                videoMuted,
-            }));
-            this.emit(CallEvent.FeedsChanged, this.feeds);
+        if (this.getFeedByStreamId(stream.id)) {
+            logger.warn(`Ignoring stream with id ${stream.id} because we already have a feed for it`);
+            return;
         }
 
-        logger.info(`Call ${this.callId} Pushed remote stream (id="${
-            stream.id}", active="${stream.active}", purpose=${purpose})`);
+        this.feeds.push(new CallFeed({
+            client: this.client,
+            roomId: this.roomId,
+            userId,
+            stream,
+            purpose,
+            audioMuted,
+            videoMuted,
+        }));
+        this.emit(CallEvent.FeedsChanged, this.feeds);
+
+        logger.info(
+            `Call ${this.callId} pushed remote stream (id="${stream.id}", ` +
+            `active="${stream.active}", purpose=${purpose})`,
+        );
     }
 
     /**
@@ -655,25 +655,23 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             return;
         }
 
-        // Try to find a feed with the same stream id as the new stream,
-        // if we find it replace the old stream with the new one
-        const feed = this.getFeedByStreamId(stream.id);
-        if (feed) {
-            feed.setNewStream(stream);
-        } else {
-            this.feeds.push(new CallFeed({
-                client: this.client,
-                roomId: this.roomId,
-                audioMuted: false,
-                videoMuted: false,
-                userId,
-                stream,
-                purpose,
-            }));
-            this.emit(CallEvent.FeedsChanged, this.feeds);
+        if (this.getFeedByStreamId(stream.id)) {
+            logger.warn(`Ignoring stream with id ${stream.id} because we already have a feed for it`);
+            return;
         }
 
-        logger.info(`Call ${this.callId} Pushed remote stream (id="${stream.id}", active="${stream.active}")`);
+        this.feeds.push(new CallFeed({
+            client: this.client,
+            roomId: this.roomId,
+            audioMuted: false,
+            videoMuted: false,
+            userId,
+            stream,
+            purpose,
+        }));
+        this.emit(CallEvent.FeedsChanged, this.feeds);
+
+        logger.info(`Call ${this.callId} pushed remote stream (id="${stream.id}", active="${stream.active}")`);
     }
 
     private pushNewLocalFeed(stream: MediaStream, purpose: SDPStreamMetadataPurpose, addToPeerConnection = true): void {
@@ -685,25 +683,23 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         setTracksEnabled(stream.getAudioTracks(), true);
         setTracksEnabled(stream.getVideoTracks(), true);
 
-        // We try to replace an existing feed if there already is one with the same purpose
-        const existingFeed = this.getLocalFeeds().find((feed) => feed.purpose === purpose);
-        if (existingFeed) {
-            existingFeed.setNewStream(stream);
-        } else {
-            this.pushLocalFeed(
-                new CallFeed({
-                    client: this.client,
-                    roomId: this.roomId,
-                    audioMuted: false,
-                    videoMuted: false,
-                    userId,
-                    stream,
-                    purpose,
-                }),
-                addToPeerConnection,
-            );
-            this.emit(CallEvent.FeedsChanged, this.feeds);
+        if (this.getFeedByStreamId(stream.id)) {
+            logger.warn(`Ignoring stream with id ${stream.id} because we already have a feed for it`);
+            return;
         }
+
+        this.pushLocalFeed(
+            new CallFeed({
+                client: this.client,
+                roomId: this.roomId,
+                audioMuted: false,
+                videoMuted: false,
+                userId,
+                stream,
+                purpose,
+            }),
+            addToPeerConnection,
+        );
     }
 
     /**

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -180,15 +180,6 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
     }
 
     /**
-     * Replaces the current MediaStream with a new one.
-     * This method should be only used by MatrixCall.
-     * @param newStream new stream with which to replace the current one
-     */
-    public setNewStream(newStream: MediaStream): void {
-        this.updateStream(this.stream, newStream);
-    }
-
-    /**
      * Set one or both of feed's internal audio and video video mute state
      * Either value may be null to leave it as-is
      * @param muted is the feed's video muted?

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -180,6 +180,17 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
     }
 
     /**
+     * Replaces the current MediaStream with a new one.
+     * The stream will be different and new stream as remore parties are
+     * concerned, but this can be used for convenience locally to set up
+     * volume listeners automatically on the new stream etc.
+     * @param newStream new stream with which to replace the current one
+     */
+    public setNewStream(newStream: MediaStream): void {
+        this.updateStream(this.stream, newStream);
+    }
+
+    /**
      * Set one or both of feed's internal audio and video video mute state
      * Either value may be null to leave it as-is
      * @param muted is the feed's video muted?

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,6 +1609,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/sdp-transform@^2.4.5":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@types/sdp-transform/-/sdp-transform-2.4.5.tgz#3167961e0a1a5265545e278627aa37c606003f53"
+  integrity sha512-GVO0gnmbyO3Oxm2HdPsYUNcyihZE3GyCY8ysMYHuQGfLhGZq89Nm4lSzULWTzZoyHtg+VO/IdrnxZHPnPSGnAg==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -5814,6 +5819,11 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sdp-transform@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/sdp-transform/-/sdp-transform-2.14.1.tgz#2bb443583d478dee217df4caa284c46b870d5827"
+  integrity sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==
 
 semver@7.0.0:
   version "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,7 +1307,6 @@
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz":
   version "3.2.12"
-  uid "0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
   resolved "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz#0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
@@ -1438,9 +1437,9 @@
     "@octokit/openapi-types" "^12.10.0"
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.20"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.20.tgz#11a657875de6008622d53f56e063a6347c51a6dd"
-  integrity sha512-kVaO5aEFZb33nPMTZBxiPEkY+slxiPtqC7QX8f9B3eGOMBvEfuMfxp9DSTTCsRJPumPKjrge4yagyssO4q6qzQ==
+  version "0.24.26"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.26.tgz#84f9e8c1d93154e734a7947609a1dc7c7a81cc22"
+  integrity sha512-1ZVIyyS1NXDRVT8GjWD5jULjhDyM3IsIHef2VGUMdnWOlX2tkPjyEX/7K0TGSH2S8EaPhp1ylFdjSjUGQ+gecg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1581,9 +1580,9 @@
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/node@*":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
-  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
+  version "18.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
+  integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
 
 "@types/node@16":
   version "16.11.45"
@@ -4802,10 +4801,10 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-matrix-mock-request@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/matrix-mock-request/-/matrix-mock-request-2.1.0.tgz#86f5b0ef846865d0767d3a8e64f5bcd6ca94c178"
-  integrity sha512-Cjpl3yP6h0yu5GKG89m1XZXZlm69Kg/qHV41N/t6SrQsgcfM3Bfavqx9YrtG0UnuXGy4bBSZIe1QiWVeFPZw1A==
+matrix-mock-request@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/matrix-mock-request/-/matrix-mock-request-2.1.2.tgz#11e38ed1233dced88a6f2bfba1684d5c5b3aa2c2"
+  integrity sha512-/OXCIzDGSLPJ3fs+uzDrtaOHI/Sqp4iEuniRn31U8S06mPXbvAnXknHqJ4c6A/KVwJj/nPFbGXpK4wPM038I6A==
   dependencies:
     expect "^28.1.0"
 


### PR DESCRIPTION
This merges the latest changes from develop again. This is as simple a merge as possible: I've not introduced any other changes at this stage.

Reintroduces the setNewStream method which was removed
in https://github.com/matrix-org/matrix-js-sdk/pull/2551 (I think it makes
sense as a convenient way to re-use the feed wrapper object but switch out
the feed? Comment updated appropriately.)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->