### PR TITLE
Update comment for `m.key.verification.ready` event type definition

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -61,7 +61,7 @@ export enum EventType {
     KeyVerificationDone = "m.key.verification.done",
     KeyVerificationKey = "m.key.verification.key",
     KeyVerificationAccept = "m.key.verification.accept",
-    // XXX this event is not yet supported by js-sdk
+    // Not used directly - see READY_TYPE in VerificationRequest.
     KeyVerificationReady = "m.key.verification.ready",
     // use of this is discouraged https://matrix.org/docs/spec/client_server/r0.6.1#m-room-message-feedback
     RoomMessageFeedback = "m.room.message.feedback",


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->