### PR TITLE
Deprecate a function containing a typo

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1443,8 +1443,18 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * Checks if this event is associated with another event. See `getAssociatedId`.
      *
      * @return {boolean}
+     * @deprecated use hasAssociation instead.
      */
     public hasAssocation(): boolean {
+        return !!this.getAssociatedId();
+    }
+
+    /**
+     * Checks if this event is associated with another event. See `getAssociatedId`.
+     *
+     * @return {boolean}
+     */
+    public hasAssociation(): boolean {
         return !!this.getAssociatedId();
     }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -99,7 +99,7 @@ export class MatrixScheduler<T = ISendEventResponse> {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public static QUEUE_MESSAGES(event: MatrixEvent): "message" | null {
         // enqueue messages or events that associate with another event (redactions and relations)
-        if (event.getType() === EventType.RoomMessage || event.hasAssocation()) {
+        if (event.getType() === EventType.RoomMessage || event.hasAssociation()) {
             // put these events in the 'message' queue.
             return "message";
         }


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate a function containing a typo ([\#2904](https://github.com/matrix-org/matrix-js-sdk/pull/2904)). Contributed by @poljar.<!-- CHANGELOG_PREVIEW_END -->