### PR TITLE
Break coupling between `Room` and `Crypto.trackRoomDevices`

### DIFF
--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -624,6 +624,16 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
     }
 
     /**
+     * Check if loading of out-of-band-members has completed
+     *
+     * @returns true if the full membership list of this room has been loaded. False if it is not started or is in
+     *    progress.
+     */
+    public outOfBandMembersReady(): boolean {
+        return this.oobMemberFlags.status === OobStatus.Finished;
+    }
+
+    /**
      * Mark this room state as waiting for out-of-band members,
      * ensuring it doesn't ask for them to be requested again
      * through needsOutOfBandMembers

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -889,6 +889,20 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
+     * Check if loading of out-of-band-members has completed
+     *
+     * @returns true if the full membership list of this room has been loaded (including if lazy-loading is disabled).
+     *    False if the load is not started or is in progress.
+     */
+    public membersLoaded(): boolean {
+        if (!this.opts.lazyLoadMembers) {
+            return true;
+        }
+
+        return this.currentState.outOfBandMembersReady();
+    }
+
+    /**
      * Preloads the member list in case lazy loading
      * of memberships is in use. Can be called multiple times,
      * it will only preload once.
@@ -909,10 +923,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const inMemoryUpdate = this.loadMembers()
             .then((result) => {
                 this.currentState.setOutOfBandMembers(result.memberEvents);
-                // now the members are loaded, start to track the e2e devices if needed
-                if (this.client.isCryptoEnabled() && this.client.isRoomEncrypted(this.roomId)) {
-                    this.client.crypto!.trackRoomDevices(this.roomId);
-                }
                 return result.fromServer;
             })
             .catch((err) => {


### PR DESCRIPTION
`Room` and `Crypto` currently have some tight coupling in the form of a call to `trackRoomDevices` when out-of-band members are loaded. We can improve this by instead having Crypto listen out for a `RoomSateEvent.Update` notification.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->