### PR TITLE
Remove 'qs' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "matrix-events-sdk": "0.0.1",
         "matrix-widget-api": "^1.0.0",
         "p-retry": "4",
-        "qs": "^6.9.6",
         "sdp-transform": "^2.14.1",
         "unhomoglyph": "^1.0.6",
         "uuid": "9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5872,13 +5872,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.9.6:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
-
 querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
'qs' ([package](https://www.npmjs.com/package/qs), [source](https://github.com/ljharb/qs)) appears to be unused since 34c5598 (PR #2719), and can be safely removed.

It's worth noting that 'qs' has the deepest dependency graph of all (non-development) dependencies.

```
$ npm ls --depth=32 --omit=dev
...
├─┬ qs@6.11.0
│ └─┬ side-channel@1.0.4
│   ├─┬ call-bind@1.0.2
│   │ ├── function-bind@1.1.1
│   │ └── get-intrinsic@1.1.3 deduped
│   ├─┬ get-intrinsic@1.1.3
│   │ ├── function-bind@1.1.1 deduped
│   │ ├── has-symbols@1.0.3
│   │ └─┬ has@1.0.3
│   │   └── function-bind@1.1.1 deduped
│   └── object-inspect@1.12.2
...
```

No other dependencies have more than one level of nesting.

#244 is relevant here (maybe?), though this doesn't go particularly far. A full dev install still weighs 372M on my machine, though this reduces a production install from 9.3M to 8.6M.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->