### PR TITLE
Remove deprecated `m.room.aliases` references

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -33,10 +33,6 @@ export enum EventType {
     RoomGuestAccess = "m.room.guest_access",
     RoomServerAcl = "m.room.server_acl",
     RoomTombstone = "m.room.tombstone",
-    /**
-     * @deprecated Should not be used.
-     */
-    RoomAliases = "m.room.aliases", // deprecated https://matrix.org/docs/spec/client_server/r0.6.1#historical-events
 
     SpaceChild = "m.space.child",
     SpaceParent = "m.space.parent",

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1585,7 +1585,6 @@ const REDACT_KEEP_CONTENT_MAP = {
         'kick': 1, 'redact': 1, 'state_default': 1,
         'users': 1, 'users_default': 1,
     },
-    [EventType.RoomAliases]: { 'aliases': 1 },
 };
 
 /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1372,35 +1372,6 @@ export class Room extends ReadReceipt<EmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
-     * Get the aliases this room has according to the room's state
-     * The aliases returned by this function may not necessarily
-     * still point to this room.
-     * @return {array} The room's alias as an array of strings
-     * @deprecated this uses m.room.aliases events, replaced by Room::getAltAliases()
-     */
-    public getAliases(): string[] {
-        const aliasStrings: string[] = [];
-
-        const aliasEvents = this.currentState.getStateEvents(EventType.RoomAliases);
-        if (aliasEvents) {
-            for (const aliasEvent of aliasEvents) {
-                if (Array.isArray(aliasEvent.getContent().aliases)) {
-                    const filteredAliases = aliasEvent.getContent<{ aliases: string[] }>().aliases.filter(a => {
-                        if (typeof(a) !== "string") return false;
-                        if (a[0] !== '#') return false;
-                        if (!a.endsWith(`:${aliasEvent.getStateKey()}`)) return false;
-
-                        // It's probably valid by here.
-                        return true;
-                    });
-                    aliasStrings.push(...filteredAliases);
-                }
-            }
-        }
-        return aliasStrings;
-    }
-
-    /**
      * Get this room's canonical alias
      * The alias returned by this function may not necessarily
      * still point to this room.


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/12680
Requires https://github.com/matrix-org/matrix-react-sdk/pull/9431

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Remove deprecated `m.room.aliases` references ([\#2759](https://github.com/matrix-org/matrix-js-sdk/pull/2759)). Fixes vector-im/element-web#12680.<!-- CHANGELOG_PREVIEW_END -->