### PR TITLE
Revert "Extra insurance that we don't mix events in the wrong timelines"

### DIFF
--- a/spec/unit/event-timeline-set.spec.ts
+++ b/spec/unit/event-timeline-set.spec.ts
@@ -55,23 +55,6 @@ describe('EventTimelineSet', () => {
         });
     };
 
-    const mkThreadResponse = (root: MatrixEvent) => utils.mkEvent({
-        event: true,
-        type: EventType.RoomMessage,
-        user: userA,
-        room: roomId,
-        content: {
-            "body": "Thread response :: " + Math.random(),
-            "m.relates_to": {
-                "event_id": root.getId(),
-                "m.in_reply_to": {
-                    "event_id": root.getId(),
-                },
-                "rel_type": "m.thread",
-            },
-        },
-    }, room.client);
-
     beforeEach(() => {
         client = utils.mock(MatrixClient, 'MatrixClient');
         client.reEmitter = utils.mock(ReEmitter, 'ReEmitter');
@@ -134,13 +117,6 @@ describe('EventTimelineSet', () => {
     });
 
     describe('addEventToTimeline', () => {
-        let thread: Thread;
-
-        beforeEach(() => {
-            (client.supportsExperimentalThreads as jest.Mock).mockReturnValue(true);
-            thread = new Thread("!thread_id:server", messageEvent, { room, client });
-        });
-
         it("Adds event to timeline", () => {
             const liveTimeline = eventTimelineSet.getLiveTimeline();
             expect(liveTimeline.getEvents().length).toStrictEqual(0);
@@ -167,41 +143,6 @@ describe('EventTimelineSet', () => {
                     false,
                 );
             }).not.toThrow();
-        });
-
-        it("should not add an event to a timeline that does not belong to the timelineSet", () => {
-            const eventTimelineSet2 = new EventTimelineSet(room);
-            const liveTimeline2 = eventTimelineSet2.getLiveTimeline();
-            expect(liveTimeline2.getEvents().length).toStrictEqual(0);
-
-            expect(() => {
-                eventTimelineSet.addEventToTimeline(messageEvent, liveTimeline2, {
-                    toStartOfTimeline: true,
-                });
-            }).toThrowError();
-        });
-
-        it("should not add a threaded reply to the main room timeline", () => {
-            const liveTimeline = eventTimelineSet.getLiveTimeline();
-            expect(liveTimeline.getEvents().length).toStrictEqual(0);
-
-            const threadedReplyEvent = mkThreadResponse(messageEvent);
-
-            eventTimelineSet.addEventToTimeline(threadedReplyEvent, liveTimeline, {
-                toStartOfTimeline: true,
-            });
-            expect(liveTimeline.getEvents().length).toStrictEqual(0);
-        });
-
-        it("should not add a normal message to the timelineSet representing a thread", () => {
-            const eventTimelineSetForThread = new EventTimelineSet(room, {}, client, thread);
-            const liveTimeline = eventTimelineSetForThread.getLiveTimeline();
-            expect(liveTimeline.getEvents().length).toStrictEqual(0);
-
-            eventTimelineSetForThread.addEventToTimeline(messageEvent, liveTimeline, {
-                toStartOfTimeline: true,
-            });
-            expect(liveTimeline.getEvents().length).toStrictEqual(0);
         });
     });
 

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -702,19 +702,6 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             );
         }
 
-        if (timeline.getTimelineSet() !== this) {
-            throw new Error(`EventTimelineSet.addEventToTimeline: Timeline=${timeline.toString()} does not belong " + 
-                "in timelineSet(threadId=${this.thread?.id})`);
-        }
-
-        // Make sure events don't get mixed in timelines they shouldn't be in
-        // (e.g. a threaded message should not be in the main timeline).
-        if (!this.canContain(event)) {
-            logger.warn(`EventTimelineSet.addEventToTimeline: Ignoring event=${event.getId()} that does not belong " + 
-                "in timeline=${timeline.toString()} timelineSet(threadId=${this.thread?.id})`);
-            return;
-        }
-
         const eventId = event.getId()!;
         timeline.addEvent(event, {
             toStartOfTimeline,

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -107,7 +107,7 @@ export interface IEventRelation {
     event_id?: string;
     is_falling_back?: boolean;
     "m.in_reply_to"?: {
-        event_id?: string;
+        event_id: string;
     };
     key?: string;
 }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1862,7 +1862,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         shouldLiveInThread: boolean;
         threadId?: string;
     } {
-        if (!this.client?.supportsExperimentalThreads()) {
+        if (!this.client.supportsExperimentalThreads()) {
             return {
                 shouldLiveInRoom: true,
                 shouldLiveInThread: false,


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#2848

Reverting due to it not working for notification timeline sets - causing downstream breakages https://dashboard.cypress.io/projects/ppvnzg/runs/5793/test-results/3be6d26d-bc97-4167-b966-a0c7aa2a6930