### PR TITLE
Add tests for incoming calls in group calls

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -620,7 +620,7 @@ describe('Group Call', function() {
             expect(mockCall.answerWithCallFeeds).not.toHaveBeenCalled();
         });
 
-        it("answers calls for the right room & group call ID", async () => { 
+        it("answers calls for the right room & group call ID", async () => {
             const mockCall = new MockCall(room.roomId, groupCall.groupCallId);
 
             mockClient.emit(CallEventHandlerEvent.Incoming, mockCall as unknown as MatrixCall);

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType, GroupCallIntent, GroupCallType, MatrixEvent, Room, RoomMember } from '../../../src';
+import { EventType, GroupCallIntent, GroupCallType, MatrixCall, MatrixEvent, Room, RoomMember } from '../../../src';
 import { GroupCall } from "../../../src/webrtc/groupCall";
 import { MatrixClient } from "../../../src/client";
 import {
@@ -29,6 +29,9 @@ import { sleep } from "../../../src/utils";
 import { ReEmitter } from "../../../src/ReEmitter";
 import { TypedEventEmitter } from '../../../src/models/typed-event-emitter';
 import { MediaHandler } from '../../../src/webrtc/mediaHandler';
+import { CallEventHandlerEvent, CallEventHandlerEventHandlerMap } from '../../../src/webrtc/callEventHandler';
+import { CallFeed } from '../../../src/webrtc/callFeed';
+import { CallState } from '../../../src/webrtc/call';
 
 const FAKE_ROOM_ID = "!fake:test.dummy";
 const FAKE_CONF_ID = "fakegroupcallid";
@@ -94,10 +97,11 @@ const createAndEnterGroupCall = async (cli: MatrixClient, room: Room): Promise<G
     return groupCall;
 };
 
-class MockCallMatrixClient {
+class MockCallMatrixClient extends TypedEventEmitter<CallEventHandlerEvent.Incoming, CallEventHandlerEventHandlerMap> {
     public mediaHandler: MediaHandler = new MockMediaHandler() as unknown as MediaHandler;
 
     constructor(public userId: string, public deviceId: string, public sessionId: string) {
+        super();
     }
 
     groupCallEventHandler = {
@@ -118,14 +122,33 @@ class MockCallMatrixClient {
     getDeviceId() { return this.deviceId; }
     getSessionId() { return this.sessionId; }
 
-    emit = jest.fn();
-    on = jest.fn();
-    removeListener = jest.fn();
     getTurnServers = () => [];
     isFallbackICEServerAllowed = () => false;
     reEmitter = new ReEmitter(new TypedEventEmitter());
     getUseE2eForGroupCall = () => false;
     checkTurnServers = () => null;
+}
+
+class MockCall {
+    constructor(public roomId: string, public groupCallId: string) {
+    }
+
+    public state = CallState.Ringing;
+    public opponentUserId = FAKE_USER_ID_2;
+    public callId = "1";
+
+    public reject = jest.fn<void, []>();
+    public answerWithCallFeeds = jest.fn<void, [CallFeed[]]>();
+    public hangup = jest.fn<void, []>();
+
+    on = jest.fn();
+    removeListener = jest.fn();
+
+    getOpponentMember() {
+        return {
+            userId: this.opponentUserId,
+        };
+    }
 }
 
 describe('Group Call', function() {
@@ -409,7 +432,7 @@ describe('Group Call', function() {
         });
     });
 
-    describe("muting", () => {
+    describe("Events on a single group call", () => {
         let mockClient: MatrixClient;
         let room: Room;
 
@@ -543,6 +566,88 @@ describe('Group Call', function() {
                 expect(feed.isVideoMuted()).toBe(true);
 
                 groupCall.terminate();
+            });
+        });
+
+        describe("Incoming Calls", function() {
+            it("ignores incoming calls for other rooms", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+
+                try {
+                    const mockCall = new MockCall("!someotherroom.fake.dummy", groupCall.groupCallId);
+
+                    mockClient.emit(CallEventHandlerEvent.Incoming, mockCall as unknown as MatrixCall);
+
+                    expect(mockCall.reject).not.toHaveBeenCalled();
+                    expect(mockCall.answerWithCallFeeds).not.toHaveBeenCalled();
+                } finally {
+                    groupCall.leave();
+                }
+            });
+
+            it("rejects incoming calls for the wrong group call", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+
+                try {
+                    const mockCall = new MockCall(room.roomId, "not " + groupCall.groupCallId);
+
+                    mockClient.emit(CallEventHandlerEvent.Incoming, mockCall as unknown as MatrixCall);
+
+                    expect(mockCall.reject).toHaveBeenCalled();
+                } finally {
+                    groupCall.leave();
+                }
+            });
+
+            it("ignores incoming calls not in the ringing state", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+
+                try {
+                    const mockCall = new MockCall(room.roomId, groupCall.groupCallId);
+                    mockCall.state = CallState.Connected;
+
+                    mockClient.emit(CallEventHandlerEvent.Incoming, mockCall as unknown as MatrixCall);
+
+                    expect(mockCall.reject).not.toHaveBeenCalled();
+                    expect(mockCall.answerWithCallFeeds).not.toHaveBeenCalled();
+                } finally {
+                    groupCall.leave();
+                }
+            });
+
+            it("answers calls for the right room & group call ID", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+
+                try {
+                    const mockCall = new MockCall(room.roomId, groupCall.groupCallId);
+
+                    mockClient.emit(CallEventHandlerEvent.Incoming, mockCall as unknown as MatrixCall);
+
+                    expect(mockCall.reject).not.toHaveBeenCalled();
+                    expect(mockCall.answerWithCallFeeds).toHaveBeenCalled();
+                    expect(groupCall.calls).toEqual([mockCall]);
+                } finally {
+                    groupCall.leave();
+                }
+            });
+
+            it("replaces calls if it already has one with the same user", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+
+                try {
+                    const oldMockCall = new MockCall(room.roomId, groupCall.groupCallId);
+                    const newMockCall = new MockCall(room.roomId, groupCall.groupCallId);
+                    newMockCall.callId = "not " + oldMockCall.callId;
+
+                    mockClient.emit(CallEventHandlerEvent.Incoming, oldMockCall as unknown as MatrixCall);
+                    mockClient.emit(CallEventHandlerEvent.Incoming, newMockCall as unknown as MatrixCall);
+
+                    expect(oldMockCall.hangup).toHaveBeenCalled();
+                    expect(newMockCall.answerWithCallFeeds).toHaveBeenCalled();
+                    expect(groupCall.calls).toEqual([newMockCall]);
+                } finally {
+                    groupCall.leave();
+                }
             });
         });
     });


### PR DESCRIPTION
Inspiration wwlecome for the renamed describe group which we're
really abusing for a bunch of things that happen to have the same
dependencies.

Fixes https://github.com/vector-im/element-call/issues/532

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->