### PR TITLE
Fix "verifyLinks" functionality of getRoomUpgradeHistory

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4996,6 +4996,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const upgradeHistory = [currentRoom];
 
         // Work backwards first, looking at create events.
+        let successorRoomId = currentRoom.roomId;
         let createEvent = currentRoom.currentState.getStateEvents(EventType.RoomCreate, "");
         while (createEvent) {
             const predecessor = createEvent.getContent()["predecessor"];
@@ -5006,13 +5007,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 if (verifyLinks) {
                     const tombstone = refRoom.currentState.getStateEvents(EventType.RoomTombstone, "");
 
-                    if (!tombstone || tombstone.getContent()["replacement_room"] !== refRoom.roomId) {
+                    if (!tombstone || tombstone.getContent()["replacement_room"] !== successorRoomId) {
                         break;
                     }
                 }
 
                 // Insert at the front because we're working backwards from the currentRoom
                 upgradeHistory.splice(0, 0, refRoom);
+                successorRoomId = refRoom.roomId;
                 createEvent = refRoom.currentState.getStateEvents(EventType.RoomCreate, "");
             } else {
                 // No further create events to look at


### PR DESCRIPTION
Fixes a bug I found in `getRoomUpgradeHistory` while I was testing it for MSC3946.

When we were verifying links, we were looking for the wrong room ID in a tombstone event, so we never successfully verified correct links between rooms.

I note that two places (SpaceStore and SpaceHierarchy) in matrix-react-sdk do supply the `verifyLinks` flag, so this may possibly fix some bugs in spaces.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix "verifyLinks" functionality of getRoomUpgradeHistory ([\#3089](https://github.com/matrix-org/matrix-js-sdk/pull/3089)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->