### PR TITLE
bugfix: sliding sync initial room timelines shouldn't notify

### DIFF
--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -23,7 +23,7 @@ import { TestClient } from "../TestClient";
 import { IRoomEvent, IStateEvent } from "../../src/sync-accumulator";
 import {
     MatrixClient, MatrixEvent, NotificationCountType, JoinRule, MatrixError,
-    EventType, IPushRules, PushRuleKind, TweakName, ClientEvent, RoomMemberEvent,
+    EventType, IPushRules, PushRuleKind, TweakName, ClientEvent, RoomMemberEvent, RoomEvent, Room, EventTimelineSet, IRoomTimelineData,
 } from "../../src";
 import { SlidingSyncSdk } from "../../src/sliding-sync-sdk";
 import { SyncState } from "../../src/sync";
@@ -170,6 +170,7 @@ describe("SlidingSyncSdk", () => {
             const roomE = "!e_with_invite:localhost";
             const roomF = "!f_calc_room_name:localhost";
             const roomG = "!g_join_invite_counts:localhost";
+            const roomH = "!g_num_live:localhost";
             const data: Record<string, MSC3575RoomData> = {
                 [roomA]: {
                     name: "A",
@@ -275,6 +276,18 @@ describe("SlidingSyncSdk", () => {
                     invited_count: 2,
                     initial: true,
                 },
+                [roomH]: {
+                    name: "H",
+                    required_state: [],
+                    timeline: [
+                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
+                        mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
+                        mkOwnEvent(EventType.RoomMessage, { body: "live event" }),
+                    ],
+                    initial: true,
+                    num_live: 1,
+                },
             };
 
             it("can be created with required_state and timeline", () => {
@@ -324,6 +337,27 @@ describe("SlidingSyncSdk", () => {
                 if (gotRoom == null) { return; }
                 expect(gotRoom.getInvitedMemberCount()).toEqual(data[roomG].invited_count);
                 expect(gotRoom.getJoinedMemberCount()).toEqual(data[roomG].joined_count);
+            });
+
+            it("can be created with live events", () => {
+                let seenLiveEvent = false;
+                const listener = (ev: MatrixEvent, room?: Room, toStartOfTimeline?: boolean, deleted?: boolean, timelineData?: IRoomTimelineData) => {
+                    if (timelineData?.liveEvent) {
+                        assertTimelineEvents([ev], data[roomH].timeline.slice(-1));
+                        seenLiveEvent = true;
+                    }
+                };
+                client!.on(RoomEvent.Timeline, listener);
+                mockSlidingSync!.emit(SlidingSyncEvent.RoomData, roomH, data[roomH]);
+                client!.off(RoomEvent.Timeline, listener);
+                const gotRoom = client!.getRoom(roomH);
+                expect(gotRoom).toBeDefined();
+                if (gotRoom == null) { return; }
+                expect(gotRoom.name).toEqual(data[roomH].name);
+                expect(gotRoom.getMyMembership()).toEqual("join");
+                // check the entire timeline is correct
+                assertTimelineEvents(gotRoom.getLiveTimeline().getEvents(), data[roomH].timeline);
+                expect(seenLiveEvent).toBe(true);
             });
 
             it("can be created with invite_state", () => {

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -23,7 +23,7 @@ import { TestClient } from "../TestClient";
 import { IRoomEvent, IStateEvent } from "../../src/sync-accumulator";
 import {
     MatrixClient, MatrixEvent, NotificationCountType, JoinRule, MatrixError,
-    EventType, IPushRules, PushRuleKind, TweakName, ClientEvent, RoomMemberEvent, RoomEvent, Room, EventTimelineSet, IRoomTimelineData,
+    EventType, IPushRules, PushRuleKind, TweakName, ClientEvent, RoomMemberEvent, RoomEvent, Room, IRoomTimelineData,
 } from "../../src";
 import { SlidingSyncSdk } from "../../src/sliding-sync-sdk";
 import { SyncState } from "../../src/sync";
@@ -341,7 +341,13 @@ describe("SlidingSyncSdk", () => {
 
             it("can be created with live events", () => {
                 let seenLiveEvent = false;
-                const listener = (ev: MatrixEvent, room?: Room, toStartOfTimeline?: boolean, deleted?: boolean, timelineData?: IRoomTimelineData) => {
+                const listener = (
+                    ev: MatrixEvent,
+                    room?: Room,
+                    toStartOfTimeline?: boolean,
+                    deleted?: boolean,
+                    timelineData?: IRoomTimelineData,
+                ) => {
                     if (timelineData?.liveEvent) {
                         assertTimelineEvents([ev], data[roomH].timeline.slice(-1));
                         seenLiveEvent = true;

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -726,7 +726,8 @@ export class SlidingSyncSdk {
      * at the *START* of the timeline list if it is supplied.
      * @param {MatrixEvent[]} [timelineEventList] A list of timeline events. Lower index
      * is earlier in time. Higher index is later.
-     * @param {boolean} isInitial whether timeline list is from an initial: true room.
+     * @param {number} numLive the number of events in timelineEventList which just happened,
+     * supplied from the server.
      */
     public injectRoomEvents(
         room: Room,

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -95,6 +95,7 @@ export interface MSC3575RoomData {
     limited?: boolean;
     is_dm?: boolean;
     prev_batch?: string;
+    num_live?: number;
 }
 
 interface ListResponse {


### PR DESCRIPTION
Flag timeline events as `fromCache` when `initial: true` rooms are received. This stops notifications appearing inappropriately when you scroll the room list or spider the room list, as it causes `liveEvent=false`.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * bugfix: sliding sync initial room timelines shouldn't notify ([\#2933](https://github.com/matrix-org/matrix-js-sdk/pull/2933)).<!-- CHANGELOG_PREVIEW_END -->