### PR TITLE
Remove extensible events v1 field population on legacy events

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1177,10 +1177,10 @@ describe("MatrixClient", function () {
                 .when("PUT", "/send")
                 .check((req) => {
                     expect(req.data).toStrictEqual({
-                        "msgtype": "m.emote",
-                        "body": "Body",
-                        "formatted_body": "<h1>Body</h1>",
-                        "format": "org.matrix.custom.html",
+                        msgtype: "m.emote",
+                        body: "Body",
+                        formatted_body: "<h1>Body</h1>",
+                        format: "org.matrix.custom.html",
                     });
                 })
                 .respond(200, { event_id: "$foobar" });
@@ -1196,10 +1196,10 @@ describe("MatrixClient", function () {
                 .when("PUT", "/send")
                 .check((req) => {
                     expect(req.data).toStrictEqual({
-                        "msgtype": "m.text",
-                        "body": "Body",
-                        "formatted_body": "<h1>Body</h1>",
-                        "format": "org.matrix.custom.html",
+                        msgtype: "m.text",
+                        body: "Body",
+                        formatted_body: "<h1>Body</h1>",
+                        format: "org.matrix.custom.html",
                     });
                 })
                 .respond(200, { event_id: "$foobar" });

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1181,7 +1181,6 @@ describe("MatrixClient", function () {
                         "body": "Body",
                         "formatted_body": "<h1>Body</h1>",
                         "format": "org.matrix.custom.html",
-                        "org.matrix.msc1767.message": expect.anything(),
                     });
                 })
                 .respond(200, { event_id: "$foobar" });
@@ -1201,7 +1200,6 @@ describe("MatrixClient", function () {
                         "body": "Body",
                         "formatted_body": "<h1>Body</h1>",
                         "format": "org.matrix.custom.html",
-                        "org.matrix.msc1767.message": expect.anything(),
                     });
                 })
                 .respond(200, { event_id: "$foobar" });

--- a/src/client.ts
+++ b/src/client.ts
@@ -4545,8 +4545,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId = null;
         }
 
-        let eventType: string = EventType.RoomMessage;
-        let sendContent: IContent = content as IContent;
+        const eventType: string = EventType.RoomMessage;
+        const sendContent: IContent = content as IContent;
 
         return this.sendEvent(roomId, threadId as string | null, eventType, sendContent, txnId);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ limitations under the License.
  * This is an internal module. See {@link MatrixClient} for the public class.
  */
 
-import { EmoteEvent, IPartialEvent, MessageEvent, NoticeEvent, Optional } from "matrix-events-sdk";
+import { Optional } from "matrix-events-sdk";
 
 import type { IMegolmSessionData } from "./@types/crypto";
 import { ISyncStateData, SyncApi, SyncApiOptions, SyncState } from "./sync";
@@ -4545,44 +4545,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId = null;
         }
 
-        // Populate all outbound events with Extensible Events metadata to ensure there's a
-        // reasonably large pool of messages to parse.
         let eventType: string = EventType.RoomMessage;
         let sendContent: IContent = content as IContent;
-        const makeContentExtensible = (content: IContent = {}, recurse = true): IPartialEvent<object> | undefined => {
-            let newEvent: IPartialEvent<IContent> | undefined;
-
-            if (content["msgtype"] === MsgType.Text) {
-                newEvent = MessageEvent.from(content["body"], content["formatted_body"]).serialize();
-            } else if (content["msgtype"] === MsgType.Emote) {
-                newEvent = EmoteEvent.from(content["body"], content["formatted_body"]).serialize();
-            } else if (content["msgtype"] === MsgType.Notice) {
-                newEvent = NoticeEvent.from(content["body"], content["formatted_body"]).serialize();
-            }
-
-            if (newEvent && content["m.new_content"] && recurse) {
-                const newContent = makeContentExtensible(content["m.new_content"], false);
-                if (newContent) {
-                    newEvent.content["m.new_content"] = newContent.content;
-                }
-            }
-
-            if (newEvent) {
-                // copy over all other fields we don't know about
-                for (const [k, v] of Object.entries(content)) {
-                    if (!newEvent.content.hasOwnProperty(k)) {
-                        newEvent.content[k] = v;
-                    }
-                }
-            }
-
-            return newEvent;
-        };
-        const result = makeContentExtensible(sendContent);
-        if (result) {
-            eventType = result.type;
-            sendContent = result.content;
-        }
 
         return this.sendEvent(roomId, threadId as string | null, eventType, sendContent, txnId);
     }


### PR DESCRIPTION
With extensible events v2, affected events are now gated by a room version, so we don't need this code anymore. 

The proposal has generally moved away from mixing m.room.message with extensible fields as well.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Remove extensible events v1 field population on legacy events ([\#3040](https://github.com/matrix-org/matrix-js-sdk/pull/3040)).<!-- CHANGELOG_PREVIEW_END -->