### PR TITLE
Handle group call getting initialised twice in quick succession

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -208,6 +208,7 @@ export class GroupCall extends TypedEventEmitter<
     private resendMemberStateTimer: ReturnType<typeof setInterval> | null = null;
     private initWithAudioMuted = false;
     private initWithVideoMuted = false;
+    private initCallFeedPromise?: Promise<void>;
 
     public constructor(
         private client: MatrixClient,
@@ -348,38 +349,41 @@ export class GroupCall extends TypedEventEmitter<
     }
 
     public async initLocalCallFeed(): Promise<void> {
-        logger.log(`groupCall ${this.groupCallId} initLocalCallFeed`);
-
         if (this.state !== GroupCallState.LocalCallFeedUninitialized) {
             throw new Error(`Cannot initialize local call feed in the "${this.state}" state.`);
         }
-
         this.state = GroupCallState.InitializingLocalCallFeed;
 
-        let stream: MediaStream;
+        // wraps the real method to serialise calls, because we don't want to try starting
+        // multiple call feeds at once
+        if (this.initCallFeedPromise) return this.initCallFeedPromise;
 
-        let disposed = false;
-        const onState = (state: GroupCallState): void => {
-            if (state === GroupCallState.LocalCallFeedUninitialized) {
-                disposed = true;
-            }
-        };
-        this.on(GroupCallEvent.GroupCallStateChanged, onState);
+        try {
+            this.initCallFeedPromise = this.initLocalCallFeedInternal();
+            await this.initCallFeedPromise;
+        } finally {
+            this.initCallFeedPromise = undefined;
+        }
+    }
+
+    private async initLocalCallFeedInternal(): Promise<void> {
+        logger.log(`groupCall ${this.groupCallId} initLocalCallFeed`);
+
+        let stream: MediaStream;
 
         try {
             stream = await this.client.getMediaHandler().getUserMediaStream(true, this.type === GroupCallType.Video);
         } catch (error) {
             this.state = GroupCallState.LocalCallFeedUninitialized;
             throw error;
-        } finally {
-            this.off(GroupCallEvent.GroupCallStateChanged, onState);
         }
 
-        // The call could've been disposed while we were waiting
-        if (disposed) {
-            logger.info("Group call disposed while gathering media stream");
+        // The call could've been disposed while we were waiting, and could
+        // also have been started back up again (hello, React 18) so if we're
+        // still in this 'initializing' state, carry on, otherwise bail.
+        if (this._state !== GroupCallState.InitializingLocalCallFeed) {
             this.client.getMediaHandler().stopUserMediaStream(stream);
-            return;
+            throw new Error("Group call disposed while gathering media stream");
         }
 
         const callFeed = new CallFeed({

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -347,7 +347,7 @@ export class GroupCall extends TypedEventEmitter<
         );
     }
 
-    public async initLocalCallFeed(): Promise<CallFeed> {
+    public async initLocalCallFeed(): Promise<void> {
         logger.log(`groupCall ${this.groupCallId} initLocalCallFeed`);
 
         if (this.state !== GroupCallState.LocalCallFeedUninitialized) {
@@ -376,7 +376,11 @@ export class GroupCall extends TypedEventEmitter<
         }
 
         // The call could've been disposed while we were waiting
-        if (disposed) throw new Error("Group call disposed");
+        if (disposed) {
+            logger.info("Group call disposed while gathering media stream");
+            this.client.getMediaHandler().stopUserMediaStream(stream);
+            return;
+        }
 
         const callFeed = new CallFeed({
             client: this.client,
@@ -396,8 +400,6 @@ export class GroupCall extends TypedEventEmitter<
         this.addUserMediaFeed(callFeed);
 
         this.state = GroupCallState.LocalCallFeedInitialized;
-
-        return callFeed;
     }
 
     public async updateLocalUsermediaStream(stream: MediaStream): Promise<void> {


### PR DESCRIPTION
This happens in dev mode with React 18 and caused extra user media stream to end up floating around.

Fixes https://github.com/vector-im/element-call/issues/847

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Handle group call getting initialised twice in quick succession ([\#3078](https://github.com/matrix-org/matrix-js-sdk/pull/3078)). Fixes vector-im/element-call#847.<!-- CHANGELOG_PREVIEW_END -->