### PR TITLE
Let leave requests outlive the window

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -212,7 +212,7 @@ describe('Group Call', function() {
                         ],
                     }),
                     FAKE_USER_ID_1,
-                    false,
+                    { keepAlive: false },
                 );
             } finally {
                 groupCall.leave();
@@ -234,7 +234,7 @@ describe('Group Call', function() {
                 EventType.GroupCallMemberPrefix,
                 expect.objectContaining({ "m.calls": [] }),
                 FAKE_USER_ID_1,
-                true, // Request should outlive the window
+                { keepAlive: true }, // Request should outlive the window
             );
         });
 

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -212,10 +212,30 @@ describe('Group Call', function() {
                         ],
                     }),
                     FAKE_USER_ID_1,
+                    false,
                 );
             } finally {
                 groupCall.leave();
             }
+        });
+
+        it("sends member state event to room on leave", async () => {
+            room.currentState.members[FAKE_USER_ID_1] = {
+                userId: FAKE_USER_ID_1,
+            } as unknown as RoomMember;
+
+            await groupCall.create();
+            await groupCall.enter();
+            mockSendState.mockClear();
+
+            groupCall.leave();
+            expect(mockSendState).toHaveBeenCalledWith(
+                FAKE_ROOM_ID,
+                EventType.GroupCallMemberPrefix,
+                expect.objectContaining({ "m.calls": [] }),
+                FAKE_USER_ID_1,
+                true, // Request should outlive the window
+            );
         });
 
         it("starts with mic unmuted in regular calls", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,6 +65,7 @@ import {
     FileType,
     UploadResponse,
     HTTPError,
+    IRequestOpts,
 } from "./http-api";
 import {
     Crypto,
@@ -7517,7 +7518,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param {string} eventType
      * @param {Object} content
      * @param {string} stateKey
-     * @param {boolean} keepAlive Whether the request should outlive the window.
+     * @param {IRequestOpts} opts Options for the request function.
      * @return {Promise} Resolves: TODO
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
@@ -7526,7 +7527,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         eventType: string,
         content: any,
         stateKey = "",
-        keepAlive = false,
+        opts: IRequestOpts = {},
     ): Promise<ISendEventResponse> {
         const pathParams = {
             $roomId: roomId,
@@ -7537,7 +7538,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (stateKey !== undefined) {
             path = utils.encodeUri(path + "/$stateKey", pathParams);
         }
-        return this.http.authedRequest(Method.Put, path, undefined, content, { keepAlive });
+        return this.http.authedRequest(Method.Put, path, undefined, content, opts);
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -7517,6 +7517,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param {string} eventType
      * @param {Object} content
      * @param {string} stateKey
+     * @param {boolean} keepAlive Whether the request should outlive the window.
      * @return {Promise} Resolves: TODO
      * @return {module:http-api.MatrixError} Rejects: with an error response.
      */
@@ -7525,6 +7526,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         eventType: string,
         content: any,
         stateKey = "",
+        keepAlive = false,
     ): Promise<ISendEventResponse> {
         const pathParams = {
             $roomId: roomId,
@@ -7535,7 +7537,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (stateKey !== undefined) {
             path = utils.encodeUri(path + "/$stateKey", pathParams);
         }
-        return this.http.authedRequest(Method.Put, path, undefined, content);
+        return this.http.authedRequest(Method.Put, path, undefined, content, { keepAlive });
     }
 
     /**

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -234,7 +234,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         method: Method,
         url: URL | string,
         body?: Body,
-        opts: Pick<IRequestOpts, "headers" | "json" | "localTimeoutMs" | "abortSignal"> = {},
+        opts: Pick<IRequestOpts, "headers" | "json" | "localTimeoutMs" | "keepAlive" | "abortSignal"> = {},
     ): Promise<ResponseType<T, O>> {
         const headers = Object.assign({}, opts.headers || {});
         const json = opts.json ?? true;
@@ -252,6 +252,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         }
 
         const timeout = opts.localTimeoutMs ?? this.opts.localTimeoutMs;
+        const keepAlive = opts.keepAlive ?? false;
         const signals = [
             this.abortController.signal,
         ];
@@ -284,6 +285,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
                 referrerPolicy: "no-referrer",
                 cache: "no-cache",
                 credentials: "omit", // we send credentials via headers
+                keepalive: keepAlive,
             });
         } catch (e) {
             if ((<Error>e).name === "AbortError") {

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -38,6 +38,7 @@ export interface IRequestOpts {
     headers?: Record<string, string>;
     abortSignal?: AbortSignal;
     localTimeoutMs?: number;
+    keepAlive?: boolean; // defaults to false
     json?: boolean; // defaults to true
 
     // Set to true to prevent the request function from emitting a Session.logged_out event.

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -726,10 +726,13 @@ export class GroupCall extends TypedEventEmitter<
     private async removeMemberStateEvent(): Promise<ISendEventResponse> {
         if (this.resendMemberStateTimer !== null) clearInterval(this.resendMemberStateTimer);
         this.resendMemberStateTimer = null;
-        return await this.updateMemberCallState(undefined);
+        return await this.updateMemberCallState(undefined, true);
     }
 
-    private async updateMemberCallState(memberCallState?: IGroupCallRoomMemberCallState): Promise<ISendEventResponse> {
+    private async updateMemberCallState(
+        memberCallState?: IGroupCallRoomMemberCallState,
+        keepAlive = false,
+    ): Promise<ISendEventResponse> {
         const localUserId = this.client.getUserId()!;
 
         const memberState = this.getMemberStateEvents(localUserId)?.getContent<IGroupCallRoomMemberState>();
@@ -758,7 +761,9 @@ export class GroupCall extends TypedEventEmitter<
             "m.expires_ts": Date.now() + CALL_MEMBER_STATE_TIMEOUT,
         };
 
-        return this.client.sendStateEvent(this.room.roomId, EventType.GroupCallMemberPrefix, content, localUserId);
+        return this.client.sendStateEvent(
+            this.room.roomId, EventType.GroupCallMemberPrefix, content, localUserId, keepAlive,
+        );
     }
 
     public onMemberStateChanged = async (event: MatrixEvent) => {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -762,7 +762,7 @@ export class GroupCall extends TypedEventEmitter<
         };
 
         return this.client.sendStateEvent(
-            this.room.roomId, EventType.GroupCallMemberPrefix, content, localUserId, keepAlive,
+            this.room.roomId, EventType.GroupCallMemberPrefix, content, localUserId, { keepAlive },
         );
     }
 


### PR DESCRIPTION
Yay `fetch`!

Closes https://github.com/vector-im/element-call/issues/639

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Let leave requests outlive the window ([\#2815](https://github.com/matrix-org/matrix-js-sdk/pull/2815)). Fixes vector-im/element-call#639.<!-- CHANGELOG_PREVIEW_END -->