### PR TITLE
Handle optional last_known_event_id property in m.predecessor

### DIFF
--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -986,8 +986,12 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
             const predecessorEvent = this.getStateEvents(EventType.RoomPredecessor, "");
             if (predecessorEvent) {
                 const roomId = predecessorEvent.getContent()["predecessor_room_id"];
+                let eventId = predecessorEvent.getContent()["last_known_event_id"];
+                if (typeof eventId !== "string") {
+                    eventId = null;
+                }
                 if (typeof roomId === "string") {
-                    return { roomId, eventId: null };
+                    return { roomId, eventId };
                 }
             }
         }


### PR DESCRIPTION
Part of [MSC3946](https://github.com/matrix-org/matrix-spec-proposals/pull/3946)

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Handle optional last_known_event_id property in m.predecessor ([\#3119](https://github.com/matrix-org/matrix-js-sdk/pull/3119)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->