### PR TITLE
Add alt event type matching in Relations model

### DIFF
--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -14,13 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { M_POLL_START } from "matrix-events-sdk";
+
 import { EventTimelineSet } from "../../src/models/event-timeline-set";
 import { MatrixEvent, MatrixEventEvent } from "../../src/models/event";
 import { Room } from "../../src/models/room";
 import { Relations } from "../../src/models/relations";
 import { TestClient } from "../TestClient";
+import { RelationType } from "../../src";
+import { logger } from "../../src/logger";
 
 describe("Relations", function () {
+    afterEach(() => {
+        jest.spyOn(logger, "error").mockRestore();
+    });
+
     it("should deduplicate annotations", function () {
         const room = new Room("room123", null!, null!);
         const relations = new Relations("m.annotation", "m.reaction", room);
@@ -73,6 +81,92 @@ describe("Relations", function () {
             expect(key).toEqual("👍️");
             expect(events.size).toEqual(1);
         }
+    });
+
+    describe("addEvent()", () => {
+        const relationType = RelationType.Reference;
+        const eventType = M_POLL_START.stable!;
+        const altEventTypes = [M_POLL_START.unstable!];
+        const room = new Room("room123", null!, null!);
+
+        it("should not add events without a relation", async () => {
+            // dont pollute console
+            const logSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+            const relations = new Relations(relationType, eventType, room);
+            const emitSpy = jest.spyOn(relations, "emit");
+            const event = new MatrixEvent({ type: eventType });
+
+            await relations.addEvent(event);
+            expect(logSpy).toHaveBeenCalledWith("Event must have relation info");
+            // event not added
+            expect(relations.getRelations().length).toBe(0);
+            expect(emitSpy).not.toHaveBeenCalled();
+        });
+
+        it("should not add events of incorrect event type", async () => {
+            // dont pollute console
+            const logSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+            const relations = new Relations(relationType, eventType, room);
+            const emitSpy = jest.spyOn(relations, "emit");
+            const event = new MatrixEvent({
+                type: "different-event-type",
+                content: {
+                    "m.relates_to": {
+                        event_id: "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
+                        rel_type: relationType,
+                    },
+                },
+            });
+
+            await relations.addEvent(event);
+
+            expect(logSpy).toHaveBeenCalledWith(`Event relation info doesn't match this container`);
+            // event not added
+            expect(relations.getRelations().length).toBe(0);
+            expect(emitSpy).not.toHaveBeenCalled();
+        });
+
+        it("adds events that match alt event types", async () => {
+            const relations = new Relations(relationType, eventType, room, altEventTypes);
+            const emitSpy = jest.spyOn(relations, "emit");
+            const event = new MatrixEvent({
+                type: M_POLL_START.unstable!,
+                content: {
+                    "m.relates_to": {
+                        event_id: "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
+                        rel_type: relationType,
+                    },
+                },
+            });
+
+            await relations.addEvent(event);
+
+            // event added
+            expect(relations.getRelations()).toEqual([event]);
+            expect(emitSpy).toHaveBeenCalled();
+        });
+
+        it("should not add events of incorrect relation type", async () => {
+            const logSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+            const relations = new Relations(relationType, eventType, room);
+            const event = new MatrixEvent({
+                type: eventType,
+                content: {
+                    "m.relates_to": {
+                        event_id: "$2s4yYpEkVQrPglSCSqB_m6E8vDhWsg0yFNyOJdVIb_o",
+                        rel_type: "m.annotation",
+                    },
+                },
+            });
+
+            await relations.addEvent(event);
+            const emitSpy = jest.spyOn(relations, "emit");
+
+            expect(logSpy).toHaveBeenCalledWith(`Event relation info doesn't match this container`);
+            // event not added
+            expect(relations.getRelations().length).toBe(0);
+            expect(emitSpy).not.toHaveBeenCalled();
+        });
     });
 
     it("should emit created regardless of ordering", async function () {

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -33,6 +33,9 @@ export type EventHandlerMap = {
     [RelationsEvent.Redaction]: (event: MatrixEvent) => void;
 };
 
+const matchesEventType = (eventType: string, targetEventType: string, altTargetEventTypes: string[] = []): boolean =>
+    [targetEventType, ...altTargetEventTypes].includes(eventType);
+
 /**
  * A container for relation events that supports easy access to common ways of
  * aggregating such events. Each instance holds events that of a single relation
@@ -60,6 +63,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
         public readonly relationType: RelationType | string,
         public readonly eventType: string,
         client: MatrixClient | Room,
+        public readonly altEventTypes?: string[],
     ) {
         super();
         this.client = client instanceof Room ? client.client : client;
@@ -84,7 +88,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
         const relationType = relation.rel_type;
         const eventType = event.getType();
 
-        if (this.relationType !== relationType || this.eventType !== eventType) {
+        if (this.relationType !== relationType || !matchesEventType(eventType, this.eventType, this.altEventTypes)) {
             logger.error("Event relation info doesn't match this container");
             return;
         }
@@ -131,7 +135,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
         const relationType = relation.rel_type;
         const eventType = event.getType();
 
-        if (this.relationType !== relationType || this.eventType !== eventType) {
+        if (this.relationType !== relationType || !matchesEventType(eventType, this.eventType, this.altEventTypes)) {
             logger.error("Event relation info doesn't match this container");
             return;
         }

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -58,6 +58,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
      * @param relationType - The type of relation involved, such as "m.annotation", "m.reference", "m.replace", etc.
      * @param eventType - The relation event's type, such as "m.reaction", etc.
      * @param client - The client which created this instance. For backwards compatibility also accepts a Room.
+     * @param altEventTypes - alt event types for relation events, for example to support unstable prefixed event types
      */
     public constructor(
         public readonly relationType: RelationType | string,

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -126,20 +126,6 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
             return;
         }
 
-        const relation = event.getRelation();
-        if (!relation) {
-            logger.error("Event must have relation info");
-            return;
-        }
-
-        const relationType = relation.rel_type;
-        const eventType = event.getType();
-
-        if (this.relationType !== relationType || !matchesEventType(eventType, this.eventType, this.altEventTypes)) {
-            logger.error("Event relation info doesn't match this container");
-            return;
-        }
-
         this.relations.delete(event);
 
         if (this.relationType === RelationType.Annotation) {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Allow one set of relations to support both stable and unstable variants of an event type.
Enables nicer poll response aggregation.

`RelatedRelations` can be used to combine `Relations` instances, but it produces a new object on every call of `getRelations`. 

Also removes unnecessary (copy-pasted?) code from `removeEvent`

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
