### PR TITLE
Make calls go back to 'connecting' state when media lost

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2104,6 +2104,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 logger.info(`Hanging up call ${this.callId} (ICE disconnected for too long)`);
                 this.hangup(CallErrorCode.IceFailed, false);
             }, 30 * 1000);
+            this.setState(CallState.Connecting);
         }
 
         // In PTT mode, override feed status to muted when we lose connection to


### PR DESCRIPTION
This is a change in how the state machine works: technically it's a breaking change, although likely not worth a specific major release given the level of breakage. Calls will now now go back into the connecting state if the media connection is lost (they'll try to re-establish the connection).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for new code (and old code if feasible)
* [ ] Linter and other CI checks pass
* [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make calls go back to 'connecting' state when media lost ([\#2880](https://github.com/matrix-org/matrix-js-sdk/pull/2880)).<!-- CHANGELOG_PREVIEW_END -->