### PR TITLE
Cache read receipts for unknown threads

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -201,6 +201,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private txnToEvent: Record<string, MatrixEvent> = {}; // Pending in-flight requests { string: MatrixEvent }
     private notificationCounts: NotificationCount = {};
     private readonly threadNotifications = new Map<string, NotificationCount>();
+    public readonly cachedThreadReadReceipts = new Map<string, { event: MatrixEvent, synthetic: boolean }[]>();
     private readonly timelineSets: EventTimelineSet[];
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
@@ -2053,6 +2054,16 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             this.updateThreadRootEvents(thread, toStartOfTimeline, false);
         }
 
+        // Pulling all the cached thread read receipts we've discovered when we
+        // did an initial sync, and applying them to the thread now that it exists
+        // on the client side
+        if (this.cachedThreadReadReceipts.has(threadId)) {
+            for (const { event, synthetic } of this.cachedThreadReadReceipts.get(threadId)!) {
+                this.addReceipt(event, synthetic);
+            }
+            this.cachedThreadReadReceipts.delete(threadId);
+        }
+
         this.emit(ThreadEvent.New, thread, toStartOfTimeline);
 
         return thread;
@@ -2628,13 +2639,24 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                     const receiptDestination: Thread | this | undefined = receiptForMainTimeline
                         ? this
                         : this.threads.get(receipt.thread_id ?? "");
-                    receiptDestination?.addReceiptToStructure(
-                        eventId,
-                        receiptType as ReceiptType,
-                        userId,
-                        receipt,
-                        synthetic,
-                    );
+
+                    if (receiptDestination) {
+                        receiptDestination.addReceiptToStructure(
+                            eventId,
+                            receiptType as ReceiptType,
+                            userId,
+                            receipt,
+                            synthetic,
+                        );
+                    } else {
+                        // The thread does not exist locally, keep the read receipt
+                        // in a cache locally, and re-apply  the `addReceipt` logic
+                        // when the thread is created
+                        this.cachedThreadReadReceipts.set(receipt.thread_id!, [
+                            ...(this.cachedThreadReadReceipts.get(receipt.thread_id!) ?? []),
+                            { event, synthetic },
+                        ]);
+                    }
                 });
             });
         });


### PR DESCRIPTION
Hopefully helps with https://github.com/vector-im/element-web/issues/23921

All read receipts are sent down during initial sync, however the code would previously throw the read receipts to unknown threads down the drain
This pull requests changes that and caches all those receipts, upon a thread discovery, the cache is checked and those receipts are applied

This should alleviate highlight notifications appearing for threads you've already read

> **Warning**
> My gut feeling tells me we might need to force an initial sync so that all read receipts are downloaded once again as we've already thrown quite a few away unfortunately

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Cache read receipts for unknown threads ([\#2953](https://github.com/matrix-org/matrix-js-sdk/pull/2953)).<!-- CHANGELOG_PREVIEW_END -->