### PR TITLE
Redo key sharing after own device verification

### DIFF
--- a/spec/unit/crypto/verification/setDeviceVerification.spec.ts
+++ b/spec/unit/crypto/verification/setDeviceVerification.spec.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '../../../olm-loader';
+
+import { CRYPTO_ENABLED, MatrixClient } from "../../../../src/client";
+import { TestClient } from "../../../TestClient";
+
+const Olm = global.Olm;
+
+describe("crypto.setDeviceVerification", () => {
+    const userId = "@alice:example.com";
+    const deviceId1 = "device1";
+    let client: MatrixClient;
+
+    if (!CRYPTO_ENABLED) {
+        return;
+    }
+
+    beforeAll(async () => {
+        await Olm.init();
+    });
+
+    beforeEach(async () => {
+        client = (new TestClient(userId, deviceId1)).client;
+        await client.initCrypto();
+    });
+
+    it("client should provide crypto", () => {
+        expect(client.crypto).not.toBeUndefined();
+    });
+
+    describe("when setting an own device as verified", () => {
+        beforeEach(async () => {
+            jest.spyOn(client.crypto!, "cancelAndResendAllOutgoingKeyRequests");
+            await client.crypto!.setDeviceVerification(
+                userId,
+                deviceId1,
+                true,
+            );
+        });
+
+        it("cancelAndResendAllOutgoingKeyRequests should be called", () => {
+            expect(client.crypto!.cancelAndResendAllOutgoingKeyRequests).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2270,6 +2270,9 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
                 await upload({ shouldEmit: true });
                 // XXX: we'll need to wait for the device list to be updated
             }
+
+            // redo key requests after verification
+            this.cancelAndResendAllOutgoingKeyRequests();
         }
 
         const deviceObj = DeviceInfo.fromStorage(dev, deviceId);


### PR DESCRIPTION
If you don't set up key backup and verify one of your other devices, you won't receive keys for the messages of already viewed rooms. This PR triggers key requests after verifying an own device.

See the linked issue for a detailed description on how to reproduce it.

Fixes https://github.com/vector-im/element-web/issues/23333

Before

https://user-images.githubusercontent.com/6216686/204786166-4bce51c9-81a8-4b22-8d8a-a0417d002abe.mp4

After

https://user-images.githubusercontent.com/6216686/204786195-32c7692a-6562-446b-b6e5-fc2a9ab50b8b.mp4

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Redo key sharing after own device verification ([\#2921](https://github.com/matrix-org/matrix-js-sdk/pull/2921)). Fixes vector-im/element-web#23333.<!-- CHANGELOG_PREVIEW_END -->