### PR TITLE
Add types to the call unit test suites

### DIFF
--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -212,6 +212,11 @@ export class MockMediaStream {
     clone() {
         return new MockMediaStream(this.id, this.tracks);
     }
+
+    // syntactic sugar for typing
+    typed(): MediaStream {
+        return this as unknown as MediaStream;
+    }
 }
 
 export class MockMediaDeviceInfo {

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -564,8 +564,6 @@ describe('Call', function() {
         (call as any).updateRemoteSDPStreamMetadata({
             "remote_usermedia_stream_id": {
                 purpose: SDPStreamMetadataPurpose.Usermedia,
-                // XXX: This type doesn't include 'id'?
-                id: "remote_usermedia_feed_id",
                 audio_muted: false,
                 video_muted: false,
             },

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -115,7 +115,7 @@ describe('Call', function() {
             untypedClient.mediaHandler = new MockMediaHandler;
             untypedClient.turnServersExpiry = Date.now() + 60 * 60 * 1000;
         }
-        //client.client.getMediaHandler = () => client.client.mediaHandler;
+
         client.httpBackend.when("GET", "/voip/turnServer").respond(200, {});
         client.client.getRoom = () => {
             return {
@@ -169,7 +169,7 @@ describe('Call', function() {
                 },
             ],
         }));
-        expect(mockAddIceCandidate.mock.calls.length).toBe(1);
+        expect(mockAddIceCandidate).toHaveBeenCalled();
 
         call.onRemoteIceCandidatesReceived(makeMockEvent("@test:foo", {
             version: 1,

--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -182,7 +182,7 @@ describe('Call', function() {
                 },
             ],
         }));
-        expect(mockAddIceCandidate.mock.calls.length).toBe(1);
+        expect(mockAddIceCandidate).toHaveBeenCalled();
     });
 
     it('should add candidates received before answer if party ID is correct', async function() {
@@ -213,7 +213,7 @@ describe('Call', function() {
             ],
         }));
 
-        expect(mockAddIceCandidate.mock.calls.length).toBe(0);
+        expect(mockAddIceCandidate).not.toHaveBeenCalled();
 
         await call.onAnswerReceived(makeMockEvent("@test:foo", {
             version: 1,
@@ -224,7 +224,7 @@ describe('Call', function() {
             },
         }));
 
-        expect(mockAddIceCandidate.mock.calls.length).toBe(1);
+        expect(mockAddIceCandidate).toHaveBeenCalled();
         expect(mockAddIceCandidate).toHaveBeenCalledWith({
             candidate: 'the_correct_candidate',
             sdpMid: '',


### PR DESCRIPTION
Still involves quite a few casts to any unfortunately as it turns
out we access quite a few private methods on the Call class in these
tests.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->