### PR TITLE
[Backport staging] Catch server versions API call exception when starting the client

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -274,6 +274,16 @@ describe("MatrixClient syncing", () => {
 
             expect(fires).toBe(1);
         });
+
+        it("should work when all network calls fail", async () => {
+            httpBackend!.expectedRequests = [];
+            httpBackend!.when("GET", "").fail(0, new Error("CORS or something"));
+            const prom = client!.startClient();
+            await Promise.all([
+                expect(prom).resolves.toBeUndefined(),
+            httpBackend!.flushAllExpected(),
+            ]);
+        });
     });
 
     describe("initial sync", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1197,7 +1197,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
             // This should be done with `canSupport`
             // TODO: https://github.com/vector-im/element-web/issues/23643
-            const { threads, list, fwdPagination } = await this.doesServerSupportThread();
+            const { threads, list } = await this.doesServerSupportThread();
             Thread.setServerSideSupport(threads);
             Thread.setServerSideListSupport(list);
         } catch (e) {


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/2828 to hotfix release

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * [Backport staging] Catch server versions API call exception when starting the client ([\#2832](https://github.com/matrix-org/matrix-js-sdk/pull/2832)).<!-- CHANGELOG_PREVIEW_END -->