### PR TITLE
Remove usage of v1 Identity Server API

### DIFF
--- a/spec/unit/autodiscovery.spec.ts
+++ b/spec/unit/autodiscovery.spec.ts
@@ -544,7 +544,7 @@ describe("AutoDiscovery", function () {
                 .respond(200, {
                     versions: ["r0.0.1"],
                 });
-            httpBackend.when("GET", "/_matrix/identity/api/v1").respond(404, {});
+            httpBackend.when("GET", "/_matrix/identity/v2").respond(404, {});
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
                 "m.homeserver": {
                     // Note: we also expect this test to trim the trailing slash
@@ -591,7 +591,7 @@ describe("AutoDiscovery", function () {
                 .respond(200, {
                     versions: ["r0.0.1"],
                 });
-            httpBackend.when("GET", "/_matrix/identity/api/v1").respond(500, {});
+            httpBackend.when("GET", "/_matrix/identity/v2").respond(500, {});
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
                 "m.homeserver": {
                     // Note: we also expect this test to trim the trailing slash
@@ -636,9 +636,9 @@ describe("AutoDiscovery", function () {
                 versions: ["r0.0.1"],
             });
         httpBackend
-            .when("GET", "/_matrix/identity/api/v1")
+            .when("GET", "/_matrix/identity/v2")
             .check((req) => {
-                expect(req.path).toEqual("https://identity.example.org/_matrix/identity/api/v1");
+                expect(req.path).toEqual("https://identity.example.org/_matrix/identity/v2");
             })
             .respond(200, {});
         httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
@@ -682,9 +682,9 @@ describe("AutoDiscovery", function () {
                 versions: ["r0.0.1"],
             });
         httpBackend
-            .when("GET", "/_matrix/identity/api/v1")
+            .when("GET", "/_matrix/identity/v2")
             .check((req) => {
-                expect(req.path).toEqual("https://identity.example.org/_matrix/identity/api/v1");
+                expect(req.path).toEqual("https://identity.example.org/_matrix/identity/v2");
             })
             .respond(200, {});
         httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -214,7 +214,7 @@ export class AutoDiscovery {
 
             // Step 5b: Verify there is an identity server listening on the provided
             // URL.
-            const isResponse = await this.fetchWellKnownObject(`${isUrl}/_matrix/identity/api/v1`);
+            const isResponse = await this.fetchWellKnownObject(`${isUrl}/_matrix/identity/v2`);
             if (!isResponse?.raw || isResponse.action !== AutoDiscoveryAction.SUCCESS) {
                 logger.error("Invalid /api/v1 response");
                 failingClientConfig["m.identity_server"].error = AutoDiscovery.ERROR_INVALID_IDENTITY_SERVER;

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -216,7 +216,7 @@ export class AutoDiscovery {
             // URL.
             const isResponse = await this.fetchWellKnownObject(`${isUrl}/_matrix/identity/v2`);
             if (!isResponse?.raw || isResponse.action !== AutoDiscoveryAction.SUCCESS) {
-                logger.error("Invalid /api/v1 response");
+                logger.error("Invalid /v2 response");
                 failingClientConfig["m.identity_server"].error = AutoDiscovery.ERROR_INVALID_IDENTITY_SERVER;
 
                 // Supply the base_url to the caller because they may be ignoring

--- a/src/http-api/prefix.ts
+++ b/src/http-api/prefix.ts
@@ -35,11 +35,6 @@ export enum ClientPrefix {
 
 export enum IdentityPrefix {
     /**
-     * URI path for v1 of the identity API
-     * @deprecated Use v2.
-     */
-    V1 = "/_matrix/identity/api/v1",
-    /**
      * URI path for the v2 identity API
      */
     V2 = "/_matrix/identity/v2",


### PR DESCRIPTION
It's been deprecated for over a year at this point - everyone should be able to support v2.

**Requires https://github.com/matrix-org/matrix-react-sdk/pull/9818**
Required by https://github.com/vector-im/element-web/pull/24086

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove usage of v1 Identity Server API ([\#3003](https://github.com/matrix-org/matrix-js-sdk/pull/3003)).<!-- CHANGELOG_PREVIEW_END -->