### PR TITLE
Further improvements to e2ee logging

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3269,9 +3269,9 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         }
 
         logger.info(
-            `Got room key withheld event from ${event.getSender()} (${content.sender_key}) `
-            + `for ${content.algorithm}/${content.room_id}/${content.session_id} `
-            + `with reason ${content.code} (${content.reason})`,
+            `Got room key withheld event from ${event.getSender()}q `
+            + `for ${content.algorithm} session ${content.sender_key}|${content.session_id} `
+            + `in room ${content.room_id} with code ${content.code} (${content.reason})`,
         );
 
         const alg = this.getRoomDecryptor(content.room_id, content.algorithm);

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3269,7 +3269,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         }
 
         logger.info(
-            `Got room key withheld event from ${event.getSender()}q `
+            `Got room key withheld event from ${event.getSender()} `
             + `for ${content.algorithm} session ${content.sender_key}|${content.session_id} `
             + `in room ${content.room_id} with code ${content.code} (${content.reason})`,
         );


### PR DESCRIPTION
A followup to #2884. In particular, it is not always the case that the
`sender_key` in a `m.room_key_withheld` message is the sender of that message.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Further improvements to e2ee logging ([\#2900](https://github.com/matrix-org/matrix-js-sdk/pull/2900)).<!-- CHANGELOG_PREVIEW_END -->