### PR TITLE
Have setup-node set up the npmrc for NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: "yarn"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: 🔨 Install dependencies
         run: "yarn install --pure-lockfile"


### PR DESCRIPTION
Without this, dist-tag will fail as it did [here](https://github.com/matrix-org/matrix-js-sdk/actions/runs/3044693309/jobs/4905368087)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->