### PR TITLE
Upload device keys during initCrypto

### DIFF
--- a/spec/integ/matrix-client-crypto.spec.ts
+++ b/spec/integ/matrix-client-crypto.spec.ts
@@ -55,10 +55,7 @@ interface OlmPayload {
 
 async function bobUploadsDeviceKeys(): Promise<void> {
     bobTestClient.expectDeviceKeyUpload();
-    await Promise.all([
-        bobTestClient.client.uploadKeys(),
-        bobTestClient.httpBackend.flushAllExpected(),
-    ]);
+    await bobTestClient.httpBackend.flushAllExpected();
     expect(Object.keys(bobTestClient.deviceKeys!).length).not.toEqual(0);
 }
 

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -511,7 +511,12 @@ describe("MatrixClient", function() {
         }
 
         beforeEach(function() {
-            return client!.initCrypto();
+            // running initCrypto should trigger a key upload
+            httpBackend!.when("POST", "/keys/upload").respond(200, {});
+            return Promise.all([
+                client!.initCrypto(),
+                httpBackend!.flush("/keys/upload", 1),
+            ]);
         });
 
         afterEach(() => {
@@ -1369,6 +1374,13 @@ describe("MatrixClient", function() {
             const prom = client!.setPowerLevel("!room_id:server", userId, 100, event);
             await httpBackend!.flushAllExpected();
             await prom;
+        });
+    });
+
+    describe("uploadKeys", () => {
+        // uploadKeys() is a no-op nowadays, so there's not much to test here.
+        it("should complete successfully", async () => {
+            await client!.uploadKeys();
         });
     });
 });

--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -993,7 +993,13 @@ describe("Crypto", function() {
             });
 
             client = new TestClient("@alice:example.org", "aliceweb");
-            await client.client.initCrypto();
+
+            // running initCrypto should trigger a key upload
+            client.httpBackend.when("POST", "/keys/upload").respond(200, {});
+            await Promise.all([
+                client.client.initCrypto(),
+                client.httpBackend.flush("/keys/upload", 1),
+            ]);
 
             encryptedPayload = {
                 algorithm: "m.olm.v1.curve25519-aes-sha2",

--- a/spec/unit/crypto/backup.spec.ts
+++ b/spec/unit/crypto/backup.spec.ts
@@ -127,7 +127,7 @@ function makeTestClient(cryptoStore) {
     ].reduce((r, k) => {r[k] = jest.fn(); return r;}, {}) as MockedObject<MatrixScheduler>;
     const store = new StubStore();
 
-    return new MatrixClient({
+    const client = new MatrixClient({
         baseUrl: "https://my.home.server",
         idBaseUrl: "https://identity.server",
         accessToken: "my.access.token",
@@ -139,6 +139,10 @@ function makeTestClient(cryptoStore) {
         cryptoStore: cryptoStore,
         cryptoCallbacks: { getCrossSigningKey, saveCrossSigningKeys },
     });
+
+    // initialising the crypto library will trigger a key upload request, which we can stub out
+    client.uploadKeysRequest = jest.fn();
+    return client;
 }
 
 describe("MegolmBackup", function() {
@@ -502,6 +506,8 @@ describe("MegolmBackup", function() {
                 deviceId: "device",
                 cryptoStore: cryptoStore,
             });
+            // initialising the crypto library will trigger a key upload request, which we can stub out
+            client.uploadKeysRequest = jest.fn();
 
             megolmDecryption = new MegolmDecryption({
                 userId: '@user:id',
@@ -718,6 +724,9 @@ describe("MegolmBackup", function() {
                 deviceId: "device",
                 cryptoStore,
             });
+            // initialising the crypto library will trigger a key upload request, which we can stub out
+            client.uploadKeysRequest = jest.fn();
+
             await client.initCrypto();
 
             cryptoStore.countSessionsNeedingBackup = jest.fn().mockReturnValue(6);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1199,10 +1199,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             this.store.storeUser(new User(userId));
         }
 
-        if (this.crypto) {
-            this.crypto.uploadDeviceKeys();
-        }
-
         // periodically poll for turn servers if we support voip
         if (this.canSupportVoip) {
             this.checkTurnServersIntervalID = setInterval(() => {
@@ -1851,6 +1847,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // if crypto initialisation was successful, tell it to attach its event handlers.
         crypto.registerEventHandlers(this as Parameters<Crypto["registerEventHandlers"]>[0]);
         this.crypto = crypto;
+
+        // upload our keys in the background
+        this.crypto.uploadDeviceKeys().catch((e) => {
+            // TODO: throwing away this error is a really bad idea.
+            logger.error("Error uploading device keys", e);
+        });
     }
 
     /**
@@ -1882,15 +1884,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Upload the device keys to the homeserver.
-     * @return {Promise<void>} A promise that will resolve when the keys are uploaded.
+     * @deprecated Does nothing.
      */
     public async uploadKeys(): Promise<void> {
-        if (!this.crypto) {
-            throw new Error("End-to-end encryption disabled");
-        }
-
-        await this.crypto.uploadDeviceKeys();
+        logger.warn("MatrixClient.uploadKeys is deprecated");
     }
 
     /**


### PR DESCRIPTION
Rather than waiting for the application to call `.startClient`, upload the
device keys during `initCrypto()`. Element-R is going to approach this slightly
differently (the rust-sdk wants to manage the decision on key uploads itself),
so this lays some groundwork by collecting the libolm-specific bits together.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->