### PR TITLE
Exclude generated files from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,9 @@ lib-cov
 out
 /dist
 /lib
+/examples/browser/lib
+/examples/crypto-browser/lib
+/examples/voip/lib
 
 # version file and tarball created by `npm pack` / `yarn pack`
 /git-revision.txt


### PR DESCRIPTION
The example directories include symlinks to the generated matrix.js, which we
should not prettify.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->