### PR TITLE
Implement new extensible events parsing interface and intercept non-extensible messages in supported rooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",
         "loglevel": "^1.7.1",
-        "matrix-events-sdk": "0.0.1",
+        "matrix-events-sdk": "^2.0.0",
         "matrix-widget-api": "^1.0.0",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -2138,9 +2138,9 @@ describe("MatrixClient", function () {
         describe("roomId,content,txnId signature", () => {
             it("should translate these values to the correct request", async () => {
                 const roomId = "!room:example.org";
-                const content: IContent = {hello: "world"};
+                const content: IContent = { hello: "world" };
                 const txnId = "m.1234";
-                const response = {event_id: "$example"};
+                const response = { event_id: "$example" };
 
                 const sendSpy = jest.spyOn(client, "sendEvent").mockResolvedValue(response);
 
@@ -2154,9 +2154,9 @@ describe("MatrixClient", function () {
             it("should translate these values to the correct request", async () => {
                 const roomId = "!room:example.org";
                 const threadId = "$thread";
-                const content: IContent = {hello: "world"};
+                const content: IContent = { hello: "world" };
                 const txnId = "m.1234";
-                const response = {event_id: "$example"};
+                const response = { event_id: "$example" };
 
                 const sendSpy = jest.spyOn(client, "sendEvent").mockResolvedValue(response);
 
@@ -2175,22 +2175,19 @@ describe("MatrixClient", function () {
                 formatted_body: "<b>test</b>",
             };
             const expectedContent: IContent = {
-                "org.matrix.msc1767.markup": [
-                    {body: "**test**"},
-                    {body: "<b>test</b>", mimetype: "text/html"},
-                ],
+                "org.matrix.msc1767.markup": [{ body: "**test**" }, { body: "<b>test</b>", mimetype: "text/html" }],
             };
             const expectedEventType = msgtype === "m.emote" ? "org.matrix.msc1767.emote" : "org.matrix.msc1767.message";
             const txnId = "m.1234";
-            const response = {event_id: "$example"};
+            const response = { event_id: "$example" };
 
             client.getRoom = (rid) => {
                 if (rid === roomId) {
                     // XXX: This is a really bad mock.
-                    return {unstableRequiresExtensibleEvents: () => true} as unknown as Room;
+                    return { unstableRequiresExtensibleEvents: () => true } as unknown as Room;
                 }
                 return null;
-            }
+            };
             const sendSpy = jest.spyOn(client, "sendEvent").mockResolvedValue(response);
 
             const result = await client.sendMessage(roomId, content, txnId);

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -193,6 +193,22 @@ describe("Room", function () {
         });
     });
 
+    describe("unstableRequiresExtensibleEvents", () => {
+        it("should return true for MSC1767 room version prefixes", () => {
+            room.getVersion = () => "org.matrix.msc1767.10";
+            expect(room.unstableRequiresExtensibleEvents()).toBe(true);
+
+            room.getVersion = () => "org.matrix.msc1767.9";
+            expect(room.unstableRequiresExtensibleEvents()).toBe(true);
+
+            room.getVersion = () => "not.extensible.10";
+            expect(room.unstableRequiresExtensibleEvents()).toBe(false);
+
+            room.getVersion = () => "10";
+            expect(room.unstableRequiresExtensibleEvents()).toBe(false);
+        });
+    });
+
     describe("getAvatarUrl", function () {
         const hsUrl = "https://my.home.server";
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -548,6 +548,18 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
+     * Unstable/experimental function to determine if the room requires MSC1767-style
+     * events or not.
+     *
+     * @deprecated Use stable functions where possible. This function may be removed or
+     * changed without notice.
+     */
+    public unstableRequiresExtensibleEvents(): boolean {
+        // TODO(TR): We need a better check for this that doesn't involve hardcoding supported room versions
+        return this.getVersion().startsWith("org.matrix.msc1767.");
+    }
+
+    /**
      * Gets the version of the room
      * @returns The version of the room, or null if it could not be determined
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,11 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ajv-errors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
+  integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
+
 ajv@^6.10.0, ajv@^6.12.4, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1952,6 +1957,16 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@~6.12.6:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.2:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -4929,6 +4944,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -5150,10 +5170,13 @@ marked@^4.2.5:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.5.tgz#979813dfc1252cc123a79b71b095759a32f42a5d"
   integrity sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==
 
-matrix-events-sdk@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
-  integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
+matrix-events-sdk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-2.0.0.tgz#f5f8dafbe4eae07fdbb628627f430ca5b1fd8c7a"
+  integrity sha512-UZbifYIO2o9+sNn4YuGjhMof/88TG68PyecKnH/pt8V3MFq0RZsbBUe+3/k5ZeVcEtr0pQLmcKB7d8aQVsVO/w==
+  dependencies:
+    ajv "^8.11.2"
+    ajv-errors "^3.0.0"
 
 matrix-mock-request@^2.5.0:
   version "2.6.0"
@@ -6120,6 +6143,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/pull/1767 covers this in a whole lot more detail, but the tldr is extensible events (v2) is gated by a room version: any old events sent in that room version are not supposed to be rendered, and we're supposed to be sending the new extensible event types.

This PR implements the new event parsing interface from the events-sdk (normally a breaking change, but not here because unstable), and converts `m.room.message` events to their extensible versions in room versions where it matters, for the event types we know we can support with the events-sdk.

This is very much a work in progress and a bit of a hack - the intention is to demonstrate the functionality and hopefully improve on it later. 

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->