### PR TITLE
Add `exportRoomKeys` to `CryptoBackend`

### DIFF
--- a/spec/unit/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto.spec.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RustCrypto } from "../../src/rust-crypto/rust-crypto";
+import { initRustCrypto } from "../../src/rust-crypto";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+afterEach(() => {
+    // reset fake-indexeddb after each test, to make sure we don't leak connections
+    // cf https://github.com/dumbmatter/fakeIndexedDB#wipingresetting-the-indexeddb-for-a-fresh-state
+    // eslint-disable-next-line no-global-assign
+    indexedDB = new IDBFactory();
+});
+
+describe("RustCrypto", () => {
+    const TEST_USER = "@alice:example.com";
+    const TEST_DEVICE_ID = "TEST_DEVICE";
+
+    let rustCrypto: RustCrypto;
+
+    beforeEach(async () => {
+        rustCrypto = (await initRustCrypto(TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
+    });
+
+    describe(".exportRoomKeys", () => {
+        it("should return a list", async () => {
+            const keys = await rustCrypto.exportRoomKeys();
+            expect(Array.isArray(keys)).toBeTruthy();
+        });
+    });
+});

--- a/spec/unit/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto.spec.ts
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
 
 import { RustCrypto } from "../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../src/rust-crypto";
-import { IDBFactory } from "fake-indexeddb";
 
 afterEach(() => {
     // reset fake-indexeddb after each test, to make sure we don't leak connections

--- a/spec/unit/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto.spec.ts
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import "fake-indexeddb/auto";
+
 import { RustCrypto } from "../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../src/rust-crypto";
-import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 
 afterEach(() => {

--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -44,3 +44,29 @@ export interface IEventDecryptionResult {
     claimedEd25519Key?: string;
     untrusted?: boolean;
 }
+
+interface Extensible {
+    [key: string]: any;
+}
+
+/* eslint-disable camelcase */
+
+/** The result of a call to {@link MatrixClient.exportRoomKeys} */
+export interface IMegolmSessionData extends Extensible {
+    /** Sender's Curve25519 device key */
+    sender_key: string;
+    /** Devices which forwarded this session to us (normally empty). */
+    forwarding_curve25519_key_chain: string[];
+    /** Other keys the sender claims. */
+    sender_claimed_keys: Record<string, string>;
+    /** Room this session is used in */
+    room_id: string;
+    /** Unique id for the session */
+    session_id: string;
+    /** Base64'ed key data */
+    session_key: string;
+    algorithm?: string;
+    untrusted?: boolean;
+}
+
+/* eslint-enable camelcase */

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@ limitations under the License.
 
 import { EmoteEvent, IPartialEvent, MessageEvent, NoticeEvent, Optional } from "matrix-events-sdk";
 
+import type { IMegolmSessionData } from "./@types/crypto";
 import { ISyncStateData, SyncApi, SyncState } from "./sync";
 import {
     EventStatus,
@@ -74,7 +75,6 @@ import {
     ICryptoCallbacks,
     IBootstrapCrossSigningOpts,
     ICheckOwnCrossSigningTrustOpts,
-    IMegolmSessionData,
     isCryptoAvailable,
     VerificationMethod,
     IRoomKeyRequestBody,
@@ -3033,10 +3033,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *    session export objects
      */
     public exportRoomKeys(): Promise<IMegolmSessionData[]> {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             return Promise.reject(new Error("End-to-end encryption disabled"));
         }
-        return this.crypto.exportRoomKeys();
+        return this.cryptoBackend.exportRoomKeys();
     }
 
     /**

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { IEventDecryptionResult } from "../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import { MatrixEvent } from "../models/event";
 
 /**
@@ -60,4 +60,14 @@ export interface CryptoBackend {
      * Rejects with an error if there is a problem decrypting the event.
      */
     decryptEvent(event: MatrixEvent): Promise<IEventDecryptionResult>;
+
+    /**
+     * Get a list containing all of the room keys
+     *
+     * This should be encrypted before returning it to the user.
+     *
+     * @returns a promise which resolves to a list of
+     *    session export objects
+     */
+    exportRoomKeys(): Promise<IMegolmSessionData[]>;
 }

--- a/src/crypto/OlmDevice.ts
+++ b/src/crypto/OlmDevice.ts
@@ -21,8 +21,7 @@ import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
 import * as algorithms from "./algorithms";
 import { CryptoStore, IProblem, ISessionInfo, IWithheld } from "./store/base";
 import { IOlmDevice, IOutboundGroupSessionKey } from "./algorithms/megolm";
-import { IMegolmSessionData } from "./index";
-import { OlmGroupSessionExtraData } from "../@types/crypto";
+import { IMegolmSessionData, OlmGroupSessionExtraData } from "../@types/crypto";
 import { IMessage } from "./algorithms/olm";
 
 // The maximum size of an event is 65K, and we base64 the content, so this is a

--- a/src/crypto/algorithms/base.ts
+++ b/src/crypto/algorithms/base.ts
@@ -18,11 +18,12 @@ limitations under the License.
  * Internal module. Defines the base classes of the encryption implementations
  */
 
+import type { IMegolmSessionData } from "../../@types/crypto";
 import { MatrixClient } from "../../client";
 import { Room } from "../../models/room";
 import { OlmDevice } from "../OlmDevice";
 import { IContent, MatrixEvent, RoomMember } from "../../matrix";
-import { Crypto, IEncryptedContent, IEventDecryptionResult, IMegolmSessionData, IncomingRoomKeyRequest } from "..";
+import { Crypto, IEncryptedContent, IEventDecryptionResult, IncomingRoomKeyRequest } from "..";
 import { DeviceInfo } from "../deviceinfo";
 import { IRoomEncryption } from "../RoomList";
 

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { v4 as uuidv4 } from "uuid";
 
-import type { IEventDecryptionResult } from "../../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../../@types/crypto";
 import { logger } from "../../logger";
 import * as olmlib from "../olmlib";
 import {
@@ -39,7 +39,7 @@ import { IOlmSessionResult } from "../olmlib";
 import { DeviceInfoMap } from "../DeviceList";
 import { IContent, MatrixEvent } from "../../models/event";
 import { EventType, MsgType, ToDeviceMessageId } from "../../@types/event";
-import { IMegolmEncryptedContent, IMegolmSessionData, IncomingRoomKeyRequest, IEncryptedContent } from "../index";
+import { IMegolmEncryptedContent, IncomingRoomKeyRequest, IEncryptedContent } from "../index";
 import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager";
 import { OlmGroupSessionExtraData } from "../../@types/crypto";
 import { MatrixError } from "../../http-api";

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -18,6 +18,7 @@ limitations under the License.
  * Classes for dealing with key backup.
  */
 
+import type { IMegolmSessionData } from "../@types/crypto";
 import { MatrixClient } from "../client";
 import { logger } from "../logger";
 import { MEGOLM_ALGORITHM, verifySignature } from "./olmlib";
@@ -36,7 +37,7 @@ import {
     IKeyBackupSession,
 } from "./keybackup";
 import { UnstableValue } from "../NamespacedValue";
-import { CryptoEvent, IMegolmSessionData } from "./index";
+import { CryptoEvent } from "./index";
 import { crypto } from "./crypto";
 import { HTTPError, MatrixError } from "../http-api";
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -20,7 +20,7 @@ limitations under the License.
 import anotherjson from "another-json";
 import { v4 as uuidv4 } from "uuid";
 
-import type { IEventDecryptionResult } from "../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { PkDecryption, PkSigning } from "@matrix-org/olm";
 import { EventType, ToDeviceMessageId } from "../@types/event";
 import { TypedReEmitter } from "../ReEmitter";
@@ -171,26 +171,6 @@ export interface IRoomKeyRequestBody extends IRoomKey {
     sender_key: string;
 }
 
-interface Extensible {
-    [key: string]: any;
-}
-
-export interface IMegolmSessionData extends Extensible {
-    // Sender's Curve25519 device key
-    sender_key: string;
-    // Devices which forwarded this session to us (normally empty).
-    forwarding_curve25519_key_chain: string[];
-    // Other keys the sender claims.
-    sender_claimed_keys: Record<string, string>;
-    // Room this session is used in
-    room_id: string;
-    // Unique id for the session
-    session_id: string;
-    // Base64'ed key data
-    session_key: string;
-    algorithm?: string;
-    untrusted?: boolean;
-}
 /* eslint-enable camelcase */
 
 interface IDeviceVerificationUpgrade {
@@ -3894,5 +3874,5 @@ class IncomingRoomKeyRequestCancellation {
     }
 }
 
-// IEventDecryptionResult is re-exported for backwards compatibility, in case any applications are referencing it.
-export type { IEventDecryptionResult } from "../@types/crypto";
+// a number of types are re-exported for backwards compatibility, in case any applications are referencing it.
+export type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
 
-import { IEventDecryptionResult } from "../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import { MatrixEvent } from "../models/event";
 import { CryptoBackend } from "../common-crypto/CryptoBackend";
 
@@ -56,5 +56,10 @@ export class RustCrypto implements CryptoBackend {
     public async userHasCrossSigningKeys(): Promise<boolean> {
         // TODO
         return false;
+    }
+
+    public async exportRoomKeys(): Promise<IMegolmSessionData[]> {
+        // TODO
+        return [];
     }
 }


### PR DESCRIPTION
Element-web calls `exportRoomKeys` on logout, so we need a stub implementation to get it EW working with the rust crypto sdk.

Part of https://github.com/vector-im/element-web/issues/21972.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->