### PR TITLE
Fix failure to start in firefox private browser

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1690,12 +1690,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                         resolve(0);
                     };
                     req.onerror = (e): void => {
-                        logger.error(`Failed to remove IndexedDB instance ${dbname}: ${e}`);
-                        reject(new Error(`Error clearing storage: ${e}`));
+                        // In private browsing, Firefox has a global.indexedDB, but attempts to delete an indexeddb
+                        // (even a non-existent one) fail with "DOMException: A mutation operation was attempted on a
+                        // database that did not allow mutations."
+                        //
+                        // it seems like the only thing we can really do is ignore the error.
+                        logger.warn(`Failed to remove IndexedDB instance ${dbname}:`, e);
+                        resolve(0);
                     };
                     req.onblocked = (e): void => {
                         logger.info(`cannot yet remove IndexedDB instance ${dbname}`);
-                        //reject(new Error(`Error clearing storage: ${e}`));
                     };
                 });
                 await prom;


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/24216

This is a quick fix so we can unblock the release. I'd like to investigate whether we can (a) report errors in this code, rather than swallowing them; (b) test that app load and login work with an indexeddb impl that behaves this way.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix failure to start in firefox private browser ([\#3058](https://github.com/matrix-org/matrix-js-sdk/pull/3058)). Fixes vector-im/element-web#24216.<!-- CHANGELOG_PREVIEW_END -->