### PR TITLE
Correctly handle limited sync responses by resetting the thread timeline

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -411,6 +411,6 @@ describe("Thread", () => {
 
             room.resetLiveTimeline("b1", "f1");
             expect(mock).toHaveBeenCalledWith("b1", "f1");
-        })
+        });
     });
 });

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1223,7 +1223,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const event = this.findEventById(eventId);
         const thread = this.findThreadForEvent(event);
         if (thread) {
-            return thread.timelineSet.getLiveTimeline();
+            return thread.timelineSet.getTimelineForEvent(eventId);
         } else {
             return this.getUnfilteredTimelineSet().getTimelineForEvent(eventId);
         }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1114,6 +1114,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         for (const timelineSet of this.timelineSets) {
             timelineSet.resetLiveTimeline(backPaginationToken ?? undefined, forwardPaginationToken ?? undefined);
         }
+        for (const thread of this.threads.values()) {
+            thread.resetLiveTimeline(backPaginationToken, forwardPaginationToken);
+        }
 
         this.fixUpLegacyTimelineFields();
     }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -361,7 +361,10 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
     /**
      * Reset the live timeline of all timelineSets, and start new ones.
      *
-     * <p>This is used when /sync returns a 'limited' timeline.
+     * <p>This is used when /sync returns a 'limited' timeline. 'Limited' means that there's a gap between the messages
+     * /sync returned, and the last known message in our timeline. In such a case, our live timeline isn't live anymore
+     * and has to be replaced by a new one. To make sure we can continue paginating our timelines correctly, we have to
+     * set new pagination tokens on the old and the new timeline.
      *
      * @param backPaginationToken -   token for back-paginating the new timeline
      * @param forwardPaginationToken - token for forward-paginating the old live timeline,

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -358,6 +358,21 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         this.pendingReplyCount = pendingEvents.length;
     }
 
+    /**
+     * Reset the live timeline of all timelineSets, and start new ones.
+     *
+     * <p>This is used when /sync returns a 'limited' timeline.
+     *
+     * @param backPaginationToken -   token for back-paginating the new timeline
+     * @param forwardPaginationToken - token for forward-paginating the old live timeline,
+     * if absent or null, all timelines are reset, removing old ones (including the previous live
+     * timeline which would otherwise be unable to paginate forwards without this token).
+     * Removing just the old live timeline whilst preserving previous ones is not supported.
+     */
+    public resetLiveTimeline(backPaginationToken?: string | null, forwardPaginationToken?: string | null): void {
+        this.timelineSet.resetLiveTimeline(backPaginationToken ?? undefined, forwardPaginationToken ?? undefined);
+    }
+
     private async updateThreadMetadata(): Promise<void> {
         this.updatePendingReplyCount();
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -369,7 +369,10 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
      * timeline which would otherwise be unable to paginate forwards without this token).
      * Removing just the old live timeline whilst preserving previous ones is not supported.
      */
-    public async resetLiveTimeline(backPaginationToken?: string | null, forwardPaginationToken?: string | null): Promise<void> {
+    public async resetLiveTimeline(
+        backPaginationToken?: string | null,
+        forwardPaginationToken?: string | null,
+    ): Promise<void> {
         const oldLive = this.liveTimeline;
         this.timelineSet.resetLiveTimeline(backPaginationToken ?? undefined, forwardPaginationToken ?? undefined);
         const newLive = this.liveTimeline;
@@ -387,14 +390,15 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         let newBackward: string | undefined;
         let oldForward: string | undefined;
         if (backPaginationToken) {
-            const res = await this.client.createMessagesRequest(
-                this.roomId, backPaginationToken, 1, Direction.Forward,
-            );
+            const res = await this.client.createMessagesRequest(this.roomId, backPaginationToken, 1, Direction.Forward);
             newBackward = res.end;
         }
         if (forwardPaginationToken) {
             const res = await this.client.createMessagesRequest(
-                this.roomId, forwardPaginationToken, 1, Direction.Backward,
+                this.roomId,
+                forwardPaginationToken,
+                1,
+                Direction.Backward,
             );
             oldForward = res.start;
         }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -256,7 +256,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
         this.setEventMetadata(event);
 
         const lastReply = this.lastReply();
-        const isNewestReply = !lastReply || event.localTimestamp > lastReply!.localTimestamp;
+        const isNewestReply = !lastReply || event.localTimestamp >= lastReply!.localTimestamp;
 
         // Add all incoming events to the thread's timeline set when there's  no server support
         if (!Thread.hasServerSideSupport) {


### PR DESCRIPTION
Type: Defect
Fixes: https://github.com/vector-im/element-web/issues/23952

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Correctly handle limited sync responses by resetting the thread timeline ([\#3056](https://github.com/matrix-org/matrix-js-sdk/pull/3056)). Fixes vector-im/element-web#23952. Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->