### PR TITLE
sliding sync: Fix issue where no unsubs are sent when switching rooms

### DIFF
--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -397,6 +397,10 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
      * @param sub - The subscription information.
      */
     public addCustomSubscription(name: string, sub: MSC3575RoomSubscription): void {
+        if (this.customSubscriptions.get(name) !== undefined) {
+            logger.warn(`addCustomSubscription: ${name} already exists as a custom subscription, ignoring.`);
+            return;
+        }
         this.customSubscriptions.set(name, sub);
     }
 
@@ -408,6 +412,11 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
      * will be used.
      */
     public useCustomSubscription(roomId: string, name: string): void {
+        // We already know about this custom subscription, as it is immutable,
+        // we don't need to unconfirm the subscription.
+        if (this.roomIdToCustomSubscription.get(roomId) === name) {
+            return;
+        }
         this.roomIdToCustomSubscription.set(roomId, name);
         // unconfirm this subscription so a resend() will send it up afresh.
         this.confirmedRoomSubscriptions.delete(roomId);

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -397,7 +397,7 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
      * @param sub - The subscription information.
      */
     public addCustomSubscription(name: string, sub: MSC3575RoomSubscription): void {
-        if (this.customSubscriptions.get(name) !== undefined) {
+        if (this.customSubscriptions.has(name)) {
             logger.warn(`addCustomSubscription: ${name} already exists as a custom subscription, ignoring.`);
             return;
         }


### PR DESCRIPTION
Should fix an issue where no `unsubscribe_rooms` are sent when switching rooms. 
This happens because we're deleting the room from the `confirmedRoomSubscription` list when switching between unencrypted rooms and the `unsubscribe_rooms` list can't be calculated correctly, resulting in an ever growing subscriptions list on the server side.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * sliding sync: Fix issue where no unsubs are sent when switching rooms ([\#2991](https://github.com/matrix-org/matrix-js-sdk/pull/2991)). Contributed by @S7evinK.<!-- CHANGELOG_PREVIEW_END -->