### PR TITLE
Revert "Sliding sync: add include_old_rooms; remove is_tombstoned"

### DIFF
--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -33,7 +33,6 @@ const BUFFER_PERIOD_MS = 10 * 1000;
 export interface MSC3575RoomSubscription {
     required_state?: string[][];
     timeline_limit?: number;
-    include_old_rooms?: MSC3575RoomSubscription;
 }
 
 /**
@@ -43,6 +42,7 @@ export interface MSC3575Filter {
     is_dm?: boolean;
     is_encrypted?: boolean;
     is_invite?: boolean;
+    is_tombstoned?: boolean;
     room_name_like?: string;
     room_types?: string[];
     not_room_types?: string[];


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#2785 due to the react-sdk companion PR not being ready to land at the same time