### PR TITLE
Don't require e2e keys for foci

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -676,6 +676,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     private async initOpponentCrypto(): Promise<void> {
         if (!this.opponentDeviceId) return;
         if (!this.client.getUseE2eForGroupCall()) return;
+        // We (currently) don't speak e2e with foci. It's debateable whether there would be
+        // any benefit in doing so.
+        if (this.isFocus) return;
         // It's possible to want E2EE and yet not have the means to manage E2EE
         // ourselves (for example if the client is a RoomWidgetClient)
         if (!this.client.isCryptoEnabled()) {


### PR DESCRIPTION
Since we don't speak e2e to them anyway

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't require e2e keys for foci ([\#3118](https://github.com/matrix-org/matrix-js-sdk/pull/3118)).<!-- CHANGELOG_PREVIEW_END -->