### PR TITLE
Poll history: decrypt poll relations before processing

### DIFF
--- a/spec/unit/models/poll.spec.ts
+++ b/spec/unit/models/poll.spec.ts
@@ -20,6 +20,7 @@ import { M_POLL_END, M_POLL_KIND_DISCLOSED, M_POLL_RESPONSE } from "../../../src
 import { PollStartEvent } from "../../../src/extensible_events_v1/PollStartEvent";
 import { Poll } from "../../../src/models/poll";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../test-utils/client";
+import { flushPromises } from "../../test-utils/flushPromises";
 
 jest.useFakeTimers();
 
@@ -27,6 +28,7 @@ describe("Poll", () => {
     const userId = "@alice:server.org";
     const mockClient = getMockClientWithEventEmitter({
         ...mockClientMethodsUser(userId),
+        decryptEventIfNeeded: jest.fn().mockResolvedValue(true),
         relations: jest.fn(),
     });
     const roomId = "!room:server";
@@ -171,6 +173,8 @@ describe("Poll", () => {
                 const poll = new Poll(basePollStartEvent, mockClient, room);
                 jest.spyOn(poll, "emit");
                 const responses = await poll.getResponses();
+
+                await flushPromises();
 
                 expect(mockClient.relations.mock.calls).toEqual([
                     [roomId, basePollStartEvent.getId(), "m.reference", undefined, { from: undefined }],

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -149,11 +149,14 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
             },
         );
 
+        await Promise.all(allRelations.events.map((event) => this.matrixClient.decryptEventIfNeeded(event)));
+
         const responses =
             this.responses ||
             new Relations("m.reference", M_POLL_RESPONSE.name, this.matrixClient, [M_POLL_RESPONSE.altName!]);
 
         const pollEndEvent = allRelations.events.find((event) => M_POLL_END.matches(event.getType()));
+
         if (this.validateEndEvent(pollEndEvent)) {
             this.endEvent = pollEndEvent;
             this.refilterResponsesOnEnd();


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

`matrixClient.relations` only decrypts events when there is an `eventType` filter set
Explicitly decrypt poll relation events before processing.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->