### PR TITLE
MediaHandler Tests

### DIFF
--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -279,12 +279,10 @@ export class MockMediaHandler {
 }
 
 export class MockMediaDevices {
-    enumerateDevices = jest.fn<Promise<MediaDeviceInfo[]>, []>().mockReturnValue(
-        Promise.resolve([
-            new MockMediaDeviceInfo("audioinput").typed(),
-            new MockMediaDeviceInfo("videoinput").typed(),
-        ]),
-    );
+    enumerateDevices = jest.fn<Promise<MediaDeviceInfo[]>, []>().mockResolvedValue([
+        new MockMediaDeviceInfo("audioinput").typed(),
+        new MockMediaDeviceInfo("videoinput").typed(),
+    ]);
 
     getUserMedia = jest.fn<Promise<MediaStream>, [MediaStreamConstraints]>().mockReturnValue(
         Promise.resolve(new MockMediaStream("local_stream").typed()),

--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -160,7 +160,7 @@ export class MockRTCRtpSender {
 export class MockMediaStreamTrack {
     constructor(public readonly id: string, public readonly kind: "audio" | "video", public enabled = true) { }
 
-    stop() { }
+    stop = jest.fn<void, []>();
 
     listeners: [string, (...args: any[]) => any][] = [];
     public isStopped = false;
@@ -184,6 +184,8 @@ export class MockMediaStreamTrack {
             return t !== eventType || c !== callback;
         });
     }
+
+    typed(): MediaStreamTrack { return this as unknown as MediaStreamTrack; }
 }
 
 // XXX: Using EventTarget in jest doesn't seem to work, so we write our own
@@ -286,6 +288,10 @@ export class MockMediaDevices {
 
     getUserMedia = jest.fn<Promise<MediaStream>, [MediaStreamConstraints]>().mockReturnValue(
         Promise.resolve(new MockMediaStream("local_stream").typed()),
+    );
+
+    getDisplayMedia = jest.fn<Promise<MediaStream>, [DisplayMediaStreamConstraints]>().mockReturnValue(
+        Promise.resolve(new MockMediaStream("local_display_stream").typed()),
     );
 
     typed(): MediaDevices { return this as unknown as MediaDevices; }

--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -164,6 +164,9 @@ export class MockMediaStreamTrack {
 
     listeners: [string, (...args: any[]) => any][] = [];
     public isStopped = false;
+    public settings: MediaTrackSettings;
+
+    getSettings(): MediaTrackSettings { return this.settings; }
 
     // XXX: Using EventTarget in jest doesn't seem to work, so we write our own
     // implementation
@@ -217,8 +220,12 @@ export class MockMediaStream {
     }
     removeTrack(track: MockMediaStreamTrack) { this.tracks.splice(this.tracks.indexOf(track), 1); }
 
-    clone() {
-        return new MockMediaStream(this.id, this.tracks);
+    clone(): MediaStream {
+        return new MockMediaStream(this.id + ".clone", this.tracks).typed();
+    }
+
+    isCloneOf(stream: MediaStream) {
+        return this.id === stream.id + ".clone";
     }
 
     // syntactic sugar for typing
@@ -231,6 +238,8 @@ export class MockMediaDeviceInfo {
     constructor(
         public kind: "audioinput" | "videoinput" | "audiooutput",
     ) { }
+
+    typed(): MediaDeviceInfo { return this as unknown as MediaDeviceInfo; }
 }
 
 export class MockMediaHandler {
@@ -267,15 +276,25 @@ export class MockMediaHandler {
     typed(): MediaHandler { return this as unknown as MediaHandler; }
 }
 
+export class MockMediaDevices {
+    enumerateDevices = jest.fn<Promise<MediaDeviceInfo[]>, []>().mockReturnValue(
+        Promise.resolve([
+            new MockMediaDeviceInfo("audioinput").typed(),
+            new MockMediaDeviceInfo("videoinput").typed(),
+        ]),
+    );
+
+    getUserMedia = jest.fn<Promise<MediaStream>, [MediaStreamConstraints]>().mockReturnValue(
+        Promise.resolve(new MockMediaStream("local_stream").typed()),
+    );
+
+    typed(): MediaDevices { return this as unknown as MediaDevices; }
+}
+
 export function installWebRTCMocks() {
     global.navigator = {
-        mediaDevices: {
-            // @ts-ignore Mock
-            getUserMedia: () => new MockMediaStream("local_stream"),
-            // @ts-ignore Mock
-            enumerateDevices: async () => [new MockMediaDeviceInfo("audio"), new MockMediaDeviceInfo("video")],
-        },
-    };
+        mediaDevices: new MockMediaDevices().typed(),
+    } as unknown as Navigator;
 
     global.window = {
         // @ts-ignore Mock

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -20,8 +20,6 @@ import { MockMediaDeviceInfo, MockMediaDevices, MockMediaStream, MockMediaStream
 
 const FAKE_AUDIO_INPUT_ID = "aaaaaaaa";
 const FAKE_VIDEO_INPUT_ID = "vvvvvvvv";
-const FAKE_AUDIO_INPUT_ID_2 = "aaaaaaa2";
-const FAKE_VIDEO_INPUT_ID_2 = "vvvvvvv2";
 
 describe('Media Handler', function() {
     let mockMediaDevices: MockMediaDevices;

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -336,6 +336,8 @@ describe('Media Handler', function() {
             mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
             await mediaHandler.getScreensharingStream();
             expect(onLocalStreamChanged).toHaveBeenCalled();
+
+            mediaHandler.off(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
         });
     });
 
@@ -365,6 +367,8 @@ describe('Media Handler', function() {
             mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
             mediaHandler.stopUserMediaStream(stream);
             expect(onLocalStreamChanged).toHaveBeenCalled();
+
+            mediaHandler.off(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
         });
     });
 
@@ -434,6 +438,8 @@ describe('Media Handler', function() {
             mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
             mediaHandler.stopAllStreams();
             expect(onLocalStreamChanged).toHaveBeenCalled();
+
+            mediaHandler.off(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
         });
     });
 });

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -340,7 +340,7 @@ describe('Media Handler', function() {
     });
 
     describe("stopUserMediaStream", () => {
-        let stream;
+        let stream: MediaStream;
 
         beforeEach(async () => {
             stream = await mediaHandler.getUserMediaStream(true, false);
@@ -369,7 +369,7 @@ describe('Media Handler', function() {
     });
 
     describe("stopUserMediaStream", () => {
-        let stream;
+        let stream: MediaStream;
 
         beforeEach(async () => {
             stream = await mediaHandler.getScreensharingStream();
@@ -400,8 +400,8 @@ describe('Media Handler', function() {
     });
 
     describe("stopAllStreams", () => {
-        let userMediaStream;
-        let screenSharingStream;
+        let userMediaStream: MediaStream;
+        let screenSharingStream: MediaStream;
 
         beforeEach(async () => {
             userMediaStream = await mediaHandler.getUserMediaStream(true, false);

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -394,6 +394,8 @@ describe('Media Handler', function() {
             mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
             mediaHandler.stopScreensharingStream(stream);
             expect(onLocalStreamChanged).toHaveBeenCalled();
+
+            mediaHandler.off(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamChanged);
         });
     });
 

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -112,18 +112,19 @@ describe('Media Handler', function() {
             mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, localStreamsChangedHandler);
         });
 
+        afterEach(() => {
+            mediaHandler.off(MediaHandlerEvent.LocalStreamsChanged, localStreamsChangedHandler);
+        });
+
         it("does nothing if it has no streams", async () => {
             mediaHandler.updateLocalUsermediaStreams();
             expect(mockMediaDevices.getUserMedia).not.toHaveBeenCalled();
         });
 
         it("does not emit LocalStreamsChanged if it had no streams", async () => {
-            const onLocalStreamsChanged = jest.fn();
-            mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamsChanged);
-
             await mediaHandler.updateLocalUsermediaStreams();
 
-            expect(onLocalStreamsChanged).not.toHaveBeenCalled();
+            expect(localStreamsChangedHandler).not.toHaveBeenCalled();
         });
 
         describe("with existing streams", () => {

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -409,7 +409,7 @@ describe('Media Handler', function() {
         let screenSharingStream;
 
         beforeEach(async () => {
-            userMediaStream = await mediaHandler.getUserMediaStream();
+            userMediaStream = await mediaHandler.getUserMediaStream(true, false);
             screenSharingStream = await mediaHandler.getScreensharingStream();
         });
 

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -1,0 +1,276 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { GroupCall, MatrixCall, MatrixClient } from "../../../src";
+import { MediaHandler, MediaHandlerEvent } from "../../../src/webrtc/mediaHandler";
+import { MockMediaDeviceInfo, MockMediaDevices, MockMediaStream, MockMediaStreamTrack } from "../../test-utils/webrtc";
+
+const FAKE_AUDIO_INPUT_ID = "aaaaaaaa";
+const FAKE_VIDEO_INPUT_ID = "vvvvvvvv";
+const FAKE_AUDIO_INPUT_ID_2 = "aaaaaaa2";
+const FAKE_VIDEO_INPUT_ID_2 = "vvvvvvv2";
+
+describe('Media Handler', function() {
+    let mockMediaDevices: MockMediaDevices;
+    let mediaHandler: MediaHandler;
+    let calls: Map<string, MatrixCall>;
+    let groupCalls: Map<string, GroupCall>;
+
+    beforeEach(() => {
+        mockMediaDevices = new MockMediaDevices();
+
+        global.navigator = {
+            mediaDevices: mockMediaDevices.typed(),
+        } as unknown as Navigator;
+
+        calls = new Map();
+        groupCalls = new Map();
+
+        mediaHandler = new MediaHandler({
+            callEventHandler: {
+                calls,
+            },
+            groupCallEventHandler: {
+                groupCalls,
+            },
+        } as unknown as MatrixClient);
+    });
+
+    it("does not trigger update after restore media settings ", () => {
+        mediaHandler.restoreMediaSettings(FAKE_AUDIO_INPUT_ID, FAKE_VIDEO_INPUT_ID);
+
+        expect(mockMediaDevices.getUserMedia).not.toHaveBeenCalled();
+    });
+
+    it("sets device IDs on restore media settings", async () => {
+        mediaHandler.restoreMediaSettings(FAKE_AUDIO_INPUT_ID, FAKE_VIDEO_INPUT_ID);
+
+        await mediaHandler.getUserMediaStream(true, true);
+        expect(mockMediaDevices.getUserMedia).toHaveBeenCalledWith(expect.objectContaining({
+            audio: expect.objectContaining({
+                deviceId: { ideal: FAKE_AUDIO_INPUT_ID },
+            }),
+            video: expect.objectContaining({
+                deviceId: { ideal: FAKE_VIDEO_INPUT_ID },
+            }),
+        }));
+    });
+
+    it("sets audio device ID", async () => {
+        await mediaHandler.setAudioInput(FAKE_AUDIO_INPUT_ID);
+
+        await mediaHandler.getUserMediaStream(true, false);
+        expect(mockMediaDevices.getUserMedia).toHaveBeenCalledWith(expect.objectContaining({
+            audio: expect.objectContaining({
+                deviceId: { ideal: FAKE_AUDIO_INPUT_ID },
+            }),
+        }));
+    });
+
+    it("sets video device ID", async () => {
+        await mediaHandler.setVideoInput(FAKE_VIDEO_INPUT_ID);
+
+        await mediaHandler.getUserMediaStream(false, true);
+        expect(mockMediaDevices.getUserMedia).toHaveBeenCalledWith(expect.objectContaining({
+            video: expect.objectContaining({
+                deviceId: { ideal: FAKE_VIDEO_INPUT_ID },
+            }),
+        }));
+    });
+
+    it("sets media inputs", async () => {
+        await mediaHandler.setMediaInputs(FAKE_AUDIO_INPUT_ID, FAKE_VIDEO_INPUT_ID);
+
+        await mediaHandler.getUserMediaStream(true, true);
+        expect(mockMediaDevices.getUserMedia).toHaveBeenCalledWith(expect.objectContaining({
+            audio: expect.objectContaining({
+                deviceId: { ideal: FAKE_AUDIO_INPUT_ID },
+            }),
+            video: expect.objectContaining({
+                deviceId: { ideal: FAKE_VIDEO_INPUT_ID },
+            }),
+        }));
+    });
+
+    describe("updateLocalUsermediaStreams", () => {
+        let localStreamsChangedHandler: jest.Mock<void, []>;
+
+        beforeEach(() => {
+            localStreamsChangedHandler = jest.fn();
+            mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, localStreamsChangedHandler);
+        });
+
+        it("does nothing if it has no streams", async () => {
+            mediaHandler.updateLocalUsermediaStreams();
+            expect(mockMediaDevices.getUserMedia).not.toHaveBeenCalled();
+        });
+
+        it("does not emit LocalStreamsChanged if it had no streams", async () => {
+            const onLocalStreamsChanged = jest.fn();
+            mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamsChanged);
+
+            await mediaHandler.updateLocalUsermediaStreams();
+
+            expect(onLocalStreamsChanged).not.toHaveBeenCalled();
+        });
+
+        describe("with existing streams", () => {
+            let stopTrack: jest.Mock<void, []>;
+
+            beforeEach(() => {
+                stopTrack = jest.fn();
+
+                mediaHandler.userMediaStreams = [
+                    {
+                        getTracks: () => [{
+                            stop: stopTrack,
+                        } as unknown as MediaStreamTrack],
+                    } as unknown as MediaStream,
+                ];
+            });
+
+            it("stops existing streams", async () => {
+                mediaHandler.updateLocalUsermediaStreams();
+                expect(stopTrack).toHaveBeenCalled();
+            });
+
+            it("replaces streams on calls", async () => {
+                const updateLocalUsermediaStream = jest.fn();
+
+                calls.set("some_call", {
+                    hasLocalUserMediaAudioTrack: true,
+                    hasLocalUserMediaVideoTrack: true,
+                    callHasEnded: jest.fn().mockReturnValue(false),
+                    updateLocalUsermediaStream,
+                } as unknown as MatrixCall);
+
+                await mediaHandler.updateLocalUsermediaStreams();
+                expect(updateLocalUsermediaStream).toHaveBeenCalled();
+            });
+
+            it("doesn't replace streams on ended calls", async () => {
+                const updateLocalUsermediaStream = jest.fn();
+
+                calls.set("some_call", {
+                    hasLocalUserMediaAudioTrack: true,
+                    hasLocalUserMediaVideoTrack: true,
+                    callHasEnded: jest.fn().mockReturnValue(true),
+                    updateLocalUsermediaStream,
+                } as unknown as MatrixCall);
+
+                await mediaHandler.updateLocalUsermediaStreams();
+                expect(updateLocalUsermediaStream).not.toHaveBeenCalled();
+            });
+
+            it("replaces streams on group calls", async () => {
+                const updateLocalUsermediaStream = jest.fn();
+
+                groupCalls.set("some_group_call", {
+                    localCallFeed: {},
+                    updateLocalUsermediaStream,
+                } as unknown as GroupCall);
+
+                await mediaHandler.updateLocalUsermediaStreams();
+                expect(updateLocalUsermediaStream).toHaveBeenCalled();
+            });
+
+            it("doesn't replace streams on group calls with no localCallFeed", async () => {
+                const updateLocalUsermediaStream = jest.fn();
+
+                groupCalls.set("some_group_call", {
+                    localCallFeed: null,
+                    updateLocalUsermediaStream,
+                } as unknown as GroupCall);
+
+                await mediaHandler.updateLocalUsermediaStreams();
+                expect(updateLocalUsermediaStream).not.toHaveBeenCalled();
+            });
+
+            it("emits LocalStreamsChanged", async () => {
+                const onLocalStreamsChanged = jest.fn();
+                mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamsChanged);
+
+                await mediaHandler.updateLocalUsermediaStreams();
+
+                expect(onLocalStreamsChanged).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe("hasAudioDevice", () => {
+        it("returns true if the system has audio inputs", async () => {
+            expect(await mediaHandler.hasAudioDevice()).toEqual(true);
+        });
+
+        it("returns false if the system has no audio inputs", async () => {
+            mockMediaDevices.enumerateDevices.mockReturnValue(Promise.resolve([
+                new MockMediaDeviceInfo("videoinput").typed(),
+            ]));
+            expect(await mediaHandler.hasAudioDevice()).toEqual(false);
+        });
+    });
+
+    describe("hasVideoDevice", () => {
+        it("returns true if the system has video inputs", async () => {
+            expect(await mediaHandler.hasVideoDevice()).toEqual(true);
+        });
+
+        it("returns false if the system has no video inputs", async () => {
+            mockMediaDevices.enumerateDevices.mockReturnValue(Promise.resolve([
+                new MockMediaDeviceInfo("audioinput").typed(),
+            ]));
+            expect(await mediaHandler.hasVideoDevice()).toEqual(false);
+        });
+    });
+
+    describe("getUserMediaStream", () => {
+        beforeEach(() => {
+            // replace this with one that returns a new object each time so we can
+            // tell whether we've ended up with the same stream
+            mockMediaDevices.getUserMedia.mockImplementation((constraints: MediaStreamConstraints) => {
+                const stream = new MockMediaStream("local_stream");
+                if (constraints.audio) {
+                    const track = new MockMediaStreamTrack("audio_track", "audio");
+                    track.settings = { deviceId: FAKE_AUDIO_INPUT_ID };
+                    stream.addTrack(track);
+                }
+                if (constraints.video) {
+                    const track = new MockMediaStreamTrack("video_track", "video");
+                    track.settings = { deviceId: FAKE_VIDEO_INPUT_ID };
+                    stream.addTrack(track);
+                }
+
+                return Promise.resolve(stream.typed());
+            });
+
+            mediaHandler.restoreMediaSettings(FAKE_AUDIO_INPUT_ID, FAKE_VIDEO_INPUT_ID);
+        });
+
+        it("returns the same stream for reusable streams", async () => {
+            const stream1 = await mediaHandler.getUserMediaStream(true, false);
+            const stream2 = await mediaHandler.getUserMediaStream(true, false) as unknown as MockMediaStream;
+
+            expect(stream2.isCloneOf(stream1)).toEqual(true);
+        });
+
+        it("doesn't re-use stream if reusable is false", async () => {
+            const stream1 = await mediaHandler.getUserMediaStream(true, false, false);
+            const stream2 = await mediaHandler.getUserMediaStream(true, false);
+
+            expect(stream1).not.toBe(stream2);
+        });
+    });
+});

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -200,12 +200,9 @@ describe('Media Handler', function() {
             });
 
             it("emits LocalStreamsChanged", async () => {
-                const onLocalStreamsChanged = jest.fn();
-                mediaHandler.on(MediaHandlerEvent.LocalStreamsChanged, onLocalStreamsChanged);
-
                 await mediaHandler.updateLocalUsermediaStreams();
 
-                expect(onLocalStreamsChanged).toHaveBeenCalled();
+                expect(localStreamsChangedHandler).toHaveBeenCalled();
             });
         });
     });

--- a/spec/unit/webrtc/mediaHandler.spec.ts
+++ b/spec/unit/webrtc/mediaHandler.spec.ts
@@ -129,6 +129,7 @@ describe('Media Handler', function() {
 
         describe("with existing streams", () => {
             let stopTrack: jest.Mock<void, []>;
+            let updateLocalUsermediaStream: jest.Mock;
 
             beforeEach(() => {
                 stopTrack = jest.fn();
@@ -140,6 +141,8 @@ describe('Media Handler', function() {
                         } as unknown as MediaStreamTrack],
                     } as unknown as MediaStream,
                 ];
+
+                updateLocalUsermediaStream = jest.fn();
             });
 
             it("stops existing streams", async () => {
@@ -148,8 +151,6 @@ describe('Media Handler', function() {
             });
 
             it("replaces streams on calls", async () => {
-                const updateLocalUsermediaStream = jest.fn();
-
                 calls.set("some_call", {
                     hasLocalUserMediaAudioTrack: true,
                     hasLocalUserMediaVideoTrack: true,
@@ -162,8 +163,6 @@ describe('Media Handler', function() {
             });
 
             it("doesn't replace streams on ended calls", async () => {
-                const updateLocalUsermediaStream = jest.fn();
-
                 calls.set("some_call", {
                     hasLocalUserMediaAudioTrack: true,
                     hasLocalUserMediaVideoTrack: true,
@@ -176,8 +175,6 @@ describe('Media Handler', function() {
             });
 
             it("replaces streams on group calls", async () => {
-                const updateLocalUsermediaStream = jest.fn();
-
                 groupCalls.set("some_group_call", {
                     localCallFeed: {},
                     updateLocalUsermediaStream,
@@ -188,8 +185,6 @@ describe('Media Handler', function() {
             });
 
             it("doesn't replace streams on group calls with no localCallFeed", async () => {
-                const updateLocalUsermediaStream = jest.fn();
-
                 groupCalls.set("some_group_call", {
                     localCallFeed: null,
                     updateLocalUsermediaStream,

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -179,13 +179,28 @@ export class MediaHandler extends TypedEventEmitter<
 
         let stream: MediaStream;
 
-        if (
-            !this.localUserMediaStream ||
-            (this.localUserMediaStream.getAudioTracks().length === 0 && shouldRequestAudio) ||
-            (this.localUserMediaStream.getVideoTracks().length === 0 && shouldRequestVideo) ||
-            (this.localUserMediaStream.getAudioTracks()[0]?.getSettings()?.deviceId !== this.audioInput) ||
-            (this.localUserMediaStream.getVideoTracks()[0]?.getSettings()?.deviceId !== this.videoInput)
-        ) {
+        let canReuseStream = true;
+        if (this.localUserMediaStream) {
+            if (shouldRequestAudio) {
+                if (
+                    this.localUserMediaStream.getAudioTracks().length === 0 ||
+                    this.localUserMediaStream.getAudioTracks()[0]?.getSettings()?.deviceId !== this.audioInput
+                ) {
+                    canReuseStream = false;
+                }
+            }
+            if (shouldRequestVideo) {
+                if (
+                    this.localUserMediaStream.getVideoTracks().length === 0 ||
+                    this.localUserMediaStream.getVideoTracks()[0]?.getSettings()?.deviceId !== this.videoInput) {
+                    canReuseStream = false;
+                }
+            }
+        } else {
+            canReuseStream = false;
+        }
+
+        if (!canReuseStream) {
             const constraints = this.getUserMediaContraints(shouldRequestAudio, shouldRequestVideo);
             stream = await navigator.mediaDevices.getUserMedia(constraints);
             logger.log(`mediaHandler getUserMediaStream streamId ${stream.id} shouldRequestAudio ${

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -181,6 +181,9 @@ export class MediaHandler extends TypedEventEmitter<
 
         let canReuseStream = true;
         if (this.localUserMediaStream) {
+            // This code checks that the device ID is the same as the localUserMediaStream stream, but we update
+            // the localUserMediaStream whenever the device ID changes (apart from when restoring) so it's not
+            // clear why this would ever be different, unless there's a race.
             if (shouldRequestAudio) {
                 if (
                     this.localUserMediaStream.getAudioTracks().length === 0 ||


### PR DESCRIPTION
This was originally test for part of the file, but just adding the rest onto this PR rather than making another one off this one.

Also fixes a bug where streams wouldn't be re-used if only a video or audio stream was requested.

For https://github.com/vector-im/element-call/issues/544

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->