### PR TITLE
Make GroupCall work better with widgets

### DIFF
--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -416,6 +416,9 @@ export class MockCallMatrixClient extends TypedEventEmitter<EmittedEvents, Emitt
     public getRooms = jest.fn<Room[], []>().mockReturnValue([]);
     public getRoom = jest.fn();
 
+    public supportsExperimentalThreads(): boolean { return true; }
+    public async decryptEventIfNeeded(): Promise<void> {}
+
     public typed(): MatrixClient { return this as unknown as MatrixClient; }
 
     public emitRoomState(event: MatrixEvent, state: RoomState): void {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -285,6 +285,21 @@ export class GroupCall extends TypedEventEmitter<
         this._creationTs = value;
     }
 
+    private _enteredViaAnotherSession = false;
+
+    /**
+     * Whether the local device has entered this call via another session, such
+     * as a widget.
+     */
+    public get enteredViaAnotherSession(): boolean {
+        return this._enteredViaAnotherSession;
+    }
+
+    public set enteredViaAnotherSession(value: boolean) {
+        this._enteredViaAnotherSession = value;
+        this.updateParticipants();
+    }
+
     /**
      * Executes the given callback on all calls in this group call.
      * @param f The callback.
@@ -1170,7 +1185,7 @@ export class GroupCall extends TypedEventEmitter<
 
         const participants = new Map<RoomMember, Map<string, ParticipantState>>();
         const now = Date.now();
-        const entered = this.state === GroupCallState.Entered;
+        const entered = this.state === GroupCallState.Entered || this.enteredViaAnotherSession;
         let nextExpiration = Infinity;
 
         for (const e of this.getMemberStateEvents()) {
@@ -1344,8 +1359,11 @@ export class GroupCall extends TypedEventEmitter<
         await this.updateDevices(devices => {
             const newDevices = devices.filter(d => {
                 const device = deviceMap.get(d.device_id);
-                return device?.last_seen_ts !== undefined
-                    && !(d.device_id === this.client.getDeviceId()! && this.state !== GroupCallState.Entered);
+                return device?.last_seen_ts !== undefined && !(
+                    d.device_id === this.client.getDeviceId()!
+                    && this.state !== GroupCallState.Entered
+                    && !this.enteredViaAnotherSession
+                );
             });
 
             // Skip the update if the devices are unchanged


### PR DESCRIPTION
If the client uses a widget to join group calls, like Element Web does, then the local device could be joined to the call without GroupCall knowing. This adds a field to GroupCall that allows the client to tell GroupCall when it's using another session to join the call.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Make GroupCall work better with widgets ([\#2935](https://github.com/matrix-org/matrix-js-sdk/pull/2935)).<!-- CHANGELOG_PREVIEW_END -->