### PR TITLE
Implement MSC3912: Relation-based redactions

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -28,6 +28,7 @@ import {
     UNSTABLE_MSC3088_ENABLED,
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
+    MSC3912_RELATION_BASED_REDACTIONS_PROP,
 } from "../../src/@types/event";
 import { MEGOLM_ALGORITHM } from "../../src/crypto/olmlib";
 import { Crypto } from "../../src/crypto";
@@ -1092,7 +1093,7 @@ describe("MatrixClient", function () {
                 );
             });
 
-            describe("and the server supports relation based redactions", () => {
+            describe("and the server supports relation based redactions (unstable)", () => {
                 beforeEach(async () => {
                     unstableFeatures["org.matrix.msc3912"] = true;
                     // load supported features
@@ -1110,7 +1111,7 @@ describe("MatrixClient", function () {
                                 `/${encodeURIComponent(txnId)}`,
                             expectBody: {
                                 reason: "redaction test",
-                                with_relations: [RelationType.Reference],
+                                [MSC3912_RELATION_BASED_REDACTIONS_PROP.unstable!]: [RelationType.Reference],
                             },
                             data: { event_id: eventId },
                         },

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -166,6 +166,15 @@ export const UNSTABLE_MSC3089_BRANCH = new UnstableValue("m.branch", "org.matrix
 export const UNSTABLE_MSC2716_MARKER = new UnstableValue("m.room.marker", "org.matrix.msc2716.marker");
 
 /**
+ * Name of the "with_relations" request property for relation based redactions.
+ * {@link https://github.com/matrix-org/matrix-spec-proposals/pull/3912}
+ */
+export const MSC3912_RELATION_BASED_REDACTIONS_PROP = new UnstableValue(
+    "with_relations",
+    "org.matrix.msc3912.with_relations",
+);
+
+/**
  * Functional members type for declaring a purpose of room members (e.g. helpful bots).
  * Note that this reference is UNSTABLE and subject to breaking changes, including its
  * eventual removal.

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -21,7 +21,7 @@ import { IRoomEventFilter } from "../filter";
 import { Direction } from "../models/event-timeline";
 import { PushRuleAction } from "./PushRules";
 import { IRoomEvent } from "../sync-accumulator";
-import { EventType, RoomType } from "./event";
+import { EventType, RelationType, RoomType } from "./event";
 
 // allow camelcase as these are things that go onto the wire
 /* eslint-disable camelcase */
@@ -47,6 +47,8 @@ export interface IJoinRoomOpts {
 
 export interface IRedactOpts {
     reason?: string;
+    // also delete related events, if the server supports it (MSC3912)
+    with_relations?: Array<RelationType | string>;
 }
 
 export interface ISendEventResponse {

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -48,7 +48,11 @@ export interface IJoinRoomOpts {
 export interface IRedactOpts {
     reason?: string;
     /**
-     * Also try to delete related events of the relation types in this array.
+     * Whether events related to the redacted event should be redacted.
+     *
+     * If specified, then any events which relate to the event being redacted with
+     * any of the relationship types listed will also be redacted.
+     *
      * <b>Raises an Error if the server does not support it.</b>
      * Check for server-side support before using this param with
      * <code>client.canSupport.get(Feature.RelationBasedRedactions)</code>.

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -47,7 +47,13 @@ export interface IJoinRoomOpts {
 
 export interface IRedactOpts {
     reason?: string;
-    // also delete related events, if the server supports it (MSC3912)
+    /**
+     * Also try to delete related events of the relation types in this array.
+     * <b>Raises an Error if the server does not support it.</b>
+     * Check for server-side support before using this param with
+     * <code>client.canSupport.get(Feature.RelationBasedRedactions)</code>.
+     * {@link https://github.com/matrix-org/matrix-spec-proposals/pull/3912}
+     */
     with_relations?: Array<RelationType | string>;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -154,6 +154,7 @@ import {
     UNSTABLE_MSC3088_ENABLED,
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
+    MSC3912_RELATION_BASED_REDACTIONS_PROP,
 } from "./@types/event";
 import { IdServerUnbindResult, IImageInfo, Preset, Visibility } from "./@types/partials";
 import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper";
@@ -4376,13 +4377,21 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             );
         }
 
+        const withRelations = opts?.with_relations
+            ? {
+                  [this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Stable
+                      ? MSC3912_RELATION_BASED_REDACTIONS_PROP.stable!
+                      : MSC3912_RELATION_BASED_REDACTIONS_PROP.unstable!]: opts?.with_relations,
+              }
+            : {};
+
         return this.sendCompleteEvent(
             roomId,
             threadId,
             {
                 type: EventType.RoomRedaction,
                 content: {
-                    ...(opts?.with_relations ? { with_relations: opts?.with_relations } : {}),
+                    ...withRelations,
                     reason,
                 },
                 redacts: eventId,

--- a/src/client.ts
+++ b/src/client.ts
@@ -4335,9 +4335,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * @param txnId -  transaction id. One will be made up if not supplied.
-     * @param opts - Options to pass on, may contain `reason`.
+     * @param opts - Options to pass on, may contain `reason` an `with_relations` (MSC3912).
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
+     * @throws Error if called with `with_relations` (MSC3912) but the server does not support it.
+     *         Callers should check whether the server supports MSC3912 via `MatrixClient.canSupport`.
      */
     public redactEvent(
         roomId: string,

--- a/src/client.ts
+++ b/src/client.ts
@@ -4445,7 +4445,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * @param txnId -  transaction id. One will be made up if not supplied.
-     * @param opts - Options to pass on, may contain `reason` an `with_relations` (MSC3912).
+     * @param opts - Options to pass on, may contain `reason` and `with_relations` (MSC3912)
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
      * @throws Error if called with `with_relations` (MSC3912) but the server does not support it.

--- a/src/client.ts
+++ b/src/client.ts
@@ -4365,12 +4365,26 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId = null;
         }
         const reason = opts?.reason;
+
+        if (
+            opts?.with_relations &&
+            this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Unsupported
+        ) {
+            throw new Error(
+                "Server does not support relation based redactions " +
+                    `roomId ${roomId} eventId ${eventId} txnId: ${txnId} threadId ${threadId}`,
+            );
+        }
+
         return this.sendCompleteEvent(
             roomId,
             threadId,
             {
                 type: EventType.RoomRedaction,
-                content: { reason },
+                content: {
+                    ...(opts?.with_relations ? { with_relations: opts?.with_relations } : {}),
+                    reason,
+                },
                 redacts: eventId,
             },
             txnId as string,

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -26,6 +26,7 @@ export enum Feature {
     Thread = "Thread",
     ThreadUnreadNotifications = "ThreadUnreadNotifications",
     LoginTokenRequest = "LoginTokenRequest",
+    RelationBasedRedactions = "RelationBasedRedactions",
 }
 
 type FeatureSupportCondition = {
@@ -44,6 +45,9 @@ const featureSupportResolver: Record<string, FeatureSupportCondition> = {
     },
     [Feature.LoginTokenRequest]: {
         unstablePrefixes: ["org.matrix.msc3882"],
+    },
+    [Feature.RelationBasedRedactions]: {
+        unstablePrefixes: ["org.matrix.msc3912"],
     },
 };
 


### PR DESCRIPTION
SDK support for [MSC3912](https://github.com/matrix-org/matrix-spec-proposals/pull/3912)

Should be reviewed commitwise, because it contains a heavy refactoring of the client spec.

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement MSC3912: Relation-based redactions ([\#2954](https://github.com/matrix-org/matrix-js-sdk/pull/2954)).<!-- CHANGELOG_PREVIEW_END -->