### PR TITLE
Resolve races between `initLocalCallFeed` and `leave`

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -23,7 +23,7 @@ import {
     Room,
     RoomMember,
 } from '../../../src';
-import { GroupCall, GroupCallEvent } from "../../../src/webrtc/groupCall";
+import { GroupCall, GroupCallEvent, GroupCallState } from "../../../src/webrtc/groupCall";
 import { MatrixClient } from "../../../src/client";
 import {
     installWebRTCMocks,
@@ -172,6 +172,13 @@ describe('Group Call', function() {
             expect(groupCall.initLocalCallFeed).not.toHaveBeenCalled();
 
             groupCall.leave();
+        });
+
+        it("stops initializing local call feed when leaving", async () => {
+            const initPromise = groupCall.initLocalCallFeed();
+            groupCall.leave();
+            await expect(initPromise).rejects.toBeDefined();
+            expect(groupCall.state).toBe(GroupCallState.LocalCallFeedUninitialized);
         });
 
         it("sends state event to room when creating", async () => {


### PR DESCRIPTION
Unfortunately there are still other methods that could race with `leave` and result in broken group call state, such as `enter` and `terminate`. For the future, should consider writing a more careful specification of how the whole group call state machine is meant to work.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Resolve races between `initLocalCallFeed` and `leave` ([\#2826](https://github.com/matrix-org/matrix-js-sdk/pull/2826)).<!-- CHANGELOG_PREVIEW_END -->