### PR TITLE
Remove `Crypto.start()`

### DIFF
--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -1122,4 +1122,22 @@ describe("Crypto", function() {
             expect(free).toHaveBeenCalled();
         });
     });
+
+    describe("start", () => {
+        let client: TestClient;
+
+        beforeEach(async () => {
+            client = new TestClient("@alice:example.org", "aliceweb");
+            await client.client.initCrypto();
+        });
+
+        afterEach(async function() {
+            await client!.stop();
+        });
+
+        // start() is a no-op nowadays, so there's not much to test here.
+        it("should complete successfully", async () => {
+            await client!.client.crypto!.start();
+        });
+    });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1200,7 +1200,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         if (this.crypto) {
             this.crypto.uploadDeviceKeys();
-            this.crypto.start();
         }
 
         // periodically poll for turn servers if we support voip

--- a/src/crypto/OutgoingRoomKeyRequestManager.ts
+++ b/src/crypto/OutgoingRoomKeyRequestManager.ts
@@ -100,20 +100,13 @@ export class OutgoingRoomKeyRequestManager {
     // of sendOutgoingRoomKeyRequests
     private sendOutgoingRoomKeyRequestsRunning = false;
 
-    private clientRunning = false;
+    private clientRunning = true;
 
     constructor(
         private readonly baseApis: MatrixClient,
         private readonly deviceId: string,
         private readonly cryptoStore: CryptoStore,
     ) {}
-
-    /**
-     * Called when the client is started. Sets background processes running.
-     */
-    public start(): void {
-        this.clientRunning = true;
-    }
 
     /**
      * Called when the client is stopped. Stops any running background processes.

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1775,11 +1775,6 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         eventEmitter.on(MatrixEventEvent.Decrypted, this.onTimelineEvent);
     }
 
-    /** Start background processes related to crypto */
-    public start(): void {
-        this.outgoingRoomKeyRequestManager.start();
-    }
-
     /** Stop background processes related to crypto */
     public stop(): void {
         this.outgoingRoomKeyRequestManager.stop();

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1775,6 +1775,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         eventEmitter.on(MatrixEventEvent.Decrypted, this.onTimelineEvent);
     }
 
+    /**
+     * @deprecated this does nothing and will be removed in a future version
+     */
+    public start(): void {
+        logger.warn("MatrixClient.crypto.start() is deprecated");
+    }
+
     /** Stop background processes related to crypto */
     public stop(): void {
         this.outgoingRoomKeyRequestManager.stop();


### PR DESCRIPTION
This isn't really needed, and its semantics are poorly defined. (Contrary to the comment, it dos *not* set any background processes running).

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->