### PR TITLE
Improve MatrixError message

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -121,7 +121,7 @@ describe("MatrixClient", function() {
             }, function(error) {
                 expect(error.httpStatus).toEqual(400);
                 expect(error.errcode).toEqual("M_SNAFU");
-                expect(error.message).toEqual("broken");
+                expect(error.message).toEqual("MatrixError: [400] broken");
             });
 
             httpBackend!.flush('');

--- a/src/http-api/errors.ts
+++ b/src/http-api/errors.ts
@@ -37,11 +37,17 @@ export class MatrixError extends Error {
     public readonly errcode?: string;
     public readonly data: IErrorJson;
 
-    constructor(errorJson: IErrorJson = {}, public httpStatus?: number) {
-        super(`MatrixError: ${errorJson.errcode}`);
+    constructor(errorJson: IErrorJson = {}, public httpStatus?: number, public url?: string) {
+        let message = errorJson.error || "Unknown message";
+        if (httpStatus) {
+            message = `[${httpStatus}] ${message}`;
+        }
+        if (url) {
+            message = `${message} (${url})`;
+        }
+        super(`MatrixError: ${message}`);
         this.errcode = errorJson.errcode;
         this.name = errorJson.errcode || "Unknown error code";
-        this.message = errorJson.error || "Unknown message";
         this.data = errorJson;
     }
 }

--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -80,7 +80,11 @@ export function parseErrorResponse(response: XMLHttpRequest | Response, body?: s
     }
 
     if (contentType?.type === "application/json" && body) {
-        return new MatrixError(JSON.parse(body), response.status);
+        return new MatrixError(
+            JSON.parse(body),
+            response.status,
+            isXhr(response) ? response.responseURL : response.url,
+        );
     }
     if (contentType?.type === "text/plain") {
         return new Error(`Server returned ${response.status} error: ${body}`);


### PR DESCRIPTION
Unfortunately `fetch` also does not maintain stack traces, so errors are super opaque without this

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->