### PR TITLE
Provide eventId as well as roomId from Room.findPredecessor

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3356,19 +3356,19 @@ describe("Room", function () {
 
         it("Returns null if there is no create event", () => {
             const room = new Room("roomid", client!, "@u:example.com");
-            expect(room.findPredecessorRoomId()).toBeNull();
+            expect(room.findPredecessor()).toBeNull();
         });
 
         it("Returns null if the create event has no predecessor", () => {
             const room = new Room("roomid", client!, "@u:example.com");
             room.addLiveEvents([roomCreateEvent("roomid", null)]);
-            expect(room.findPredecessorRoomId()).toBeNull();
+            expect(room.findPredecessor()).toBeNull();
         });
 
         it("Returns the predecessor ID if one is provided via create event", () => {
             const room = new Room("roomid", client!, "@u:example.com");
             room.addLiveEvents([roomCreateEvent("roomid", "replacedroomid")]);
-            expect(room.findPredecessorRoomId()).toBe("replacedroomid");
+            expect(room.findPredecessor()).toEqual({ roomId: "replacedroomid", eventId: "id_of_last_known_event" });
         });
 
         it("Prefers the m.predecessor event if one exists", () => {
@@ -3378,7 +3378,10 @@ describe("Room", function () {
                 predecessorEvent("roomid", "otherreplacedroomid"),
             ]);
             const useMsc3946 = true;
-            expect(room.findPredecessorRoomId(useMsc3946)).toBe("otherreplacedroomid");
+            expect(room.findPredecessor(useMsc3946)).toEqual({
+                roomId: "otherreplacedroomid",
+                eventId: null, // m.predecessor does not include an event_id
+            });
         });
 
         it("Ignores the m.predecessor event if we don't ask to use it", () => {
@@ -3389,7 +3392,7 @@ describe("Room", function () {
             ]);
             // Don't provide an argument for msc3946ProcessDynamicPredecessor -
             // we should ignore the predecessor event.
-            expect(room.findPredecessorRoomId()).toBe("replacedroomid");
+            expect(room.findPredecessor()).toEqual({ roomId: "replacedroomid", eventId: "id_of_last_known_event" });
         });
 
         it("Ignores the m.predecessor event and returns null if we don't ask to use it", () => {
@@ -3400,7 +3403,7 @@ describe("Room", function () {
             ]);
             // Don't provide an argument for msc3946ProcessDynamicPredecessor -
             // we should ignore the predecessor event.
-            expect(room.findPredecessorRoomId()).toBeNull();
+            expect(room.findPredecessor()).toBeNull();
         });
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -3791,7 +3791,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const replacedRooms = new Set();
         for (const r of allRooms) {
-            const predecessor = r.findPredecessorRoomId(msc3946ProcessDynamicPredecessor);
+            const predecessor = r.findPredecessor(msc3946ProcessDynamicPredecessor)?.roomId;
             if (predecessor) {
                 replacedRooms.add(predecessor);
             }
@@ -5014,7 +5014,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const ret: Room[] = [];
 
         // Work backwards from newer to older rooms
-        let predecessorRoomId = room.findPredecessorRoomId(msc3946ProcessDynamicPredecessor);
+        let predecessorRoomId = room.findPredecessor(msc3946ProcessDynamicPredecessor)?.roomId;
         while (predecessorRoomId !== null) {
             const predecessorRoom = this.getRoom(predecessorRoomId);
             if (predecessorRoom === null) {
@@ -5031,7 +5031,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             ret.splice(0, 0, predecessorRoom);
 
             room = predecessorRoom;
-            predecessorRoomId = room.findPredecessorRoomId(msc3946ProcessDynamicPredecessor);
+            predecessorRoomId = room.findPredecessor(msc3946ProcessDynamicPredecessor)?.roomId;
         }
         return ret;
     }
@@ -5047,7 +5047,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             if (successorRoom.roomId === room.roomId) break; // Tombstone is referencing its own room
 
             if (verifyLinks) {
-                const predecessorRoomId = successorRoom.findPredecessorRoomId(msc3946ProcessDynamicPredecessor);
+                const predecessorRoomId = successorRoom.findPredecessor(msc3946ProcessDynamicPredecessor)?.roomId;
                 if (!predecessorRoomId || predecessorRoomId !== room.roomId) {
                     break;
                 }


### PR DESCRIPTION
Inside matrix-react-sdk we need a room's predecessor event id (the id of the last known event in the room) as well as the predecessor room id, so provide both.

This changes a public function, but it was only added yesterday so I don't see it as a breaking change.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Provide eventId as well as roomId from Room.findPredecessor ([\#3095](https://github.com/matrix-org/matrix-js-sdk/pull/3095)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->