### PR TITLE
Don't throw with no `opponentDeviceInfo`

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2335,11 +2335,16 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
             const userId = this.invitee || this.getOpponentMember()!.userId;
             if (this.client.getUseE2eForGroupCall()) {
+                if (!this.opponentDeviceInfo) {
+                    logger.warn(`Call ${this.callId} sendVoipEvent() failed: we do not have opponentDeviceInfo`);
+                    return;
+                }
+
                 await this.client.encryptAndSendToDevices(
                     [
                         {
                             userId,
-                            deviceInfo: this.opponentDeviceInfo!,
+                            deviceInfo: this.opponentDeviceInfo,
                         },
                     ],
                     {


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't throw with no `opponentDeviceInfo` ([\#3107](https://github.com/matrix-org/matrix-js-sdk/pull/3107)).<!-- CHANGELOG_PREVIEW_END -->