### PR TITLE
Always mark legacy threaded event as read

### DIFF
--- a/src/@types/read_receipts.ts
+++ b/src/@types/read_receipts.ts
@@ -54,3 +54,11 @@ export type Receipts = {
         [userId: string]: [WrappedReceipt | null, WrappedReceipt | null]; // Pair<real receipt, synthetic receipt> (both nullable)
     };
 };
+
+export type CachedReceiptStructure = {
+    eventId: string;
+    receiptType: string | ReceiptType;
+    userId: string;
+    receipt: Receipt;
+    synthetic: boolean;
+};

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -310,6 +310,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private readonly threadNotifications = new Map<string, NotificationCount>();
     public readonly cachedThreadReadReceipts = new Map<string, CachedReceiptStructure[]>();
     public oldestRecordedThreadedReceiptTs = Infinity;
+    public newestRecordedUnthreadedReceiptTs = 0;
     private readonly timelineSets: EventTimelineSet[];
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
@@ -2739,9 +2740,13 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                     // means that we can opt-out of that logic for threads that have their last
                     // reply before
                     const me = this.client.getSafeUserId();
-                    if (!receiptForMainTimeline && userId === me) {
-                        if (receipt.ts < this.oldestRecordedThreadedReceiptTs) {
+                    if (userId === me) {
+                        if (!receiptForMainTimeline && receipt.ts < this.oldestRecordedThreadedReceiptTs) {
                             this.oldestRecordedThreadedReceiptTs = receipt.ts;
+                        }
+
+                        if (!receipt.thread_id && receipt.ts > this.newestRecordedUnthreadedReceiptTs) {
+                            this.newestRecordedUnthreadedReceiptTs = receipt.ts;
                         }
                     }
                 });

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -54,7 +54,13 @@ import {
     FILTER_RELATED_BY_SENDERS,
     ThreadFilterType,
 } from "./thread";
-import { MAIN_ROOM_TIMELINE, Receipt, ReceiptContent, ReceiptType } from "../@types/read_receipts";
+import {
+    CachedReceiptStructure,
+    MAIN_ROOM_TIMELINE,
+    Receipt,
+    ReceiptContent,
+    ReceiptType,
+} from "../@types/read_receipts";
 import { IStateEventWithRoomId } from "../@types/search";
 import { RelationsContainer } from "./relations-container";
 import { ReadReceipt, synthesizeReceipt } from "./read-receipt";
@@ -302,7 +308,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private txnToEvent: Record<string, MatrixEvent> = {}; // Pending in-flight requests { string: MatrixEvent }
     private notificationCounts: NotificationCount = {};
     private readonly threadNotifications = new Map<string, NotificationCount>();
-    public readonly cachedThreadReadReceipts = new Map<string, { event: MatrixEvent; synthetic: boolean }[]>();
+    public readonly cachedThreadReadReceipts = new Map<string, CachedReceiptStructure[]>();
     public oldestRecordedThreadedReceiptTs = Infinity;
     private readonly timelineSets: EventTimelineSet[];
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
@@ -2722,7 +2728,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                         // when the thread is created
                         this.cachedThreadReadReceipts.set(receipt.thread_id!, [
                             ...(this.cachedThreadReadReceipts.get(receipt.thread_id!) ?? []),
-                            { event, synthetic },
+                            { eventId, receiptType, userId, receipt, synthetic },
                         ]);
                     }
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -512,6 +512,16 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         throw new Error("Unsupported function on the thread model");
     }
 
+    public getEventReadUpTo(userId: string, ignoreSynthesized = false): string | null {
+        if (userId === this.client.getUserId()) {
+            if ((this?.lastReply()?.getTs() ?? 0) < this.room.oldestRecordedThreadedReceiptTs) {
+                return this.lastReply()!.getId() ?? null;
+            }
+        }
+
+        return super.getEventReadUpTo(userId, ignoreSynthesized);
+    }
+
     public hasUserReadEvent(userId: string, eventId: string): boolean {
         if (userId === this.client.getUserId()) {
             // We consider all threaded events read if they are part of a thread

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -514,7 +514,6 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
 
     public hasUserReadEvent(userId: string, eventId: string): boolean {
         if (userId === this.client.getUserId()) {
-
             // We consider all threaded events read if they are part of a thread
             // that has no activity since the first ever threaded event recorded in that room
             // This prevents rooms to generated unwanted notifications for threads

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -102,6 +102,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
      * with server suppport.
      */
     public replayEvents: MatrixEvent[] | null = [];
+    public replayReceipts: CachedReceiptStructure[] = [];
 
     public constructor(public readonly id: string, public rootEvent: MatrixEvent | undefined, opts: IThreadOpts) {
         super();
@@ -133,7 +134,9 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         this.room.on(RoomEvent.LocalEchoUpdated, this.onLocalEcho);
         this.timelineSet.on(RoomEvent.Timeline, this.onTimelineEvent);
 
-        this.processReceipts(opts.receipts);
+        if (opts.receipts) {
+            this.replayReceipts = opts.receipts;
+        }
 
         // even if this thread is thought to be originating from this client, we initialise it as we may be in a
         // gappy sync and a thread around this event may already exist.
@@ -390,6 +393,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
                     this.addEvent(event, false);
                 }
                 this.replayEvents = null;
+                this.processReceipts(this.replayReceipts);
                 // just to make sure that, if we've created a timeline window for this thread before the thread itself
                 // existed (e.g. when creating a new thread), we'll make sure the panel is force refreshed correctly.
                 this.emit(RoomEvent.TimelineReset, this.room, this.timelineSet, true);

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -507,7 +507,12 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
     public getEventReadUpTo(userId: string, ignoreSynthesized = false): string | null {
         if (userId === this.client.getUserId()) {
             if (this.lastReply()) {
-                if ((this?.lastReply()?.getTs() ?? 0) < this.room.oldestRecordedThreadedReceiptTs) {
+                const beforeFirstThreadedReceipt =
+                    this?.lastReply()?.getTs() ?? 0 < this.room.oldestRecordedThreadedReceiptTs;
+                const beforeLastUnthreadedReceipt =
+                    this?.lastReply()?.getTs() ?? 0 < this.room.newestRecordedUnthreadedReceiptTs;
+
+                if (beforeFirstThreadedReceipt || beforeLastUnthreadedReceipt) {
                     return this.lastReply()?.getId() ?? null;
                 }
             }
@@ -522,7 +527,12 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
             // that has no activity since the first ever threaded event recorded in that room
             // This prevents rooms to generated unwanted notifications for threads
             // created before MSC3771
-            if ((this?.lastReply()?.getTs() ?? 0) < this.room.oldestRecordedThreadedReceiptTs) {
+            const beforeFirstThreadedReceipt =
+                this?.lastReply()?.getTs() ?? 0 < this.room.oldestRecordedThreadedReceiptTs;
+            const beforeLastUnthreadedReceipt =
+                this?.lastReply()?.getTs() ?? 0 < this.room.newestRecordedUnthreadedReceiptTs;
+
+            if (beforeFirstThreadedReceipt || beforeLastUnthreadedReceipt) {
                 return true;
             }
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -506,8 +506,10 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
 
     public getEventReadUpTo(userId: string, ignoreSynthesized = false): string | null {
         if (userId === this.client.getUserId()) {
-            if ((this?.lastReply()?.getTs() ?? 0) < this.room.oldestRecordedThreadedReceiptTs) {
-                return this.lastReply()!.getId() ?? null;
+            if (this.lastReply()) {
+                if ((this?.lastReply()?.getTs() ?? 0) < this.room.oldestRecordedThreadedReceiptTs) {
+                    return this.lastReply()?.getId() ?? null;
+                }
             }
         }
 


### PR DESCRIPTION
Needed for https://github.com/matrix-org/matrix-react-sdk/pull/9763
Will help https://github.com/vector-im/element-web/issues/23907

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Always mark legacy threaded event as read ([\#3020](https://github.com/matrix-org/matrix-js-sdk/pull/3020)).<!-- CHANGELOG_PREVIEW_END -->