### PR TITLE
Deprecate/remove some get/set methods on `Crypto`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2108,11 +2108,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param {boolean} value whether to blacklist all unverified devices by default
      */
-    public setGlobalBlacklistUnverifiedDevices(value: boolean) {
+    public setGlobalBlacklistUnverifiedDevices(value: boolean): boolean {
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.setGlobalBlacklistUnverifiedDevices(value);
+        this.crypto.globalBlacklistUnverifiedDevices = value;
+        return value;
     }
 
     /**
@@ -2122,7 +2123,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.getGlobalBlacklistUnverifiedDevices();
+        return this.crypto.globalBlacklistUnverifiedDevices;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -2136,11 +2136,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param {boolean} value whether error on unknown devices
      */
-    public setGlobalErrorOnUnknownDevices(value: boolean) {
+    public setGlobalErrorOnUnknownDevices(value: boolean): void {
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.setGlobalErrorOnUnknownDevices(value);
+        this.crypto.globalErrorOnUnknownDevices = value;
     }
 
     /**
@@ -2152,7 +2152,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.getGlobalErrorOnUnknownDevices();
+        return this.crypto.globalErrorOnUnknownDevices;
     }
 
     /**

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -975,7 +975,7 @@ class MegolmEncryption extends EncryptionAlgorithm {
                     logger.debug(`Getting devices in ${this.roomId}`);
                     const [devicesInRoom, blocked] = await this.getDevicesInRoom(room);
 
-                    if (this.crypto.getGlobalErrorOnUnknownDevices()) {
+                    if (this.crypto.globalErrorOnUnknownDevices) {
                         // Drop unknown devices for now.  When the message gets sent, we'll
                         // throw an error, but we'll still be prepared to send to the known
                         // devices.
@@ -1028,7 +1028,7 @@ class MegolmEncryption extends EncryptionAlgorithm {
 
         // check if any of these devices are not yet known to the user.
         // if so, warn the user so they can verify or ignore.
-        if (this.crypto.getGlobalErrorOnUnknownDevices()) {
+        if (this.crypto.globalErrorOnUnknownDevices) {
             this.checkForUnknownDevices(devicesInRoom);
         }
 

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1163,7 +1163,7 @@ class MegolmEncryption extends EncryptionAlgorithm {
         });
 
         // The global value is treated as a default for when rooms don't specify a value.
-        let isBlacklisting = this.crypto.getGlobalBlacklistUnverifiedDevices();
+        let isBlacklisting = this.crypto.globalBlacklistUnverifiedDevices;
         const isRoomBlacklisting = room.getBlacklistUnverifiedDevices();
         if (typeof isRoomBlacklisting === 'boolean') {
             isBlacklisting = isRoomBlacklisting;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -308,7 +308,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
 
     private deviceKeys: Record<string, string> = {}; // type: key
 
-    private globalBlacklistUnverifiedDevices = false;
+    public globalBlacklistUnverifiedDevices = false;
     private globalErrorOnUnknownDevices = true;
 
     // list of IncomingRoomKeyRequests/IncomingRoomKeyRequestCancellations
@@ -1811,6 +1811,9 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * do not specify a value.
      *
      * @param {boolean} value whether to blacklist all unverified devices by default
+     *
+     * @deprecated For external code, use {@link MatrixClient#setGlobalBlacklistUnverifiedDevices}. For
+     *   internal code, set {@link #globalBlacklistUnverifiedDevices} directly.
      */
     public setGlobalBlacklistUnverifiedDevices(value: boolean): void {
         this.globalBlacklistUnverifiedDevices = value;
@@ -1818,6 +1821,9 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
 
     /**
      * @return {boolean} whether to blacklist all unverified devices by default
+     *
+     * @deprecated For external code, use {@link MatrixClient#getGlobalBlacklistUnverifiedDevices}. For
+     *   internal code, reference {@link #globalBlacklistUnverifiedDevices} directly.
      */
     public getGlobalBlacklistUnverifiedDevices(): boolean {
         return this.globalBlacklistUnverifiedDevices;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -309,7 +309,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     private deviceKeys: Record<string, string> = {}; // type: key
 
     public globalBlacklistUnverifiedDevices = false;
-    private globalErrorOnUnknownDevices = true;
+    public globalErrorOnUnknownDevices = true;
 
     // list of IncomingRoomKeyRequests/IncomingRoomKeyRequestCancellations
     // we received in the current sync.
@@ -1827,29 +1827,6 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      */
     public getGlobalBlacklistUnverifiedDevices(): boolean {
         return this.globalBlacklistUnverifiedDevices;
-    }
-
-    /**
-     * Set whether sendMessage in a room with unknown and unverified devices
-     * should throw an error and not send them message. This has 'Global' for
-     * symmetry with setGlobalBlacklistUnverifiedDevices but there is currently
-     * no room-level equivalent for this setting.
-     *
-     * This API is currently UNSTABLE and may change or be removed without notice.
-     *
-     * @param {boolean} value whether error on unknown devices
-     */
-    public setGlobalErrorOnUnknownDevices(value: boolean): void {
-        this.globalErrorOnUnknownDevices = value;
-    }
-
-    /**
-     * @return {boolean} whether to error on unknown devices
-     *
-     * This API is currently UNSTABLE and may change or be removed without notice.
-     */
-    public getGlobalErrorOnUnknownDevices(): boolean {
-        return this.globalErrorOnUnknownDevices;
     }
 
     /**


### PR DESCRIPTION
* `Crypto.{get,set}GlobalErrorOnUnknownDevices` are UNSTABLE so we can safely remove them, right?
* Deprecate `Crypto.{get,set}GlobalBlacklistUnverifiedDevices` and signpoint the right entry points.