### PR TITLE
fix registration add phone number not working

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8749,11 +8749,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         clientSecret: string,
         msisdnToken: string,
     ): Promise<any> { // TODO: Types
-        const u = new URL(url);
-        u.searchParams.set("sid", sid);
-        u.searchParams.set("client_secret", clientSecret);
-        u.searchParams.set("token", msisdnToken);
-        return this.http.requestOtherUrl(Method.Post, u);
+        const params = {
+            sid: sid,
+            client_secret: clientSecret,
+            token: msisdnToken,
+        };
+        return this.http.requestOtherUrl(Method.Post, url, params);
     }
 
     /**


### PR DESCRIPTION
This PR will resolve below defect

Step to repro the defect
1-Go to register
2-Add phone number when register
3-enter correct OTP code and submit
4-server will return error because we are sending POST data via url params.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * fix registration add phone number not working ([\#2876](https://github.com/matrix-org/matrix-js-sdk/pull/2876)). Contributed by @bagvand.<!-- CHANGELOG_PREVIEW_END -->