### PR TITLE
Factor `SyncApi` options out of `IStoredClientOptions`

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -35,9 +35,7 @@ describe("MatrixClient", function () {
     let store: MemoryStore | undefined;
 
     const defaultClientOpts: IStoredClientOpts = {
-        canResetEntireTimeline: (roomId) => false,
         experimentalThreadSupport: false,
-        crypto: {} as unknown as IStoredClientOpts["crypto"],
     };
     const setupTests = (): [MatrixClient, HttpBackend, MemoryStore] => {
         const store = new MemoryStore();

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -38,7 +38,7 @@ import {
     IRoomTimelineData,
 } from "../../src";
 import { SlidingSyncSdk } from "../../src/sliding-sync-sdk";
-import { SyncState } from "../../src/sync";
+import { SyncApiOptions, SyncState } from "../../src/sync";
 import { IStoredClientOpts } from "../../src/client";
 import { logger } from "../../src/logger";
 import { emitPromise } from "../test-utils/test-utils";
@@ -111,6 +111,7 @@ describe("SlidingSyncSdk", () => {
     // assign client/httpBackend globals
     const setupClient = async (testOpts?: Partial<IStoredClientOpts & { withCrypto: boolean }>) => {
         testOpts = testOpts || {};
+        const syncOpts: SyncApiOptions = {};
         const testClient = new TestClient(selfUserId, "DEVICE", selfAccessToken);
         httpBackend = testClient.httpBackend;
         client = testClient.client;
@@ -118,10 +119,10 @@ describe("SlidingSyncSdk", () => {
         if (testOpts.withCrypto) {
             httpBackend!.when("GET", "/room_keys/version").respond(404, {});
             await client!.initCrypto();
-            testOpts.crypto = client!.crypto;
+            syncOpts.crypto = client!.crypto;
         }
         httpBackend!.when("GET", "/_matrix/client/r0/pushrules").respond(200, {});
-        sdk = new SlidingSyncSdk(mockSlidingSync, client, testOpts);
+        sdk = new SlidingSyncSdk(mockSlidingSync, client, testOpts, syncOpts);
     };
 
     // tear down client/httpBackend globals

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -167,9 +167,9 @@ export class RoomWidgetClient extends MatrixClient {
         // still has some valuable helper methods that we make use of, so we
         // instantiate it anyways
         if (opts.slidingSync) {
-            this.syncApi = new SlidingSyncSdk(opts.slidingSync, this, opts);
+            this.syncApi = new SlidingSyncSdk(opts.slidingSync, this, opts, this.buildSyncApiOptions());
         } else {
-            this.syncApi = new SyncApi(this, opts);
+            this.syncApi = new SyncApi(this, opts, this.buildSyncApiOptions());
         }
 
         this.room = this.syncApi.createRoom(this.roomId);

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -19,7 +19,14 @@ import { logger } from "./logger";
 import * as utils from "./utils";
 import { EventTimeline } from "./models/event-timeline";
 import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client";
-import { ISyncStateData, SyncState, _createAndReEmitRoom, SyncApiOptions, defaultClientOpts } from "./sync";
+import {
+    ISyncStateData,
+    SyncState,
+    _createAndReEmitRoom,
+    SyncApiOptions,
+    defaultClientOpts,
+    defaultSyncApiOpts,
+} from "./sync";
 import { MatrixEvent } from "./models/event";
 import { Crypto } from "./crypto";
 import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator";
@@ -343,6 +350,7 @@ class ExtensionReceipts implements Extension<ExtensionReceiptsRequest, Extension
  */
 export class SlidingSyncSdk {
     private readonly opts: IStoredClientOpts;
+    private readonly syncOpts: SyncApiOptions;
     private syncState: SyncState | null = null;
     private syncStateData?: ISyncStateData;
     private lastPos: string | null = null;
@@ -353,15 +361,10 @@ export class SlidingSyncSdk {
         private readonly slidingSync: SlidingSync,
         private readonly client: MatrixClient,
         opts?: IStoredClientOpts,
-        private readonly syncOpts: SyncApiOptions = {},
+        syncOpts?: SyncApiOptions,
     ) {
         this.opts = defaultClientOpts(opts);
-
-        if (!syncOpts.canResetEntireTimeline) {
-            syncOpts.canResetEntireTimeline = (_roomId: string): boolean => {
-                return false;
-            };
-        }
+        this.syncOpts = defaultSyncApiOpts(syncOpts);
 
         if (client.getNotifTimelineSet()) {
             client.reEmitter.reEmit(client.getNotifTimelineSet()!, [RoomEvent.Timeline, RoomEvent.TimelineReset]);

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -18,8 +18,8 @@ import { NotificationCountType, Room, RoomEvent } from "./models/room";
 import { logger } from "./logger";
 import * as utils from "./utils";
 import { EventTimeline } from "./models/event-timeline";
-import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering } from "./client";
-import { ISyncStateData, SyncState, _createAndReEmitRoom, SyncApiOptions } from "./sync";
+import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client";
+import { ISyncStateData, SyncState, _createAndReEmitRoom, SyncApiOptions, defaultClientOpts } from "./sync";
 import { MatrixEvent } from "./models/event";
 import { Crypto } from "./crypto";
 import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator";
@@ -342,6 +342,7 @@ class ExtensionReceipts implements Extension<ExtensionReceiptsRequest, Extension
  * sliding sync API, see sliding-sync.ts or the class SlidingSync.
  */
 export class SlidingSyncSdk {
+    private readonly opts: IStoredClientOpts;
     private syncState: SyncState | null = null;
     private syncStateData?: ISyncStateData;
     private lastPos: string | null = null;
@@ -351,14 +352,10 @@ export class SlidingSyncSdk {
     public constructor(
         private readonly slidingSync: SlidingSync,
         private readonly client: MatrixClient,
-        private readonly opts: IStoredClientOpts = {},
+        opts?: IStoredClientOpts,
         private readonly syncOpts: SyncApiOptions = {},
     ) {
-        this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
-        this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
-        this.opts.pollTimeout = this.opts.pollTimeout || 30 * 1000;
-        this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
-        this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
+        this.opts = defaultClientOpts(opts);
 
         if (!syncOpts.canResetEntireTimeline) {
             syncOpts.canResetEntireTimeline = (_roomId: string): boolean => {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -180,7 +180,20 @@ type WrappedRoom<T> = T & {
     isBrandNewRoom: boolean;
 };
 
+/** add default settings to an IStoredClientOpts */
+export function defaultClientOpts(opts?: IStoredClientOpts): IStoredClientOpts {
+    return {
+        initialSyncLimit: 8,
+        resolveInvitesToProfiles: false,
+        pollTimeout: 30 * 1000,
+        pendingEventOrdering: PendingEventOrdering.Chronological,
+        experimentalThreadSupport: false,
+        ...opts,
+    };
+}
+
 export class SyncApi {
+    private readonly opts: IStoredClientOpts;
     private _peekRoom: Optional<Room> = null;
     private currentSyncRequest?: Promise<ISyncResponse>;
     private abortController?: AbortController;
@@ -203,14 +216,10 @@ export class SyncApi {
      */
     public constructor(
         private readonly client: MatrixClient,
-        private readonly opts: IStoredClientOpts = {},
+        opts?: IStoredClientOpts,
         private readonly syncOpts: SyncApiOptions = {},
     ) {
-        this.opts.initialSyncLimit = this.opts.initialSyncLimit ?? 8;
-        this.opts.resolveInvitesToProfiles = this.opts.resolveInvitesToProfiles || false;
-        this.opts.pollTimeout = this.opts.pollTimeout || 30 * 1000;
-        this.opts.pendingEventOrdering = this.opts.pendingEventOrdering || PendingEventOrdering.Chronological;
-        this.opts.experimentalThreadSupport = this.opts.experimentalThreadSupport === true;
+        this.opts = defaultClientOpts(opts);
 
         if (!syncOpts.canResetEntireTimeline) {
             syncOpts.canResetEntireTimeline = (roomId: string): boolean => {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -192,8 +192,17 @@ export function defaultClientOpts(opts?: IStoredClientOpts): IStoredClientOpts {
     };
 }
 
+export function defaultSyncApiOpts(syncOpts?: SyncApiOptions): SyncApiOptions {
+    return {
+        canResetEntireTimeline: (_roomId): boolean => false,
+        ...syncOpts,
+    };
+}
+
 export class SyncApi {
     private readonly opts: IStoredClientOpts;
+    private readonly syncOpts: SyncApiOptions;
+
     private _peekRoom: Optional<Room> = null;
     private currentSyncRequest?: Promise<ISyncResponse>;
     private abortController?: AbortController;
@@ -214,18 +223,9 @@ export class SyncApi {
      * @param syncOpts - sync-specific options passed by the client
      * @internal
      */
-    public constructor(
-        private readonly client: MatrixClient,
-        opts?: IStoredClientOpts,
-        private readonly syncOpts: SyncApiOptions = {},
-    ) {
+    public constructor(private readonly client: MatrixClient, opts?: IStoredClientOpts, syncOpts?: SyncApiOptions) {
         this.opts = defaultClientOpts(opts);
-
-        if (!syncOpts.canResetEntireTimeline) {
-            syncOpts.canResetEntireTimeline = (roomId: string): boolean => {
-                return false;
-            };
-        }
+        this.syncOpts = defaultSyncApiOpts(syncOpts);
 
         if (client.getNotifTimelineSet()) {
             client.reEmitter.reEmit(client.getNotifTimelineSet()!, [RoomEvent.Timeline, RoomEvent.TimelineReset]);


### PR DESCRIPTION
There are a couple of callback interfaces which are currently stuffed into `IStoredClientOpts` to make it easier to pass them into the `SyncApi` constructor. This isn't really a sensible place for them, because they aren't application options in the same way as the rest of `IStoredClientOpts` are, nor are they 'stored' in indexedDB as the other options are.

I want to add `cryptoBackend` to the things passed into `SyncApi`, so rather than perpetuating the mess, define a new interface `SyncApiOptions` to be passed in separately.

(sorry, this isn't quite passing the code coverage gate. But it almost does, and it's super-annoying to add the tests to make it do so.)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->