### PR TITLE
Avoid triggering decryption errors when decrypting redacted events

### DIFF
--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -167,6 +167,35 @@ describe("Crypto", function () {
 
             client.stopClient();
         });
+
+        it("doesn't throw an error when attempting to decrypt a redacted event", async () => {
+            const client = new TestClient("@alice:example.com", "deviceid").client;
+            await client.initCrypto();
+
+            const event = new MatrixEvent({
+                content: {},
+                event_id: "$event_id",
+                room_id: "!room_id",
+                sender: "@bob:example.com",
+                type: "m.room.encrypted",
+                unsigned: {
+                    redacted_because: {
+                        content: {},
+                        event_id: "$redaction_event_id",
+                        redacts: "$event_id",
+                        room_id: "!room_id",
+                        origin_server_ts: 1234567890,
+                        sender: "@bob:example.com",
+                        type: "m.room.redaction",
+                        unsigned: {},
+                    },
+                },
+            });
+            await event.attemptDecryption(client.crypto!);
+            expect(event.isDecryptionFailure()).toBeFalsy();
+
+            client.stopClient();
+        });
     });
 
     describe("Session management", function () {

--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -193,6 +193,9 @@ describe("Crypto", function () {
             });
             await event.attemptDecryption(client.crypto!);
             expect(event.isDecryptionFailure()).toBeFalsy();
+            // since the redaction event isn't encrypted, the redacted_because
+            // should be the same as in the original event
+            expect(event.getRedactionEvent()).toEqual(event.getUnsigned().redacted_because);
 
             client.stopClient();
         });

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2873,12 +2873,14 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
                 room_id: event.getRoomId(),
                 ...event.getUnsigned().redacted_because,
             });
-            let redactedBecause: IEvent;
-            try {
-                const decryptedEvent = await this.decryptEvent(redactionEvent);
-                redactedBecause = decryptedEvent.clearEvent as IEvent;
-            } catch {
-                redactedBecause = event.getUnsigned().redacted_because!;
+            let redactedBecause: IEvent = event.getUnsigned().redacted_because!;
+            if (redactionEvent.isEncrypted()) {
+                try {
+                    const decryptedEvent = await this.decryptEvent(redactionEvent);
+                    redactedBecause = decryptedEvent.clearEvent as IEvent;
+                } catch (e) {
+                    logger.warn("Decryption of redaction failed. Falling back to unencrypted event.", e);
+                }
             }
 
             return {


### PR DESCRIPTION
Currently, when processing a redacted event, it tries to decrypt the `redacted_because`  (https://github.com/matrix-org/matrix-js-sdk/pull/1589).  However, since this often is not encrypted, the decryption will fail, and this failure will bubble up to the parent event.  This patch simply uses the plain `redacted_because` if it is unable to decrypt it.

fixes https://github.com/vector-im/element-web/issues/24084 and https://github.com/matrix-org/matrix-js-sdk/issues/1648

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Avoid triggering decryption errors when decrypting redacted events ([\#3004](https://github.com/matrix-org/matrix-js-sdk/pull/3004)). Fixes vector-im/element-web#24084.<!-- CHANGELOG_PREVIEW_END -->