### PR TITLE
Element R: Fix obscure errors when we fail to decrypt to-device events

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -77,6 +77,15 @@ export class RustCrypto implements CryptoBackend {
     }
 
     public async decryptEvent(event: MatrixEvent): Promise<IEventDecryptionResult> {
+        const roomId = event.getRoomId();
+        if (!roomId) {
+            // presumably, a to-device message. These are normally decrypted in preprocessToDeviceMessages
+            // so the fact it has come back here suggests that decryption failed.
+            //
+            // once we drop support for the libolm crypto implementation, we can stop passing to-device messages
+            // through decryptEvent and hence get rid of this case.
+            throw new Error("to-device event was not decrypted in preprocessToDeviceMessages");
+        }
         const res = (await this.olmMachine.decryptRoomEvent(
             JSON.stringify({
                 event_id: event.getId(),


### PR DESCRIPTION
Previously, if we failed to decrypt a to-device event, we would raise an "expected a string" error when we later tried to decrypt it as a room event. This at least makes the error clearer.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->