### PR TITLE
Emit UnreadNotification event on notifications reset

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -33,7 +33,7 @@ import {
     RoomEvent,
 } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
-import { NotificationCountType, Room } from "../../src/models/room";
+import { NotificationCountType, Room, RoomNameType } from "../../src/models/room";
 import { RoomState } from "../../src/models/room-state";
 import { UNSTABLE_ELEMENT_FUNCTIONAL_USERS } from "../../src/@types/event";
 import { TestClient } from "../TestClient";
@@ -2722,6 +2722,19 @@ describe("Room", function() {
 
             expect(room.getThreadUnreadNotificationCount("123", NotificationCountType.Total)).toBe(666);
             expect(room.getThreadUnreadNotificationCount("456", NotificationCountType.Highlight)).toBe(0);
+        });
+
+        it("emits event on notifications reset", () => {
+            const cb = jest.fn();
+
+            room.on(RoomEvent.UnreadNotifications, cb);
+
+            room.setThreadUnreadNotificationCount("123", NotificationCountType.Total, 666);
+            room.setThreadUnreadNotificationCount("456", NotificationCountType.Highlight, 123);
+
+            room.resetThreadUnreadNotificationCount();
+
+            expect(cb).toHaveBeenLastCalledWith();
         });
     });
 

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -33,7 +33,7 @@ import {
     RoomEvent,
 } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
-import { NotificationCountType, Room, RoomNameType } from "../../src/models/room";
+import { NotificationCountType, Room } from "../../src/models/room";
 import { RoomState } from "../../src/models/room-state";
 import { UNSTABLE_ELEMENT_FUNCTIONAL_USERS } from "../../src/@types/event";
 import { TestClient } from "../TestClient";

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -173,7 +173,7 @@ export type RoomEventHandlerMap = {
         room: Room,
     ) => void;
     [RoomEvent.UnreadNotifications]: (
-        unreadNotifications: NotificationCount,
+        unreadNotifications?: NotificationCount,
         threadId?: string,
     ) => void;
     [RoomEvent.TimelineRefresh]: (room: Room, eventTimelineSet: EventTimelineSet) => void;
@@ -1277,6 +1277,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.threadNotifications.clear();
         }
+        this.emit(RoomEvent.UnreadNotifications);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23590
We need a way for people consuming a room to know when the unread notification have been reset

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Emit UnreadNotification event on notifications reset ([\#2804](https://github.com/matrix-org/matrix-js-sdk/pull/2804)). Fixes vector-im/element-web#23590.<!-- CHANGELOG_PREVIEW_END -->