### PR TITLE
Remove incorrect comment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2244,8 +2244,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * See getCryptoTrustCrossSignedDevices
-
-     * This may be set before initCrypto() is called to ensure no races occur.
      *
      * @param {boolean} val True to trust cross-signed devices
      */


### PR DESCRIPTION
A trivial fix I happened to notice: as with most of the crypto functionality, `setCryptoTrustCrossSignedDevices` cannot be called until after `initCrypto`. We don't call this out for any of the other entrypoints so I haven't done so here either.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->