### PR TITLE
Fix `examples/browser`

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,9 +1,9 @@
 To try it out, **you must build the SDK first** and then host this folder:
 
 ```
- $ npm run build
+ $ yarn build
  $ cd examples/browser
- $ python -m SimpleHTTPServer 8003
+ $ python -m http.server 8003
 ```
 
 Then visit ``http://localhost:8003``.

--- a/examples/browser/browserTest.js
+++ b/examples/browser/browserTest.js
@@ -1,11 +1,7 @@
 console.log("Loading browser sdk");
 
-var client = matrixcs.createClient("https://matrix.org");
-client.publicRooms(function (err, data) {
-    if (err) {
-	   console.error("err %s", JSON.stringify(err));
-       return;
-    }
+var client = matrixcs.createClient({baseUrl: "https://matrix.org"});
+client.publicRooms().then(function (data) {
     console.log("data %s [...]", JSON.stringify(data).substring(0, 100));
     console.log("Congratulations! The SDK is working on the browser!");
     var result = document.getElementById("result");


### PR DESCRIPTION
This seems to have been broken for ages

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->