### PR TITLE
Catch server versions API call exception when starting the client

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -274,6 +274,15 @@ describe("MatrixClient syncing", () => {
 
             expect(fires).toBe(1);
         });
+
+        it("should work when all network calls fail", async () => {
+            httpBackend!.when("GET", "").fail(0, new Error("CORS or something"));
+            const prom = client!.startClient();
+            await Promise.all([
+                expect(prom).resolves.toBeUndefined(),
+            httpBackend!.flushAllExpected(),
+            ]);
+        });
     });
 
     describe("initial sync", () => {

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -276,6 +276,7 @@ describe("MatrixClient syncing", () => {
         });
 
         it("should work when all network calls fail", async () => {
+            httpBackend!.expectedRequests = [];
             httpBackend!.when("GET", "").fail(0, new Error("CORS or something"));
             const prom = client!.startClient();
             await Promise.all([

--- a/src/client.ts
+++ b/src/client.ts
@@ -6726,7 +6726,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                     prefix: '',
                 },
             );
-            // throw "YOLO";
         } catch (e) {
             // Need to unset this if it fails, otherwise we'll never retry
             this.serverVersionsPromise = undefined;

--- a/src/client.ts
+++ b/src/client.ts
@@ -6717,21 +6717,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             return this.serverVersionsPromise;
         }
 
-        try {
-            this.serverVersionsPromise = this.http.request<IServerVersions>(
-                Method.Get, "/_matrix/client/versions",
-                undefined, // queryParams
-                undefined, // data
-                {
-                    prefix: '',
-                },
-            );
-        } catch (e) {
+        this.serverVersionsPromise = this.http.request<IServerVersions>(
+            Method.Get, "/_matrix/client/versions",
+            undefined, // queryParams
+            undefined, // data
+            {
+                prefix: '',
+            },
+        ).catch(e => {
             // Need to unset this if it fails, otherwise we'll never retry
             this.serverVersionsPromise = undefined;
             // but rethrow the exception to anything that was waiting
             throw e;
-        }
+        });
 
         const serverVersions = await this.serverVersionsPromise;
         this.canSupport = await buildFeatureSupportMap(serverVersions);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1195,14 +1195,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         try {
             await this.getVersions();
+
+            // This should be done with `canSupport`
+            // TODO: https://github.com/vector-im/element-web/issues/23643
+            const { threads, list, fwdPagination } = await this.doesServerSupportThread();
+            Thread.setServerSideSupport(threads);
+            Thread.setServerSideListSupport(list);
+            Thread.setServerSideFwdPaginationSupport(fwdPagination);
         } catch (e) {
             logger.error("Can't fetch server versions, continuing to initialise sync, this will be retried later", e);
         }
-
-        const { threads, list, fwdPagination } = await this.doesServerSupportThread();
-        Thread.setServerSideSupport(threads);
-        Thread.setServerSideListSupport(list);
-        Thread.setServerSideFwdPaginationSupport(fwdPagination);
 
         // shallow-copy the opts dict before modifying and storing it
         this.clientOpts = Object.assign({}, opts) as IStoredClientOpts;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23634

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Catch server versions API call exception when starting the client ([\#2828](https://github.com/matrix-org/matrix-js-sdk/pull/2828)). Fixes vector-im/element-web#23634.<!-- CHANGELOG_PREVIEW_END -->