### PR TITLE
Close all streams when a call ends

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2475,18 +2475,20 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     }
 
     private stopAllMedia(): void {
-        logger.debug(
-            !this.groupCallId
-                ? `Call ${this.callId} stopping all media`
-                : `Call ${this.callId} stopping all media except local feeds`,
-        );
+        logger.debug(`Call ${this.callId} stopping all media`);
 
         for (const feed of this.feeds) {
-            if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Usermedia && !this.groupCallId) {
+            // Slightly awkward as local feed need to go via the correct method on
+            // the mediahandler so they get removed from mediahandler (remote tracks
+            // don't)
+            // NB. We clone local streams when passing them to individual calls in a group
+            // call, so we can (and should) stop the clones once we no longer need them:
+            // the other clones will continue fine.
+            if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Usermedia) {
                 this.client.getMediaHandler().stopUserMediaStream(feed.stream);
-            } else if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Screenshare && !this.groupCallId) {
+            } else if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Screenshare) {
                 this.client.getMediaHandler().stopScreensharingStream(feed.stream);
-            } else if (!feed.isLocal() || !this.groupCallId) {
+            } else if (!feed.isLocal()) {
                 logger.debug("Stopping remote stream", feed.stream.id);
                 for (const track of feed.stream.getTracks()) {
                     track.stop();


### PR DESCRIPTION
We didn't close streams in group calls (presumably from back when we used the same stream for all calls rather than cloning?) but this left stray screenshare streams in the mediahandler when a participant left whilst we were screensharing.

Fixes https://github.com/vector-im/element-call/issues/742

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Close all streams when a call ends ([\#2992](https://github.com/matrix-org/matrix-js-sdk/pull/2992)). Fixes vector-im/element-call#742.<!-- CHANGELOG_PREVIEW_END -->