### PR TITLE
Improve logging on Olm session errors

### DIFF
--- a/src/crypto/OlmDevice.ts
+++ b/src/crypto/OlmDevice.ts
@@ -916,6 +916,7 @@ export class OlmDevice {
     }
 
     public async recordSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {
+        logger.info(`Recording problem on olm session with ${deviceKey} of type ${type}. Recreating: ${fixed}`);
         await this.cryptoStore.storeEndToEndSessionProblem(deviceKey, type, fixed);
     }
 

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1313,7 +1313,7 @@ class MegolmDecryption extends DecryptionAlgorithm {
             if (problem) {
                 logger.info(
                     `When handling UISI from ${event.getSender()} (sender key ${content.sender_key}): ` +
-                    `recent session problem with that sender: ${problem}`
+                    `recent session problem with that sender: ${problem}`,
                 );
                 let problemDescription = PROBLEM_DESCRIPTIONS[problem.type as "no_olm"] || PROBLEM_DESCRIPTIONS.unknown;
                 if (problem.fixed) {

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1311,6 +1311,10 @@ class MegolmDecryption extends DecryptionAlgorithm {
                 content.sender_key, event.getTs() - 120000,
             );
             if (problem) {
+                logger.info(
+                    `When handling UISI from ${event.getSender()} (sender key ${content.sender_key}): ` +
+                    `recent session problem with that sender: ${problem}`
+                );
                 let problemDescription = PROBLEM_DESCRIPTIONS[problem.type as "no_olm"] || PROBLEM_DESCRIPTIONS.unknown;
                 if (problem.fixed) {
                     problemDescription +=


### PR DESCRIPTION
I strongly suspect we are logging "secure channel corruption" errors when no
such thing happened, bit I can't quite figure it out yet. Add a bit more
logging to try to track them down.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Improve logging on Olm session errors ([\#2885](https://github.com/matrix-org/matrix-js-sdk/pull/2885)).<!-- CHANGELOG_PREVIEW_END -->