### PR TITLE
Remove flaky megolm test

### DIFF
--- a/spec/unit/crypto/algorithms/megolm.spec.ts
+++ b/spec/unit/crypto/algorithms/megolm.spec.ts
@@ -579,15 +579,6 @@ describe("MegolmDecryption", function () {
             }
         });
 
-        it("defers before completing", async () => {
-            megolm.prepareToEncrypt(room);
-            // Ensure that `Crypto#checkDeviceTrust` has been called *fewer*
-            // than the full nine times, after yielding once.
-            await sleep(0);
-            const callCount = mockCrypto.checkDeviceTrust.mock.calls.length;
-            expect(callCount).toBeLessThan(9);
-        });
-
         it("is cancellable", async () => {
             const stop = megolm.prepareToEncrypt(room);
 


### PR DESCRIPTION
cc @andybalaam 

I introduced a flaky test in #3035 to confirm that `MegolmEncryption#prepareToEncrypt` didn't block the main thread too much, but it turns out that, when run in varying environments, it tends to fail.

The same behavior is guaranteed by [the following cancellation test](https://github.com/matrix-org/matrix-js-sdk/blob/66ae985af592cdc5e9a9f92bb8a91cc8a4069327/spec/unit/crypto/algorithms/megolm.spec.ts#L591-L600) – if the thread is blocked, it can't be cancelled.

Refs:
* https://matrix.to/#/!bEWtlqtDwCLFIAKAcv:matrix.org/$seEu9__-mwtnsjmrBheOMhpvow0qzldCnSqMtntINog
* https://github.com/matrix-org/matrix-js-sdk/actions/runs/3998796658/jobs/6861889997
* https://github.com/matrix-org/matrix-js-sdk/actions/runs/4006364721/jobs/6877800626

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove flaky megolm test ([\#3098](https://github.com/matrix-org/matrix-js-sdk/pull/3098)). Contributed by @clarkf.<!-- CHANGELOG_PREVIEW_END -->