### PR TITLE
Fix IdentityPrefix.V2 containing spurious `/api`

### DIFF
--- a/src/http-api/prefix.ts
+++ b/src/http-api/prefix.ts
@@ -42,7 +42,7 @@ export enum IdentityPrefix {
     /**
      * URI path for the v2 identity API
      */
-    V2 = "/_matrix/identity/api/v2",
+    V2 = "/_matrix/identity/v2",
 }
 
 export enum MediaPrefix {


### PR DESCRIPTION
Testing the value of an enum is not sensible, a future end-to-end test involving a mock mail server and a sydent instance is planned.

Fixes https://github.com/vector-im/element-web/issues/23505

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix IdentityPrefix.V2 containing spurious `/api` ([\#2761](https://github.com/matrix-org/matrix-js-sdk/pull/2761)). Fixes vector-im/element-web#23505.<!-- CHANGELOG_PREVIEW_END -->