### PR TITLE
Add support for stable identifier for fixed MAC in SAS verification

### DIFF
--- a/spec/unit/crypto/verification/sas.spec.ts
+++ b/spec/unit/crypto/verification/sas.spec.ts
@@ -215,7 +215,7 @@ describe("SAS verification", function () {
             ]);
 
             // make sure that it uses the preferred method
-            expect(macMethod).toBe("org.matrix.msc3783.hkdf-hmac-sha256");
+            expect(macMethod).toBe("hkdf-hmac-sha256.v2");
             expect(keyAgreement).toBe("curve25519-hkdf-sha256");
 
             // make sure Alice and Bob verified each other

--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -159,6 +159,7 @@ function generateSas(sasBytes: Uint8Array, methods: string[]): IGeneratedSas {
 const macMethods = {
     "hkdf-hmac-sha256": "calculate_mac",
     "org.matrix.msc3783.hkdf-hmac-sha256": "calculate_mac_fixed_base64",
+    "hkdf-hmac-sha256.v2": "calculate_mac_fixed_base64",
     "hmac-sha256": "calculate_mac_long_kdf",
 } as const;
 
@@ -202,7 +203,12 @@ type KeyAgreement = keyof typeof calculateKeyAgreement;
  */
 const KEY_AGREEMENT_LIST: KeyAgreement[] = ["curve25519-hkdf-sha256", "curve25519"];
 const HASHES_LIST = ["sha256"];
-const MAC_LIST: MacMethod[] = ["org.matrix.msc3783.hkdf-hmac-sha256", "hkdf-hmac-sha256", "hmac-sha256"];
+const MAC_LIST: MacMethod[] = [
+    "hkdf-hmac-sha256.v2",
+    "org.matrix.msc3783.hkdf-hmac-sha256",
+    "hkdf-hmac-sha256",
+    "hmac-sha256",
+];
 const SAS_LIST = Object.keys(sasGenerators);
 
 const KEY_AGREEMENT_SET = new Set(KEY_AGREEMENT_LIST);


### PR DESCRIPTION
[MSC3783](https://github.com/matrix-org/matrix-spec-proposals/pull/3783) has finished FCP, so we can use the stable identifiers for the MAC with fixed base64 encoding now.

Related spec PR: https://github.com/matrix-org/matrix-spec/pull/1412

Polyjuice Client Test (test.uhoreg.ca) has also been [updated](https://gitlab.com/polyjuice/polyjuice_client_test/-/commit/12694cc99316a03a5d0efad7f418e919448c7b09).  With current app.element.io, it will show:

![image](https://user-images.githubusercontent.com/1012976/214700456-130af47b-721c-4cf5-a266-85fee9b27889.png)

But with this patch, it shows

![image](https://user-images.githubusercontent.com/1012976/214700582-710dd92f-e22d-4e3f-bb6e-87ce0cc937eb.png)


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add support for stable identifier for fixed MAC in SAS verification ([\#3101](https://github.com/matrix-org/matrix-js-sdk/pull/3101)).<!-- CHANGELOG_PREVIEW_END -->