### PR TITLE
Revert "Add login flow types from matrix-react-sdk (#2633)"

### DIFF
--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -28,61 +28,6 @@ export interface IRefreshTokenResponse {
 
 /* eslint-enable camelcase */
 
-/**
- * Response to GET login flows as per https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3login
- */
-export interface ILoginFlowsResponse {
-    flows: LoginFlow[];
-}
-
-export type LoginFlow = ISSOFlow | IPasswordFlow | ILoginFlow;
-
-export interface ILoginFlow {
-    type: string;
-}
-
-export interface IPasswordFlow extends ILoginFlow {
-    type: "m.login.password";
-}
-
-/**
- * Representation of SSO flow as per https://spec.matrix.org/latest/client-server-api/#client-login-via-sso
- */
-export interface ISSOFlow extends ILoginFlow {
-    type: "m.login.sso" | "m.login.cas";
-    // eslint-disable-next-line camelcase
-    identity_providers?: IIdentityProvider[];
-}
-
-export enum IdentityProviderBrand {
-    Gitlab = "gitlab",
-    Github = "github",
-    Apple = "apple",
-    Google = "google",
-    Facebook = "facebook",
-    Twitter = "twitter",
-}
-
-export interface IIdentityProvider {
-    id: string;
-    name: string;
-    icon?: string;
-    brand?: IdentityProviderBrand | string;
-}
-
-/**
- * Parameters to login request as per https://spec.matrix.org/latest/client-server-api/#login
- */
-/* eslint-disable camelcase */
-export interface ILoginParams {
-    identifier?: object;
-    password?: string;
-    token?: string;
-    device_id?: string;
-    initial_device_display_name?: string;
-}
-/* eslint-enable camelcase */
-
 export enum SSOAction {
     /** The user intends to login to an existing account */
     LOGIN = "login",

--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -28,6 +28,61 @@ export interface IRefreshTokenResponse {
 
 /* eslint-enable camelcase */
 
+/**
+ * Response to GET login flows as per https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3login
+ */
+export interface ILoginFlowsResponse {
+    flows: LoginFlow[];
+}
+
+export type LoginFlow = ISSOFlow | IPasswordFlow | ILoginFlow;
+
+export interface ILoginFlow {
+    type: string;
+}
+
+export interface IPasswordFlow extends ILoginFlow {
+    type: "m.login.password";
+}
+
+/**
+ * Representation of SSO flow as per https://spec.matrix.org/latest/client-server-api/#client-login-via-sso
+ */
+export interface ISSOFlow extends ILoginFlow {
+    type: "m.login.sso" | "m.login.cas";
+    // eslint-disable-next-line camelcase
+    identity_providers?: IIdentityProvider[];
+}
+
+export enum IdentityProviderBrand {
+    Gitlab = "gitlab",
+    Github = "github",
+    Apple = "apple",
+    Google = "google",
+    Facebook = "facebook",
+    Twitter = "twitter",
+}
+
+export interface IIdentityProvider {
+    id: string;
+    name: string;
+    icon?: string;
+    brand?: IdentityProviderBrand | string;
+}
+
+/**
+ * Parameters to login request as per https://spec.matrix.org/latest/client-server-api/#login
+ */
+/* eslint-disable camelcase */
+export interface ILoginParams {
+    identifier?: object;
+    password?: string;
+    token?: string;
+    device_id?: string;
+    initial_device_display_name?: string;
+}
+/* eslint-enable camelcase */
+
 export enum SSOAction {
     /** The user intends to login to an existing account */
     LOGIN = "login",

--- a/src/client.ts
+++ b/src/client.ts
@@ -188,7 +188,7 @@ import { IPusher, IPusherRequest, IPushRules, PushRuleAction, PushRuleKind, Rule
 import { IThreepid } from "./@types/threepids";
 import { CryptoStore } from "./crypto/store/base";
 import { MediaHandler } from "./webrtc/mediaHandler";
-import { ILoginFlowsResponse, IRefreshTokenResponse, SSOAction } from "./@types/auth";
+import { IRefreshTokenResponse, SSOAction } from "./@types/auth";
 import { TypedEventEmitter } from "./models/typed-event-emitter";
 import { ReceiptType } from "./@types/read_receipts";
 import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse, SlidingSync } from "./sliding-sync";
@@ -7080,10 +7080,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * @param {module:client.callback} callback Optional.
-     * @return {Promise<ILoginFlowsResponse>} Resolves to the available login flows
+     * @return {Promise} Resolves: TODO
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
-    public loginFlows(callback?: Callback): Promise<ILoginFlowsResponse> {
+    public loginFlows(callback?: Callback): Promise<any> { // TODO: Types
         return this.http.request(callback, Method.Get, "/login");
     }
 


### PR DESCRIPTION
Partially reverts https://github.com/matrix-org/matrix-js-sdk/pull/2633 due to the required React SDK PR not being ready to land at the same time

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->