### PR TITLE
Fix the message ID on key-share messages

### DIFF
--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -1756,7 +1756,7 @@ class MegolmDecryption extends DecryptionAlgorithm {
                 algorithm: olmlib.OLM_ALGORITHM,
                 sender_key: this.olmDevice.deviceCurve25519Key,
                 ciphertext: {},
-                [ToDeviceMessageId]: uuidv4,
+                [ToDeviceMessageId]: uuidv4(),
             };
 
             return this.olmlib.encryptMessageForDevice(


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/2938 introduced message IDs on
outgoing to-device messages, but a typo meant that the IDs on key-share
messages were invalid.