### PR TITLE
Include pending events in thread summary and count again

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2017,6 +2017,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const thread = new Thread(threadId, rootEvent, {
             room: this,
             client: this.client,
+            pendingEventOrdering: this.opts.pendingEventOrdering,
         });
 
         // This is necessary to be able to jump to events in threads:

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -16,10 +16,10 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import { MatrixClient } from "../client";
+import { MatrixClient, PendingEventOrdering } from "../client";
 import { TypedReEmitter } from "../ReEmitter";
 import { RelationType } from "../@types/event";
-import { IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event";
+import { EventStatus, IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event";
 import { EventTimeline } from "./event-timeline";
 import { EventTimelineSet, EventTimelineSetHandlerMap } from './event-timeline-set';
 import { NotificationCountType, Room, RoomEvent } from './room';
@@ -51,6 +51,7 @@ export type EventHandlerMap = {
 interface IThreadOpts {
     room: Room;
     client: MatrixClient;
+    pendingEventOrdering?: PendingEventOrdering;
 }
 
 export enum FeatureSupport {
@@ -88,9 +89,12 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
 
     private lastEvent: MatrixEvent | undefined;
     private replyCount = 0;
+    private lastPendingEvent: MatrixEvent | undefined;
+    private pendingReplyCount = 0;
 
     public readonly room: Room;
     public readonly client: MatrixClient;
+    private readonly pendingEventOrdering: PendingEventOrdering;
 
     public initialEventsFetched = !Thread.hasServerSideSupport;
 
@@ -109,6 +113,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
 
         this.room = opts.room;
         this.client = opts.client;
+        this.pendingEventOrdering = opts.pendingEventOrdering ?? PendingEventOrdering.Chronological;
         this.timelineSet = new EventTimelineSet(this.room, {
             timelineSupport: true,
             pendingEvents: true,
@@ -300,6 +305,18 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
             bundledRelationship = this.getRootEventBundledRelationship();
         }
 
+        let pendingEvents: MatrixEvent[] = [];
+        if (this.pendingEventOrdering === PendingEventOrdering.Detached) {
+            pendingEvents = this.room.getPendingEvents().filter((ev) => {
+                const isNotSent = ev.status === EventStatus.NOT_SENT;
+                const belongsToTheThread = this.id === ev.threadRootId;
+                return isNotSent && belongsToTheThread;
+            });
+            await Promise.all(pendingEvents.map(ev => this.processEvent(ev)));
+        }
+        this.lastPendingEvent = pendingEvents.length ? pendingEvents[pendingEvents.length - 1] : undefined;
+        this.pendingReplyCount = pendingEvents.length;
+
         if (Thread.hasServerSideSupport && bundledRelationship) {
             this.replyCount = bundledRelationship.count;
             this._currentUserParticipated = !!bundledRelationship.current_user_participated;
@@ -393,14 +410,14 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
      * exclude annotations from that number
      */
     public get length(): number {
-        return this.replyCount;
+        return this.replyCount + this.pendingReplyCount;
     }
 
     /**
      * A getter for the last event added to the thread, if known.
      */
     public get replyToEvent(): Optional<MatrixEvent> {
-        return this.lastEvent ?? this.lastReply();
+        return this.lastPendingEvent ?? this.lastEvent ?? this.lastReply();
     }
 
     public get events(): MatrixEvent[] {


### PR DESCRIPTION
Type: Enhancement
Fixes: https://github.com/vector-im/element-web/issues/23642

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Include pending events in thread summary and count again ([\#2922](https://github.com/matrix-org/matrix-js-sdk/pull/2922)). Fixes vector-im/element-web#23642. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->