### PR TITLE
Introduce Membership TS type

### DIFF
--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -6,7 +6,7 @@ import '../olm-loader';
 
 import { logger } from '../../src/logger';
 import { IContent, IEvent, IUnsigned, MatrixEvent, MatrixEventEvent } from "../../src/models/event";
-import { ClientEvent, EventType, IPusher, MatrixClient, MsgType } from "../../src";
+import { ClientEvent, EventType, IPusher, MatrixClient, Membership, MsgType } from "../../src";
 import { SyncState } from "../../src/sync";
 import { eventMapperFor } from "../../src/event-mapper";
 
@@ -180,7 +180,7 @@ export function mkPresence(opts: IPresenceOpts & { event?: boolean }): Partial<I
 
 interface IMembershipOpts {
     room?: string;
-    mship: string;
+    mship: Membership;
     sender?: string;
     user?: string;
     skey?: string;
@@ -226,7 +226,7 @@ export function mkMembership(opts: IMembershipOpts & { event?: boolean }): Parti
 }
 
 export function mkMembershipCustom<T>(
-    base: T & { membership: string, sender: string, content?: IContent },
+    base: T & { membership: Membership, sender: string, content?: IContent },
 ): T & { type: EventType, sender: string, state_key: string, content: IContent } & GeneratedMetadata {
     const content = base.content || {};
     return mkEventCustom({

--- a/src/@types/partials.ts
+++ b/src/@types/partials.ts
@@ -86,3 +86,5 @@ export interface IUsageLimit {
     // eslint-disable-next-line camelcase
     admin_contact?: string;
 }
+
+export type Membership = "ban" | "invite" | "join" | "knock" | "leave" | string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -166,7 +166,7 @@ import {
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
 } from "./@types/event";
-import { IdServerUnbindResult, IImageInfo, Preset, Visibility } from "./@types/partials";
+import { IdServerUnbindResult, IImageInfo, Membership, Preset, Visibility } from "./@types/partials";
 import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper";
 import { randomString } from "./randomstring";
 import { BackupManager, IKeyBackup, IKeyBackupCheck, IPreparedKeyBackupVersion, TrustInfo } from "./crypto/backup";
@@ -633,7 +633,7 @@ export interface IOpenIDToken {
 
 interface IRoomInitialSyncResponse {
     room_id: string;
-    membership: "invite" | "join" | "leave" | "ban";
+    membership: Membership;
     messages?: {
         start?: string;
         end?: string;
@@ -786,7 +786,7 @@ interface IThirdPartyUser {
 
 interface IRoomSummary extends Omit<IPublicRoomsChunkRoom, "canonical_alias" | "aliases"> {
     room_type?: RoomType;
-    membership?: string;
+    membership?: Membership;
     is_encrypted: boolean;
 }
 
@@ -4921,7 +4921,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     private membershipChange(
         roomId: string,
         userId: string | undefined,
-        membership: string,
+        membership: Membership | 'forget',
         reason?: string,
     ): Promise<{}> { // API returns an empty object
         const path = utils.encodeUri("/rooms/$room_id/$membership", {

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -26,6 +26,7 @@ import { RoomState } from "./room-state";
 import { logger } from "../logger";
 import { TypedEventEmitter } from "./typed-event-emitter";
 import { EventType } from "../@types/event";
+import { Membership } from "../@types/partials";
 
 export enum RoomMemberEvent {
     Membership = "RoomMember.membership",
@@ -53,7 +54,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
     public powerLevel = 0;
     public powerLevelNorm = 0;
     public user?: User;
-    public membership?: string;
+    public membership?: Membership;
     public disambiguate = false;
     public events: {
         member?: MatrixEvent;
@@ -78,7 +79,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
      * @prop {Number} powerLevelNorm The normalised power level (0-100) for this
      * room member.
      * @prop {User} user The User object for this room member, if one exists.
-     * @prop {string} membership The membership state for this room member e.g. 'join'.
+     * @prop {Membership} membership The membership state for this room member e.g. 'join'.
      * @prop {Object} events The events describing this RoomMember.
      * @prop {MatrixEvent} events.member The m.room.member event for this RoomMember.
      * @prop {boolean} disambiguate True if the member's name is disambiguated.
@@ -409,7 +410,7 @@ function calculateDisplayName(
  * @event module:client~MatrixClient#"RoomMember.membership"
  * @param {MatrixEvent} event The matrix event which caused this event to fire.
  * @param {RoomMember} member The member whose RoomMember.membership changed.
- * @param {string?} oldMembership The previous membership state. Null if it's a
+ * @param {Membership?} oldMembership The previous membership state. Null if it's a
  *    new member.
  * @example
  * matrixClient.on("RoomMember.membership", function(event, member, oldMembership){


### PR DESCRIPTION
According to the [Matrix Spec](https://spec.matrix.org/v1.4/client-server-api/#room-membership) the room membership is enum with finite numbers of possible states. 

This PR introduces a new typescript type `Membrship` to be able to strictly specify what the exact membership is instead of the generic `string` type. The scope includes:
- New Membership type
- Update type definitions in `Client`, `Room`, `RoomMember` and `EventContent` interfaces
- Update existing conditions to use the new type instead of hardcoded strings
- Update spec files with the new type

Signed-off-by: Stanislav Demydiuk [s.demydiuk@gmail.com](mailto:s.demydiuk@gmail.com)

## Checklist

* [X] Tests written for new code (and old code if feasible) - NA
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))



<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Introduce Membership TS type ([\#2723](https://github.com/matrix-org/matrix-js-sdk/pull/2723)). Contributed by @stas-demydiuk.<!-- CHANGELOG_PREVIEW_END -->