### PR TITLE
Re-emit room state events on rooms

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,10 @@ module.exports = {
             // We're okay with assertion errors when we ask for them
             "@typescript-eslint/no-non-null-assertion": "off",
 
+            // The non-TypeScript rule produces false positives
+            "func-call-spacing": "off",
+            "@typescript-eslint/func-call-spacing": ["error"],
+
             "quotes": "off",
             // We use a `logger` intermediary module
             "no-console": "error",

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1090,7 +1090,6 @@ export class Room extends TypedEventEmitter<EmittedEvents, RoomEventHandlerMap> 
             // Re-emit various events on the current room state
             // TODO: If currentState really only exists for backwards
             // compatibility, shouldn't we be doing this some other way?
-
             this.reEmitter.stopReEmitting(previousCurrentState, [
                 RoomStateEvent.Events,
                 RoomStateEvent.Members,

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -19,7 +19,7 @@ import { logger } from './logger';
 import * as utils from "./utils";
 import { EventTimeline } from "./models/event-timeline";
 import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
-import { ISyncStateData, SyncState, createRoom } from "./sync";
+import { ISyncStateData, SyncState, _createAndReEmitRoom } from "./sync";
 import { MatrixEvent } from "./models/event";
 import { Crypto } from "./crypto";
 import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState } from "./sync-accumulator";
@@ -288,7 +288,7 @@ export class SlidingSyncSdk {
                 logger.debug("initial flag not set but no stored room exists for room ", roomId, roomData);
                 return;
             }
-            room = createRoom(this.client, roomId, this.opts);
+            room = _createAndReEmitRoom(this.client, roomId, this.opts);
         }
         this.processRoomData(this.client, room, roomData);
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -199,7 +199,7 @@ export class SyncApi {
      * @return {Room}
      */
     public createRoom(roomId: string): Room {
-        const room = createRoom(this.client, roomId, this.opts);
+        const room = _createAndReEmitRoom(this.client, roomId, this.opts);
 
         room.on(RoomStateEvent.Marker, (markerEvent, markerFoundOptions) => {
             this.onMarkerStateEvent(room, markerEvent, markerFoundOptions);
@@ -1722,7 +1722,7 @@ function createNewUser(client: MatrixClient, userId: string): User {
 
 // /!\ This function is not intended for public use! It's only exported from
 // here in order to share some common logic with sliding-sync-sdk.ts.
-export function createRoom(client: MatrixClient, roomId: string, opts: Partial<IStoredClientOpts>): Room {
+export function _createAndReEmitRoom(client: MatrixClient, roomId: string, opts: Partial<IStoredClientOpts>): Room {
     const { timelineSupport } = client;
 
     const room = new Room(roomId, client, client.getUserId(), {


### PR DESCRIPTION
This also fixes some potential memory leaks and abuse of `removeAllListeners` in sync.ts.

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Re-emit room state events on rooms ([\#2607](https://github.com/matrix-org/matrix-js-sdk/pull/2607)).<!-- CHANGELOG_PREVIEW_END -->