### PR TITLE
Correct the dir parameter of MSC3715

### DIFF
--- a/spec/integ/matrix-client-relations.spec.ts
+++ b/spec/integ/matrix-client-relations.spec.ts
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 Dominik Henneke
+Copyright 2022 Nordeck IT + Consulting GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import HttpBackend from "matrix-mock-request";
+
+import { Direction, MatrixClient, MatrixScheduler } from "../../src/matrix";
+import { TestClient } from "../TestClient";
+
+describe("MatrixClient relations", () => {
+    const userId = "@alice:localhost";
+    const accessToken = "aseukfgwef";
+    const roomId = "!room:here";
+    let client: MatrixClient | undefined;
+    let httpBackend: HttpBackend | undefined;
+
+    const setupTests = (): [MatrixClient, HttpBackend] => {
+        const scheduler = new MatrixScheduler();
+        const testClient = new TestClient(
+            userId,
+            "DEVICE",
+            accessToken,
+            undefined,
+            { scheduler },
+        );
+        const httpBackend = testClient.httpBackend;
+        const client = testClient.client;
+
+        return [client, httpBackend];
+    };
+
+    beforeEach(() => {
+        [client, httpBackend] = setupTests();
+    });
+
+    afterEach(() => {
+        httpBackend!.verifyNoOutstandingExpectation();
+        return httpBackend!.stop();
+    });
+
+    it("should read related events with the default options", async () => {
+        const response = client!.relations(roomId, '$event-0', null, null);
+
+        httpBackend!
+            .when("GET", "/rooms/!room%3Ahere/relations/%24event-0?dir=b")
+            .respond(200, { chunk: [], next_batch: 'NEXT' });
+
+        await httpBackend!.flushAllExpected();
+
+        expect(await response).toEqual({ "events": [], "nextBatch": "NEXT" });
+    });
+
+    it("should read related events with relation type", async () => {
+        const response = client!.relations(roomId, '$event-0', 'm.reference', null);
+
+        httpBackend!
+            .when("GET", "/rooms/!room%3Ahere/relations/%24event-0/m.reference?dir=b")
+            .respond(200, { chunk: [], next_batch: 'NEXT' });
+
+        await httpBackend!.flushAllExpected();
+
+        expect(await response).toEqual({ "events": [], "nextBatch": "NEXT" });
+    });
+
+    it("should read related events with relation type and event type", async () => {
+        const response = client!.relations(roomId, '$event-0', 'm.reference', 'm.room.message');
+
+        httpBackend!
+            .when(
+                "GET",
+                "/rooms/!room%3Ahere/relations/%24event-0/m.reference/m.room.message?dir=b",
+            )
+            .respond(200, { chunk: [], next_batch: 'NEXT' });
+
+        await httpBackend!.flushAllExpected();
+
+        expect(await response).toEqual({ "events": [], "nextBatch": "NEXT" });
+    });
+
+    it("should read related events with custom options", async () => {
+        const response = client!.relations(roomId, '$event-0', null, null, {
+            dir: Direction.Forward,
+            from: 'FROM',
+            limit: 10,
+            to: 'TO',
+        });
+
+        httpBackend!
+            .when(
+                "GET",
+                "/rooms/!room%3Ahere/relations/%24event-0?dir=f&from=FROM&limit=10&to=TO",
+            )
+            .respond(200, { chunk: [], next_batch: 'NEXT' });
+
+        await httpBackend!.flushAllExpected();
+
+        expect(await response).toEqual({ "events": [], "nextBatch": "NEXT" });
+    });
+});

--- a/spec/integ/matrix-client-relations.spec.ts
+++ b/spec/integ/matrix-client-relations.spec.ts
@@ -109,4 +109,19 @@ describe("MatrixClient relations", () => {
 
         expect(await response).toEqual({ "events": [], "nextBatch": "NEXT" });
     });
+
+    it('should use default direction in the fetchRelations endpoint', async () => {
+        const response = client!.fetchRelations(roomId, '$event-0', null, null);
+
+        httpBackend!
+            .when(
+                "GET",
+                "/rooms/!room%3Ahere/relations/%24event-0?dir=b",
+            )
+            .respond(200, { chunk: [], next_batch: 'NEXT' });
+
+        await httpBackend!.flushAllExpected();
+
+        expect(await response).toEqual({ "chunk": [], "next_batch": "NEXT" });
+    });
 });

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -160,7 +160,7 @@ export interface IRelationsRequestOpts {
     from?: string;
     to?: string;
     limit?: number;
-    direction?: Direction;
+    dir?: Direction;
 }
 
 export interface IRelationsResponse {

--- a/src/client.ts
+++ b/src/client.ts
@@ -5399,7 +5399,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             if (Thread.hasServerSideSupport && timelineSet.thread) {
                 const thread = timelineSet.thread;
                 const opts: IRelationsRequestOpts = {
-                    direction: Direction.Backward,
+                    dir: Direction.Backward,
                     limit: 50,
                 };
 
@@ -6920,7 +6920,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         eventId: string,
         relationType?: RelationType | string | null,
         eventType?: EventType | string | null,
-        opts: IRelationsRequestOpts = { direction: Direction.Backward },
+        opts: IRelationsRequestOpts = { dir: Direction.Backward },
     ): Promise<{
         originalEvent: MatrixEvent;
         events: MatrixEvent[];
@@ -7498,7 +7498,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         eventId: string,
         relationType?: RelationType | string | null,
         eventType?: EventType | string | null,
-        opts: IRelationsRequestOpts = { direction: Direction.Backward },
+        opts: IRelationsRequestOpts = { dir: Direction.Backward },
     ): Promise<IRelationsResponse> {
         const queryString = utils.encodeParams(opts as Record<string, string | number>);
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -406,7 +406,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         return this.timelineSet.getLiveTimeline();
     }
 
-    public async fetchEvents(opts: IRelationsRequestOpts = { limit: 20, direction: Direction.Backward }): Promise<{
+    public async fetchEvents(opts: IRelationsRequestOpts = { limit: 20, dir: Direction.Backward }): Promise<{
         originalEvent: MatrixEvent;
         events: MatrixEvent[];
         nextBatch?: string | null;
@@ -438,7 +438,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
             return this.client.decryptEventIfNeeded(event);
         }));
 
-        const prependEvents = (opts.direction ?? Direction.Backward) === Direction.Backward;
+        const prependEvents = (opts.dir ?? Direction.Backward) === Direction.Backward;
 
         this.timelineSet.addEventsToTimeline(
             events,


### PR DESCRIPTION
The implementation of [MSC3715](https://github.com/matrix-org/matrix-doc/pull/3715) was stabilized in [synapse](https://github.com/matrix-org/synapse/issues/13919) and we might want to use the new parameter. Note that the old name `direction` was always wrong and never worked so I don't think we need the fallback to the prefixed version. This change would also need a PR at the react-sdk but there only seems to be a [single usage](https://github.com/matrix-org/matrix-react-sdk/blob/cf029c51dc466db448c7324d3dda1fa484a9f3ee/src/stores/widgets/StopGapWidgetDriver.ts#L452). If you accept this change I can do a second PR to update it. I assume merging would need to be coordinated to not break the build(?).

An alternative could be to keep the name `direction` in the interface and convert it to `dir` when adding it to the query params. That wouldn't require a potential breaking change and a change in a downstream project. Let me know if you would prefer that solution.

I added some primitive tests that only focus on the HTTP calls and not on the actual behavior of the relations function.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Correct the dir parameter of MSC3715 ([\#2745](https://github.com/matrix-org/matrix-js-sdk/pull/2745)). Contributed by @dhenneke.<!-- CHANGELOG_PREVIEW_END -->