### PR TITLE
In release.yml use an env section to get ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: 🔪 Prepare
               env:
-                GITHUB_REF_NAME: ${{ github.ref_name }}
+                  GITHUB_REF_NAME: ${{ github.ref_name }}
               run: |
                   tag="${GITHUB_REF_NAME}"
                   VERSION="${tag#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
                   ref: gh-pages
 
             - name: 🔪 Prepare
+              env:
+                GITHUB_REF_NAME: ${{ github.ref_name }}
               run: |
-                  tag="${{ github.ref_name }}"
+                  tag="${GITHUB_REF_NAME}"
                   VERSION="${tag#v}"
                   [ ! -e "$VERSION" ] || rm -r $VERSION
                   cp -r $RUNNER_TEMP/_docs/ $VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
               env:
                   GITHUB_REF_NAME: ${{ github.ref_name }}
               run: |
-                  tag="${GITHUB_REF_NAME}"
-                  VERSION="${tag#v}"
+                  VERSION="${GITHUB_REF_NAME#v}"
                   [ ! -e "$VERSION" ] || rm -r $VERSION
                   cp -r $RUNNER_TEMP/_docs/ $VERSION
 


### PR DESCRIPTION
This is completely untested, but follows the example in https://github.com/vector-im/element-call/blob/main/.github/workflows/netlify-pr.yaml#L49-L51

Related to https://github.com/matrix-org/internal-config/issues/1388

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * In release.yml use an env section to get ref_name ([\#3017](https://github.com/matrix-org/matrix-js-sdk/pull/3017)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->