### PR TITLE
Do not calculate highlight notifs for threads unknown to the room

### DIFF
--- a/spec/unit/notifications.spec.ts
+++ b/spec/unit/notifications.spec.ts
@@ -138,6 +138,29 @@ describe("fixNotificationCountOnDecryption", () => {
         expect(room.getThreadUnreadNotificationCount(THREAD_ID, NotificationCountType.Highlight)).toBe(0);
     });
 
+    it("does not calculate for threads unknown to the room", () => {
+        room.setThreadUnreadNotificationCount(THREAD_ID, NotificationCountType.Total, 0);
+        room.setThreadUnreadNotificationCount(THREAD_ID, NotificationCountType.Highlight, 0);
+
+        const unknownThreadEvent = mkEvent({
+            type: EventType.RoomMessage,
+            content: {
+                "m.relates_to": {
+                    rel_type: RelationType.Thread,
+                    event_id: "$unknownthread",
+                },
+                "msgtype": MsgType.Text,
+                "body": "Thread reply",
+            },
+            event: true,
+        });
+
+        fixNotificationCountOnDecryption(mockClient, unknownThreadEvent);
+
+        expect(room.getThreadUnreadNotificationCount(THREAD_ID, NotificationCountType.Total)).toBe(0);
+        expect(room.getThreadUnreadNotificationCount(THREAD_ID, NotificationCountType.Highlight)).toBe(0);
+    });
+
     it("emits events", () => {
         const cb = jest.fn();
         room.on(RoomEvent.UnreadNotifications, cb);

--- a/src/client.ts
+++ b/src/client.ts
@@ -9363,9 +9363,21 @@ export function fixNotificationCountOnDecryption(cli: MatrixClient, event: Matri
     if (oldHighlight !== newHighlight || currentCount > 0) {
         // TODO: Handle mentions received while the client is offline
         // See also https://github.com/vector-im/element-web/issues/9069
-        const hasReadEvent = isThreadEvent
-            ? room.getThread(event.threadRootId)?.hasUserReadEvent(cli.getUserId()!, event.getId()!)
-            : room.hasUserReadEvent(cli.getUserId()!, event.getId()!);
+        let hasReadEvent;
+        if (isThreadEvent) {
+            const thread = room.getThread(event.threadRootId);
+            hasReadEvent = thread
+                ? thread.hasUserReadEvent(cli.getUserId()!, event.getId()!)
+                // If the thread object does not exist in the room yet, we don't
+                // want to calculate notification for this event yet. We have not
+                // restored the read receipts yet and can't accurately calculate
+                // highlight notifications at this stage.
+                //
+                // This issue can likely go away when MSC3874 is implemented
+                : true;
+        } else {
+            hasReadEvent = room.hasUserReadEvent(cli.getUserId()!, event.getId()!);
+        }
 
         if (!hasReadEvent) {
             let newCount = currentCount;


### PR DESCRIPTION
Hugely helps with https://github.com/vector-im/element-web/issues/23921
This should fully go away with things like MSC3874.

Threaded events are sent down `/sync` and are considered threaded events by the code that fixes notifications for encrypted rooms. However, if the thread root has not been discovered then the thread model does not exist yet and the optional chaining operator would make the `hasUserReadEvent` variable `undefined` who then got casted to a falsy value... 

## Checklist

* [x] Tests written for new code (and old code if feasible)
* [x] Linter and other CI checks pass
* [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Do not calculate highlight notifs for threads unknown to the room ([\#2957](https://github.com/matrix-org/matrix-js-sdk/pull/2957)).<!-- CHANGELOG_PREVIEW_END -->