### PR TITLE
Make error handling in decryptionLoop more generic

### DIFF
--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { MatrixEvent, MatrixEventEvent } from "../../../src/models/event";
 import { emitPromise } from "../../test-utils/test-utils";
-import { EventType } from "../../../src";
 import { Crypto } from "../../../src/crypto";
 
 describe("MatrixEvent", () => {

--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -88,22 +88,6 @@ describe("MatrixEvent", () => {
         expect(ev.getWireContent().ciphertext).toBeUndefined();
     });
 
-    it("should abort decryption if fails with an error other than a DecryptionError", async () => {
-        const ev = new MatrixEvent({
-            type: EventType.RoomMessageEncrypted,
-            content: {
-                body: "Test",
-            },
-            event_id: "$event1:server",
-        });
-        await ev.attemptDecryption({
-            decryptEvent: jest.fn().mockRejectedValue(new Error("Not a DecryptionError")),
-        } as unknown as Crypto);
-        expect(ev.isEncrypted()).toBeTruthy();
-        expect(ev.isBeingDecrypted()).toBeFalsy();
-        expect(ev.isDecryptionFailure()).toBeFalsy();
-    });
-
     describe("applyVisibilityEvent", () => {
         it("should emit VisibilityChange if a change was made", async () => {
             const ev = new MatrixEvent({
@@ -131,6 +115,21 @@ describe("MatrixEvent", () => {
                 content: {
                     ciphertext: "secrets",
                 },
+            });
+        });
+
+        it("should report decryption errors", async () => {
+            const crypto = {
+                decryptEvent: jest.fn().mockRejectedValue(new Error("test error")),
+            } as unknown as Crypto;
+
+            await encryptedEvent.attemptDecryption(crypto);
+            expect(encryptedEvent.isEncrypted()).toBeTruthy();
+            expect(encryptedEvent.isBeingDecrypted()).toBeFalsy();
+            expect(encryptedEvent.isDecryptionFailure()).toBeTruthy();
+            expect(encryptedEvent.getContent()).toEqual({
+                msgtype: "m.bad.encrypted",
+                body: "** Unable to decrypt: Error: test error **",
             });
         });
 


### PR DESCRIPTION
Not everything is a `DecryptionError`, and there's no real reason that we should only do retries for `DecryptionError`s.

Part of https://github.com/vector-im/element-web/issues/21972.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->