### PR TITLE
Automatically reconnect sessions when sliding sync expires them

### DIFF
--- a/spec/integ/sliding-sync.spec.ts
+++ b/spec/integ/sliding-sync.spec.ts
@@ -90,15 +90,15 @@ describe("SlidingSync", () => {
                 required_state: [["m.room.create", ""]],
             };
             const listInfo = {
-                ranges: [[0,10]],
+                ranges: [[0, 10]],
                 filters: {
                     is_dm: true,
                 },
             };
             const ext = {
                 name: () => "custom_extension",
-                onRequest: (initial) => { return { initial: initial } },
-                onResponse: (res) => { return {} },
+                onRequest: (initial) => { return { initial: initial }; },
+                onResponse: (res) => { return {}; },
                 when: () => ExtensionState.PreProcess,
             };
             slidingSync.modifyRoomSubscriptions(new Set([roomId]));
@@ -117,7 +117,7 @@ describe("SlidingSync", () => {
                 });
                 expect(body.lists[0]).toEqual(listInfo);
                 expect(body.extensions).toBeTruthy();
-                expect(body.extensions["custom_extension"]).toEqual({initial:true});
+                expect(body.extensions["custom_extension"]).toEqual({ initial: true });
                 txnId = body.txn_id;
             }).respond(200, function() {
                 return {
@@ -135,10 +135,10 @@ describe("SlidingSync", () => {
                 logger.debug("got ", body);
                 expect(body.room_subscriptions).toBeFalsy();
                 expect(body.lists[0]).toEqual({
-                    ranges: [[0,10]],
+                    ranges: [[0, 10]],
                 });
                 expect(body.extensions).toBeTruthy();
-                expect(body.extensions["custom_extension"]).toEqual({initial:false});
+                expect(body.extensions["custom_extension"]).toEqual({ initial: false });
             }).respond(200, function() {
                 return {
                     pos: "12",
@@ -166,7 +166,7 @@ describe("SlidingSync", () => {
                 });
                 expect(body.lists[0]).toEqual(listInfo);
                 expect(body.extensions).toBeTruthy();
-                expect(body.extensions["custom_extension"]).toEqual({initial:true});
+                expect(body.extensions["custom_extension"]).toEqual({ initial: true });
             }).respond(200, function() {
                 return {
                     pos: "1",


### PR DESCRIPTION
This can happen when you close your laptop overnight,
as the server will not hold onto in-memory resources
for your connection indefinitely. When this happen,
the server will HTTP 400 you with "session expired".

At this point, it is no longer safe to remember anything
and you must forget everything and resend any sticky
parameters. This commit does the sticky parameters and
re-establishes the connection, but it may need additional
work to make the JS SDK forget now invalid data.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
