### PR TITLE
Add a property aggregating all names of a NamespacedValue

### DIFF
--- a/spec/unit/NamespacedValue.spec.ts
+++ b/spec/unit/NamespacedValue.spec.ts
@@ -21,18 +21,21 @@ describe("NamespacedValue", () => {
         const ns = new NamespacedValue("stable", "unstable");
         expect(ns.name).toBe(ns.stable);
         expect(ns.altName).toBe(ns.unstable);
+        expect(ns.names).toEqual([ns.stable, ns.unstable]);
     });
 
     it("should return unstable if there is no stable", () => {
         const ns = new NamespacedValue(null, "unstable");
         expect(ns.name).toBe(ns.unstable);
         expect(ns.altName).toBeFalsy();
+        expect(ns.names).toEqual([ns.unstable]);
     });
 
     it("should have a falsey unstable if needed", () => {
         const ns = new NamespacedValue("stable", null);
         expect(ns.name).toBe(ns.stable);
         expect(ns.altName).toBeFalsy();
+        expect(ns.names).toEqual([ns.stable]);
     });
 
     it("should match against either stable or unstable", () => {
@@ -58,12 +61,14 @@ describe("UnstableValue", () => {
         const ns = new UnstableValue("stable", "unstable");
         expect(ns.name).toBe(ns.unstable);
         expect(ns.altName).toBe(ns.stable);
+        expect(ns.names).toEqual([ns.unstable, ns.stable]);
     });
 
     it("should return unstable if there is no stable", () => {
         const ns = new UnstableValue(null, "unstable");
         expect(ns.name).toBe(ns.unstable);
         expect(ns.altName).toBeFalsy();
+        expect(ns.names).toEqual([ns.unstable]);
     });
 
     it("should not permit falsey unstable values", () => {

--- a/src/NamespacedValue.ts
+++ b/src/NamespacedValue.ts
@@ -41,6 +41,13 @@ export class NamespacedValue<S extends string, U extends string> {
         return this.unstable;
     }
 
+    public get names(): (U | S)[] {
+        const names = [this.name];
+        const altName = this.altName;
+        if (altName) names.push(altName);
+        return names;
+    }
+
     public matches(val: string): boolean {
         return this.name === val || this.altName === val;
     }


### PR DESCRIPTION
For convenience

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add a property aggregating all names of a NamespacedValue ([\#2656](https://github.com/matrix-org/matrix-js-sdk/pull/2656)).<!-- CHANGELOG_PREVIEW_END -->