### PR TITLE
Make sure that MegolmEncryption.setupPromise always resolves 

### DIFF
--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -491,7 +491,7 @@ describe("MegolmDecryption", function () {
                 expect(mockBaseApis.queueToDevice).not.toHaveBeenCalled();
             });
 
-            it("sholdn't wedge the setup promise if sharing a room key fails", async () => {
+            it("shouldn't wedge the setup promise if sharing a room key fails", async () => {
                 // @ts-ignore - private field access
                 const initialSetupPromise = await megolmEncryption.setupPromise;
                 expect(initialSetupPromise).toBe(null);

--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -490,6 +490,26 @@ describe("MegolmDecryption", function () {
 
                 expect(mockBaseApis.queueToDevice).not.toHaveBeenCalled();
             });
+
+            it("sholdn't wedge the setup promise if sharing a room key fails", async () => {
+                // @ts-ignore - private field access
+                const initialSetupPromise = await megolmEncryption.setupPromise;
+                expect(initialSetupPromise).toBe(null);
+
+                // @ts-ignore - private field access
+                megolmEncryption.prepareSession = () => {
+                    throw new Error("Can't prepare session");
+                };
+
+                await expect(() =>
+                    // @ts-ignore - private field access
+                    megolmEncryption.ensureOutboundSession(mockRoom, {}, {}, true),
+                ).rejects.toThrow();
+
+                // @ts-ignore - private field access
+                const finalSetupPromise = await megolmEncryption.setupPromise;
+                expect(finalSetupPromise).toBe(null);
+            });
         });
     });
 

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -248,6 +248,23 @@ export class MegolmEncryption extends EncryptionAlgorithm {
      * @param singleOlmCreationPhase - Only perform one round of olm
      *     session creation
      *
+     * This method updates the setupPromise field of the class by chaining a new
+     * call on top of the existing promise, and then catching and discarding any
+     * errors that might happen while setting up the outbound group session. This
+     * is done to ensure that `setupPromise` always resolves to `null` or the
+     * `OutboundSessionInfo`.
+     *
+     * Using `>>=` to represent the promise chaining operation, it does the
+     * following:
+     *
+     * ```
+     * setupPromise = previousSetupPromise >>= setup >>= discardErrors
+     * ```
+     *
+     * The initial value for the `setupPromise` is a promise that resolves to
+     * `null`. The forceDiscardSession() resets setupPromise to this initial
+     * promise.
+     *
      * @returns Promise which resolves to the
      *    OutboundSessionInfo when setup is complete.
      */
@@ -278,18 +295,20 @@ export class MegolmEncryption extends EncryptionAlgorithm {
         };
 
         // first wait for the previous share to complete
-        const prom = this.setupPromise.then(setup);
+        const fallible = this.setupPromise.then(setup);
 
-        // Ensure any failures are logged for debugging
-        prom.catch((e) => {
+        // Ensure any failures are logged for debugging and make sure that the
+        // promise chain remains unbroken
+        //
+        // setupPromise resolves to `null` or the `OutboundSessionInfo` whether
+        // or not the share succeeds
+        this.setupPromise = fallible.catch((e) => {
             logger.error(`Failed to setup outbound session in ${this.roomId}`, e);
+            return null;
         });
 
-        // setupPromise resolves to `session` whether or not the share succeeds
-        this.setupPromise = prom;
-
         // but we return a promise which only resolves if the share was successful.
-        return prom;
+        return fallible;
     }
 
     private async prepareSession(


### PR DESCRIPTION
This is another go at trying to get https://github.com/matrix-org/matrix-js-sdk/pull/2908 merged. The original PR has been now split out since it contained two semi-related changes.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Make sure that MegolmEncryption.setupPromise always resolves  ([\#2960](https://github.com/matrix-org/matrix-js-sdk/pull/2960)). Contributed by @poljar.<!-- CHANGELOG_PREVIEW_END -->