### PR TITLE
Element-R: implement remaining OutgoingMessage request types

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.2",
+        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.3",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -1,0 +1,112 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import MockHttpBackend from "matrix-mock-request";
+import { Mocked } from "jest-mock";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import {
+    KeysBackupRequest,
+    KeysClaimRequest,
+    KeysQueryRequest,
+    KeysUploadRequest,
+    SignatureUploadRequest,
+} from "@matrix-org/matrix-sdk-crypto-js";
+
+import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
+import { HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi } from "../../../src";
+import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+
+describe("OutgoingRequestProcessor", () => {
+    /** the OutgoingRequestProcessor implementation under test */
+    let processor: OutgoingRequestProcessor;
+
+    /** A mock http backend which processor is connected to */
+    let httpBackend: MockHttpBackend;
+
+    /** a mocked-up OlmMachine which processor is connected to */
+    let olmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;
+
+    /** wait for a call to olmMachine.markRequestAsSent */
+    function awaitCallToMarkAsSent(): Promise<void> {
+        return new Promise((resolve, _reject) => {
+            olmMachine.markRequestAsSent.mockImplementationOnce(async () => {
+                console.log("received call to markAsSent");
+                resolve(undefined);
+            });
+        });
+    }
+
+    beforeEach(async () => {
+        httpBackend = new MockHttpBackend();
+
+        const dummyEventEmitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
+        const httpApi = new MatrixHttpApi(dummyEventEmitter, {
+            baseUrl: "https://example.com",
+            prefix: "/_matrix",
+            fetchFn: httpBackend.fetchFn as typeof global.fetch,
+            onlyData: true,
+        });
+
+        olmMachine = {
+            markRequestAsSent: jest.fn(),
+        } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
+
+        processor = new OutgoingRequestProcessor(olmMachine, httpApi);
+    });
+
+    /* simple requests that map directly to the request body */
+    const tests: Array<[any, "POST" | "PUT", string]> = [
+        [KeysUploadRequest, "POST", "https://example.com/_matrix/client/v3/keys/upload"],
+        [KeysQueryRequest, "POST", "https://example.com/_matrix/client/v3/keys/query"],
+        [KeysClaimRequest, "POST", "https://example.com/_matrix/client/v3/keys/claim"],
+        [SignatureUploadRequest, "POST", "https://example.com/_matrix/client/v3/keys/signatures/upload"],
+        [KeysBackupRequest, "PUT", "https://example.com/_matrix/client/v3/room_keys/keys"],
+    ];
+
+    for (const [RequestClass, expectedMethod, expectedPath] of tests) {
+        it(`should handle ${RequestClass.name}s`, async () => {
+            const testBody = '{ "foo": "bar" }';
+            const outgoingRequest = new RequestClass("1234", testBody);
+
+            const reqProm = processor.makeOutgoingRequest(outgoingRequest);
+
+            const testResponse = '{ "result": 1 }';
+            httpBackend
+                .when(expectedMethod, "/_matrix")
+                .check((req) => {
+                    expect(req.path).toEqual(expectedPath);
+                    expect(req.rawData).toEqual(testBody);
+                    expect(req.headers["Accept"]).toEqual("application/json");
+                    expect(req.headers["Content-Type"]).toEqual("application/json");
+                })
+                .respond(200, testResponse, true);
+
+            const markSentCallPromise = awaitCallToMarkAsSent();
+            await httpBackend.flushAllExpected();
+
+            await Promise.all([reqProm, markSentCallPromise]);
+            expect(olmMachine.markRequestAsSent).toHaveBeenCalledWith("1234", outgoingRequest.type, testResponse);
+            httpBackend.verifyNoOutstandingRequests();
+        });
+    }
+
+    it("does not explode with unknown requests", async () => {
+        const outgoingRequest = { id: "5678", type: 987 };
+        const markSentCallPromise = awaitCallToMarkAsSent();
+        await Promise.all([processor.makeOutgoingRequest(outgoingRequest), markSentCallPromise]);
+        expect(olmMachine.markRequestAsSent).toHaveBeenCalledWith("5678", 987, "");
+    });
+});

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+    OlmMachine,
+    KeysBackupRequest,
+    KeysClaimRequest,
+    KeysQueryRequest,
+    KeysUploadRequest,
+    SignatureUploadRequest,
+} from "@matrix-org/matrix-sdk-crypto-js";
+
+import { logger } from "../logger";
+import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
+import { QueryDict } from "../utils";
+
+/**
+ * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
+ */
+export interface OutgoingRequest {
+    readonly id: string | undefined;
+    readonly type: number;
+}
+
+/**
+ * OutgoingRequestManager: turns `OutgoingRequest`s from the rust sdk into HTTP requests
+ *
+ * We have one of these per `RustCrypto` (and hence per `MatrixClient`), not that it does anything terribly complicated.
+ * It's responsible for:
+ *
+ *   * holding the reference to the `MatrixHttpApi`
+ *   * turning `OutgoingRequest`s from the rust backend into HTTP requests, and sending them
+ *   * sending the results of such requests back to the rust backend.
+ */
+export class OutgoingRequestProcessor {
+    public constructor(
+        private readonly olmMachine: OlmMachine,
+        private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+    ) {}
+
+    public async makeOutgoingRequest(msg: OutgoingRequest): Promise<void> {
+        let resp: string;
+
+        /* refer https://docs.rs/matrix-sdk-crypto/0.6.0/matrix_sdk_crypto/requests/enum.OutgoingRequests.html
+         * for the complete list of request types
+         */
+        if (msg instanceof KeysUploadRequest) {
+            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/upload", {}, msg.body);
+        } else if (msg instanceof KeysQueryRequest) {
+            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/query", {}, msg.body);
+        } else if (msg instanceof KeysClaimRequest) {
+            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/claim", {}, msg.body);
+        } else if (msg instanceof SignatureUploadRequest) {
+            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/signatures/upload", {}, msg.body);
+        } else if (msg instanceof KeysBackupRequest) {
+            resp = await this.rawJsonRequest(Method.Put, "/_matrix/client/v3/room_keys/keys", {}, msg.body);
+        } else {
+            // TODO: ToDeviceRequest, RoomMessageRequest
+            logger.warn("Unsupported outgoing message", Object.getPrototypeOf(msg));
+            resp = "";
+        }
+
+        if (msg.id) {
+            await this.olmMachine.markRequestAsSent(msg.id, msg.type, resp);
+        }
+    }
+
+    private async rawJsonRequest(method: Method, path: string, queryParams: QueryDict, body: string): Promise<string> {
+        const opts = {
+            // inhibit the JSON stringification and parsing within HttpApi.
+            json: false,
+
+            // nevertheless, we are sending, and accept, JSON.
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+
+            // we use the full prefix
+            prefix: "",
+        };
+
+        return await this.http.authedRequest<string>(method, path, queryParams, body, opts);
+    }
+}

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -20,7 +20,9 @@ import {
     KeysClaimRequest,
     KeysQueryRequest,
     KeysUploadRequest,
+    RoomMessageRequest,
     SignatureUploadRequest,
+    ToDeviceRequest,
 } from "@matrix-org/matrix-sdk-crypto-js";
 
 import { logger } from "../logger";
@@ -67,8 +69,17 @@ export class OutgoingRequestProcessor {
             resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/signatures/upload", {}, msg.body);
         } else if (msg instanceof KeysBackupRequest) {
             resp = await this.rawJsonRequest(Method.Put, "/_matrix/client/v3/room_keys/keys", {}, msg.body);
+        } else if (msg instanceof ToDeviceRequest) {
+            const path =
+                `/_matrix/client/v3/sendToDevice/${encodeURIComponent(msg.event_type)}/` +
+                encodeURIComponent(msg.txn_id);
+            resp = await this.rawJsonRequest(Method.Put, path, {}, msg.body);
+        } else if (msg instanceof RoomMessageRequest) {
+            const path =
+                `/_matrix/client/v3/room/${encodeURIComponent(msg.room_id)}/send/` +
+                `${encodeURIComponent(msg.event_type)}/${encodeURIComponent(msg.txn_id)}`;
+            resp = await this.rawJsonRequest(Method.Put, path, {}, msg.body);
         } else {
-            // TODO: ToDeviceRequest, RoomMessageRequest
             logger.warn("Unsupported outgoing message", Object.getPrototypeOf(msg));
             resp = "";
         }

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -15,14 +15,6 @@ limitations under the License.
 */
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
-import {
-    DecryptedRoomEvent,
-    KeysBackupRequest,
-    KeysClaimRequest,
-    KeysQueryRequest,
-    KeysUploadRequest,
-    SignatureUploadRequest,
-} from "@matrix-org/matrix-sdk-crypto-js";
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { IToDeviceEvent } from "../sync-accumulator";
@@ -30,17 +22,9 @@ import type { IEncryptedEventInfo } from "../crypto/api";
 import { MatrixEvent } from "../models/event";
 import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
 import { logger } from "../logger";
-import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
-import { QueryDict } from "../utils";
+import { IHttpOpts, MatrixHttpApi } from "../http-api";
 import { DeviceTrustLevel, UserTrustLevel } from "../crypto/CrossSigning";
-
-/**
- * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
- */
-interface OutgoingRequest {
-    readonly id: string | undefined;
-    readonly type: number;
-}
+import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
 
 /**
  * An implementation of {@link CryptoBackend} using the Rust matrix-sdk-crypto.
@@ -55,12 +39,16 @@ export class RustCrypto implements CryptoBackend {
     /** whether {@link outgoingRequestLoop} is currently running */
     private outgoingRequestLoopRunning = false;
 
+    private outgoingRequestProcessor: OutgoingRequestProcessor;
+
     public constructor(
         private readonly olmMachine: RustSdkCryptoJs.OlmMachine,
-        private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+        http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
         _userId: string,
         _deviceId: string,
-    ) {}
+    ) {
+        this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
+    }
 
     public stop(): void {
         // stop() may be called multiple times, but attempting to close() the OlmMachine twice
@@ -87,7 +75,7 @@ export class RustCrypto implements CryptoBackend {
                 origin_server_ts: event.getTs(),
             }),
             new RustSdkCryptoJs.RoomId(event.getRoomId()!),
-        )) as DecryptedRoomEvent;
+        )) as RustSdkCryptoJs.DecryptedRoomEvent;
         return {
             clearEvent: JSON.parse(res.event),
             claimedEd25519Key: res.senderClaimedEd25519Key,
@@ -190,7 +178,7 @@ export class RustCrypto implements CryptoBackend {
                     return;
                 }
                 for (const msg of outgoingRequests) {
-                    await this.doOutgoingRequest(msg as OutgoingRequest);
+                    await this.outgoingRequestProcessor.makeOutgoingRequest(msg as OutgoingRequest);
                 }
             }
         } catch (e) {
@@ -198,50 +186,5 @@ export class RustCrypto implements CryptoBackend {
         } finally {
             this.outgoingRequestLoopRunning = false;
         }
-    }
-
-    private async doOutgoingRequest(msg: OutgoingRequest): Promise<void> {
-        let resp: string;
-
-        /* refer https://docs.rs/matrix-sdk-crypto/0.6.0/matrix_sdk_crypto/requests/enum.OutgoingRequests.html
-         * for the complete list of request types
-         */
-        if (msg instanceof KeysUploadRequest) {
-            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/upload", {}, msg.body);
-        } else if (msg instanceof KeysQueryRequest) {
-            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/query", {}, msg.body);
-        } else if (msg instanceof KeysClaimRequest) {
-            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/claim", {}, msg.body);
-        } else if (msg instanceof SignatureUploadRequest) {
-            resp = await this.rawJsonRequest(Method.Post, "/_matrix/client/v3/keys/signatures/upload", {}, msg.body);
-        } else if (msg instanceof KeysBackupRequest) {
-            resp = await this.rawJsonRequest(Method.Put, "/_matrix/client/v3/room_keys/keys", {}, msg.body);
-        } else {
-            // TODO: ToDeviceRequest, RoomMessageRequest
-            logger.warn("Unsupported outgoing message", Object.getPrototypeOf(msg));
-            resp = "";
-        }
-
-        if (msg.id) {
-            await this.olmMachine.markRequestAsSent(msg.id, msg.type, resp);
-        }
-    }
-
-    private async rawJsonRequest(method: Method, path: string, queryParams: QueryDict, body: string): Promise<string> {
-        const opts = {
-            // inhibit the JSON stringification and parsing within HttpApi.
-            json: false,
-
-            // nevertheless, we are sending, and accept, JSON.
-            headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-
-            // we use the full prefix
-            prefix: "",
-        };
-
-        return await this.http.authedRequest<string>(method, path, queryParams, body, opts);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,10 +1398,10 @@
   dependencies:
     lodash "^4.17.21"
 
-"@matrix-org/matrix-sdk-crypto-js@^0.1.0-alpha.2":
-  version "0.1.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.2.tgz#a09d0fea858e817da971a3c9f904632ef7b49eb6"
-  integrity sha512-oVkBCh9YP7H9i4gAoQbZzswniczfo/aIptNa4dxRi4Ff9lSvUCFv6Hvzi7C+90c0/PWZLXjIDTIAWZYmwyd2fA==
+"@matrix-org/matrix-sdk-crypto-js@^0.1.0-alpha.3":
+  version "0.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.3.tgz#829ea03bcad8051dc1e4f0da18a66d4ba273f78f"
+  integrity sha512-KpEddjC34aobFlUYf2mIaXqkjLC0goRmYnbDZLTd0MwiFtau4b1TrPptQ8XFc90Z2VeAcvf18CBqA2otmZzUKQ==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
This is a follow-up to https://github.com/matrix-org/matrix-js-sdk/pull/3019: it implements the remaining two types of message types, now that rust SDK has sensibly-shaped types for them.

It turns out that I need to pull this stuff out to a separate class, so this PR also includes that.

Suggest review commit-by-commit.

Part of vector-im/element-web#21972.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->