### PR TITLE
Fix sync init when thread unread notif is not supported

### DIFF
--- a/spec/unit/feature.spec.ts
+++ b/spec/unit/feature.spec.ts
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { buildFeatureSupportMap, Feature } from "../../src/feature";
+
+describe("Feature detection", () => {
+    it("checks the matrix version", async () => {
+        const support = await buildFeatureSupportMap({
+            versions: ["v1.3"],
+            unstable_features: {},
+        });
+
+        expect(support.get(Feature.Thread)).toBe(true);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(false);
+    });
+
+    it("checks the matrix msc number", async () => {
+        const support = await buildFeatureSupportMap({
+            versions: ["v1.2"],
+            unstable_features: {
+                "org.matrix.msc3771": true,
+                "org.matrix.msc3773": true,
+            },
+        });
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(true);
+    });
+
+    it("requires two MSCs to pass", async () => {
+        const support = await buildFeatureSupportMap({
+            versions: ["v1.2"],
+            unstable_features: {
+                "org.matrix.msc3771": false,
+                "org.matrix.msc3773": true,
+            },
+        });
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(false);
+    });
+
+    it("requires two MSCs OR matrix versions to pass", async () => {
+        const support = await buildFeatureSupportMap({
+            versions: ["v1.4"],
+            unstable_features: {
+                "org.matrix.msc3771": false,
+                "org.matrix.msc3773": true,
+            },
+        });
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(true);
+    });
+});

--- a/spec/unit/feature.spec.ts
+++ b/spec/unit/feature.spec.ts
@@ -35,7 +35,7 @@ describe("Feature detection", () => {
                 "org.matrix.msc3773": true,
             },
         });
-        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Experimental);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Unstable);
     });
 
     it("requires two MSCs to pass", async () => {

--- a/spec/unit/feature.spec.ts
+++ b/spec/unit/feature.spec.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { buildFeatureSupportMap, Feature } from "../../src/feature";
+import { buildFeatureSupportMap, Feature, ServerSupport } from "../../src/feature";
 
 describe("Feature detection", () => {
     it("checks the matrix version", async () => {
@@ -23,8 +23,8 @@ describe("Feature detection", () => {
             unstable_features: {},
         });
 
-        expect(support.get(Feature.Thread)).toBe(true);
-        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(false);
+        expect(support.get(Feature.Thread)).toBe(ServerSupport.Stable);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Unsupported);
     });
 
     it("checks the matrix msc number", async () => {
@@ -35,7 +35,7 @@ describe("Feature detection", () => {
                 "org.matrix.msc3773": true,
             },
         });
-        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(true);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Experimental);
     });
 
     it("requires two MSCs to pass", async () => {
@@ -46,7 +46,7 @@ describe("Feature detection", () => {
                 "org.matrix.msc3773": true,
             },
         });
-        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(false);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Unsupported);
     });
 
     it("requires two MSCs OR matrix versions to pass", async () => {
@@ -57,6 +57,6 @@ describe("Feature detection", () => {
                 "org.matrix.msc3773": true,
             },
         });
-        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(true);
+        expect(support.get(Feature.ThreadUnreadNotifications)).toBe(ServerSupport.Stable);
     });
 });

--- a/spec/unit/filter.spec.ts
+++ b/spec/unit/filter.spec.ts
@@ -1,3 +1,4 @@
+import { UNREAD_THREAD_NOTIFICATIONS } from "../../src/@types/sync";
 import { Filter, IFilterDefinition } from "../../src/filter";
 
 describe("Filter", function() {
@@ -50,7 +51,7 @@ describe("Filter", function() {
             expect(filter.getDefinition()).toEqual({
                 room: {
                     timeline: {
-                        unread_thread_notifications: true,
+                        [UNREAD_THREAD_NOTIFICATIONS.name]: true,
                     },
                 },
             });

--- a/src/@types/sync.ts
+++ b/src/@types/sync.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { UnstableValue } from "matrix-events-sdk/lib/NamespacedValue";
+import { ServerControlledNamespacedValue } from "../NamespacedValue";
 
 /**
  * https://github.com/matrix-org/matrix-doc/pull/3773
  *
  * @experimental
  */
-export const UNREAD_THREAD_NOTIFICATIONS = new UnstableValue(
+export const UNREAD_THREAD_NOTIFICATIONS = new ServerControlledNamespacedValue(
     "unread_thread_notifications",
     "org.matrix.msc3773.unread_thread_notifications");

--- a/src/client.ts
+++ b/src/client.ts
@@ -204,10 +204,8 @@ import { MAIN_ROOM_TIMELINE } from "./models/read-receipt";
 import { IgnoredInvites } from "./models/invites-ignorer";
 import { UIARequest, UIAResponse } from "./@types/uia";
 import { LocalNotificationSettings } from "./@types/local_notifications";
-import { ServerSupport } from "./feature";
-import { Feature } from "./feature";
-import { buildFeatureSupportMap } from "./feature";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
+import { buildFeatureSupportMap, Feature, ServerSupport } from "./feature";
 
 export type Store = IStore;
 
@@ -1207,7 +1205,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.canSupport = await buildFeatureSupportMap(serverVersions);
 
         const support = this.canSupport.get(Feature.ThreadUnreadNotifications);
-        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(support === ServerSupport.Experimental);
+        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(support === ServerSupport.Unstable);
 
         const { threads, list } = await this.doesServerSupportThread();
         Thread.setServerSideSupport(threads);

--- a/src/client.ts
+++ b/src/client.ts
@@ -204,7 +204,10 @@ import { MAIN_ROOM_TIMELINE } from "./models/read-receipt";
 import { IgnoredInvites } from "./models/invites-ignorer";
 import { UIARequest, UIAResponse } from "./@types/uia";
 import { LocalNotificationSettings } from "./@types/local_notifications";
-import { buildFeatureSupportMap, Feature } from "./feature";
+import { ServerSupport } from "./feature";
+import { Feature } from "./feature";
+import { buildFeatureSupportMap } from "./feature";
+import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
 
 export type Store = IStore;
 
@@ -968,7 +971,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected clientWellKnownIntervalID: ReturnType<typeof setInterval>;
     protected canResetTimelineCallback: ResetTimelineCallback;
 
-    public canSupport = new Map<Feature, boolean>();
+    public canSupport = new Map<Feature, ServerSupport>();
 
     // The pushprocessor caches useful things, so keep one and re-use it
     protected pushProcessor = new PushProcessor(this);
@@ -1202,6 +1205,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const serverVersions = await this.getVersions();
         this.canSupport = await buildFeatureSupportMap(serverVersions);
+
+        const support = this.canSupport.get(ServerSupport.ThreadUnreadNotifications);
+        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(support === ServerSupport.Experimental);
 
         const { threads, list } = await this.doesServerSupportThread();
         Thread.setServerSideSupport(threads);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1206,7 +1206,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const serverVersions = await this.getVersions();
         this.canSupport = await buildFeatureSupportMap(serverVersions);
 
-        const support = this.canSupport.get(ServerSupport.ThreadUnreadNotifications);
+        const support = this.canSupport.get(Feature.ThreadUnreadNotifications);
         UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(support === ServerSupport.Experimental);
 
         const { threads, list } = await this.doesServerSupportThread();

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IServerVersions } from "./client";
+
+export enum Feature {
+    Thread = "Thread",
+    ThreadUnreadNotifications = "ThreadUnreadNotifications",
+}
+
+type FeatureSupportCondition = {
+    unstablePrefixes?: string[];
+    matrixVersion?: string;
+};
+
+const featureSupportResolver: Record<string, FeatureSupportCondition> = {
+    [Feature.Thread]: {
+        unstablePrefixes: ["org.matrix.msc3440"],
+        matrixVersion: "v1.3",
+    },
+    [Feature.ThreadUnreadNotifications]: {
+        unstablePrefixes: ["org.matrix.msc3771", "org.matrix.msc3773"],
+        matrixVersion: "v1.4",
+    },
+};
+
+export async function buildFeatureSupportMap(versions: IServerVersions): Promise<Map<Feature, boolean>> {
+    const supportMap = new Map<Feature, boolean>();
+
+    for (const [feature, supportCondition] of Object.entries(featureSupportResolver)) {
+        const supportUnstablePrefixes = supportCondition.unstablePrefixes?.every(unstablePrefix => {
+            return versions.unstable_features?.[unstablePrefix] === true;
+        }) ?? false;
+
+        const supportMatrixVersion = versions.versions?.includes(supportCondition.matrixVersion) ?? false;
+        supportMap.set(
+            feature as Feature,
+            supportUnstablePrefixes || supportMatrixVersion,
+        );
+    }
+
+    return supportMap;
+}

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -45,7 +45,7 @@ export async function buildFeatureSupportMap(versions: IServerVersions): Promise
             return versions.unstable_features?.[unstablePrefix] === true;
         }) ?? false;
 
-        const supportMatrixVersion = versions.versions?.includes(supportCondition.matrixVersion) ?? false;
+        const supportMatrixVersion = versions.versions?.includes(supportCondition.matrixVersion || "") ?? false;
         supportMap.set(
             feature as Feature,
             supportUnstablePrefixes || supportMatrixVersion,

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -18,7 +18,7 @@ import { IServerVersions } from "./client";
 
 export enum ServerSupport {
     Stable,
-    Experimental,
+    Unstable,
     Unsupported
 }
 
@@ -53,7 +53,7 @@ export async function buildFeatureSupportMap(versions: IServerVersions): Promise
         if (supportMatrixVersion) {
             supportMap.set(feature as Feature, ServerSupport.Stable);
         } else if (supportUnstablePrefixes) {
-            supportMap.set(feature as Feature, ServerSupport.Experimental);
+            supportMap.set(feature as Feature, ServerSupport.Unstable);
         } else {
             supportMap.set(feature as Feature, ServerSupport.Unsupported);
         }

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -73,7 +73,7 @@ export interface IFilterComponent {
  * @param {Object} filterJson the definition of this filter JSON, e.g. { 'contains_url': true }
  */
 export class FilterComponent {
-    constructor(private filterJson: IFilterComponent, public readonly userId?: string) {}
+    constructor(private filterJson: IFilterComponent, public readonly userId?: string | undefined) {}
 
     /**
      * Checks with the filter component matches the given event

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -73,7 +73,7 @@ export interface IFilterComponent {
  * @param {Object} filterJson the definition of this filter JSON, e.g. { 'contains_url': true }
  */
 export class FilterComponent {
-    constructor(private filterJson: IFilterComponent, public readonly userId?: string | undefined) {}
+    constructor(private filterJson: IFilterComponent, public readonly userId?: string | undefined | undefined) {}
 
     /**
      * Checks with the filter component matches the given event

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -73,7 +73,7 @@ export interface IFilterComponent {
  * @param {Object} filterJson the definition of this filter JSON, e.g. { 'contains_url': true }
  */
 export class FilterComponent {
-    constructor(private filterJson: IFilterComponent, public readonly userId?: string | undefined | undefined) {}
+    constructor(private filterJson: IFilterComponent, public readonly userId?: string | undefined | null) {}
 
     /**
      * Checks with the filter component matches the given event

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -99,7 +99,7 @@ export class Filter {
      * @param {Object} jsonObj
      * @return {Filter}
      */
-    public static fromJson(userId: string, filterId: string, jsonObj: IFilterDefinition): Filter {
+    public static fromJson(userId: string | undefined | null, filterId: string, jsonObj: IFilterDefinition): Filter {
         const filter = new Filter(userId, filterId);
         filter.setDefinition(jsonObj);
         return filter;
@@ -109,7 +109,7 @@ export class Filter {
     private roomFilter: FilterComponent;
     private roomTimelineFilter: FilterComponent;
 
-    constructor(public readonly userId: string | undefined, public filterId?: string) {}
+    constructor(public readonly userId: string | undefined | null, public filterId?: string) {}
 
     /**
      * Get the ID of this filter on your homeserver (if known)

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -22,6 +22,7 @@ import {
     EventType,
     RelationType,
 } from "./@types/event";
+import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
 import { FilterComponent, IFilterComponent } from "./filter-component";
 import { MatrixEvent } from "./models/event";
 
@@ -227,7 +228,16 @@ export class Filter {
      * @param {boolean} enabled
      */
     public setUnreadThreadNotifications(enabled: boolean): void {
-        setProp(this.definition, "room.timeline.unread_thread_notifications", !!enabled);
+        this.definition = {
+            ...this.definition,
+            room: {
+                ...this.definition?.room,
+                timeline: {
+                    ...this.definition?.room?.timeline,
+                    [UNREAD_THREAD_NOTIFICATIONS.name]: !!enabled,
+                },
+            },
+        };
     }
 
     setLazyLoadMembers(enabled: boolean): void {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -109,7 +109,7 @@ export class Filter {
     private roomFilter: FilterComponent;
     private roomTimelineFilter: FilterComponent;
 
-    constructor(public readonly userId: string, public filterId?: string) {}
+    constructor(public readonly userId: string | undefined, public filterId?: string) {}
 
     /**
      * Get the ID of this filter on your homeserver (if known)

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -227,7 +227,7 @@ export class MemoryStore implements IStore {
      * @param {Filter} filter
      */
     public storeFilter(filter: Filter): void {
-        if (!filter) {
+        if (!filter || !filter.userId) {
             return;
         }
         if (!this.filters[filter.userId]) {

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -227,7 +227,7 @@ export class MemoryStore implements IStore {
      * @param {Filter} filter
      */
     public storeFilter(filter: Filter): void {
-        if (!filter || !filter.userId) {
+        if (!filter?.userId) {
             return;
         }
         if (!this.filters[filter.userId]) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -59,7 +59,7 @@ import { BeaconEvent } from "./models/beacon";
 import { IEventsResponse } from "./@types/requests";
 import { IAbortablePromise } from "./@types/partials";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
-import { Feature } from "./feature";
+import { Feature, ServerSupport } from "./feature";
 
 const DEBUG = true;
 
@@ -564,7 +564,7 @@ export class SyncApi {
 
     private buildDefaultFilter = () => {
         const filter = new Filter(this.client.credentials.userId);
-        if (this.client.canSupport.get(Feature.ThreadUnreadNotifications)) {
+        if (this.client.canSupport.get(Feature.ThreadUnreadNotifications) !== ServerSupport.Unsupported) {
             filter.setUnreadThreadNotifications(true);
         }
         return filter;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -59,6 +59,7 @@ import { BeaconEvent } from "./models/beacon";
 import { IEventsResponse } from "./@types/requests";
 import { IAbortablePromise } from "./@types/partials";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
+import { Feature } from "./feature";
 
 const DEBUG = true;
 
@@ -562,7 +563,11 @@ export class SyncApi {
     };
 
     private buildDefaultFilter = () => {
-        return new Filter(this.client.credentials.userId);
+        const filter = new Filter(this.client.credentials.userId);
+        if (this.client.canSupport.get(Feature.ThreadUnreadNotifications)) {
+            filter.setUnreadThreadNotifications(true);
+        }
+        return filter;
     };
 
     private checkLazyLoadStatus = async () => {
@@ -706,10 +711,6 @@ export class SyncApi {
                 const initialFilter = this.buildDefaultFilter();
                 initialFilter.setDefinition(filter.getDefinition());
                 initialFilter.setTimelineLimit(this.opts.initialSyncLimit);
-                const supportsThreadNotifications =
-                    await this.client.doesServerSupportUnstableFeature("org.matrix.msc3773")
-                 || await this.client.isVersionSupported("v1.4");
-                initialFilter.setUnreadThreadNotifications(supportsThreadNotifications);
                 // Use an inline filter, no point uploading it for a single usage
                 firstSyncFilter = JSON.stringify(initialFilter.getDefinition());
             }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23435

Creates a solution to detect features available on a given homeserver.
Developers can now document what matrix version will support a feature as well as the unstable prefixes. This code path is then accessible synchronously

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix sync init when thread unread notif is not supported ([\#2739](https://github.com/matrix-org/matrix-js-sdk/pull/2739)). Fixes vector-im/element-web#23435.<!-- CHANGELOG_PREVIEW_END -->