### PR TITLE
Pass to-device messages into rust crypto-sdk

### DIFF
--- a/spec/unit/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto.spec.ts
@@ -22,6 +22,7 @@ import {
     KeysClaimRequest,
     KeysQueryRequest,
     KeysUploadRequest,
+    OlmMachine,
     SignatureUploadRequest,
 } from "@matrix-org/matrix-sdk-crypto-js";
 import { Mocked } from "jest-mock";
@@ -29,7 +30,7 @@ import MockHttpBackend from "matrix-mock-request";
 
 import { RustCrypto } from "../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../src/rust-crypto";
-import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, MatrixHttpApi } from "../../src";
+import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, IToDeviceEvent, MatrixHttpApi } from "../../src";
 import { TypedEventEmitter } from "../../src/models/typed-event-emitter";
 
 afterEach(() => {
@@ -54,6 +55,47 @@ describe("RustCrypto", () => {
         it("should return a list", async () => {
             const keys = await rustCrypto.exportRoomKeys();
             expect(Array.isArray(keys)).toBeTruthy();
+        });
+    });
+
+    describe("to-device messages", () => {
+        let rustCrypto: RustCrypto;
+
+        beforeEach(async () => {
+            const mockHttpApi = {} as MatrixHttpApi<IHttpOpts>;
+            rustCrypto = (await initRustCrypto(mockHttpApi, TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
+        });
+
+        it("should pass through unencrypted to-device messages", async () => {
+            const inputs: IToDeviceEvent[] = [
+                { content: { key: "value" }, type: "org.matrix.test", sender: "@alice:example.com" },
+            ];
+            const res = await rustCrypto.preprocessToDeviceMessages(inputs);
+            expect(res).toEqual(inputs);
+        });
+
+        it("should pass through bad encrypted messages", async () => {
+            const olmMachine: OlmMachine = rustCrypto["olmMachine"];
+            const keys = olmMachine.identityKeys;
+            const inputs: IToDeviceEvent[] = [
+                {
+                    type: "m.room.encrypted",
+                    content: {
+                        algorithm: "m.olm.v1.curve25519-aes-sha2",
+                        sender_key: "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA",
+                        ciphertext: {
+                            [keys.curve25519.toBase64()]: {
+                                type: 0,
+                                body: "ajyjlghi",
+                            },
+                        },
+                    },
+                    sender: "@alice:example.com",
+                },
+            ];
+
+            const res = await rustCrypto.preprocessToDeviceMessages(inputs);
+            expect(res).toEqual(inputs);
         });
     });
 

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
+import type { IToDeviceEvent } from "../sync-accumulator";
 import { MatrixEvent } from "../models/event";
 
 /**
@@ -74,6 +75,20 @@ export interface CryptoBackend extends SyncCryptoCallbacks {
 
 /** The methods which crypto implementations should expose to the Sync api */
 export interface SyncCryptoCallbacks {
+    /**
+     * Called by the /sync loop whenever there are incoming to-device messages.
+     *
+     * The implementation may preprocess the received messages (eg, decrypt them) and return an
+     * updated list of messages for dispatch to the rest of the system.
+     *
+     * Note that, unlike {@link ClientEvent.ToDeviceEvent} events, this is called on the raw to-device
+     * messages, rather than the results of any decryption attempts.
+     *
+     * @param events - the received to-device messages
+     * @returns A list of preprocessed to-device messages.
+     */
+    preprocessToDeviceMessages(events: IToDeviceEvent[]): Promise<IToDeviceEvent[]>;
+
     /**
      * Called by the /sync loop after each /sync response is processed.
      *

--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -60,6 +60,9 @@ export function eventMapperFor(client: MatrixClient, options: MapperOpts): Event
             event.setThread(thread);
         }
 
+        // TODO: once we get rid of the old libolm-backed crypto, we can restrict this to room events (rather than
+        //   to-device events), because the rust implementation decrypts to-device messages at a higher level.
+        //   Generally we probably want to use a different eventMapper implementation for to-device events because
         if (event.isEncrypted()) {
             if (!preventReEmit) {
                 client.reEmitter.reEmit(event, [MatrixEventEvent.Decrypted]);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -24,6 +24,7 @@ import {
 } from "@matrix-org/matrix-sdk-crypto-js";
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
+import type { IToDeviceEvent } from "../sync-accumulator";
 import { MatrixEvent } from "../models/event";
 import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
 import { logger } from "../logger";
@@ -92,6 +93,25 @@ export class RustCrypto implements CryptoBackend {
     // SyncCryptoCallbacks implementation
     //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /** called by the sync loop to preprocess incoming to-device messages
+     *
+     * @param events - the received to-device messages
+     * @returns A list of preprocessed to-device messages.
+     */
+    public async preprocessToDeviceMessages(events: IToDeviceEvent[]): Promise<IToDeviceEvent[]> {
+        // send the received to-device messages into receiveSyncChanges. We have no info on device-list changes,
+        // one-time-keys, or fallback keys, so just pass empty data.
+        const result = await this.olmMachine.receiveSyncChanges(
+            JSON.stringify(events),
+            new RustSdkCryptoJs.DeviceLists(),
+            new Map(),
+            new Set(),
+        );
+
+        // receiveSyncChanges returns a JSON-encoded list of decrypted to-device messages.
+        return JSON.parse(result);
+    }
 
     /** called by the sync loop after processing each sync.
      *


### PR DESCRIPTION
This introduces a new method in `SyncCryptoCallbacks`. We can't just piggyback onto `ClientEvent.ToDeviceEvent`, because that is only emitted for successfully decrypted to-device events.

We also don't really want to hook into the EventMapper mechanism (as the current `Crypto` implementation does), because the rust crypto api expects the raw to-device events, rather than those that have been mangled into MatrixEvents.

Part of https://github.com/vector-im/element-web/issues/21972.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->