### PR TITLE
Re-use transceivers for user media

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -914,14 +914,18 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             const sender = transceiver?.sender;
 
             let added = false;
-            // XXX: We don't re-use transceivers with the SFU: this is to work around
+            // XXX: We don't re-use transceivers for screen shares with the SFU: this is to work around
             // https://github.com/matrix-org/waterfall/issues/98 - see the bug for more.
             // Since we use WebRTC data channels to renegotiate with the SFU, we're not
             // limited to the size of a Matrix event, so it's 'ok' if the SDP grows
             // indefinitely (although presumably this would break if we tried to do
             // an ICE restart over to-device messages after you'd turned screen sharing
             // on & off too many times...)
-            if (sender && !this.isFocus) {
+            // The reason we're OK re-using transceivers for user media is that we establish
+            // usermedia transceivers in sendrecv mode anyway and let the SFU use the other
+            // direction to send us some other media (for better or worse) so the same bug
+            // doesn't occur.
+            if (sender && (!this.isFocus || callFeed.purpose == SDPStreamMetadataPurpose.Usermedia)) {
                 try {
                     // We already have a sender, so we re-use it. We try to
                     // re-use transceivers as much as possible because they


### PR DESCRIPTION
As per comment.

This is again somewhat of a temporary hack workaround until we work out a way to manage our transceivers sensibly.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Re-use transceivers for user media ([\#3144](https://github.com/matrix-org/matrix-js-sdk/pull/3144)).<!-- CHANGELOG_PREVIEW_END -->