### PR TITLE
Add throwOnFail to groupCall.setScreensharingEnabled

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -600,6 +600,7 @@ export class GroupCall extends TypedEventEmitter<
 
                 return true;
             } catch (error) {
+                if (opts.throwOnFail) throw error;
                 logger.error("Enabling screensharing error", error);
                 this.emit(GroupCallEvent.Error,
                     new GroupCallError(GroupCallErrorCode.NoUserMedia, "Failed to get screen-sharing stream: ", error),

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -33,6 +33,11 @@ export type MediaHandlerEventHandlerMap = {
 export interface IScreensharingOpts {
     desktopCapturerSourceId?: string;
     audio?: boolean;
+    // For electron screen capture, there are very few options for detecting electron
+    // apart from inspecting the user agent or just trying getDisplayMedia() and
+    // catching the failure, so we do the latter - this flag tells the function to just
+    // throw an error so we can catch it in this case, rather than logging an emitting.
+    throwOnFail?: boolean;
 }
 
 export class MediaHandler extends TypedEventEmitter<

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -36,7 +36,7 @@ export interface IScreensharingOpts {
     // For electron screen capture, there are very few options for detecting electron
     // apart from inspecting the user agent or just trying getDisplayMedia() and
     // catching the failure, so we do the latter - this flag tells the function to just
-    // throw an error so we can catch it in this case, rather than logging an emitting.
+    // throw an error so we can catch it in this case, rather than logging and emitting.
     throwOnFail?: boolean;
 }
 


### PR DESCRIPTION
For https://github.com/vector-im/element-call/pull/652

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add throwOnFail to groupCall.setScreensharingEnabled ([\#2787](https://github.com/matrix-org/matrix-js-sdk/pull/2787)).<!-- CHANGELOG_PREVIEW_END -->