### PR TITLE
Cleanup pre MSC3773 thread unread notif logic

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4840,8 +4840,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             $eventId: event.getId()!,
         });
 
-        const supportsThreadRR = this.canSupport.get(Feature.ThreadUnreadNotifications) !== ServerSupport.Unsupported;
-        if (supportsThreadRR && !unthreaded) {
+        if (!unthreaded) {
             const isThread = !!event.threadRootId;
             body = {
                 ...body,
@@ -7045,9 +7044,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const serverVersions = await this.serverVersionsPromise;
         this.canSupport = await buildFeatureSupportMap(serverVersions);
 
-        // We can set flag values to use their stable or unstable version
-        const support = this.canSupport.get(Feature.ThreadUnreadNotifications);
-        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(support === ServerSupport.Unstable);
+        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(false);
 
         return this.serverVersionsPromise;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -209,7 +209,6 @@ import { ToDeviceBatch } from "./models/ToDeviceMessage";
 import { IgnoredInvites } from "./models/invites-ignorer";
 import { UIARequest, UIAResponse } from "./@types/uia";
 import { LocalNotificationSettings } from "./@types/local_notifications";
-import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
 import { buildFeatureSupportMap, Feature, ServerSupport } from "./feature";
 import { CryptoBackend } from "./common-crypto/CryptoBackend";
 import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants";

--- a/src/client.ts
+++ b/src/client.ts
@@ -7044,8 +7044,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const serverVersions = await this.serverVersionsPromise;
         this.canSupport = await buildFeatureSupportMap(serverVersions);
 
-        UNREAD_THREAD_NOTIFICATIONS.setPreferUnstable(false);
-
         return this.serverVersionsPromise;
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -64,7 +64,6 @@ import {
 import { IStateEventWithRoomId } from "../@types/search";
 import { RelationsContainer } from "./relations-container";
 import { ReadReceipt, synthesizeReceipt } from "./read-receipt";
-import { Feature, ServerSupport } from "../feature";
 import { Poll, PollEvent } from "./poll";
 
 // These constants are used as sane defaults when the homeserver doesn't support
@@ -1299,10 +1298,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public getUnreadNotificationCount(type = NotificationCountType.Total): number {
         let count = this.getRoomUnreadNotificationCount(type);
-        if (this.client.canSupport.get(Feature.ThreadUnreadNotifications) !== ServerSupport.Unsupported) {
-            for (const threadNotification of this.threadNotifications.values()) {
-                count += threadNotification[type] ?? 0;
-            }
+        for (const threadNotification of this.threadNotifications.values()) {
+            count += threadNotification[type] ?? 0;
         }
         return count;
     }


### PR DESCRIPTION
A lot of logic regarding servers that do not support thread notifications (pre MSC3773) exists. This PR removes some of it. 
Comes with its react-sdk counterpart too.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->