### PR TITLE
Element-R: stub implementations of some methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2507,10 +2507,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns
      */
     public checkUserTrust(userId: string): UserTrustLevel {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.checkUserTrust(userId);
+        return this.cryptoBackend.checkUserTrust(userId);
     }
 
     /**
@@ -2522,10 +2522,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param deviceId - The ID of the device to check
      */
     public checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.checkDeviceTrust(userId, deviceId);
+        return this.cryptoBackend.checkDeviceTrust(userId, deviceId);
     }
 
     /**
@@ -2689,10 +2689,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns The event information.
      */
     public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.getEventEncryptionInfo(event);
+        return this.cryptoBackend.getEventEncryptionInfo(event);
     }
 
     /**

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -16,7 +16,9 @@ limitations under the License.
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { IToDeviceEvent } from "../sync-accumulator";
+import type { DeviceTrustLevel, UserTrustLevel } from "../crypto/CrossSigning";
 import { MatrixEvent } from "../models/event";
+import { IEncryptedEventInfo } from "../crypto/api";
 
 /**
  * Common interface for the crypto implementations
@@ -55,12 +57,38 @@ export interface CryptoBackend extends SyncCryptoCallbacks {
     userHasCrossSigningKeys(): Promise<boolean>;
 
     /**
+     * Get the verification level for a given user
+     *
+     * TODO: define this better
+     *
+     * @param userId - user to be checked
+     */
+    checkUserTrust(userId: string): UserTrustLevel;
+
+    /**
+     * Get the verification level for a given device
+     *
+     * TODO: define this better
+     *
+     * @param userId - user to be checked
+     * @param deviceId - device to be checked
+     */
+    checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel;
+
+    /**
      * Decrypt a received event
      *
      * @returns a promise which resolves once we have finished decrypting.
      * Rejects with an error if there is a problem decrypting the event.
      */
     decryptEvent(event: MatrixEvent): Promise<IEventDecryptionResult>;
+
+    /**
+     * Get information about the encryption of an event
+     *
+     * @param event - event to be checked
+     */
+    getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo;
 
     /**
      * Get a list containing all of the room keys

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -25,11 +25,13 @@ import {
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { IToDeviceEvent } from "../sync-accumulator";
+import type { IEncryptedEventInfo } from "../crypto/api";
 import { MatrixEvent } from "../models/event";
 import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
 import { logger } from "../logger";
 import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
 import { QueryDict } from "../utils";
+import { DeviceTrustLevel, UserTrustLevel } from "../crypto/CrossSigning";
 
 /**
  * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
@@ -78,6 +80,24 @@ export class RustCrypto implements CryptoBackend {
         throw new Error("not implemented");
     }
 
+    public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
+        // TODO: make this work properly. Or better, replace it.
+
+        const ret: Partial<IEncryptedEventInfo> = {};
+
+        ret.senderKey = event.getSenderKey() ?? undefined;
+        ret.algorithm = event.getWireContent().algorithm;
+
+        if (!ret.senderKey || !ret.algorithm) {
+            ret.encrypted = false;
+            return ret as IEncryptedEventInfo;
+        }
+        ret.encrypted = true;
+        ret.authenticated = true;
+        ret.mismatchedSender = true;
+        return ret as IEncryptedEventInfo;
+    }
+
     public async userHasCrossSigningKeys(): Promise<boolean> {
         // TODO
         return false;
@@ -86,6 +106,16 @@ export class RustCrypto implements CryptoBackend {
     public async exportRoomKeys(): Promise<IMegolmSessionData[]> {
         // TODO
         return [];
+    }
+
+    public checkUserTrust(userId: string): UserTrustLevel {
+        // TODO
+        return new UserTrustLevel(false, false, false);
+    }
+
+    public checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel {
+        // TODO
+        return new DeviceTrustLevel(false, false, false, false);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
These are all called by the react-sdk when showing an encrypted event:

 * `getEventEncryptionInfo`
 * `checkUserTrust`
 * `checkDeviceTrust`

I don't particularly want to keep this API, but as a rapid means to an end while we figure out the shape of the Rust SDK's api (https://github.com/matrix-org/matrix-rust-sdk/issues/1366), let's stub them for now.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->