### PR TITLE
sliding sync: Fix duplicate rooms by re-sending modified lists

### DIFF
--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -861,10 +861,16 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
                     logger.debug("list modified during await call, not updating list");
                     doNotUpdateList = true;
                 }
-                // mark all these lists as having been sent as sticky so we don't keep sending sticky params
-                this.lists.forEach((l) => {
-                    l.setModified(false);
-                });
+
+                // Only mark the lists as sticky if our lists weren't modified during the call.
+                // This will result in us sending the lists again, but ensures they are correct.
+                if (!doNotUpdateList) {
+                    // mark all these lists as having been sent as sticky so we don't keep sending sticky params
+                    this.lists.forEach((l) => {
+                        l.setModified(false);
+                    });
+                }
+
                 // set default empty values so we don't need to null check
                 resp.lists = resp.lists || [];
                 resp.rooms = resp.rooms || {};


### PR DESCRIPTION
Before this change, it could happend that we send wrong lists (without any filters) to the server and marking our copy as sticky.
```
{"lists":[{"ranges":[[0,20]]},{"ranges":[[0,99],[100,199]]},{"ranges":[[0,20]]},{"ranges":[[0,20]]},{"ranges":[[0,20]]},{"ranges":[[0,20]]},{"ranges":[[0,20]]}],"extensions":{"to_device":{"since":"0"}},"txn_id":"m1673354184357.1"}
```

Those lists _should_ have the filters as defined [here](https://github.com/matrix-org/matrix-react-sdk/blob/c94a4abe3deafaf43e0594f2aab04e7633b37ef6/src/stores/room-list/SlidingRoomListStore.ts#L43-L74). As per my debugging, they are passed to [ensureListRegistered](https://github.com/matrix-org/matrix-react-sdk/blob/c94a4abe3deafaf43e0594f2aab04e7633b37ef6/src/SlidingSyncManager.ts#L213-L263) correctly, but don't make it to the request.

If the request is modified in flight, we were marking the lists as sticky anyway, without any filters applied. Now we're re-sending them to ensure we have the correct filters set.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * sliding sync: Fix duplicate rooms by re-sending modified lists ([\#3044](https://github.com/matrix-org/matrix-js-sdk/pull/3044)). Contributed by @S7evinK.<!-- CHANGELOG_PREVIEW_END -->