### PR TITLE
MSC3946 Dynamic room predecessors

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3266,6 +3266,20 @@ describe("Room", function () {
             });
         }
 
+        function predecessorEvent(newRoomId: string, predecessorRoomId: string): MatrixEvent {
+            return new MatrixEvent({
+                content: {
+                    predecessor_room_id: predecessorRoomId,
+                },
+                event_id: `predecessor_event_id_pred_${predecessorRoomId}`,
+                origin_server_ts: 1432735824653,
+                room_id: newRoomId,
+                sender: "@daryl:alexandria.example.com",
+                state_key: "",
+                type: "org.matrix.msc3946.room_predecessor",
+            });
+        }
+
         it("Returns null if there is no create event", () => {
             const room = new Room("roomid", client!, "@u:example.com");
             expect(room.findPredecessorRoomId()).toBeNull();
@@ -3281,6 +3295,38 @@ describe("Room", function () {
             const room = new Room("roomid", client!, "@u:example.com");
             room.addLiveEvents([roomCreateEvent("roomid", "replacedroomid")]);
             expect(room.findPredecessorRoomId()).toBe("replacedroomid");
+        });
+
+        it("Prefers the m.predecessor event if one exists", () => {
+            const room = new Room("roomid", client!, "@u:example.com");
+            room.addLiveEvents([
+                roomCreateEvent("roomid", "replacedroomid"),
+                predecessorEvent("roomid", "otherreplacedroomid"),
+            ]);
+            const useMsc3946 = true;
+            expect(room.findPredecessorRoomId(useMsc3946)).toBe("otherreplacedroomid");
+        });
+
+        it("Ignores the m.predecessor event if we don't ask to use it", () => {
+            const room = new Room("roomid", client!, "@u:example.com");
+            room.addLiveEvents([
+                roomCreateEvent("roomid", "replacedroomid"),
+                predecessorEvent("roomid", "otherreplacedroomid"),
+            ]);
+            // Don't provide an argument for msc3946ProcessDynamicPredecessor -
+            // we should ignore the predecessor event.
+            expect(room.findPredecessorRoomId()).toBe("replacedroomid");
+        });
+
+        it("Ignores the m.predecessor event and returns null if we don't ask to use it", () => {
+            const room = new Room("roomid", client!, "@u:example.com");
+            room.addLiveEvents([
+                roomCreateEvent("roomid", null), // Create event has no predecessor
+                predecessorEvent("roomid", "otherreplacedroomid"),
+            ]);
+            // Don't provide an argument for msc3946ProcessDynamicPredecessor -
+            // we should ignore the predecessor event.
+            expect(room.findPredecessorRoomId()).toBeNull();
         });
     });
 });

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -33,6 +33,7 @@ export enum EventType {
     RoomGuestAccess = "m.room.guest_access",
     RoomServerAcl = "m.room.server_acl",
     RoomTombstone = "m.room.tombstone",
+    RoomPredecessor = "org.matrix.msc3946.room_predecessor",
 
     SpaceChild = "m.space.child",
     SpaceParent = "m.space.parent",

--- a/src/client.ts
+++ b/src/client.ts
@@ -3780,14 +3780,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * This is essentially getRooms() with some rooms filtered out, eg. old versions
      * of rooms that have been replaced or (in future) other rooms that have been
      * marked at the protocol level as not to be displayed to the user.
+     *
+     * @param msc3946ProcessDynamicPredecessor - if true, look for an
+     *                                           m.room.predecessor state event and
+     *                                           use it if found (MSC3946).
      * @returns A list of rooms, or an empty list if there is no data store.
      */
-    public getVisibleRooms(): Room[] {
+    public getVisibleRooms(msc3946ProcessDynamicPredecessor = false): Room[] {
         const allRooms = this.store.getRooms();
 
         const replacedRooms = new Set();
         for (const r of allRooms) {
-            const predecessor = r.findPredecessorRoomId();
+            const predecessor = r.findPredecessorRoomId(msc3946ProcessDynamicPredecessor);
             if (predecessor) {
                 replacedRooms.add(predecessor);
             }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2991,13 +2991,25 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
+     * @param msc3946ProcessDynamicPredecessor - if true, look for an
+     *                                           m.room.predecessor state event and
+     *                                           use it if found (MSC3946).
      * @returns the ID of the room that was this room's predecessor, or null if
      *          this room has no predecessor.
      */
-    public findPredecessorRoomId(): string | null {
+    public findPredecessorRoomId(msc3946ProcessDynamicPredecessor = false): string | null {
         const currentState = this.getLiveTimeline().getState(EventTimeline.FORWARDS);
         if (!currentState) {
             return null;
+        }
+        if (msc3946ProcessDynamicPredecessor) {
+            const predecessorEvent = currentState.getStateEvents(EventType.RoomPredecessor, "");
+            if (predecessorEvent) {
+                const roomId = predecessorEvent.getContent()["predecessor_room_id"];
+                if (roomId) {
+                    return roomId;
+                }
+            }
         }
 
         const createEvent = currentState.getStateEvents(EventType.RoomCreate, "");


### PR DESCRIPTION
See [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946). Support looking up room predecessors using this MSC if the caller explicitly opts in.

Adds an optional boolean argument to `getVisibleRooms`, `getRoomUpgradeHistory` and `getPredecessorRoomId` that specifies whether to use the new logic.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * MSC3946 Dynamic room predecessors ([\#3042](https://github.com/matrix-org/matrix-js-sdk/pull/3042)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->