### PR TITLE
Use the correct sender key when checking shared secret

### DIFF
--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -549,7 +549,7 @@ export class SecretStorage {
 
         const senderKeyUser = this.baseApis.crypto.deviceList.getUserByIdentityKey(
             olmlib.OLM_ALGORITHM,
-            event.getSenderKey(),
+            event.getSenderKey() || "",
         );
         if (senderKeyUser !== event.getSender()) {
             logger.error("sending device does not belong to the user it claims to be from");

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -549,7 +549,7 @@ export class SecretStorage {
 
         const senderKeyUser = this.baseApis.crypto.deviceList.getUserByIdentityKey(
             olmlib.OLM_ALGORITHM,
-            content.sender_key,
+            event.getSenderKey(),
         );
         if (senderKeyUser !== event.getSender()) {
             logger.error("sending device does not belong to the user it claims to be from");


### PR DESCRIPTION
fixes https://github.com/vector-im/element-web/issues/23374

Bug was introduced in the recent security release.

The incorrect code is checking the `sender_key` in the encrypted content, which is normally not set.  It should have been checking the `sender_key` in the cleartext content, or `event.getSenderKey()`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use the correct sender key when checking shared secret ([\#2730](https://github.com/matrix-org/matrix-js-sdk/pull/2730)). Fixes vector-im/element-web#23374.<!-- CHANGELOG_PREVIEW_END -->