### PR TITLE
Switch ESLint warnings to be errors instead

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     // NOTE: These rules are frozen and new rules should not be added here.
     // New changes belong in https://github.com/matrix-org/eslint-plugin-matrix-org/
     rules: {
-        "no-var": ["warn"],
+        "no-var": ["error"],
         "prefer-rest-params": ["error"],
         "prefer-spread": ["error"],
         "one-var": ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,12 +21,12 @@ module.exports = {
     // New changes belong in https://github.com/matrix-org/eslint-plugin-matrix-org/
     rules: {
         "no-var": ["warn"],
-        "prefer-rest-params": ["warn"],
-        "prefer-spread": ["warn"],
-        "one-var": ["warn"],
-        "padded-blocks": ["warn"],
-        "no-extend-native": ["warn"],
-        "camelcase": ["warn"],
+        "prefer-rest-params": ["error"],
+        "prefer-spread": ["error"],
+        "one-var": ["error"],
+        "padded-blocks": ["error"],
+        "no-extend-native": ["error"],
+        "camelcase": ["error"],
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
         "space-before-function-paren": ["error", {
             "anonymous": "never",


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/23600

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->