### PR TITLE
replace .at(-1) with array.length-1

### DIFF
--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -515,7 +515,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
      */
     public getEventReadUpTo(userId: string, ignoreSynthesized?: boolean): string | null {
         const isCurrentUser = userId === this.client.getUserId();
-        const lastReply = this.timeline.at(-1);
+        const lastReply = this.timeline[this.timeline.length - 1];
         if (isCurrentUser && lastReply) {
             // If the last activity in a thread is prior to the first threaded read receipt
             // sent in the room (suggesting that it was sent before the user started


### PR DESCRIPTION
Follow up of https://github.com/matrix-org/matrix-react-sdk/pull/9933

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Notes: Fix backwards compability for environment not support Array.prototype.at


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix backwards compability for environment not support Array.prototype.at ([\#3080](https://github.com/matrix-org/matrix-js-sdk/pull/3080)).<!-- CHANGELOG_PREVIEW_END -->