### PR TITLE
Fix finding event read up to if stable private read receipts is missing

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2458,25 +2458,43 @@ describe("Room", function() {
                 }
             });
 
-            it("should compare correctly by timestamp", () => {
-                for (let i = 1; i <= 3; i++) {
+            describe("correctly compares by timestamp", () => {
+                it("should correctly compare, if we have all receipts", () => {
+                    for (let i = 1; i <= 3; i++) {
+                        room.getUnfilteredTimelineSet = () => ({
+                            compareEventOrdering: (_1, _2) => null,
+                        } as EventTimelineSet);
+                        room.getReadReceiptForUserId = (userId, ignore, receiptType) => {
+                            if (receiptType === ReceiptType.ReadPrivate) {
+                                return { eventId: "eventId1", data: { ts: i === 1 ? 1 : 0 } } as IWrappedReceipt;
+                            }
+                            if (receiptType === ReceiptType.UnstableReadPrivate) {
+                                return { eventId: "eventId2", data: { ts: i === 2 ? 1 : 0 } } as IWrappedReceipt;
+                            }
+                            if (receiptType === ReceiptType.Read) {
+                                return { eventId: "eventId3", data: { ts: i === 3 ? 1 : 0 } } as IWrappedReceipt;
+                            }
+                        };
+
+                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
+                    }
+                });
+
+                it("should correctly compare, if private read receipt is missing", () => {
                     room.getUnfilteredTimelineSet = () => ({
                         compareEventOrdering: (_1, _2) => null,
                     } as EventTimelineSet);
                     room.getReadReceiptForUserId = (userId, ignore, receiptType) => {
-                        if (receiptType === ReceiptType.ReadPrivate) {
-                            return { eventId: "eventId1", data: { ts: i === 1 ? 1 : 0 } } as IWrappedReceipt;
-                        }
                         if (receiptType === ReceiptType.UnstableReadPrivate) {
-                            return { eventId: "eventId2", data: { ts: i === 2 ? 1 : 0 } } as IWrappedReceipt;
+                            return { eventId: "eventId1", data: { ts: 0 } } as IWrappedReceipt;
                         }
                         if (receiptType === ReceiptType.Read) {
-                            return { eventId: "eventId3", data: { ts: i === 3 ? 1 : 0 } } as IWrappedReceipt;
+                            return { eventId: "eventId2", data: { ts: 1 } } as IWrappedReceipt;
                         }
                     };
 
-                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
-                }
+                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId2`);
+                });
             });
 
             describe("fallback precedence", () => {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2592,7 +2592,7 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
 
         let latest = privateReadReceipt;
         [unstablePrivateReadReceipt, publicReadReceipt].forEach((receipt) => {
-            if (receipt?.data?.ts > latest?.data?.ts) {
+            if (receipt?.data?.ts > latest?.data?.ts || !latest) {
                 latest = receipt;
             }
         });


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23027
Details on what is happening in https://github.com/vector-im/element-web/issues/23027#issuecomment-1211819879

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix finding event read up to if stable private read receipts is missing ([\#2585](https://github.com/matrix-org/matrix-js-sdk/pull/2585)). Fixes vector-im/element-web#23027.<!-- CHANGELOG_PREVIEW_END -->