### PR TITLE
Target widget actions at a specific room

### DIFF
--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -24,6 +24,7 @@ import {
     ISendToDeviceToWidgetActionRequest,
 } from "matrix-widget-api";
 
+import type { IEvent, IContent } from "./models/event";
 import { ISendEventResponse } from "./@types/requests";
 import { EventType } from "./@types/event";
 import { logger } from "./logger";
@@ -69,27 +70,30 @@ export class RoomWidgetClient extends MatrixClient {
         super(opts);
 
         // Request capabilities for the functionality this client needs to support
-        this.capabilities.sendState?.forEach(({ eventType, stateKey }) =>
-            this.widgetApi.requestCapabilityToSendState(eventType, stateKey),
+        if (capabilities.sendState?.length || capabilities.receiveState?.length) {
+            widgetApi.requestCapabilityForRoomTimeline(roomId);
+        }
+        capabilities.sendState?.forEach(({ eventType, stateKey }) =>
+            widgetApi.requestCapabilityToSendState(eventType, stateKey),
         );
-        this.capabilities.receiveState?.forEach(({ eventType, stateKey }) =>
-            this.widgetApi.requestCapabilityToReceiveState(eventType, stateKey),
+        capabilities.receiveState?.forEach(({ eventType, stateKey }) =>
+            widgetApi.requestCapabilityToReceiveState(eventType, stateKey),
         );
-        this.capabilities.sendToDevice?.forEach(eventType =>
-            this.widgetApi.requestCapabilityToSendToDevice(eventType),
+        capabilities.sendToDevice?.forEach(eventType =>
+            widgetApi.requestCapabilityToSendToDevice(eventType),
         );
-        this.capabilities.receiveToDevice?.forEach(eventType =>
-            this.widgetApi.requestCapabilityToReceiveToDevice(eventType),
+        capabilities.receiveToDevice?.forEach(eventType =>
+            widgetApi.requestCapabilityToReceiveToDevice(eventType),
         );
-        if (this.capabilities.turnServers) {
-            this.widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
+        if (capabilities.turnServers) {
+            widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
         }
 
-        this.widgetApi.on(`action:${WidgetApiToWidgetAction.SendEvent}`, this.onEvent);
-        this.widgetApi.on(`action:${WidgetApiToWidgetAction.SendToDevice}`, this.onToDevice);
+        widgetApi.on(`action:${WidgetApiToWidgetAction.SendEvent}`, this.onEvent);
+        widgetApi.on(`action:${WidgetApiToWidgetAction.SendToDevice}`, this.onToDevice);
 
         // Open communication with the host
-        this.widgetApi.start();
+        widgetApi.start();
     }
 
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {
@@ -121,8 +125,8 @@ export class RoomWidgetClient extends MatrixClient {
         // so it doesn't really matter what order we inject them in
         await Promise.all(
             this.capabilities.receiveState?.map(async ({ eventType, stateKey }) => {
-                const rawEvents = await this.widgetApi.readStateEvents(eventType, undefined, stateKey);
-                const events = rawEvents.map(rawEvent => new MatrixEvent(rawEvent));
+                const rawEvents = await this.widgetApi.readStateEvents(eventType, undefined, stateKey, [this.roomId]);
+                const events = rawEvents.map(rawEvent => new MatrixEvent(rawEvent as Partial<IEvent>));
 
                 await this.syncApi.injectRoomEvents(this.room, [], events);
                 events.forEach(event => {
@@ -157,8 +161,7 @@ export class RoomWidgetClient extends MatrixClient {
         content: any,
         stateKey = "",
     ): Promise<ISendEventResponse> {
-        if (roomId !== this.roomId) throw new Error(`Can't send events to ${roomId}`);
-        return await this.widgetApi.sendStateEvent(eventType, stateKey, content);
+        return await this.widgetApi.sendStateEvent(eventType, stateKey, content, roomId);
     }
 
     public async sendToDevice(
@@ -215,11 +218,20 @@ export class RoomWidgetClient extends MatrixClient {
 
     private onEvent = async (ev: CustomEvent<ISendEventToWidgetActionRequest>) => {
         ev.preventDefault();
-        const event = new MatrixEvent(ev.detail.data);
-        await this.syncApi.injectRoomEvents(this.room, [], [event]);
-        this.emit(ClientEvent.Event, event);
-        this.setSyncState(SyncState.Syncing);
-        logger.info(`Received event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
+
+        // Verify the room ID matches, since it's possible for the client to
+        // send us events from other rooms if this widget is always on screen
+        if (ev.detail.data.room_id === this.roomId) {
+            const event = new MatrixEvent(ev.detail.data as Partial<IEvent>);
+            await this.syncApi.injectRoomEvents(this.room, [], [event]);
+            this.emit(ClientEvent.Event, event);
+            this.setSyncState(SyncState.Syncing);
+            logger.info(`Received event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
+        } else {
+            const { event_id: eventId, room_id: roomId } = ev.detail.data;
+            logger.info(`Received event ${eventId} for a different room ${roomId}; discarding`);
+        }
+
         await this.ack(ev);
     };
 
@@ -229,7 +241,7 @@ export class RoomWidgetClient extends MatrixClient {
         const event = new MatrixEvent({
             type: ev.detail.data.type,
             sender: ev.detail.data.sender,
-            content: ev.detail.data.content,
+            content: ev.detail.data.content as IContent,
         });
         // Mark the event as encrypted if it was, using fake contents and keys since those are unknown to us
         if (ev.detail.data.encrypted) event.makeEncrypted(EventType.RoomMessageEncrypted, {}, "", "");


### PR DESCRIPTION
Otherwise, the RoomWidgetClient class can end up accidentally sending and receiving events from rooms it didn't intend to, if it's an always-on-screen widget.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Target widget actions at a specific room ([\#2670](https://github.com/matrix-org/matrix-js-sdk/pull/2670)).<!-- CHANGELOG_PREVIEW_END -->