### PR TITLE
Define a spec support policy for the js-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This is the [Matrix](https://matrix.org) Client-Server SDK for JavaScript and Ty
 browser or in Node.js.
 
 The Matrix specification is constantly evolving - while this SDK aims for maximum backwards compatibility, it only
-guarantees that a feature will be supported for at least 3 spec releases. For example, if a feature the js-sdk supports
-is removed in v1.4 then the feature is *eligible* for removal from the SDK when v1.7 is released. This SDK has no
+guarantees that a feature will be supported for at least 4 spec releases. For example, if a feature the js-sdk supports
+is removed in v1.4 then the feature is *eligible* for removal from the SDK when v1.8 is released. This SDK has no
 guarantee on implementing all features of any particular spec release, currently. This can mean that the SDK will call
 endpoints from before Matrix 1.1, for example.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@
 Matrix Javascript SDK
 =====================
 
-This is the [Matrix](https://matrix.org) Client-Server r0 SDK for
-JavaScript. This SDK can be run in a browser or in Node.js.
+This is the [Matrix](https://matrix.org) Client-Server SDK for JavaScript and TypeScript. This SDK can be run in a
+browser or in Node.js.
+
+The Matrix specification is constantly evolving - while this SDK aims for maximum backwards compatibility, it only
+guarantees that a feature will be supported for at least 3 spec releases. For example, if a feature the js-sdk supports
+is removed in v1.4 then the feature is *eligible* for removal from the SDK when v1.7 is released. This SDK has no
+guarantee on implementing all features of any particular spec release, currently. This can mean that the SDK will call
+endpoints from before Matrix 1.1, for example.
 
 Quickstart
 ==========


### PR DESCRIPTION
**This probably needs a team-wide conversation.**

Part of https://github.com/vector-im/element-web/issues/22346

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Define a spec support policy for the js-sdk ([\#2882](https://github.com/matrix-org/matrix-js-sdk/pull/2882)).<!-- CHANGELOG_PREVIEW_END -->