### PR TITLE
Re-emit unread notifs

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1813,6 +1813,7 @@ export function _createAndReEmitRoom(client: MatrixClient, roomId: string, opts:
         RoomEvent.MyMembership,
         RoomEvent.Timeline,
         RoomEvent.TimelineReset,
+        RoomEvent.UnreadNotifications,
         RoomStateEvent.Events,
         RoomStateEvent.Members,
         RoomStateEvent.NewMember,


### PR DESCRIPTION
This is required for sliding sync because currently the proxy does not send read receipts, which would otherwise update the unread counts. Without this, when you read a room (setting the counter to 0) on a different device, it does not live update. Needs react SDK changes as well.

Notes: Re-emit RoomEvent.UnreadNotifications

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Re-emit RoomEvent.UnreadNotifications ([\#2765](https://github.com/matrix-org/matrix-js-sdk/pull/2765)).<!-- CHANGELOG_PREVIEW_END -->