### PR TITLE
Add null check for our own member event

### DIFF
--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -1182,6 +1182,14 @@ export class GroupCall extends TypedEventEmitter<
      * Recalculates and updates the participant map to match the room state.
      */
     private updateParticipants(): void {
+        const localMember = this.room.getMember(this.client.getUserId()!)!;
+        if (!localMember) {
+            // The client hasn't fetched enough of the room state to get our own member
+            // event. This probably shouldn't happen, but sanity check & exit for now.
+            logger.warn("Tried to update participants before local room member is available");
+            return;
+        }
+
         if (this.participantsExpirationTimer !== null) {
             clearTimeout(this.participantsExpirationTimer);
             this.participantsExpirationTimer = null;
@@ -1236,7 +1244,6 @@ export class GroupCall extends TypedEventEmitter<
 
         // Apply local echo for the entered case
         if (entered) {
-            const localMember = this.room.getMember(this.client.getUserId()!)!;
             let deviceMap = participants.get(localMember);
             if (deviceMap === undefined) {
                 deviceMap = new Map();


### PR DESCRIPTION
As per comment

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Add null check for our own member event ([\#3082](https://github.com/matrix-org/matrix-js-sdk/pull/3082)).<!-- CHANGELOG_PREVIEW_END -->