### PR TITLE
Export types for MatrixEvent and Room emitted events, and make event handler map types stricter

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -188,7 +188,7 @@ export enum MatrixEventEvent {
     RelationsCreated = "Event.relationsCreated",
 }
 
-type EmittedEvents = MatrixEventEvent | ThreadEvent.Update;
+export type MatrixEventEmittedEvents = MatrixEventEvent | ThreadEvent.Update;
 
 export type MatrixEventHandlerMap = {
     [MatrixEventEvent.Decrypted]: (event: MatrixEvent, err?: Error) => void;
@@ -198,9 +198,9 @@ export type MatrixEventHandlerMap = {
     [MatrixEventEvent.Status]: (event: MatrixEvent, status: EventStatus | null) => void;
     [MatrixEventEvent.Replaced]: (event: MatrixEvent) => void;
     [MatrixEventEvent.RelationsCreated]: (relationType: string, eventType: string) => void;
-} & ThreadEventHandlerMap;
+} & Pick<ThreadEventHandlerMap, ThreadEvent.Update>;
 
-export class MatrixEvent extends TypedEventEmitter<EmittedEvents, MatrixEventHandlerMap> {
+export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, MatrixEventHandlerMap> {
     private pushActions: IActionsObject | null = null;
     private _replacingEvent: MatrixEvent | null = null;
     private _localRedactionEvent: MatrixEvent | null = null;
@@ -283,7 +283,7 @@ export class MatrixEvent extends TypedEventEmitter<EmittedEvents, MatrixEventHan
      */
     public verificationRequest?: VerificationRequest;
 
-    private readonly reEmitter: TypedReEmitter<EmittedEvents, MatrixEventHandlerMap>;
+    private readonly reEmitter: TypedReEmitter<MatrixEventEmittedEvents, MatrixEventHandlerMap>;
 
     /**
      * Construct a Matrix Event object


### PR DESCRIPTION
- Fix the event handler map for Room and MatrixEvent to contain only items for events that can be emitted (based on EmittedEvents type)
- Export emitted events type for Room and MatrixEvent so they can be used in client apps

Signed-off-by: Stanislav Demydiuk [s.demydiuk@gmail.com](mailto:s.demydiuk@gmail.com)

## Checklist

* [x] Tests written for new code (and old code if feasible) - Not applicable
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Export types for MatrixEvent and Room emitted events, and make event handler map types stricter ([\#2750](https://github.com/matrix-org/matrix-js-sdk/pull/2750)). Contributed by @stas-demydiuk.<!-- CHANGELOG_PREVIEW_END -->