### PR TITLE
We don't care about the timeline (just fire and forget to load the event)

### DIFF
--- a/src/timeline-window.ts
+++ b/src/timeline-window.ts
@@ -101,7 +101,7 @@ export class TimelineWindow {
      *
      * @return {Promise}
      */
-    public load(initialEventId?: string, initialWindowSize = 20): Promise<void> {
+    public async load(initialEventId?: string, initialWindowSize = 20): Promise<void> {
         // given an EventTimeline, find the event we were looking for, and initialise our
         // fields so that the event in question is in the middle of the window.
         const initFields = (timeline: Optional<EventTimeline>) => {
@@ -135,13 +135,14 @@ export class TimelineWindow {
         // which is important to keep room-switching feeling snappy.
         if (this.timelineSet.getTimelineForEvent(initialEventId)) {
             initFields(this.timelineSet.getTimelineForEvent(initialEventId));
-            return Promise.resolve();
+            return;
         } else if (initialEventId) {
-            return this.client.getEventTimeline(this.timelineSet, initialEventId)
+            await this.client.getEventTimeline(this.timelineSet, initialEventId)
                 .then(initFields);
+            return;
         } else {
             initFields(this.timelineSet.getLiveTimeline());
-            return Promise.resolve();
+            return;
         }
     }
 


### PR DESCRIPTION
We don't care about the timeline (just fire and forget to load the event).

> It's probably a misnomer to call it `getEventTimeline(): timeline` in the first place as it's more accurately used as `loadEventInTimeline(): Promise<void>` everywhere.
>
> *-- https://github.com/matrix-org/matrix-js-sdk/pull/2521#discussion_r920214132**

Split out from https://github.com/matrix-org/matrix-js-sdk/pull/2521


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [ ] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->