### PR TITLE
Fix threaded cache receipt when event holds multiple receipts

### DIFF
--- a/src/@types/read_receipts.ts
+++ b/src/@types/read_receipts.ts
@@ -54,3 +54,11 @@ export type Receipts = {
         [userId: string]: [WrappedReceipt | null, WrappedReceipt | null]; // Pair<real receipt, synthetic receipt> (both nullable)
     };
 };
+
+export type CachedReceiptStructure = {
+    eventId: string;
+    receiptType: string | ReceiptType;
+    userId: string;
+    receipt: Receipt;
+    synthetic: boolean;
+};

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -54,7 +54,13 @@ import {
     FILTER_RELATED_BY_SENDERS,
     ThreadFilterType,
 } from "./thread";
-import { MAIN_ROOM_TIMELINE, Receipt, ReceiptContent, ReceiptType } from "../@types/read_receipts";
+import {
+    CachedReceiptStructure,
+    MAIN_ROOM_TIMELINE,
+    Receipt,
+    ReceiptContent,
+    ReceiptType,
+} from "../@types/read_receipts";
 import { IStateEventWithRoomId } from "../@types/search";
 import { RelationsContainer } from "./relations-container";
 import { ReadReceipt, synthesizeReceipt } from "./read-receipt";
@@ -302,7 +308,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private txnToEvent: Record<string, MatrixEvent> = {}; // Pending in-flight requests { string: MatrixEvent }
     private notificationCounts: NotificationCount = {};
     private readonly threadNotifications = new Map<string, NotificationCount>();
-    public readonly cachedThreadReadReceipts = new Map<string, { event: MatrixEvent; synthetic: boolean }[]>();
+    public readonly cachedThreadReadReceipts = new Map<string, CachedReceiptStructure[]>();
     private readonly timelineSets: EventTimelineSet[];
     public readonly threadsTimelineSets: EventTimelineSet[] = [];
     // any filtered timeline sets we're maintaining for this room
@@ -2721,7 +2727,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                         // when the thread is created
                         this.cachedThreadReadReceipts.set(receipt.thread_id!, [
                             ...(this.cachedThreadReadReceipts.get(receipt.thread_id!) ?? []),
-                            { event, synthetic },
+                            { eventId, receiptType, userId, receipt, synthetic },
                         ]);
                     }
                 });


### PR DESCRIPTION
First step for https://github.com/vector-im/element-web/issues/24164

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix threaded cache receipt when event holds multiple receipts ([\#3026](https://github.com/matrix-org/matrix-js-sdk/pull/3026)).<!-- CHANGELOG_PREVIEW_END -->