### PR TITLE
sliding sync: add invited|joined_count

### DIFF
--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -280,6 +280,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomA, data[roomA]);
                 const gotRoom = client.getRoom(roomA);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(gotRoom.name).toEqual(data[roomA].name);
                 expect(gotRoom.getMyMembership()).toEqual("join");
                 assertTimelineEvents(gotRoom.getLiveTimeline().getEvents().slice(-2), data[roomA].timeline);
@@ -289,6 +290,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomB, data[roomB]);
                 const gotRoom = client.getRoom(roomB);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(gotRoom.name).toEqual(data[roomB].name);
                 expect(gotRoom.getMyMembership()).toEqual("join");
                 assertTimelineEvents(gotRoom.getLiveTimeline().getEvents().slice(-5), data[roomB].timeline);
@@ -298,6 +300,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomC, data[roomC]);
                 const gotRoom = client.getRoom(roomC);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(
                     gotRoom.getUnreadNotificationCount(NotificationCountType.Highlight),
                 ).toEqual(data[roomC].highlight_count);
@@ -307,6 +310,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomD, data[roomD]);
                 const gotRoom = client.getRoom(roomD);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(
                     gotRoom.getUnreadNotificationCount(NotificationCountType.Total),
                 ).toEqual(data[roomD].notification_count);
@@ -316,6 +320,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomG, data[roomG]);
                 const gotRoom = client.getRoom(roomG);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(gotRoom.getInvitedMemberCount()).toEqual(data[roomG].invited_count);
                 expect(gotRoom.getJoinedMemberCount()).toEqual(data[roomG].joined_count);
             });
@@ -324,6 +329,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomE, data[roomE]);
                 const gotRoom = client.getRoom(roomE);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(gotRoom.getMyMembership()).toEqual("invite");
                 expect(gotRoom.currentState.getJoinRule()).toEqual(JoinRule.Invite);
             });
@@ -332,6 +338,7 @@ describe("SlidingSyncSdk", () => {
                 mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomF, data[roomF]);
                 const gotRoom = client.getRoom(roomF);
                 expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
                 expect(
                     gotRoom.name,
                 ).toEqual(data[roomF].name);
@@ -347,6 +354,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     const gotRoom = client.getRoom(roomA);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     const newTimeline = data[roomA].timeline;
                     newTimeline.push(newEvent);
                     assertTimelineEvents(gotRoom.getLiveTimeline().getEvents().slice(-3), newTimeline);
@@ -364,6 +372,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     gotRoom = client.getRoom(roomB);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     expect(gotRoom.getJoinRule()).toEqual(JoinRule.Restricted);
                 });
 
@@ -376,6 +385,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     const gotRoom = client.getRoom(roomC);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     expect(
                         gotRoom.getUnreadNotificationCount(NotificationCountType.Highlight),
                     ).toEqual(1);
@@ -390,6 +400,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     const gotRoom = client.getRoom(roomD);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     expect(
                         gotRoom.getUnreadNotificationCount(NotificationCountType.Total),
                     ).toEqual(1);
@@ -404,6 +415,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     const gotRoom = client.getRoom(roomG);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     expect(gotRoom.getJoinedMemberCount()).toEqual(1);
                 });
 
@@ -427,6 +439,7 @@ describe("SlidingSyncSdk", () => {
                     });
                     const gotRoom = client.getRoom(roomA);
                     expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
 
                     logger.log("want:", oldTimeline.map((e) => (e.type + " : " + (e.content || {}).body)));
                     logger.log("got:", gotRoom.getLiveTimeline().getEvents().map(

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -362,6 +362,8 @@ describe("SlidingSyncSdk", () => {
 
                 it("can update with a new required_state event", async () => {
                     let gotRoom = client.getRoom(roomB);
+                    expect(gotRoom).toBeDefined();
+                    if (gotRoom == null) { return; }
                     expect(gotRoom.getJoinRule()).toEqual(JoinRule.Invite); // default
                     mockSlidingSync.emit(SlidingSyncEvent.RoomData, roomB, {
                         required_state: [

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -473,10 +473,10 @@ export class SlidingSyncSdk {
         }
 
         if (Number.isInteger(roomData.invited_count)) {
-            room.currentState.setInvitedMemberCount(roomData.invited_count);
+            room.currentState.setInvitedMemberCount(roomData.invited_count!);
         }
         if (Number.isInteger(roomData.joined_count)) {
-            room.currentState.setJoinedMemberCount(roomData.joined_count);
+            room.currentState.setJoinedMemberCount(roomData.joined_count!);
         }
 
         if (roomData.invite_state) {

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -293,13 +293,16 @@ export class SlidingSyncSdk {
         this.processRoomData(this.client, room, roomData);
     }
 
-    private onLifecycle(state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err?: Error): void {
+    private onLifecycle(state: SlidingSyncState, resp?: MSC3575SlidingSyncResponse, err?: Error): void {
         if (err) {
             logger.debug("onLifecycle", state, err);
         }
         switch (state) {
             case SlidingSyncState.Complete:
                 this.purgeNotifications();
+                if (!resp) {
+                    break;
+                }
                 // Element won't stop showing the initial loading spinner unless we fire SyncState.Prepared
                 if (!this.lastPos) {
                     this.updateSyncState(SyncState.Prepared, {

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -472,6 +472,13 @@ export class SlidingSyncSdk {
             }
         }
 
+        if (Number.isInteger(roomData.invited_count)) {
+            room.currentState.setInvitedMemberCount(roomData.invited_count);
+        }
+        if (Number.isInteger(roomData.joined_count)) {
+            room.currentState.setJoinedMemberCount(roomData.joined_count);
+        }
+
         if (roomData.invite_state) {
             const inviteStateEvents = mapEvents(this.client, room.roomId, roomData.invite_state);
             this.processRoomEvents(room, inviteStateEvents);

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -293,7 +293,7 @@ export class SlidingSyncSdk {
         this.processRoomData(this.client, room, roomData);
     }
 
-    private onLifecycle(state: SlidingSyncState, resp?: MSC3575SlidingSyncResponse, err?: Error): void {
+    private onLifecycle(state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error | null): void {
         if (err) {
             logger.debug("onLifecycle", state, err);
         }

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -84,6 +84,8 @@ export interface MSC3575RoomData {
     timeline: (IRoomEvent | IStateEvent)[];
     notification_count?: number;
     highlight_count?: number;
+    joined_count?: number;
+    invited_count?: number;
     invite_state?: IStateEvent[];
     initial?: boolean;
     limited?: boolean;

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -322,7 +322,9 @@ export enum SlidingSyncEvent {
 
 export type SlidingSyncEventHandlerMap = {
     [SlidingSyncEvent.RoomData]: (roomId: string, roomData: MSC3575RoomData) => void;
-    [SlidingSyncEvent.Lifecycle]: (state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error) => void;
+    [SlidingSyncEvent.Lifecycle]: (
+        state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error,
+    ) => void;
     [SlidingSyncEvent.List]: (
         listIndex: number, joinedCount: number, roomIndexToRoomId: Record<number, string>,
     ) => void;

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -323,7 +323,7 @@ export enum SlidingSyncEvent {
 export type SlidingSyncEventHandlerMap = {
     [SlidingSyncEvent.RoomData]: (roomId: string, roomData: MSC3575RoomData) => void;
     [SlidingSyncEvent.Lifecycle]: (
-        state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error,
+        state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error | null,
     ) => void;
     [SlidingSyncEvent.List]: (
         listIndex: number, joinedCount: number, roomIndexToRoomId: Record<number, string>,

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -322,7 +322,7 @@ export enum SlidingSyncEvent {
 
 export type SlidingSyncEventHandlerMap = {
     [SlidingSyncEvent.RoomData]: (roomId: string, roomData: MSC3575RoomData) => void;
-    [SlidingSyncEvent.Lifecycle]: (state: SlidingSyncState, resp: MSC3575SlidingSyncResponse, err: Error) => void;
+    [SlidingSyncEvent.Lifecycle]: (state: SlidingSyncState, resp: MSC3575SlidingSyncResponse | null, err: Error) => void;
     [SlidingSyncEvent.List]: (
         listIndex: number, joinedCount: number, roomIndexToRoomId: Record<number, string>,
     ) => void;


### PR DESCRIPTION
This is critical for calculating client-side push rules correctly.
Without it, the push processor may think rooms have a different
number of members, resulting typically in annoying failure modes
where rooms constantly make noises because the code thinks they
are 1:1 rooms.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Notes: add invited_count and joined_count to sliding sync room responses.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * add invited_count and joined_count to sliding sync room responses. ([\#2628](https://github.com/matrix-org/matrix-js-sdk/pull/2628)).<!-- CHANGELOG_PREVIEW_END -->