### PR TITLE
Don't load the sync accumulator if there's already a sync persist in flight

### DIFF
--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -409,8 +409,6 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     }
 
     public async syncToDatabase(userTuples: UserTuple[]): Promise<void> {
-        const syncData = this.syncAccumulator.getJSON(true);
-
         if (this.isPersisting) {
             logger.warn("Skipping syncToDatabase() as persist already in flight");
             this.pendingUserPresenceData.push(...userTuples);
@@ -421,6 +419,8 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         }
 
         try {
+            const syncData = this.syncAccumulator.getJSON(true);
+
             await Promise.all([
                 this.persistUserPresenceEvents(userTuples),
                 this.persistAccountData(syncData.accountData),


### PR DESCRIPTION
This should hopefully reduce chances of
https://github.com/vector-im/element-web/issues/21541 a bit more,
as we were incorrectly loading the sync accumulator even
if a sync persist was already in flight, thus wasting RAM
and increasing the chance of the renderer process OOMing

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't load the sync accumulator if there's already a sync persist in flight ([\#2569](https://github.com/matrix-org/matrix-js-sdk/pull/2569)).<!-- CHANGELOG_PREVIEW_END -->