### PR TITLE
Fix connectivity regressions

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -647,20 +647,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             videoMuted,
         }));
 
-        // gather transceivers from the new tracks so that we can use the same ones for tracks that
-        // we add later. We only do this for user media streams though: screenshare streams just always
-        // get their own unidirectional transceiver since a bidirectional screen share is pretty rare
-        // (we *could* re-use an existing recvonly transceiver for this, but it's simpler to just not).
-        // Actually, we don't do this since firefox doesn't implement setStreams() yet, so the only way
-        // we can group the tracks into streams is to use addTrack(). It remains here to hopefully be
-        // resurrected once Firefox sort themselves out.
-        /*if (purpose == SDPStreamMetadataPurpose.Usermedia) {
-            for (const track of stream.getTracks()) {
-                const transceiver = this.peerConn.getTransceivers().find(t => t.receiver.track == track);
-                this.transceivers.set(getTransceiverKey(purpose, track.kind), transceiver);
-            }
-        }*/
-
         this.emit(CallEvent.FeedsChanged, this.feeds);
 
         logger.info(
@@ -702,15 +688,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             stream,
             purpose,
         }));
-
-        /*
-        Another commented block for retrieving existing transceivers: re-enable once we can use
-        addTransceiver (see the many other comments).
-        for (const track of stream.getTracks()) {
-            const transceiver = this.peerConn.getTransceivers().find(t => t.receiver.track == track);
-            this.transceivers.set(getTransceiverKey(purpose, track.kind), transceiver);
-        }
-        */
 
         this.emit(CallEvent.FeedsChanged, this.feeds);
 


### PR DESCRIPTION
Switches back to addTrack, digging the transceivers out manually to re-use, because the only way to group tracks into streams re-using trasceivers from the offer is to use setStreams which FF doesn't implement.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix connectivity regressions ([\#2780](https://github.com/matrix-org/matrix-js-sdk/pull/2780)).<!-- CHANGELOG_PREVIEW_END -->