### PR TITLE
Don't swallow errors coming from the shareSession call

### DIFF
--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -499,21 +499,17 @@ describe("MegolmDecryption", function () {
                 // @ts-ignore - private field access
                 megolmEncryption.shareSession = () => {
                     throw new Error("Can't share session");
-                }
-
-                // @ts-ignore - private field access
-                const room = new Room(megolmEncryption.roomId);
+                };
 
                 await expect(() =>
                     // @ts-ignore - private field access
-                    megolmEncryption.ensureOutboundSession(mockRoom, {}, {}, true)
+                    megolmEncryption.ensureOutboundSession(mockRoom, {}, {}, true),
                 ).rejects.toThrow();
 
                 // @ts-ignore - private field access
                 const finalSetupPromise = await megolmEncryption.setupPromise;
                 expect(finalSetupPromise).toBe(null);
             });
-
         });
     });
 

--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -480,6 +480,30 @@ describe("MegolmDecryption", function() {
 
                 expect(mockBaseApis.queueToDevice).not.toHaveBeenCalled();
             });
+
+            it("sholdn't wedge the setup promise if sharing a room key fails", async () => {
+                // @ts-ignore - private field access
+                const initialSetupPromise = await megolmEncryption.setupPromise;
+                expect(initialSetupPromise).toBe(null);
+
+                // @ts-ignore - private field access
+                megolmEncryption.shareSession = () => {
+                    throw new Error("Can't share session");
+                }
+
+                // @ts-ignore - private field access
+                const room = new Room(megolmEncryption.roomId);
+
+                await expect(() =>
+                    // @ts-ignore - private field access
+                    megolmEncryption.ensureOutboundSession(mockRoom, {}, {}, true)
+                ).rejects.toThrow();
+
+                // @ts-ignore - private field access
+                const finalSetupPromise = await megolmEncryption.setupPromise;
+                expect(finalSetupPromise).toBe(null);
+            });
+
         });
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -9302,13 +9302,13 @@ export function fixNotificationCountOnDecryption(cli: MatrixClient, event: Matri
             const thread = room.getThread(event.threadRootId);
             hasReadEvent = thread
                 ? thread.hasUserReadEvent(cli.getUserId()!, event.getId()!)
-                // If the thread object does not exist in the room yet, we don't
-                // want to calculate notification for this event yet. We have not
-                // restored the read receipts yet and can't accurately calculate
-                // highlight notifications at this stage.
-                //
-                // This issue can likely go away when MSC3874 is implemented
-                : true;
+                : // If the thread object does not exist in the room yet, we don't
+                  // want to calculate notification for this event yet. We have not
+                  // restored the read receipts yet and can't accurately calculate
+                  // highlight notifications at this stage.
+                  //
+                  // This issue can likely go away when MSC3874 is implemented
+                  true;
         } else {
             hasReadEvent = room.hasUserReadEvent(cli.getUserId()!, event.getId()!);
         }

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -265,7 +265,9 @@ export class MegolmEncryption extends EncryptionAlgorithm {
      * Using `>>=` to represent the promise chaining operation, it does the
      * following:
      *
+     * ```
      * setupPromise = previousSetupPromise >>= setup >>= discardErrors
+     * ```
      *
      * The initial value for the `setupPromise` is a promise that resolves to
      * `null`. The forceDiscardSession() resets setupPromise to this initial

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -256,6 +256,21 @@ export class MegolmEncryption extends EncryptionAlgorithm {
      * @param singleOlmCreationPhase - Only perform one round of olm
      *     session creation
      *
+     * This method updates the setupPromise field of the class by chaining a new
+     * call on top of the existing promise, and then catching and discarding any
+     * errors that might happen while setting up the outbound group session. This
+     * is done to ensure that `setupPromise` always resolves to `null` or the
+     * `OutboundSessionInfo`.
+     *
+     * Using `>>=` to represent the promise chaining operation, it does the
+     * following:
+     *
+     * setupPromise = previousSetupPromise >>= setup >>= discardErrors
+     *
+     * The initial value for the `setupPromise` is a promise that resolves to
+     * `null`. The forceDiscardSession() resets setupPromise to this initial
+     * promise.
+     *
      * @returns Promise which resolves to the
      *    OutboundSessionInfo when setup is complete.
      */
@@ -286,18 +301,20 @@ export class MegolmEncryption extends EncryptionAlgorithm {
         };
 
         // first wait for the previous share to complete
-        const prom = this.setupPromise.then(setup);
+        const fallible = this.setupPromise.then(setup);
 
-        // Ensure any failures are logged for debugging
-        prom.catch(e => {
+        // Ensure any failures are logged for debugging and make sure that the
+        // promise chain remains unbroken
+        //
+        // setupPromise resolves to `null` or the `OutboundSessionInfo` whether
+        // or not the share succeeds
+        this.setupPromise = fallible.catch(e => {
             logger.error(`Failed to setup outbound session in ${this.roomId}`, e);
+            return null;
         });
 
-        // setupPromise resolves to `session` whether or not the share succeeds
-        this.setupPromise = prom;
-
         // but we return a promise which only resolves if the share was successful.
-        return prom;
+        return fallible;
     }
 
     private async prepareSession(

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -283,19 +283,12 @@ export class MegolmEncryption extends EncryptionAlgorithm {
         // takes the previous OutboundSessionInfo, and considers whether to create
         // a new one. Also shares the key with any (new) devices in the room.
         //
-        // Returns the successful session whether keyshare succeeds or not.
-        //
         // returns a promise which resolves once the keyshare is successful.
         const setup = async (oldSession: OutboundSessionInfo | null): Promise<OutboundSessionInfo> => {
             const sharedHistory = isRoomSharedHistory(room);
-
             const session = await this.prepareSession(devicesInRoom, sharedHistory, oldSession);
 
-            try {
-                await this.shareSession(devicesInRoom, sharedHistory, singleOlmCreationPhase, blocked, session);
-            } catch (e) {
-                logger.error(`Failed to ensure outbound session in ${this.roomId}`, e);
-            }
+            await this.shareSession(devicesInRoom, sharedHistory, singleOlmCreationPhase, blocked, session);
 
             return session;
         };


### PR DESCRIPTION
This PR intends to fix https://github.com/vector-im/element-web/issues/23792.

What should have been an easy fix sadly turned out to be a deciphering of the logic here. It seems to me that the `ensureOutboundSession()` has a bug which would wedge the outbound group session in the case of an error.

This wasn't problematic until now, since almost no errors happen in the `prepareSession()` call, but as we found out may happen in the `shareSession` call.

The first patch fixes the mentioned bug, aligning the code with the comments.
The second patch now propagates errors from the `shareSession` call to the caller.

The individual commits have even more info around what each of them does and means.

I tested this in Element Web, if there's an error in `shareSession` we get prompted to retry the sending of the event. If the error happened to be transient, a press of the retry button will successfully share the outbound session and send the event.

This closes:  https://github.com/vector-im/element-web/issues/23792.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't swallow errors coming from the shareSession call ([\#2908](https://github.com/matrix-org/matrix-js-sdk/pull/2908)). Fixes vector-im/element-web#23792. Contributed by @poljar.<!-- CHANGELOG_PREVIEW_END -->