### PR TITLE
Fix #23916: Prevent edits of the last message in a thread getting lost

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -27,12 +27,11 @@ import {
     MatrixEvent,
     PendingEventOrdering,
     Room,
-    RoomEvent,
 } from "../../src/matrix";
 import { logger } from "../../src/logger";
 import { encodeParams, encodeUri, QueryDict, replaceParam } from "../../src/utils";
 import { TestClient } from "../TestClient";
-import { FeatureSupport, Thread, THREAD_RELATION_TYPE } from "../../src/models/thread";
+import { FeatureSupport, Thread, THREAD_RELATION_TYPE, ThreadEvent } from "../../src/models/thread";
 import { emitPromise } from "../test-utils/test-utils";
 
 const userId = "@alice:localhost";
@@ -607,42 +606,6 @@ describe("MatrixClient event timelines", function () {
                 .respond(200, function () {
                     return THREAD_ROOT;
                 });
-
-            httpBackend
-                .when(
-                    "GET",
-                    "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                        encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        "?dir=b&limit=1",
-                )
-                .respond(200, function () {
-                    return {
-                        original_event: THREAD_ROOT,
-                        chunk: [THREAD_REPLY],
-                        // no next batch as this is the oldest end of the timeline
-                    };
-                });
-
-            const thread = room.createThread(THREAD_ROOT.event_id!, undefined, [], false);
-            await httpBackend.flushAllExpected();
-            const timelineSet = thread.timelineSet;
-
-            const timelinePromise = client.getEventTimeline(timelineSet, THREAD_REPLY.event_id!);
-            const timeline = await timelinePromise;
-
-            expect(timeline!.getEvents().find((e) => e.getId() === THREAD_ROOT.event_id!)).toBeTruthy();
-            expect(timeline!.getEvents().find((e) => e.getId() === THREAD_REPLY.event_id!)).toBeTruthy();
-        });
-
-        it("should handle thread replies with server support by fetching a contiguous thread timeline", async () => {
-            // @ts-ignore
-            client.clientOpts.experimentalThreadSupport = true;
-            Thread.setServerSideSupport(FeatureSupport.Experimental);
-            await client.stopClient(); // we don't need the client to be syncing at this time
-            const room = client.getRoom(roomId)!;
-
             httpBackend
                 .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
                 .respond(200, function () {
@@ -668,15 +631,14 @@ describe("MatrixClient event timelines", function () {
             const thread = room.createThread(THREAD_ROOT.event_id!, undefined, [], false);
             await httpBackend.flushAllExpected();
             const timelineSet = thread.timelineSet;
-
             httpBackend
                 .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
                 .respond(200, function () {
                     return THREAD_ROOT;
                 });
+            await flushHttp(emitPromise(thread, ThreadEvent.Update));
 
-            const timelinePromise = client.getEventTimeline(timelineSet, THREAD_REPLY.event_id!);
-            const [timeline] = await Promise.all([timelinePromise, httpBackend.flushAllExpected()]);
+            const timeline = await client.getEventTimeline(timelineSet, THREAD_REPLY.event_id!);
 
             const eventIds = timeline!.getEvents().map((it) => it.getId());
             expect(eventIds).toContain(THREAD_ROOT.event_id);
@@ -1285,7 +1247,7 @@ describe("MatrixClient event timelines", function () {
                             event_id: THREAD_ROOT.event_id,
                         },
                     },
-                    event: false,
+                    event: true,
                 });
 
                 // Test data for the first thread, with the second reply
@@ -1298,7 +1260,7 @@ describe("MatrixClient event timelines", function () {
                             "io.element.thread": {
                                 ...THREAD_ROOT.unsigned!["m.relations"]!["io.element.thread"],
                                 count: 2,
-                                latest_event: THREAD_REPLY2,
+                                latest_event: THREAD_REPLY2.event,
                             },
                         },
                     },
@@ -1326,12 +1288,13 @@ describe("MatrixClient event timelines", function () {
                 respondToThreads(threadsResponse);
                 respondToThreads(threadsResponse);
                 respondToEvent(THREAD_ROOT);
-                respondToEvent(THREAD_ROOT);
-                respondToEvent(THREAD2_ROOT);
                 respondToEvent(THREAD2_ROOT);
                 respondToThread(THREAD_ROOT, [THREAD_REPLY]);
                 respondToThread(THREAD2_ROOT, [THREAD2_REPLY]);
                 await flushHttp(room.fetchRoomThreads());
+                const threadIds = room.getThreads().map((thread) => thread.id);
+                expect(threadIds).toContain(THREAD_ROOT.event_id);
+                expect(threadIds).toContain(THREAD2_ROOT.event_id);
                 const [allThreads] = timelineSets!;
                 const timeline = allThreads.getLiveTimeline()!;
                 // Test threads are in chronological order
@@ -1342,12 +1305,15 @@ describe("MatrixClient event timelines", function () {
 
                 // Test adding a second event to the first thread
                 const thread = room.getThread(THREAD_ROOT.event_id!)!;
-                const prom = emitPromise(allThreads!, RoomEvent.Timeline);
-                await thread.addEvent(client.getEventMapper()(THREAD_REPLY2), false);
+                const prom = emitPromise(room, ThreadEvent.NewReply);
                 respondToEvent(THREAD_ROOT_UPDATED);
                 respondToEvent(THREAD_ROOT_UPDATED);
+                respondToEvent(THREAD_ROOT_UPDATED);
+                respondToEvent(THREAD2_ROOT);
+                room.addLiveEvents([THREAD_REPLY2]);
                 await httpBackend.flushAllExpected();
                 await prom;
+                expect(thread.length).toBe(2);
                 // Test threads are in chronological order
                 expect(timeline!.getEvents().map((it) => it.event.event_id)).toEqual([
                     THREAD2_ROOT.event_id,

--- a/spec/test-utils/thread.ts
+++ b/spec/test-utils/thread.ts
@@ -138,9 +138,6 @@ export const mkThread = ({
     }
 
     const thread = room.createThread(rootEvent.getId() ?? "", rootEvent, events, true);
-    // So that we do not have to mock the thread loading
-    thread.initialEventsFetched = true;
-    thread.addEvents(events, true);
 
     return { thread, rootEvent, events };
 };

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2475,11 +2475,11 @@ describe("Room", function () {
 
             let prom = emitPromise(room, ThreadEvent.New);
             room.addLiveEvents([randomMessage, threadRoot, threadResponse]);
-            const thread = await prom;
+            const thread: Thread = await prom;
             await emitPromise(room, ThreadEvent.Update);
 
-            expect(thread.replyToEvent.event).toEqual(threadResponse.event);
-            expect(thread.replyToEvent.getContent().body).toBe(threadResponse.getContent().body);
+            expect(thread.replyToEvent!.event).toEqual(threadResponse.event);
+            expect(thread.replyToEvent!.getContent().body).toBe(threadResponse.getContent().body);
 
             room.client.fetchRoomEvent = (eventId: string) =>
                 Promise.resolve({
@@ -2490,7 +2490,7 @@ describe("Room", function () {
                             [THREAD_RELATION_TYPE.name]: {
                                 latest_event: {
                                     ...threadResponse.event,
-                                    content: threadResponseEdit.event.content,
+                                    content: threadResponseEdit.getContent()["m.new_content"],
                                 },
                                 count: 2,
                                 current_user_participated: true,
@@ -2502,7 +2502,7 @@ describe("Room", function () {
             prom = emitPromise(room, ThreadEvent.Update);
             room.addLiveEvents([threadResponseEdit]);
             await prom;
-            expect(thread.replyToEvent.getContent().body).toBe(threadResponseEdit.getContent()["m.new_content"].body);
+            expect(thread.replyToEvent!.getContent().body).toBe(threadResponseEdit.getContent()["m.new_content"].body);
         });
 
         it("Redactions to thread responses decrement the length", async () => {
@@ -2847,7 +2847,7 @@ describe("Room", function () {
             expect(room.eventShouldLiveIn(reply2, events, roots).shouldLiveInThread).toBeFalsy();
         });
 
-        it("should aggregate relations in thread event timeline set", () => {
+        it("should aggregate relations in thread event timeline set", async () => {
             Thread.setServerSideSupport(FeatureSupport.Stable);
             const threadRoot = mkMessage();
             const rootReaction = mkReaction(threadRoot);
@@ -2856,9 +2856,10 @@ describe("Room", function () {
 
             const events = [threadRoot, rootReaction, threadResponse, threadReaction];
 
+            const prom = emitPromise(room, ThreadEvent.New);
             room.addLiveEvents(events);
-
-            const thread = threadRoot.getThread()!;
+            const thread = await prom;
+            expect(thread).toBe(threadRoot.getThread());
             expect(thread.rootEvent).toBe(threadRoot);
 
             const rootRelations = thread.timelineSet.relations

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2090,9 +2090,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         // If we jump to an event in a thread where neither the event, nor the root,
         // nor any thread event are loaded yet, we'll load the event as well as the thread root, create the thread,
         // and pass the event through this.
-        for (const event of events) {
-            thread.setEventMetadata(event);
-        }
+        thread.addEvents(events, false);
 
         // If we managed to create a thread and figure out its `id` then we can use it
         this.threads.set(thread.id, thread);

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -322,8 +322,9 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
             this.replyCount = bundledRelationship.count;
             this._currentUserParticipated = !!bundledRelationship.current_user_participated;
 
+            const mapper = this.client.getEventMapper();
             // re-insert roomId
-            this.lastEvent = new MatrixEvent({
+            this.lastEvent = mapper({
                 ...bundledRelationship.latest_event,
                 room_id: this.roomId,
             });


### PR DESCRIPTION
Type: Defect
Fixes: https://github.com/vector-im/element-web/issues/23916
Fixes: https://github.com/vector-im/element-web/issues/23942
Requires: https://github.com/matrix-org/matrix-js-sdk/pull/2965

Prevent confusion between synthesized lastEvent and the same event in the actual timeline


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix #23916: Prevent edits of the last message in a thread getting lost ([\#2951](https://github.com/matrix-org/matrix-js-sdk/pull/2951)). Fixes vector-im/element-web#23916 and vector-im/element-web#23942. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->