### PR TITLE
Making IgnoredInvites mostly sync.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "another-json": "^0.2.0",
+    "await-lock": "^2.2.2",
     "bs58": "^5.0.0",
     "content-type": "^1.0.4",
     "loglevel": "^1.7.1",

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -341,9 +341,9 @@ export class IgnoredInvites {
      *
      * The result is *not* validated but is guaranteed to be a non-null object.
      *
-     * @returns A non-null object.
+     * @returns A non-null object. NOT validated.
      */
-    private getIgnoreInvitesPolicies(): {[key: string]: any} {
+    private getIgnoreInvitesPolicies(): any {
         return this.getPoliciesAndIgnoreInvitesPolicies().ignoreInvitesPolicies;
     }
 
@@ -361,11 +361,11 @@ export class IgnoredInvites {
 
     /**
      * As `getIgnoreInvitesPolicies` but also return the `POLICIES_ACCOUNT_EVENT_TYPE`
-     * object.
+     * object. Content is NOT validated.
      */
     private getPoliciesAndIgnoreInvitesPolicies():
-        {policies: {[key: string]: any}, ignoreInvitesPolicies: {[key: string]: any}} {
-        let policies: {[key: string]: any} = {};
+        {policies: any, ignoreInvitesPolicies: any} {
+        let policies = {};
         for (const key of [POLICIES_ACCOUNT_EVENT_TYPE.name, POLICIES_ACCOUNT_EVENT_TYPE.altName]) {
             if (!key) {
                 continue;
@@ -377,7 +377,7 @@ export class IgnoredInvites {
             }
         }
 
-        let ignoreInvitesPolicies: {[key: string]: any} = {};
+        let ignoreInvitesPolicies = {};
         let hasIgnoreInvitesPolicies = false;
         for (const key of [IGNORE_INVITES_ACCOUNT_EVENT_KEY.name, IGNORE_INVITES_ACCOUNT_EVENT_KEY.altName]) {
             if (!key) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.13.tgz":
-  version "3.2.13"
-  uid "0109fde93bcc61def851f79826c9384c073b5175"
-  resolved "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.13.tgz#0109fde93bcc61def851f79826c9384c073b5175"
+"@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz":
+  version "3.2.12"
+  uid "0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
+  resolved "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz#0bce3c86f9d36a4984d3c3e07df1c3fb4c679bd9"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,10 +2012,25 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-babel-jest@^29.0.0, babel-jest@^29.1.2:
-  version "29.1.2"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.1.2.tgz#540d3241925c55240fb0c742e3ffc5f33a501978"
-  integrity sha512-IuG+F3HTHryJb7gacC7SQ59A9kO56BctUsT67uJHp1mMCHUOMXpDwOHWGifWqdWVknN2WNkCVQELPjXx0aLJ9Q==
+await-lock@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
+  integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
+
+aws4@^1.8.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+babel-jest@^29.0.0, babel-jest@^29.0.2:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.0.2.tgz#7efde496c07607949e9be499bf277aa1543ded95"
+  integrity sha512-yTu4/WSi/HzarjQtrJSwV+/0maoNt+iP0DmpvFJdv9yY+5BuNle8TbheHzzcSWj5gIHfuhpbLYHWRDYhWKyeKQ==
   dependencies:
     "@jest/transform" "^29.1.2"
     "@types/babel__core" "^7.1.14"


### PR DESCRIPTION
Experience and feedback from https://github.com/matrix-org/matrix-react-sdk/pull/9255 indicates that we cannot integrate an async `IgnoredInvites.getRuleForInvite`. This PR:

- rewrites `getRuleForInvite` to be sync;
- adds some locking within `IgnoredInvites` to avoid race conditions noticed by @t3chguy.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [X] Tests written for new code (and old code if feasible)
* [X] Linter and other CI checks pass
* [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->

Type: task