### PR TITLE
Stop the ICE disconnected timer on call terminate

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2174,6 +2174,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         // chrome doesn't implement any of the 'onstarted' events yet
         if (["connected", "completed"].includes(this.peerConn?.iceConnectionState ?? "")) {
             clearTimeout(this.iceDisconnectedTimeout);
+            this.iceDisconnectedTimeout = undefined;
             this.state = CallState.Connected;
 
             if (!this.callLengthInterval && !this.callStartTime) {
@@ -2545,6 +2546,10 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         if (this.inviteTimeout) {
             clearTimeout(this.inviteTimeout);
             this.inviteTimeout = undefined;
+        }
+        if (this.iceDisconnectedTimeout !== undefined) {
+            clearTimeout(this.iceDisconnectedTimeout);
+            this.iceDisconnectedTimeout = undefined;
         }
         if (this.callLengthInterval) {
             clearInterval(this.callLengthInterval);


### PR DESCRIPTION
It just wasn't getting stopped, so if the call ended while ICE was disconnected, we'd get confusing error messages after the call ended.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Stop the ICE disconnected timer on call terminate ([\#3147](https://github.com/matrix-org/matrix-js-sdk/pull/3147)).<!-- CHANGELOG_PREVIEW_END -->