### PR TITLE
Fix incorrect prevEv being sent in ClientEvent.AccountData events

### DIFF
--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -208,7 +208,7 @@ class ExtensionAccountData implements Extension {
     private processGlobalAccountData(globalAccountData: object[]): void {
         const events = mapEvents(this.client, undefined, globalAccountData);
         const prevEventsMap = events.reduce((m, c) => {
-            m[c.getId()] = this.client.store.getAccountData(c.getType());
+            m[c.getType()] = this.client.store.getAccountData(c.getType());
             return m;
         }, {});
         this.client.store.storeAccountDataEvents(events);
@@ -222,7 +222,7 @@ class ExtensionAccountData implements Extension {
                     const rules = accountDataEvent.getContent<IPushRules>();
                     this.client.pushRules = PushProcessor.rewriteDefaultRules(rules);
                 }
-                const prevEvent = prevEventsMap[accountDataEvent.getId()];
+                const prevEvent = prevEventsMap[accountDataEvent.getType()];
                 this.client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
                 return accountDataEvent;
             },

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1097,7 +1097,7 @@ export class SyncApi {
         if (Array.isArray(data.account_data?.events)) {
             const events = data.account_data.events.map(client.getEventMapper());
             const prevEventsMap = events.reduce((m, c) => {
-                m[c.getId()] = client.store.getAccountData(c.getType());
+                m[c.getType()] = client.store.getAccountData(c.getType());
                 return m;
             }, {});
             client.store.storeAccountDataEvents(events);
@@ -1111,7 +1111,7 @@ export class SyncApi {
                         const rules = accountDataEvent.getContent<IPushRules>();
                         client.pushRules = PushProcessor.rewriteDefaultRules(rules);
                     }
-                    const prevEvent = prevEventsMap[accountDataEvent.getId()];
+                    const prevEvent = prevEventsMap[accountDataEvent.getType()];
                     client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
                     return accountDataEvent;
                 },


### PR DESCRIPTION
Account data events don't have an ID, clobber them on type instead
If multiple account data events came down sync, the previous event of the last event in the list was used for all prevEv's sent

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix incorrect prevEv being sent in ClientEvent.AccountData events ([\#2794](https://github.com/matrix-org/matrix-js-sdk/pull/2794)).<!-- CHANGELOG_PREVIEW_END -->