### PR TITLE
Fix highlight notifications increasing when total notification is zero

### DIFF
--- a/spec/unit/notifications.spec.ts
+++ b/spec/unit/notifications.spec.ts
@@ -114,8 +114,8 @@ describe("fixNotificationCountOnDecryption", () => {
 
         fixNotificationCountOnDecryption(mockClient, event);
 
-        expect(room.getRoomUnreadNotificationCount(NotificationCountType.Total)).toBe(0);
-        expect(room.getRoomUnreadNotificationCount(NotificationCountType.Highlight)).toBe(0);
+        expect(room.getRoomUnreadNotificationCount(NotificationCountType.Total)).toBe(1);
+        expect(room.getRoomUnreadNotificationCount(NotificationCountType.Highlight)).toBe(1);
     });
 
     it("changes the thread count to highlight on decryption", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9378,7 +9378,6 @@ export function fixNotificationCountOnDecryption(cli: MatrixClient, event: Matri
 
     const isThreadEvent = !!event.threadRootId && !event.isThreadRoot;
 
-    const totalCount = room.getUnreadCountForEventContext(NotificationCountType.Total, event);
     const currentCount = room.getUnreadCountForEventContext(NotificationCountType.Highlight, event);
 
     // Ensure the unread counts are kept up to date if the event is encrypted
@@ -9386,7 +9385,7 @@ export function fixNotificationCountOnDecryption(cli: MatrixClient, event: Matri
     // have encrypted events to avoid other code from resetting 'highlight' to zero.
     const oldHighlight = !!oldActions?.tweaks?.highlight;
     const newHighlight = !!actions?.tweaks?.highlight;
-    if ((oldHighlight !== newHighlight || currentCount > 0) && totalCount > 0) {
+    if (oldHighlight !== newHighlight || currentCount > 0) {
         // TODO: Handle mentions received while the client is offline
         // See also https://github.com/vector-im/element-web/issues/9069
         const hasReadEvent = isThreadEvent

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1696,7 +1696,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             Array.from(this.threads)
                 .forEach(([, thread]) => {
                     if (thread.length === 0) return;
-                    const currentUserParticipated = thread.events.some(event => {
+                    const currentUserParticipated = thread.timeline.some(event => {
                         return event.getSender() === this.client.getUserId();
                     });
                     if (filterType !== ThreadFilterType.My || currentUserParticipated) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/23885

This was originally as an attempt to be more defensive and prevent highlight notification to appear for already read events! 
The synthetic read receipts should help

This clears the release blocker and will monitor the tracker

It also fixes an issue where `public get timeline(): MatrixEvent[]` would always return `undefined` because the `public abstract timeline: MatrixEvent[]` declaration in the parent was overriding it.
It created a lot of inconsistencies when trying to determine whether a message has been previously read or not!

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix highlight notifications increasing when total notification is zero ([\#2937](https://github.com/matrix-org/matrix-js-sdk/pull/2937)). Fixes vector-im/element-web#23885.<!-- CHANGELOG_PREVIEW_END -->