### PR TITLE
Fix race in creating calls

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -533,6 +533,7 @@ describe('Group Call', function() {
                 let newCall: MatrixCall;
                 while (
                     (newCall = groupCall1.getCallByUserId(client2.userId)) === undefined ||
+                    newCall.peerConn === undefined ||
                     newCall.callId == oldCall.callId
                 ) {
                     await flushPromises();
@@ -643,6 +644,7 @@ describe('Group Call', function() {
                 groupCall.localCallFeed.setAudioVideoMuted = jest.fn();
                 const setAVMutedArray = groupCall.calls.map(call => {
                     call.localUsermediaFeed.setAudioVideoMuted = jest.fn();
+                    call.localUsermediaFeed.isVideoMuted = jest.fn().mockReturnValue(true);
                     return call.localUsermediaFeed.setAudioVideoMuted;
                 });
                 const tracksArray = groupCall.calls.reduce((acc, call) => {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -856,12 +856,22 @@ export class GroupCall extends TypedEventEmitter<
             },
         );
 
+        if (existingCall) {
+            logger.debug(`Replacing call ${existingCall.callId} to ${member.userId} with ${newCall.callId}`);
+            this.replaceCall(existingCall, newCall, CallErrorCode.NewSession);
+        } else {
+            logger.debug(`Adding call ${newCall.callId} to ${member.userId}`);
+            this.addCall(newCall);
+        }
+
         newCall.isPtt = this.isPtt;
 
         const requestScreenshareFeed = opponentDevice.feeds.some(
             (feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);
 
-        logger.log(`Placing call to ${member.userId}.`);
+        logger.log(
+            `Placing call to ${member.userId}/${opponentDevice.device_id} session ID ${opponentDevice.session_id}.`,
+        );
 
         try {
             await newCall.placeCallWithCallFeeds(
@@ -886,12 +896,6 @@ export class GroupCall extends TypedEventEmitter<
 
         if (this.dataChannelsEnabled) {
             newCall.createDataChannel("datachannel", this.dataChannelOptions);
-        }
-
-        if (existingCall) {
-            this.replaceCall(existingCall, newCall, CallErrorCode.NewSession);
-        } else {
-            this.addCall(newCall);
         }
     };
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -891,6 +891,7 @@ export class GroupCall extends TypedEventEmitter<
                     ),
                 );
             }
+            this.removeCall(newCall, CallErrorCode.SignallingFailed);
             return;
         }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -869,7 +869,7 @@ export class GroupCall extends TypedEventEmitter<
         const requestScreenshareFeed = opponentDevice.feeds.some(
             (feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);
 
-        logger.log(
+        logger.debug(
             `Placing call to ${member.userId}/${opponentDevice.device_id} session ID ${opponentDevice.session_id}.`,
         );
 


### PR DESCRIPTION
We ran an async function between checking for an existing call and adding the new one to the map, so it would have been possible to start creating another call while we were placing the first call. This changes the code to add the call to the map as soon as we've created it.

Also adds more logging.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix race in creating calls ([\#2662](https://github.com/matrix-org/matrix-js-sdk/pull/2662)).<!-- CHANGELOG_PREVIEW_END -->