### PR TITLE
Avoid logical assignment operator

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -169,11 +169,11 @@ export class RustCrypto implements CryptoBackend {
         opts: IRequestOpts = {},
     ): Promise<string> {
         // unbeknownst to HttpApi, we are sending JSON
-        opts.headers ??= {};
+        if (!opts.headers) opts.headers = {};
         opts.headers["Content-Type"] = "application/json";
 
         // we use the full prefix
-        opts.prefix ??= "";
+        if (!opts.prefix) opts.prefix = "";
 
         const resp = await this.http.authedRequest(method, path, queryParams, body, opts);
         return await resp.text();


### PR DESCRIPTION
Apparently `??=` was only added to javascript in ES12, and our eleweb build
doesn't support it.

Fixes breakage introduced in https://github.com/matrix-org/matrix-js-sdk/pull/3019.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->