### PR TITLE
Fix issue in sync when crypto is not supported by client

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.ts
+++ b/spec/integ/matrix-client-crypto.spec.ts
@@ -132,7 +132,7 @@ async function aliDownloadsKeys(): Promise<void> {
     // check that the localStorage is updated as we expect (not sure this is
     // an integration test, but meh)
     await Promise.all([p1(), p2()]);
-    await aliTestClient.client.crypto.deviceList.saveIfDirty();
+    await aliTestClient.client.crypto!.deviceList.saveIfDirty();
     // @ts-ignore - protected
     aliTestClient.client.cryptoStore.getEndToEndDeviceData(null, (data) => {
         const devices = data.devices[bobUserId];
@@ -494,7 +494,7 @@ describe("MatrixClient crypto", () => {
         aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} }, failures: {} });
         await aliTestClient.start();
         await bobTestClient.start();
-        bobTestClient.client.crypto.deviceList.downloadKeys = () => Promise.resolve({});
+        bobTestClient.client.crypto!.deviceList.downloadKeys = () => Promise.resolve({});
         await firstSync(aliTestClient);
         await aliEnablesEncryption();
         await aliSendsFirstMessage();
@@ -505,7 +505,7 @@ describe("MatrixClient crypto", () => {
         aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} }, failures: {} });
         await aliTestClient.start();
         await bobTestClient.start();
-        bobTestClient.client.crypto.deviceList.downloadKeys = () => Promise.resolve({});
+        bobTestClient.client.crypto!.deviceList.downloadKeys = () => Promise.resolve({});
         await firstSync(aliTestClient);
         await aliEnablesEncryption();
         await aliSendsFirstMessage();
@@ -569,7 +569,7 @@ describe("MatrixClient crypto", () => {
         aliTestClient.expectKeyQuery({ device_keys: { [aliUserId]: {} }, failures: {} });
         await aliTestClient.start();
         await bobTestClient.start();
-        bobTestClient.client.crypto.deviceList.downloadKeys = () => Promise.resolve({});
+        bobTestClient.client.crypto!.deviceList.downloadKeys = () => Promise.resolve({});
         await firstSync(aliTestClient);
         await aliEnablesEncryption();
         await aliSendsFirstMessage();

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -245,21 +245,21 @@ describe("MatrixClient syncing", () => {
                     },
                 },
             };
-            httpBackend.when("GET", "/sync").respond(200, {
+            httpBackend!.when("GET", "/sync").respond(200, {
                 ...syncData,
                 rooms: inviteSyncRoomSection,
             });
 
             // First fire: an initial invite
             let fires = 0;
-            client.once(ClientEvent.Room, (room) => {
+            client!.once(ClientEvent.Room, (room) => {
                 fires++;
                 expect(room.roomId).toBe(roomId);
             });
 
             // noinspection ES6MissingAwait
-            client.startClient();
-            await httpBackend.flushAllExpected();
+            client!.startClient();
+            await httpBackend!.flushAllExpected();
 
             expect(fires).toBe(1);
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -923,7 +923,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public urlPreviewCache: { [key: string]: Promise<IPreviewUrlResponse> } = {};
     public identityServer: IIdentityServerProvider;
     public http: MatrixHttpApi; // XXX: Intended private, used in code.
-    public crypto: Crypto; // XXX: Intended private, used in code.
+    public crypto?: Crypto; // XXX: Intended private, used in code.
     public cryptoCallbacks: ICryptoCallbacks; // XXX: Intended private, used in code.
     public callEventHandler: CallEventHandler; // XXX: Intended private, used in code.
     public supportsCallTransfer = false; // XXX: Intended private, used in code.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1201,7 +1201,7 @@ export class SyncApi {
 
             const inviter = room.currentState.getStateEvents(EventType.RoomMember, client.getUserId())?.getSender();
 
-            if (client.crypto) {
+            if (client.isCryptoEnabled()) {
                 const parkedHistory = await client.crypto.cryptoStore.takeParkedSharedHistory(room.roomId);
                 for (const parked of parkedHistory) {
                     if (parked.senderId === inviter) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1200,19 +1200,22 @@ export class SyncApi {
             await this.processRoomEvents(room, stateEvents);
 
             const inviter = room.currentState.getStateEvents(EventType.RoomMember, client.getUserId())?.getSender();
-            const parkedHistory = await client.crypto.cryptoStore.takeParkedSharedHistory(room.roomId);
-            for (const parked of parkedHistory) {
-                if (parked.senderId === inviter) {
-                    await this.client.crypto.olmDevice.addInboundGroupSession(
-                        room.roomId,
-                        parked.senderKey,
-                        parked.forwardingCurve25519KeyChain,
-                        parked.sessionId,
-                        parked.sessionKey,
-                        parked.keysClaimed,
-                        true,
-                        { sharedHistory: true, untrusted: true },
-                    );
+
+            if (client.crypto) {
+                const parkedHistory = await client.crypto.cryptoStore.takeParkedSharedHistory(room.roomId);
+                for (const parked of parkedHistory) {
+                    if (parked.senderId === inviter) {
+                        await client.crypto.olmDevice.addInboundGroupSession(
+                            room.roomId,
+                            parked.senderKey,
+                            parked.forwardingCurve25519KeyChain,
+                            parked.sessionId,
+                            parked.sessionKey,
+                            parked.keysClaimed,
+                            true,
+                            { sharedHistory: true, untrusted: true },
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
When the Matrix client is initialized without crypto support it now breaks in the sync as starting from matrix-js-sdk 19.7.0 the additional code was added that directly access the client's crypto feature. 

This PR is aimed to fix the issue by introducing the additional check that crypto is actually available before accessing it

Signed-off-by: Stanislav Demydiuk <s.demydiuk@gmail.com>

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issue in sync when crypto is not supported by client ([\#2715](https://github.com/matrix-org/matrix-js-sdk/pull/2715)). Contributed by @stas-demydiuk.<!-- CHANGELOG_PREVIEW_END -->