### PR TITLE
Add tags and not_tags to the list of valid sliding sync filters

### DIFF
--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -47,6 +47,8 @@ export interface MSC3575Filter {
     room_types?: string[];
     not_room_types?: string[];
     spaces?: string[];
+    tags?: string[];
+    not_tags?: string[];
 }
 
 /**


### PR DESCRIPTION
Notes: Add `tags` and `not_tags` to the list of valid sliding sync filters.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->