### PR TITLE
Base support for MSC3847: Ignore invites with policy rooms

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -39,8 +39,11 @@ import { M_BEACON_INFO } from "../../src/@types/beacon";
 import { ContentHelpers, EventTimeline, Room } from "../../src";
 import { supportsMatrixCall } from "../../src/webrtc/call";
 import { makeBeaconEvent } from "../test-utils/beacon";
-import { IGNORE_INVITES_ACCOUNT_EVENT_KEY, POLICIES_ACCOUNT_EVENT_TYPE, PolicyScope }
-    from "../../src/models/invites-ignorer";
+import {
+    IGNORE_INVITES_ACCOUNT_EVENT_KEY,
+    POLICIES_ACCOUNT_EVENT_TYPE,
+    PolicyScope,
+} from "../../src/models/invites-ignorer";
 
 jest.useFakeTimers();
 
@@ -1498,12 +1501,14 @@ describe("MatrixClient", function() {
                 }
             };
         });
+
         it("should initialize and return the same `target` consistently", async () => {
             const target1 = await client.ignoredInvites.getOrCreateTargetRoom();
             const target2 = await client.ignoredInvites.getOrCreateTargetRoom();
             expect(target1).toBeTruthy();
             expect(target1).toBe(target2);
         });
+
         it("should initialize and return the same `sources` consistently", async () => {
             const sources1 = await client.ignoredInvites.getOrCreateSourceRooms();
             const sources2 = await client.ignoredInvites.getOrCreateSourceRooms();
@@ -1511,6 +1516,7 @@ describe("MatrixClient", function() {
             expect(sources1).toHaveLength(1);
             expect(sources1).toEqual(sources2);
         });
+
         it("should initially not reject any invite", async () => {
             const rule = await client.ignoredInvites.getRuleForInvite({
                 sender: "@foobar:example.org",
@@ -1518,6 +1524,7 @@ describe("MatrixClient", function() {
             });
             expect(rule).toBeFalsy();
         });
+
         it("should reject invites once we have added a matching rule in the target room (scope: user)", async () => {
             await client.ignoredInvites.addRule(PolicyScope.User, "*:example.org", "just a test");
 
@@ -1545,6 +1552,7 @@ describe("MatrixClient", function() {
             });
             expect(ruleWrongServerRoom).toBeFalsy();
         });
+
         it("should reject invites once we have added a matching rule in the target room (scope: server)", async () => {
             const REASON = `Just a test ${Math.random()}`;
             await client.ignoredInvites.addRule(PolicyScope.Server, "example.org", REASON);
@@ -1577,6 +1585,7 @@ describe("MatrixClient", function() {
             });
             expect(ruleWrongServer).toBeFalsy();
         });
+
         it("should reject invites once we have added a matching rule in the target room (scope: room)", async () => {
             const REASON = `Just a test ${Math.random()}`;
             const BAD_ROOM_ID = "!bad:example.org";
@@ -1601,6 +1610,7 @@ describe("MatrixClient", function() {
             });
             expect(ruleWrongRoom).toBeFalsy();
         });
+
         it("should reject invites once we have added a matching rule in a non-target source room", async () => {
             const NEW_SOURCE_ROOM_ID = "!another-source:example.org";
 
@@ -1640,6 +1650,7 @@ describe("MatrixClient", function() {
             });
             expect(ruleWrongServerRoom).toBeFalsy();
         });
+
         it("should not reject invites anymore once we have removed a rule", async () => {
             await client.ignoredInvites.addRule(PolicyScope.User, "*:example.org", "just a test");
 
@@ -1662,6 +1673,7 @@ describe("MatrixClient", function() {
             });
             expect(ruleMatch2).toBeFalsy();
         });
+
         it("should add new rules in the target room, rather than any other source room", async () => {
             const NEW_SOURCE_ROOM_ID = "!another-source:example.org";
 
@@ -1671,9 +1683,9 @@ describe("MatrixClient", function() {
             const newSourceRoom = client.getRoom(NEW_SOURCE_ROOM_ID);
 
             // Fetch the list of sources and check that we do not have the new room yet.
-            const policies = await client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE).getContent();
+            const policies = await client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE.name).getContent();
             expect(policies).toBeTruthy();
-            const ignoreInvites = policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY];
+            const ignoreInvites = policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY.name];
             expect(ignoreInvites).toBeTruthy();
             expect(ignoreInvites.sources).toBeTruthy();
             expect(ignoreInvites.sources).not.toContain(NEW_SOURCE_ROOM_ID);
@@ -1685,9 +1697,9 @@ describe("MatrixClient", function() {
             expect(added2).toBe(false);
 
             // Fetch the list of sources and check that we have added the new room.
-            const policies2 = await client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE).getContent();
+            const policies2 = await client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE.name).getContent();
             expect(policies2).toBeTruthy();
-            const ignoreInvites2 = policies2[IGNORE_INVITES_ACCOUNT_EVENT_KEY];
+            const ignoreInvites2 = policies2[IGNORE_INVITES_ACCOUNT_EVENT_KEY.name];
             expect(ignoreInvites2).toBeTruthy();
             expect(ignoreInvites2.sources).toBeTruthy();
             expect(ignoreInvites2.sources).toContain(NEW_SOURCE_ROOM_ID);

--- a/src/client.ts
+++ b/src/client.ts
@@ -197,6 +197,7 @@ import { Thread, THREAD_RELATION_TYPE } from "./models/thread";
 import { MBeaconInfoEventContent, M_BEACON_INFO } from "./@types/beacon";
 import { ToDeviceMessageQueue } from "./ToDeviceMessageQueue";
 import { ToDeviceBatch } from "./models/ToDeviceMessage";
+import { IgnoredInvites } from "./models/invites-ignorer";
 
 export type Store = IStore;
 
@@ -954,6 +955,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     private toDeviceMessageQueue: ToDeviceMessageQueue;
 
+    // A manager for determining which invites should be ignored.
+    public readonly ignoredInvites: IgnoredInvites;
+
     constructor(opts: IMatrixClientCreateOpts) {
         super();
 
@@ -1135,6 +1139,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 room.setUnreadNotificationCount(NotificationCountType.Highlight, highlightCount);
             }
         });
+
+        this.ignoredInvites = new IgnoredInvites(this);
     }
 
     /**

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -24,12 +24,12 @@ import { Room } from "./room";
 /// The event type storing the user's individual policies.
 ///
 /// Exported for testing purposes.
-export const POLICIES_ACCOUNT_EVENT_TYPE = new UnstableValue(null, "org.matrix.msc3847.policies");
+export const POLICIES_ACCOUNT_EVENT_TYPE = new UnstableValue("m.policies", "org.matrix.msc3847.policies");
 
 /// The key within the user's individual policies storing the user's ignored invites.
 ///
 /// Exported for testing purposes.
-export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue(null, "org.matrix.msc3847.ignore.invites");
+export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue("m.ignore.invites", "org.matrix.msc3847.ignore.invites");
 
 /// The types of recommendations understood.
 enum PolicyRecommendation {

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -180,15 +180,15 @@ export class IgnoredInvites {
                         // Invalid event.
                         continue;
                     }
-                    let regexp: string;
+                    let regexp: RegExp;
                     try {
-                        regexp = globToRegexp(glob, false);
+                        regexp = new RegExp(globToRegexp(glob, false));
                     } catch (ex) {
                         // Assume invalid event.
                         continue;
                     }
                     for (const entity of entities) {
-                        if (entity && entity.search(regexp) >= 0) {
+                        if (entity && regexp.test(entity)) {
                             return event;
                         }
                     }

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -29,7 +29,8 @@ export const POLICIES_ACCOUNT_EVENT_TYPE = new UnstableValue("m.policies", "org.
 /// The key within the user's individual policies storing the user's ignored invites.
 ///
 /// Exported for testing purposes.
-export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue("m.ignore.invites", "org.matrix.msc3847.ignore.invites");
+export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue("m.ignore.invites",
+    "org.matrix.msc3847.ignore.invites");
 
 /// The types of recommendations understood.
 enum PolicyRecommendation {

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -1,0 +1,245 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { MatrixClient } from "../client";
+import { EventTimeline, MatrixEvent, Preset } from "../matrix";
+import { globToRegexp } from "../utils";
+import { Room } from "./room";
+
+/// The event type storing the user's individual policies.
+const POLICIES_ACCOUNT_EVENT_TYPE = "org.matrix.msc3847.policies";
+
+/// The key within the user's individual policies storing the user's ignored invites.
+const IGNORE_INVITES_ACCOUNT_EVENT_KEY = "org.matrix.msc3847.ignore.invites";
+
+/// The types of recommendations understood.
+enum PolicyRecommendation {
+    Ban = "m.ban",
+}
+
+/**
+ * The various scopes for policies.
+ */
+export enum PolicyScope {
+    /**
+     * The policy deals with an individual user, e.g. reject invites
+     * from this user.
+     */
+    User = "m.policy.user",
+
+    /**
+     * The policy deals with a room, e.g. reject invites towards
+     * a specific room.
+     */
+    Room = "m.policy.room",
+
+    /**
+     * The policy deals with a server, e.g. reject invites from
+     * this server.
+     */
+    Server = "m.policy.server",
+}
+
+/**
+ * A container for ignored invites.
+ *
+ * # Performance
+ *
+ * This implementation is extremely naive. It expects that we are dealing
+ * with a very short list of sources (e.g. only one). If real-world
+ * applications turn out to require longer lists, we may need to rework
+ * our data structures.
+ */
+export class IgnoredInvites {
+    constructor(
+        private readonly client: MatrixClient,
+    ) {
+    }
+
+    /**
+     * Add a new rule.
+     *
+     * @param scope The scope for this rule.
+     * @param entity The entity covered by this rule. Globs are supported.
+     * @param reason A human-readable reason for introducing this new rule.
+     */
+    public async addRule(scope: PolicyScope, entity: string, reason: string) {
+        const target = await this.getOrCreateTargetRoom();
+        await this.client.sendStateEvent(target.roomId, scope, {
+            entity,
+            reason,
+            recommendation: PolicyRecommendation.Ban,
+        });
+    }
+
+    /**
+     * Remove a rule.
+     */
+    public async removeRule(event: MatrixEvent) {
+        await this.client.redactEvent(event.getRoomId()!, event.getId()!);
+    }
+
+    /**
+     * Find out whether an invite should be ignored.
+     *
+     * @param sender The user id for the user who issued the invite.
+     * @param roomId The room to which the user is invited.
+     * @returns A rule matching the entity, if any was found, `null` otherwise.
+     */
+    public async getRuleForInvite({ sender, roomId }: {
+        sender: string;
+        roomId: string;
+    }): Promise<Readonly<MatrixEvent | null>> {
+        // In this implementation, we perform a very naive lookup:
+        // - search in each policy room;
+        // - turn each (potentially glob) rule entity into a regexp.
+        //
+        // Real-world testing will tell us whether this is performant enough.
+        // In the (unfortunately likely) case it isn't, there are several manners
+        // in which we could optimize this:
+        // - match several entities per go;
+        // - pre-compile each rule entity into a regexp;
+        // - pre-compile entire rooms into a single regexp.
+        const policyRooms = await this.getOrCreateSourceRooms();
+        const senderServer = sender.split(":")[1];
+        const roomServer = roomId.split(":")[1];
+        for (const room of policyRooms) {
+            const state = room.getUnfilteredTimelineSet().getLiveTimeline().getState(EventTimeline.FORWARDS);
+
+            for (const { scope, entities } of [
+                { scope: PolicyScope.Room, entities: [roomId] },
+                { scope: PolicyScope.User, entities: [sender] },
+                { scope: PolicyScope.Server, entities: [senderServer, roomServer] },
+            ]) {
+                const events = state.getStateEvents(scope);
+                for (const event of events) {
+                    const content = event.getContent();
+                    if (content?.recommendation != PolicyRecommendation.Ban) {
+                        // Ignoring invites only looks at `m.ban` recommendations.
+                        continue;
+                    }
+                    const glob = content?.entity;
+                    if (!glob) {
+                        // Invalid event.
+                        continue;
+                    }
+                    let regexp;
+                    try {
+                        regexp = globToRegexp(glob, false);
+                    } catch (ex) {
+                        // Assume invalid event.
+                        continue;
+                    }
+                    for (const entity of entities) {
+                        if (entity && entity.search(regexp) >= 0) {
+                            return event;
+                        }
+                    }
+                    // No match.
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the target room, i.e. the room in which any new rule should be written.
+     *
+     * If there is no target room setup, a target room is created.
+     *
+     * Note: This method is public for testing reasons. Most clients should not need
+     * to call it directly.
+     */
+    public async getOrCreateTargetRoom(): Promise<Room> {
+        const policies = this.client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE)?.getContent() || {};
+        const ignoreInvitesPolicies = policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY] || {};
+        let target = ignoreInvitesPolicies.target;
+        // Validate `target`. If it is invalid, trash out the current `target`
+        // and create a new room.
+        if (typeof target !== "string") {
+            target = null;
+        }
+        if (target) {
+            // Check that the room exists and is valid.
+            const room = this.client.getRoom(target);
+            if (room) {
+                return room;
+            } else {
+                target = null;
+            }
+        }
+        // We need to create our own policy room for ignoring invites.
+        target = (await this.client.createRoom({
+            name: "Individual Policy Room",
+            preset: Preset.PrivateChat,
+        })).room_id;
+        ignoreInvitesPolicies.target = target;
+        policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY] = ignoreInvitesPolicies;
+        await this.client.setAccountData(POLICIES_ACCOUNT_EVENT_TYPE, policies);
+
+        // Since we have just called `createRoom`, `getRoom` should not be `null`.
+        return this.client.getRoom(target)!;
+    }
+
+    /**
+     * Get the list of source rooms, i.e. the rooms from which rules need to be read.
+     *
+     * If no source rooms are setup, the target room is used as sole source room.
+     *
+     * Note: This method is public for testing reasons. Most clients should not need
+     * to call it directly.
+     */
+    public async getOrCreateSourceRooms(): Promise<Room[]> {
+        const policies = this.client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE)?.getContent() || {};
+        const ignoreInvitesPolicies = policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY] || {};
+        let sources = ignoreInvitesPolicies.sources;
+
+        // Validate `sources`. If it is invalid, trash out the current `sources`
+        // and create a new list of sources from `target`.
+        let hasChanges = false;
+        if (!Array.isArray(sources)) {
+            // `sources` could not be an array.
+            hasChanges = true;
+            sources = [];
+        }
+        let sourceRooms: Room[] = sources
+            // `sources` could contain non-string / invalid room ids
+            .filter(roomId => typeof roomId === "string")
+            .map(roomId => this.client.getRoom(roomId))
+            .filter(room => !!room);
+        if (sourceRooms.length != sources.length) {
+            hasChanges = true;
+        }
+        if (sourceRooms.length == 0) {
+            // `sources` could be empty (possibly because we've removed
+            // invalid content)
+            const target = await this.getOrCreateTargetRoom();
+            hasChanges = true;
+            sourceRooms = [target];
+        }
+        if (hasChanges) {
+            // Reload `policies`/`ignoreInvitesPolicies` in case it has been changed
+            // during or by our call to `this.getTargetRoom()`.
+            const policies = this.client.getAccountData(POLICIES_ACCOUNT_EVENT_TYPE)?.getContent() || {};
+            const ignoreInvitesPolicies = policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY] || {};
+            sources = sourceRooms.map(room => room.roomId);
+            policies[IGNORE_INVITES_ACCOUNT_EVENT_KEY] = ignoreInvitesPolicies;
+            ignoreInvitesPolicies.sources = sources;
+            await this.client.setAccountData(POLICIES_ACCOUNT_EVENT_TYPE, policies);
+        }
+        return sourceRooms;
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -341,7 +341,7 @@ export function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function globToRegexp(glob: string, extended?: any): string {
+export function globToRegexp(glob: string, extended = false): string {
     // From
     // https://github.com/matrix-org/synapse/blob/abbee6b29be80a77e05730707602f3bbfc3f38cb/synapse/push/__init__.py#L132
     // Because micromatch is about 130KB with dependencies,
@@ -349,7 +349,7 @@ export function globToRegexp(glob: string, extended?: any): string {
     const replacements: ([RegExp, string | ((substring: string, ...args: any[]) => string) ])[] = [
         [/\\\*/g, '.*'],
         [/\?/g, '.'],
-        extended !== false && [
+        !extended && [
             /\\\[(!|)(.*)\\]/g,
             (_match: string, neg: string, pat: string) => [
                 '[',


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

This is a second take on the matrix-js-sdk-level machinery needed to be able to ignore invites, this time based on MSC3847.

The intention is that decisions on whether/how to display ignored invites is left in the hands of matrix-react-sdk.

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


Type: enhancement

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Base support for MSC3847: Ignore invites with policy rooms ([\#2626](https://github.com/matrix-org/matrix-js-sdk/pull/2626)). Contributed by @Yoric.<!-- CHANGELOG_PREVIEW_END -->