### PR TITLE
Move patch-package out of dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "matrix-events-sdk": "0.0.1-beta.7",
     "matrix-widget-api": "^1.0.0",
     "p-retry": "4",
+    "patch-package": "^6.5.0",
+    "postinstall-postinstall": "^2.1.0",
     "qs": "^6.9.6",
     "sdp-transform": "^2.14.1",
     "unhomoglyph": "^1.0.6"
@@ -110,8 +112,6 @@
     "jest-mock": "^29.0.0",
     "jsdoc": "^3.6.6",
     "matrix-mock-request": "^2.5.0",
-    "patch-package": "^6.5.0",
-    "postinstall-postinstall": "^2.1.0",
     "rimraf": "^3.0.2",
     "terser": "^5.5.1",
     "tsify": "^5.0.2",


### PR DESCRIPTION
patch-package is used as a postinstall hook, but since it was in `devDependencies`, upstream packages would not install it. Moving it to `dependencies` isn't ideal since it's not needed at runtime, but the patch-package approach is only a temporary workaround for https://github.com/matrix-org/matrix-events-sdk/pull/16#pullrequestreview-1166721652 anyways.

Notes: none
element-web notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->