### PR TITLE
Fix screenshare failing after several attempts

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -607,7 +607,9 @@ export class GroupCall extends TypedEventEmitter<
                 return false;
             }
         } else {
-            await Promise.all(this.calls.map(call => call.removeLocalFeed(call.localScreensharingFeed)));
+            await Promise.all(this.calls.map(call => {
+                if (call.localScreensharingFeed) call.removeLocalFeed(call.localScreensharingFeed);
+            }));
             this.client.getMediaHandler().stopScreensharingStream(this.localScreenshareFeed.stream);
             this.removeScreenshareFeed(this.localScreenshareFeed);
             this.localScreenshareFeed = undefined;


### PR DESCRIPTION
Re-use any existing transceivers when screen sharing. This prevents transceivers accumulating and making the SDP too big: see linked bug.

This also switches from `addTrack()` to `addTransceiver ()` which is not that large of a change, other than having to explicitly find the transceivers after an offer has arrived rather than just adding tracks and letting WebRTC take care of it.

Fixes https://github.com/vector-im/element-call/issues/625

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
