### PR TITLE
Unexpected ignored self key request when it's not shared history

### DIFF
--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1445,8 +1445,8 @@ class MegolmDecryption extends DecryptionAlgorithm {
             const fromUs = event.getSender() === this.baseApis.getUserId();
 
             if (!weRequested && !fromUs) {
-                // If someone sends us an unsolicited key and they're 
-                // not one of our other devices and it's not shared 
+                // If someone sends us an unsolicited key and they're
+                // not one of our other devices and it's not shared
                 // history, ignore it
                 if (!extraSessionData.sharedHistory) {
                     logger.log("forwarded key not shared history - ignoring");

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1444,9 +1444,10 @@ class MegolmDecryption extends DecryptionAlgorithm {
                     memberEvent?.getPrevContent()?.membership === "invite");
             const fromUs = event.getSender() === this.baseApis.getUserId();
 
-            if (!weRequested) {
-                // If someone sends us an unsolicited key and it's not
-                // shared history, ignore it
+            if (!weRequested && !fromUs) {
+                // If someone sends us an unsolicited key and they're 
+                // not one of our other devices and it's not shared 
+                // history, ignore it
                 if (!extraSessionData.sharedHistory) {
                     logger.log("forwarded key not shared history - ignoring");
                     return;
@@ -1455,7 +1456,7 @@ class MegolmDecryption extends DecryptionAlgorithm {
                 // If someone sends us an unsolicited key for a room
                 // we're already in, and they're not one of our other
                 // devices or the one who invited us, ignore it
-                if (room && !fromInviter && !fromUs) {
+                if (room && !fromInviter) {
                     logger.log("forwarded key not from inviter or from us - ignoring");
                     return;
                 }


### PR DESCRIPTION
### Checklist
- [ ] Tests written for new code (and old code if feasible)
- [ ] Linter and other CI checks pass
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

Signed-off-by: maghen.calinghee@beta.gouv.fr

### Step to reproduce the issue
**Scenario 1: Verification of 2 sessions when logging : session A in and session B in**
_Contexte:_
matrix-js-sdk : 20.0.0
matrix-react-sdk : 3.57.0

1. user 1 has already a session opened : session A
2. user 1 is opening a new session by logging : session B
3. on session B, a verification request dialog is opening
4. on session A, a verification dialog is waiting 
5. session B press `Continue`
6. session A displayed the verification process dialog
7. session B displayed the verification process dialog
8. session A press `They match` and waits for session B
9. session B press `They match`, a success dialog is displayed 
10. on session A , a success dialog is displayed 
11. session A press `Got it`
12. session B receive the key and decrypt the messages in a **direct message**
<img width="960" alt="Screenshot 2022-10-03 at 10 38 13" src="https://user-images.githubusercontent.com/3725676/193535306-0d6e092a-df1c-4541-848f-98ae5a7f9848.png">

13. session B **cannot** decrypt the messages in a **room**
<img width="943" alt="Screenshot 2022-10-03 at 10 38 57" src="https://user-images.githubusercontent.com/3725676/193535494-24779b9e-6c02-4bf0-a684-85e0bf3884f1.png">

14. **Re-requesting keys is not working as well**

 => Test Result : KO 🔴 


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Unexpected ignored self key request when it's not shared history ([\#2724](https://github.com/matrix-org/matrix-js-sdk/pull/2724)). Contributed by @mcalinghee.<!-- CHANGELOG_PREVIEW_END -->