### PR TITLE
Fix to keep locally computed thread notifications

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2649,8 +2649,8 @@ describe("Room", function() {
 
             room.resetThreadUnreadNotificationCount(["123"]);
 
-            expect(room.getThreadUnreadNotificationCount("123", NotificationCountType.Total)).toBe(0);
-            expect(room.getThreadUnreadNotificationCount("456", NotificationCountType.Highlight)).toBe(123);
+            expect(room.getThreadUnreadNotificationCount("123", NotificationCountType.Total)).toBe(666);
+            expect(room.getThreadUnreadNotificationCount("456", NotificationCountType.Highlight)).toBe(0);
         });
     });
 

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2642,6 +2642,16 @@ describe("Room", function() {
             room.setThreadUnreadNotificationCount("123", NotificationCountType.Total, 333);
             expect(room.threadsAggregateNotificationType).toBe(NotificationCountType.Highlight);
         });
+
+        it("partially resets room notifications", () => {
+            room.setThreadUnreadNotificationCount("123", NotificationCountType.Total, 666);
+            room.setThreadUnreadNotificationCount("456", NotificationCountType.Highlight, 123);
+
+            room.resetThreadUnreadNotificationCount(["123"]);
+
+            expect(room.getThreadUnreadNotificationCount("123", NotificationCountType.Total)).toBe(0);
+            expect(room.getThreadUnreadNotificationCount("456", NotificationCountType.Highlight)).toBe(123);
+        });
     });
 
     describe("hasThreadUnreadNotification", () => {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1277,8 +1277,16 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @experimental
      * Resets the thread notifications for this room
      */
-    public resetThreadUnreadNotificationCount(): void {
-        this.threadNotifications.clear();
+    public resetThreadUnreadNotificationCount(notificationsToKeep?: string[]): void {
+        if (notificationsToKeep) {
+            for (const [threadId] of this.threadNotifications) {
+                if (!notificationsToKeep.includes(threadId)) {
+                    this.threadNotifications.delete(threadId);
+                }
+            }
+        } else {
+            this.threadNotifications.clear();
+        }
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1271,11 +1271,15 @@ export class SyncApi {
                 }
             }
 
-            room.resetThreadUnreadNotificationCount();
             const unreadThreadNotifications = joinObj[UNREAD_THREAD_NOTIFICATIONS.name]
-                ?? joinObj[UNREAD_THREAD_NOTIFICATIONS.altName];
+            ?? joinObj[UNREAD_THREAD_NOTIFICATIONS.altName];
             if (unreadThreadNotifications) {
-                Object.entries(unreadThreadNotifications).forEach(([threadId, unreadNotification]) => {
+                // Only partially reset unread notification
+                // We want to keep the client-generated count. Particularly important
+                // for encrypted room that refresh their notification count on event
+                // decryption
+                room.resetThreadUnreadNotificationCount(Object.keys(unreadThreadNotifications));
+                for (const [threadId, unreadNotification] of Object.entries(unreadThreadNotifications)) {
                     room.setThreadUnreadNotificationCount(
                         threadId,
                         NotificationCountType.Total,
@@ -1291,7 +1295,9 @@ export class SyncApi {
                             unreadNotification.highlight_count,
                         );
                     }
-                });
+                }
+            } else {
+                room.resetThreadUnreadNotificationCount();
             }
 
             joinObj.timeline = joinObj.timeline || {} as ITimeline;


### PR DESCRIPTION
Fixes an issue where notifications were completely wiped before being re-added.
This is an issue as sometimes the count is altered client side on event decryption, and the `highlight` count might end up not being accurate if we reset everything

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->