### PR TITLE
Fix ICE restarts

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2025,6 +2025,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         } else if (this.peerConn.iceConnectionState == 'failed') {
             // Firefox for Android does not yet have support for restartIce()
             if (this.peerConn.restartIce) {
+                this.candidatesEnded = false;
                 this.peerConn.restartIce();
             } else {
                 this.hangup(CallErrorCode.IceFailed, false);


### PR DESCRIPTION
We didn't reset the 'seen end of candidates' flag when doign an ICE restart, so we would have ignored all locally gathered candidates on an ICE restart.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix ICE restarts ([\#2702](https://github.com/matrix-org/matrix-js-sdk/pull/2702)).<!-- CHANGELOG_PREVIEW_END -->