### PR TITLE
Process `m.room.encryption` events before emitting `RoomMember` events

### DIFF
--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -19,6 +19,7 @@ import { MemoryStore } from "../../src";
 import { RoomKeyRequestState } from '../../src/crypto/OutgoingRoomKeyRequestManager';
 import { RoomMember } from '../../src/models/room-member';
 import { IStore } from '../../src/store';
+import { IRoomEncryption, RoomList } from "../../src/crypto/RoomList";
 
 const Olm = global.Olm;
 
@@ -1138,6 +1139,50 @@ describe("Crypto", function() {
         // start() is a no-op nowadays, so there's not much to test here.
         it("should complete successfully", async () => {
             await client!.client.crypto!.start();
+        });
+    });
+
+    describe("setRoomEncryption", () => {
+        let mockClient: MatrixClient;
+        let mockRoomList: RoomList;
+        let clientStore: IStore;
+        let crypto: Crypto;
+
+        beforeEach(async function() {
+            mockClient = {} as MatrixClient;
+            const mockStorage = new MockStorageApi() as unknown as Storage;
+            clientStore = new MemoryStore({ localStorage: mockStorage }) as unknown as IStore;
+            const cryptoStore = new MemoryCryptoStore();
+
+            mockRoomList = {
+                getRoomEncryption: jest.fn().mockReturnValue(null),
+                setRoomEncryption: jest.fn().mockResolvedValue(undefined),
+            } as unknown as RoomList;
+
+            crypto = new Crypto(
+                mockClient,
+                "@alice:home.server",
+                "FLIBBLE",
+                clientStore,
+                cryptoStore,
+                mockRoomList,
+                [],
+            );
+        });
+
+        it("should set the algorithm if called for a known room", async () => {
+            const room = new Room("!room:id", mockClient, "@my.user:id");
+            await clientStore.storeRoom(room);
+            await crypto.setRoomEncryption("!room:id", { algorithm: "m.megolm.v1.aes-sha2" } as IRoomEncryption);
+            expect(mockRoomList!.setRoomEncryption).toHaveBeenCalledTimes(1);
+            expect(jest.mocked(mockRoomList!.setRoomEncryption).mock.calls[0][0]).toEqual("!room:id");
+        });
+
+        it("should raise if called for an unknown room", async () => {
+            await expect(async () => {
+                await crypto.setRoomEncryption("!room:id", { algorithm: "m.megolm.v1.aes-sha2" } as IRoomEncryption);
+            }).rejects.toThrow(/unknown room/);
+            expect(mockRoomList!.setRoomEncryption).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2972,10 +2972,11 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * handle an m.room.encryption event
      *
-     * @param {module:models/event.MatrixEvent} event encryption event
+     * @param room in which the event was received
+     * @param event encryption event to be processed
      */
-    public async onCryptoEvent(event: MatrixEvent): Promise<void> {
-        const roomId = event.getRoomId()!;
+    public async onCryptoEvent(room: Room, event: MatrixEvent): Promise<void> {
+        const roomId = room.roomId;
         const content = event.getContent<IRoomEncryption>();
 
         try {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -86,6 +86,7 @@ import { ISyncStateData } from "../sync";
 import { CryptoStore } from "./store/base";
 import { IVerificationChannel } from "./verification/request/Channel";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
+import { IContent } from "../models/event";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 
@@ -2882,7 +2883,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             delete content['io.element.performance_metrics'];
         }
 
-        const encryptedContent = await alg.encryptMessage(room, event.getType(), content);
+        const encryptedContent = await alg.encryptMessage(room, event.getType(), content) as IContent;
 
         if (mRelatesTo) {
             encryptedContent['m.relates_to'] = mRelatesTo;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2862,11 +2862,8 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             );
         }
 
-        if (!this.roomDeviceTrackingState[roomId]) {
-            this.trackRoomDevices(roomId);
-        }
         // wait for all the room devices to be loaded
-        await this.roomDeviceTrackingState[roomId];
+        await this.trackRoomDevicesImpl(room);
 
         let content = event.getContent();
         // If event has an m.relates_to then we need

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2856,7 +2856,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             // MatrixClient has already checked that this room should be encrypted,
             // so this is an unexpected situation.
             throw new Error(
-                "Room was previously configured to use encryption, but is " +
+                "Room " + roomId + " was previously configured to use encryption, but is " +
                 "no longer. Perhaps the homeserver is hiding the " +
                 "configuration event.",
             );

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -703,7 +703,7 @@ export class SlidingSyncSdk {
         const processRoomEvent = async (e: MatrixEvent): Promise<void> => {
             client.emit(ClientEvent.Event, e);
             if (e.isState() && e.getType() == EventType.RoomEncryption && this.opts.crypto) {
-                await this.opts.crypto.onCryptoEvent(e);
+                await this.opts.crypto.onCryptoEvent(room, e);
             }
         };
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1392,7 +1392,7 @@ export class SyncApi {
             const processRoomEvent = async (e): Promise<void> => {
                 client.emit(ClientEvent.Event, e);
                 if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
-                    await this.opts.crypto.onCryptoEvent(e);
+                    await this.opts.crypto.onCryptoEvent(room, e);
                 }
             };
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1362,6 +1362,18 @@ export class SyncApi {
                 }
             }
 
+            // process any crypto events *before* emitting the RoomStateEvent events. This
+            // avoids a race condition if the application tries to send a message after the
+            // state event is processed, but before crypto is enabled, which then causes the
+            // crypto layer to complain.
+            if (this.opts.crypto) {
+                for (const e of stateEvents.concat(events)) {
+                    if (e.isState() && e.getType() === EventType.RoomEncryption && e.getStateKey() === "") {
+                        await this.opts.crypto.onCryptoEvent(room, e);
+                    }
+                }
+            }
+
             try {
                 await this.injectRoomEvents(room, stateEvents, events, syncEventData.fromCache);
             } catch (e) {
@@ -1389,21 +1401,11 @@ export class SyncApi {
 
             this.processEventsForNotifs(room, events);
 
-            const processRoomEvent = async (e): Promise<void> => {
-                client.emit(ClientEvent.Event, e);
-                if (e.isState() && e.getType() == "m.room.encryption" && this.opts.crypto) {
-                    await this.opts.crypto.onCryptoEvent(room, e);
-                }
-            };
-
-            await utils.promiseMapSeries(stateEvents, processRoomEvent);
-            await utils.promiseMapSeries(events, processRoomEvent);
-            ephemeralEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
-            accountDataEvents.forEach(function(e) {
-                client.emit(ClientEvent.Event, e);
-            });
+            const emitEvent = (e: MatrixEvent): boolean => client.emit(ClientEvent.Event, e);
+            stateEvents.forEach(emitEvent);
+            events.forEach(emitEvent);
+            ephemeralEvents.forEach(emitEvent);
+            accountDataEvents.forEach(emitEvent);
 
             // Decrypt only the last message in all rooms to make sure we can generate a preview
             // And decrypt all events after the recorded read receipt to ensure an accurate


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23819

The root cause of https://github.com/vector-im/element-web/issues/23819 is as follows:
 * In `matrix-react-sdk`, [`ensureDMExists`](https://github.com/matrix-org/matrix-react-sdk/blob/v3.62.0-rc.1/src/createRoom.ts#L418-L433) tries to create an encrypted DM room, and assumes it is ready for use (including sending encrypted events) as soon as it receives a `RoomStateEvent.NewMember` notification indicating that the other user has been invited or joined. 
 * However, in `sync.ts`, we process the membership events in a `/sync` response  (including emitting `RoomStateEvent.NewMember` notifications) [here](https://github.com/matrix-org/matrix-js-sdk/blob/v22.0.0-rc.1/src/sync.ts#L1366), which is long before we process any `m.room.encryption` event ([here](https://github.com/matrix-org/matrix-js-sdk/blob/v22.0.0-rc.1/src/sync.ts#L1395)).
 * The upshot is that we can end up trying to send an encrypted event in the new room before processing the `m.room.encryption` event, which causes the crypto layer to blow up with the error in https://github.com/vector-im/element-web/issues/23819.

Strictly speaking, `ensureDMExists` probably ought to be listening for `ClientEvent.Room` as well as `RoomStateEvent.NewMember`; but that doesn't help us, because `ClientEvent.Room` is *also* emitted before we process the crypto event.

So, we need to process the crypto event before we start emitting these other events; but a corollary of that is that we need to do so *before* we store the new room in the client's store. That makes things tricky, because currently the crypto layer expects the room to have been stored in the client first.

So... we have to rearrange everything to pass the newly-created `Room` object into the crypto layer, rather than just the room id, so that it doesn't need to rely on getting the `Room` from the client's store.

I've tried to structure the commits in this PR in a way to make them easy to review.

(This is another go at https://github.com/matrix-org/matrix-js-sdk/pull/2910).

See also: 
 * https://github.com/matrix-org/matrix-react-sdk/pull/9650, which is a dummy PR to ensure that the current react-sdk and EW tests continue to pass with this change
 * https://github.com/matrix-org/matrix-react-sdk/pull/9619, which adds a cypress test that this works.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Process `m.room.encryption` events before emitting `RoomMember` events ([\#2914](https://github.com/matrix-org/matrix-js-sdk/pull/2914)). Fixes vector-im/element-web#23819.<!-- CHANGELOG_PREVIEW_END -->