### PR TITLE
Use stable calls to `/room_keys`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2700,7 +2700,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         try {
             res = await this.http.authedRequest<IKeyBackupInfo>(
                 undefined, Method.Get, "/room_keys/version", undefined, undefined,
-                { prefix: PREFIX_UNSTABLE },
+                { prefix: PREFIX_V3 },
             );
         } catch (e) {
             if (e.errcode === 'M_NOT_FOUND') {
@@ -2856,7 +2856,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const res = await this.http.authedRequest<IKeyBackupInfo>(
             undefined, Method.Post, "/room_keys/version", undefined, data,
-            { prefix: PREFIX_UNSTABLE },
+            { prefix: PREFIX_V3 },
         );
 
         // We could assume everything's okay and enable directly, but this ensures
@@ -2888,7 +2888,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         return this.http.authedRequest(
             undefined, Method.Delete, path, undefined, undefined,
-            { prefix: PREFIX_UNSTABLE },
+            { prefix: PREFIX_V3 },
         );
     }
 

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -18,7 +18,7 @@ import { logger } from "../logger";
 import { MatrixEvent } from "../models/event";
 import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning";
 import { IndexedDBCryptoStore } from './store/indexeddb-crypto-store';
-import { Method, PREFIX_UNSTABLE } from "../http-api";
+import { Method, PREFIX_UNSTABLE, PREFIX_V3 } from "../http-api";
 import { Crypto, IBootstrapCrossSigningOpts } from "./index";
 import {
     ClientEvent,
@@ -246,14 +246,14 @@ export class EncryptionSetupOperation {
                         algorithm: this.keyBackupInfo.algorithm,
                         auth_data: this.keyBackupInfo.auth_data,
                     },
-                    { prefix: PREFIX_UNSTABLE },
+                    { prefix: PREFIX_V3 },
                 );
             } else {
                 // add new key backup
                 await baseApis.http.authedRequest(
                     undefined, Method.Post, "/room_keys/version",
                     undefined, this.keyBackupInfo,
-                    { prefix: PREFIX_UNSTABLE },
+                    { prefix: PREFIX_V3 },
                 );
             }
         }

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -18,7 +18,7 @@ import { logger } from "../logger";
 import { MatrixEvent } from "../models/event";
 import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning";
 import { IndexedDBCryptoStore } from './store/indexeddb-crypto-store';
-import { Method, PREFIX_UNSTABLE, PREFIX_V3 } from "../http-api";
+import { Method, PREFIX_V3 } from "../http-api";
 import { Crypto, IBootstrapCrossSigningOpts } from "./index";
 import {
     ClientEvent,


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/22839

It's been stable since at least v1.1, and received the `v3` version specifier implying it's even older than that: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3room_keysversion

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Use stable calls to `/room_keys` ([\#2729](https://github.com/matrix-org/matrix-js-sdk/pull/2729)). Fixes vector-im/element-web#22839.<!-- CHANGELOG_PREVIEW_END -->