### PR TITLE
Make jsdoc generation gha regex more strict

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -40,7 +40,7 @@ jobs:
           cp -a "$RUNNER_TEMP/$VERSION" .
 
           # Add the new directory to the index if it isn't there already
-          if ! grep -q "Version $VERSION" index.html; then
+          if ! grep -q ">Version $VERSION</a>" index.html; then
             perl -i -pe 'BEGIN {$rel=shift} $_ =~ /^<\/ul>/ && print
               "<li><a href=\"${rel}/index.html\">Version ${rel}</a></li>\n"' "$VERSION" index.html
           fi


### PR DESCRIPTION
Otherwise it won't include releases in the index as the RC is a superstring of the release version

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->