### PR TITLE
Fix outgoing messages for rust-crypto

### DIFF
--- a/spec/unit/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto.spec.ts
@@ -29,7 +29,7 @@ import MockHttpBackend from "matrix-mock-request";
 
 import { RustCrypto } from "../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../src/rust-crypto";
-import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, MatrixHttpApi } from "../../src";
+import { HttpApiEvent, HttpApiEventHandlerMap, MatrixClient, MatrixHttpApi } from "../../src";
 import { TypedEventEmitter } from "../../src/models/typed-event-emitter";
 
 afterEach(() => {
@@ -47,7 +47,7 @@ describe("RustCrypto", () => {
         let rustCrypto: RustCrypto;
 
         beforeEach(async () => {
-            const mockHttpApi = {} as MatrixHttpApi<IHttpOpts>;
+            const mockHttpApi = {} as MatrixClient["http"];
             rustCrypto = (await initRustCrypto(mockHttpApi, TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
         });
 
@@ -90,6 +90,7 @@ describe("RustCrypto", () => {
                 baseUrl: "https://example.com",
                 prefix: "/_matrix",
                 fetchFn: httpBackend.fetchFn as typeof global.fetch,
+                onlyData: true,
             });
 
             // for these tests we use a mock OlmMachine, with an implementation of outgoingRequests that

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -23,7 +23,7 @@ import { RUST_SDK_STORE_PREFIX } from "./constants";
 import { IHttpOpts, MatrixHttpApi } from "../http-api";
 
 export async function initRustCrypto(
-    http: MatrixHttpApi<IHttpOpts>,
+    http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
     userId: string,
     deviceId: string,
 ): Promise<CryptoBackend> {


### PR DESCRIPTION
Fixes to #3019

It turns out that MatrixClient uses a `FetchHttpApi` instance with `opts.onlyData = true`, so it was returning the json-parsed response rather than the raw response. Change the way we call `authedRequest` so that we get the raw body back.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->