### PR TITLE
Refactor `CallFeed`s

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -22,7 +22,7 @@ limitations under the License.
  */
 
 import { v4 as uuidv4 } from "uuid";
-import { parse as parseSdp, write as writeSdp } from "sdp-transform";
+import { parse as parseSdp, SessionDescription, write as writeSdp } from "sdp-transform";
 
 import { logger } from "../logger";
 import * as utils from "../utils";
@@ -48,7 +48,6 @@ import {
     FocusTrackSubscriptionEvent,
     FocusNegotiateEvent,
     FocusSDPStreamMetadataChangedEvent,
-    SDPStreamMetadataTracks,
     FocusEvent,
     SDPStreamMetadataKeyStable,
     FocusEventBaseContent,
@@ -60,6 +59,9 @@ import { DeviceInfo } from "../crypto/deviceinfo";
 import { IScreensharingOpts } from "./mediaHandler";
 import { GroupCallUnknownDeviceError } from "./groupCall";
 import { MatrixError } from "../http-api";
+import { RemoteCallFeed } from "./remoteCallFeed";
+import { LocalCallFeed } from "./localCallFeed";
+import { LocalCallTrack } from "./localCallTrack";
 
 interface CallOpts {
     // The room ID for this call.
@@ -91,12 +93,6 @@ interface TurnServer {
 interface AssertedIdentity {
     id: string;
     displayName: string;
-}
-
-export enum SimulcastResolution {
-    Full = "f",
-    Half = "h",
-    Quarter = "q",
 }
 
 enum MediaType {
@@ -279,59 +275,6 @@ const ICE_DISCONNECTED_TIMEOUT = 30 * 1000; // ms
  */
 const SUBSCRIBE_TO_FOCUS_TIMEOUT = 2 * 1000;
 
-// Order is important here: some browsers (e.g.
-// Chrome) will only send some of the encodings, if
-// the track has a resolution to low for it to send
-// all, in that case the encoding higher in the list
-// has priority and therefore we put full as first
-// as we always want to send the full resolution
-const SIMULCAST_USERMEDIA_ENCODINGS: RTCRtpEncodingParameters[] = [
-    {
-        // 720p (base)
-        maxFramerate: 30,
-        maxBitrate: 1_700_000,
-        rid: SimulcastResolution.Full,
-    },
-    {
-        // 360p
-        maxFramerate: 20,
-        maxBitrate: 300_000,
-        rid: SimulcastResolution.Half,
-        scaleResolutionDownBy: 2.0,
-    },
-    {
-        // 180p
-        maxFramerate: 15,
-        maxBitrate: 120_000,
-
-        rid: SimulcastResolution.Quarter,
-        scaleResolutionDownBy: 4.0,
-    },
-];
-
-const SIMULCAST_SCREENSHARING_ENCODINGS: RTCRtpEncodingParameters[] = [
-    {
-        // 1080p (base)
-        maxFramerate: 30,
-        maxBitrate: 3_000_000,
-        rid: SimulcastResolution.Full,
-    },
-    {
-        // 720p
-        maxFramerate: 15,
-        maxBitrate: 1_000_000,
-        rid: SimulcastResolution.Half,
-        scaleResolutionDownBy: 1.5,
-    },
-    {
-        // 360p
-        maxFramerate: 3,
-        maxBitrate: 200_000,
-        rid: SimulcastResolution.Quarter,
-        scaleResolutionDownBy: 3,
-    },
-];
-
 export class CallError extends Error {
     public readonly code: string;
 
@@ -342,18 +285,6 @@ export class CallError extends Error {
         this.code = code;
     }
 }
-
-export const getSimulcastEncodings = (purpose: SDPStreamMetadataPurpose): RTCRtpEncodingParameters[] => {
-    if (purpose === SDPStreamMetadataPurpose.Usermedia) {
-        return SIMULCAST_USERMEDIA_ENCODINGS;
-    }
-    if (purpose === SDPStreamMetadataPurpose.Screenshare) {
-        return SIMULCAST_SCREENSHARING_ENCODINGS;
-    }
-
-    // Fallback to usermedia encodings
-    return SIMULCAST_USERMEDIA_ENCODINGS;
-};
 
 export function genCallID(): string {
     return Date.now().toString() + randomString(16);
@@ -392,16 +323,6 @@ export type CallEventHandlerMap = {
     [CallEvent.SendVoipEvent]: (event: Record<string, any>) => void;
 };
 
-// The key of the transceiver map (purpose + media type, separated by ':')
-type TransceiverKey = string;
-
-// generates keys for the map of transceivers
-// kind is unfortunately a string rather than MediaType as this is the type of
-// track.kind
-function getTransceiverKey(purpose: SDPStreamMetadataPurpose, kind: TransceiverKey): string {
-    return purpose + ":" + kind;
-}
-
 export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap> {
     public roomId?: string;
     public callId: string;
@@ -410,7 +331,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     public hangupReason?: string;
     public direction?: CallDirection;
     public ourPartyId: string;
-    public peerConn?: RTCPeerConnection;
     public toDeviceSeq = 0;
 
     // whether this call should have push-to-talk semantics
@@ -419,6 +339,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     public readonly isFocus: boolean = false;
 
     private _state = CallState.Fledgling;
+    private peerConn?: RTCPeerConnection;
     private readonly client: MatrixClient;
     private readonly forceTURN?: boolean;
     private readonly turnServers: Array<TurnServer>;
@@ -429,9 +350,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     private candidateSendTries = 0;
     private candidatesEnded = false;
     private feeds: Array<CallFeed> = [];
-
-    // our transceivers for each purpose and type of media
-    private transceivers = new Map<TransceiverKey, RTCRtpTransceiver>();
 
     private inviteOrAnswerSent = false;
     private waitForLocalAVStream = false;
@@ -569,6 +487,22 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         return this.remoteAssertedIdentity;
     }
 
+    public get localSDPString(): string | undefined {
+        return this.peerConn?.localDescription?.sdp;
+    }
+
+    public get localSDP(): SessionDescription | undefined {
+        return this.localSDPString ? parseSdp(this.localSDPString) : undefined;
+    }
+
+    public get remoteSDPString(): string | undefined {
+        return this.peerConn?.remoteDescription?.sdp;
+    }
+
+    public get remoteSDP(): SessionDescription | undefined {
+        return this.remoteSDPString ? parseSdp(this.remoteSDPString) : undefined;
+    }
+
     public get state(): CallState {
         return this._state;
     }
@@ -606,18 +540,18 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     }
 
     private get hasUserMediaAudioSender(): boolean {
-        return Boolean(this.transceivers.get(getTransceiverKey(SDPStreamMetadataPurpose.Usermedia, "audio"))?.sender);
+        return Boolean(this.localUsermediaFeed?.tracks?.find((t) => t.kind === "audio")?.sender);
     }
 
     private get hasUserMediaVideoSender(): boolean {
-        return Boolean(this.transceivers.get(getTransceiverKey(SDPStreamMetadataPurpose.Usermedia, "video"))?.sender);
+        return Boolean(this.localUsermediaFeed?.tracks?.find((t) => t.kind === "video")?.sender);
     }
 
-    public get localUsermediaFeed(): CallFeed | undefined {
+    public get localUsermediaFeed(): LocalCallFeed | undefined {
         return this.getLocalFeeds().find((feed) => feed.purpose === SDPStreamMetadataPurpose.Usermedia);
     }
 
-    public get localScreensharingFeed(): CallFeed | undefined {
+    public get localScreensharingFeed(): LocalCallFeed | undefined {
         return this.getLocalFeeds().find((feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);
     }
 
@@ -629,11 +563,11 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         return this.localScreensharingFeed?.stream;
     }
 
-    public get remoteUsermediaFeed(): CallFeed | undefined {
+    public get remoteUsermediaFeed(): RemoteCallFeed | undefined {
         return this.getRemoteFeeds().find((feed) => feed.purpose === SDPStreamMetadataPurpose.Usermedia);
     }
 
-    public get remoteScreensharingFeed(): CallFeed | undefined {
+    public get remoteScreensharingFeed(): RemoteCallFeed | undefined {
         return this.getRemoteFeeds().find((feed) => feed.purpose === SDPStreamMetadataPurpose.Screenshare);
     }
 
@@ -645,8 +579,50 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         return this.remoteScreensharingFeed?.stream;
     }
 
-    private getFeedById(feedId: string): CallFeed | undefined {
-        return this.getFeeds().find((feed) => feed.feedId === feedId);
+    public getLocalMediaLineByMid(mid: string): SessionDescription["media"][number] | undefined {
+        return this.localSDP?.media?.find((m) => m.mid == mid);
+    }
+
+    public getLocalMSIDByMid(mid: string): string[] | undefined {
+        return this.getLocalMediaLineByMid(mid)?.msid?.split(" ");
+    }
+
+    public getLocalStreamIdByMid(mid: string): string | undefined {
+        return this.getLocalMSIDByMid(mid)?.[0];
+    }
+
+    public getLocalTrackIdByMid(mid: string): string | undefined {
+        return this.getLocalMSIDByMid(mid)?.[1];
+    }
+
+    public getRemoteMediaLineByMid(mid: string): SessionDescription["media"][number] | undefined {
+        return this.remoteSDP?.media?.find((m) => m.mid == mid);
+    }
+
+    public getRemoteMediaTypeByMid(mid: string): string | undefined {
+        return this.getRemoteMediaLineByMid(mid)?.type;
+    }
+
+    public getRemoteMSIDByMid(mid: string): string[] | undefined {
+        return this.getRemoteMediaLineByMid(mid)?.msid?.split(" ");
+    }
+
+    public getRemoteStreamIdByMid(mid: string): string | undefined {
+        return this.getRemoteMSIDByMid(mid)?.[0];
+    }
+
+    public getRemoteTrackIdByMid(mid: string): string | undefined {
+        return this.getRemoteMSIDByMid(mid)?.[1];
+    }
+
+    public getRemoteTrackInfoByMid(mid: string): string {
+        return `streamId=${this.getRemoteStreamIdByMid(mid)}, trackId=${this.getRemoteTrackIdByMid(
+            mid,
+        )}, mid=${mid}, kind=${this.getRemoteMediaTypeByMid(mid)}`;
+    }
+
+    private getLocalFeedById(feedId: string): CallFeed | undefined {
+        return this.getFeeds().find((feed) => feed.id === feedId);
     }
 
     /**
@@ -661,16 +637,16 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * Returns an array of all local CallFeeds
      * @returns local CallFeeds
      */
-    public getLocalFeeds(): Array<CallFeed> {
-        return this.feeds.filter((feed) => feed.isLocal());
+    public getLocalFeeds(): Array<LocalCallFeed> {
+        return this.feeds.filter((feed) => feed instanceof LocalCallFeed) as LocalCallFeed[];
     }
 
     /**
      * Returns an array of all remote CallFeeds
      * @returns remote CallFeeds
      */
-    public getRemoteFeeds(): Array<CallFeed> {
-        return this.feeds.filter((feed) => !feed.isLocal());
+    public getRemoteFeeds(): Array<RemoteCallFeed> {
+        return this.feeds.filter((feed) => feed instanceof RemoteCallFeed) as RemoteCallFeed[];
     }
 
     private async initOpponentCrypto(): Promise<void> {
@@ -704,54 +680,13 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * Generates and returns localSDPStreamMetadata
      * @returns localSDPStreamMetadata
      */
-    private getLocalSDPStreamMetadata(): SDPStreamMetadata {
-        const sdp = this.peerConn?.localDescription?.sdp ? parseSdp(this.peerConn.localDescription.sdp) : null;
-        const metadata: SDPStreamMetadata = {};
-        for (const localFeed of this.getLocalFeeds()) {
-            // We use transceivers here because we need to send the actual
-            // trackIds and streamIds which the focus will see which will
-            // probably differ from the local trackIds and streamIds
-            let streamId = localFeed.feedId;
-            const tracks = Array.from(this.transceivers.entries()).reduce((tracks, [transceiverKey, transceiver]) => {
-                if (!transceiver.sender.track) return tracks;
-                if (
-                    ![
-                        getTransceiverKey(localFeed.purpose, "audio"),
-                        getTransceiverKey(localFeed.purpose, "video"),
-                    ].includes(transceiverKey)
-                ) {
-                    return tracks;
-                }
+    private get metadata(): SDPStreamMetadata {
+        return this.getLocalFeeds().reduce((metadata: SDPStreamMetadata, feed: LocalCallFeed) => {
+            if (!feed.streamId) return metadata;
 
-                // XXX: We only use double equals because MediaDescription::mid is in fact a number
-                const msid = sdp?.media?.find((m) => m.mid == transceiver.mid)?.msid?.split(" ");
-                if (msid?.[0]) {
-                    streamId = msid?.[0];
-                }
-                if (msid?.[1]) {
-                    tracks[msid[1]] = {
-                        kind: transceiver.sender.track?.kind,
-                        width: transceiver.sender.track.getSettings().width,
-                        height: transceiver.sender.track.getSettings().height,
-                    };
-                }
-                return tracks;
-            }, {} as SDPStreamMetadataTracks);
-            if (!Object.keys(tracks).length) continue;
-
-            metadata[streamId] = {
-                // FIXME: This allows for impersonation - the focus should be
-                // handling these
-                user_id: this.client.getUserId()!,
-                device_id: this.client.getDeviceId()!,
-                purpose: localFeed.purpose,
-                // FIXME: This is very ineffective as state is slow, we should really be sending this over DC
-                audio_muted: localFeed.isAudioMuted(),
-                video_muted: localFeed.isVideoMuted(),
-                tracks: tracks,
-            };
-        }
-        return metadata;
+            metadata[feed.streamId] = feed.metadata;
+            return metadata;
+        }, {});
     }
 
     /**
@@ -760,105 +695,26 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * @returns no incoming feeds
      */
     public noIncomingFeeds(): boolean {
-        return !this.feeds.some((feed) => !feed.isLocal());
+        return !this.feeds.some((feed) => !feed.isLocal);
     }
 
-    private pushRemoteStream(stream: MediaStream): void {
-        // Fallback to old behavior if the other side doesn't support SDPStreamMetadata
-        if (!this.opponentSupportsSDPStreamMetadata()) {
-            this.pushRemoteStreamWithoutMetadata(stream);
-            return;
-        }
-
-        const feed = this.getFeedById(stream.id);
-        if (!feed) {
-            logger.warn(
-                `Call ${this.callId} Ignoring stream because we don't have a feed for it (streamId=${stream.id})`,
-            );
-            return;
-        }
-
-        feed.setNewStream(stream);
-
-        logger.info(
-            `Call ${this.callId} Pushed remote stream (feedId=${feed.feedId}, active=${stream.active}, purpose=${feed.purpose}, userId=${feed.userId}, deviceId=${feed.deviceId})`,
-        );
-    }
-
-    /**
-     * This method is used ONLY if the other client doesn't support sending SDPStreamMetadata
-     */
-    private pushRemoteStreamWithoutMetadata(stream: MediaStream): void {
-        const userId = this.getOpponentMember()!.userId;
-        // We can guess the purpose here since the other client can only send one stream
-        const purpose = SDPStreamMetadataPurpose.Usermedia;
-        const oldRemoteStream = this.feeds.find((feed) => !feed.isLocal())?.stream;
-
-        // Note that we check by ID and always set the remote stream: Chrome appears
-        // to make new stream objects when transceiver directionality is changed and the 'active'
-        // status of streams change - Dave
-        // If we already have a stream, check this stream has the same id
-        if (oldRemoteStream && stream.id !== oldRemoteStream.id) {
-            logger.warn(
-                `Call ${this.callId} pushRemoteFeedWithoutMetadata() ignoring new stream because we already have stream (streamId=${stream.id})`,
-            );
-            return;
-        }
-
-        if (this.getFeedById(stream.id)) {
-            logger.warn(
-                `Call ${this.callId} pushRemoteFeedWithoutMetadata() ignoring stream because we already have a feed for it (streamId=${stream.id})`,
-            );
-            return;
-        }
-
-        this.feeds.push(
-            new CallFeed({
-                client: this.client,
-                call: this,
-                roomId: this.roomId,
-                audioMuted: false,
-                videoMuted: false,
-                userId,
-                deviceId: this.getOpponentDeviceId(),
-                feedId: stream.id,
-                stream,
-                purpose,
-            }),
-        );
-
-        this.emit(CallEvent.FeedsChanged, this.feeds);
-
-        logger.info(
-            `Call ${this.callId} pushRemoteFeedWithoutMetadata() pushed stream (streamId=${stream.id}, active=${stream.active})`,
-        );
-    }
-
-    private pushNewLocalFeed(stream: MediaStream, purpose: SDPStreamMetadataPurpose, addToPeerConnection = true): void {
-        const userId = this.client.getUserId()!;
-
+    private addLocalFeedFromStream(
+        stream: MediaStream,
+        purpose: SDPStreamMetadataPurpose,
+        addToPeerConnection = true,
+    ): void {
         // Tracks don't always start off enabled, eg. chrome will give a disabled
         // audio track if you ask for user media audio and already had one that
         // you'd set to disabled (presumably because it clones them internally).
         setTracksEnabled(stream.getAudioTracks(), true);
         setTracksEnabled(stream.getVideoTracks(), true);
 
-        if (this.getFeedById(stream.id)) {
-            logger.warn(
-                `Call ${this.callId} pushNewLocalFeed() ignoring stream because we already have a feed for it (streamId=${stream.id})`,
-            );
-            return;
-        }
-
         this.pushLocalFeed(
-            new CallFeed({
+            new LocalCallFeed({
                 client: this.client,
                 roomId: this.roomId,
                 audioMuted: false,
                 videoMuted: false,
-                userId,
-                deviceId: this.getOpponentDeviceId(),
-                feedId: stream.id,
                 stream,
                 purpose,
             }),
@@ -871,165 +727,91 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * @param feed - to push
      * @param addToPeerConnection - whether to add the tracks to the peer connection
      */
-    public pushLocalFeed(feed: CallFeed, addToPeerConnection = true): void {
-        if (this.getFeedById(feed.feedId)) {
-            logger.info(`Call ${this.callId} pushLocalFeed() ignoring duplicate local stream (feedId=${feed.feedId})`);
+    public pushLocalFeed(feed: LocalCallFeed, addToPeerConnection = true): void {
+        if (this.getLocalFeedById(feed.id)) {
+            logger.info(`Call ${this.callId} pushLocalFeed() ignoring duplicate local stream (feedId=${feed.id})`);
             return;
         }
 
         this.feeds.push(feed);
         this.emit(CallEvent.FeedsChanged, this.feeds);
-        logger.info(`Call ${this.callId} pushLocalFeed() succeeded (id=${feed.feedId} purpose=${feed.purpose})`);
+        logger.info(`Call ${this.callId} pushLocalFeed() succeeded (id=${feed.id} purpose=${feed.purpose})`);
 
         if (addToPeerConnection) {
-            this.addTracksOfFeedToPeerConnection(feed);
+            feed.publish(this);
         }
     }
 
-    /**
-     * This method takes the feeds tracks and adds them to the peer connection.
-     * It tries to re-use transceivers/senders by using replaceTrack(), if
-     * possible.
-     * @param callFeed - feed whose tracks we add to the peer connection
-     */
-    private async addTracksOfFeedToPeerConnection(callFeed: CallFeed): Promise<void> {
-        const purpose = callFeed.purpose;
-        const feedId = callFeed.feedId;
-        const stream = callFeed.stream;
-        if (!stream) {
-            logger.warn(
-                `Call ${this.callId} addTracksOfFeedToPeerConnection() failed: no stream (feedId=${feedId} purpose=${purpose})`,
-            );
-            return;
+    public publishTrack(track: LocalCallTrack): RTCRtpTransceiver {
+        if (!this.peerConn) {
+            throw new Error("MatrixCall publish() called on call without a peer connection");
+        }
+        logger.info(`Call ${this.callId} publishTrack() running (id=${track.id}, kind=${track.kind})`);
+
+        const { stream, encodings } = track;
+
+        const transceiver = this.peerConn.addTransceiver(track.track, {
+            streams: stream ? [stream] : undefined,
+            // Chrome does not allow us to change the encodings
+            // later, so we have to use addTransceiver() to set them
+            // (It's fine to specify the parameter on Firefox too,
+            // it just won't work.)
+            sendEncodings: this.isFocus ? track.encodings : undefined,
+            direction: track.purpose === SDPStreamMetadataPurpose.Usermedia ? "sendrecv" : "sendonly",
+        });
+
+        if (this.isFocus && isFirefox()) {
+            const parameters = transceiver.sender.getParameters();
+            transceiver.sender.setParameters({
+                ...parameters,
+                // Firefox does not support the sendEncodings
+                // parameter on addTransceiver(), so we use
+                // setParameters() to set them
+                encodings: encodings,
+            });
         }
 
-        for (const track of stream.getTracks()) {
-            logger.info(
-                `Call ${this.callId} addTracksOfFeedToPeerConnection() running (feedId=${feedId} streamPurpose=${purpose} kind=${track.kind} enabled=${track.enabled})`,
-            );
+        return transceiver;
+    }
 
-            const encodings = track.kind === "video" ? getSimulcastEncodings(callFeed.purpose) : undefined;
-            const transceiverKey = getTransceiverKey(purpose, track.kind);
-            const transceiver = this.transceivers.get(transceiverKey);
-            const sender = transceiver?.sender;
-
-            let added = false;
-            // XXX: We don't re-use transceivers for screen shares with the SFU: this is to work around
-            // https://github.com/matrix-org/waterfall/issues/98 - see the bug for more.
-            // Since we use WebRTC data channels to renegotiate with the SFU, we're not
-            // limited to the size of a Matrix event, so it's 'ok' if the SDP grows
-            // indefinitely (although presumably this would break if we tried to do
-            // an ICE restart over to-device messages after you'd turned screen sharing
-            // on & off too many times...)
-            // The reason we're OK re-using transceivers for user media is that we establish
-            // usermedia transceivers in sendrecv mode anyway and let the SFU use the other
-            // direction to send us some other media (for better or worse) so the same bug
-            // doesn't occur.
-            if (sender && (!this.isFocus || callFeed.purpose == SDPStreamMetadataPurpose.Usermedia)) {
-                try {
-                    // We already have a sender, so we re-use it. We try to
-                    // re-use transceivers as much as possible because they
-                    // can't be removed once added, so otherwise they just
-                    // accumulate which makes the SDP very large very quickly:
-                    // in fact it only takes about 6 video tracks to exceed the
-                    // maximum size of an Olm-encrypted Matrix event - Dave
-
-                    // setStreams() is currently not supported by Firefox but we
-                    // try to use it at least in other browsers (once we switch
-                    // to using mids and throw away streamIds we will be able to
-                    // throw this away)
-                    if (sender.setStreams) sender.setStreams(stream);
-
-                    sender.replaceTrack(track);
-
-                    // We don't need to set simulcast encodings in here since we
-                    // have already done that the first time we added the
-                    // transceiver
-
-                    // Set the direction of the transceiver to indicate we're
-                    // going to be sending. This may trigger re-negotiation, if
-                    // we weren't sending until now
-                    transceiver.direction = transceiver.direction === "inactive" ? "sendonly" : "sendrecv";
-
-                    added = true;
-                } catch (error) {
-                    logger.info(
-                        `Call ${this.callId} addTracksOfFeedToPeerConnection() failed to replaceTrack()`,
-                        error,
-                    );
-                }
-            }
-
-            if (!added) {
-                try {
-                    // We either don't have a sender or we failed to do
-                    // replaceTrack(), so we use addTransceiver() to add the
-                    // track
-                    const newTransceiver = this.peerConn!.addTransceiver(track, {
-                        streams: [stream],
-                        // Chrome does not allow us to change the encodings
-                        // later, so we have to use addTransceiver() to set them
-                        // (It's fine to specify the parameter on Firefox too,
-                        // it just won't work.)
-                        sendEncodings: this.isFocus ? encodings : undefined,
-                        direction: callFeed.purpose === SDPStreamMetadataPurpose.Usermedia ? "sendrecv" : "sendonly",
-                    });
-
-                    if (this.isFocus && isFirefox()) {
-                        const parameters = newTransceiver.sender.getParameters();
-                        newTransceiver.sender.setParameters({
-                            ...parameters,
-                            // Firefox does not support the sendEncodings
-                            // parameter on addTransceiver(), so we use
-                            // setParameters() to set them
-                            encodings: encodings ?? parameters.encodings,
-                        });
-                    }
-
-                    this.transceivers.set(transceiverKey, newTransceiver);
-
-                    added = true;
-                } catch (error) {
-                    logger.error(
-                        `Call ${this.callId} addTracksOfFeedToPeerConnection() failed to addTransceiver()`,
-                        error,
-                    );
-                }
-            }
+    public unpublishTrack(track: LocalCallTrack): void {
+        if (!this.peerConn) {
+            throw new Error("MatrixCall unpublish() called on call without a peer connection");
         }
+        if (!track.sender) {
+            throw new Error("MatrixCall unpublish() called with track without sender");
+        }
+        logger.info(`Call ${this.callId} unpublishTrack() running (id=${track.id}, kind=${track.kind})`);
+
+        this.peerConn?.removeTrack(track.sender);
     }
 
     /**
      * Removes local call feed from the call and its tracks from the peer
      * connection
-     * @param callFeed - to remove
+     * @param feed - to remove
      */
-    public removeLocalFeed(callFeed: CallFeed): void {
-        const audioTransceiverKey = getTransceiverKey(callFeed.purpose, "audio");
-        const videoTransceiverKey = getTransceiverKey(callFeed.purpose, "video");
+    public removeLocalFeed(feed: LocalCallFeed): void {
+        feed.unpublish();
 
-        for (const transceiverKey of [audioTransceiverKey, videoTransceiverKey]) {
-            // this is slightly mixing the track and transceiver API but is basically just shorthand.
-            // There is no way to actually remove a transceiver, so this just sets it to inactive
-            // (or recvonly) and replaces the source with nothing.
-            if (this.transceivers.has(transceiverKey)) {
-                const transceiver = this.transceivers.get(transceiverKey)!;
-                if (transceiver.sender) {
-                    this.peerConn!.removeTrack(transceiver.sender);
-                }
+        if (feed.stream) {
+            switch (feed.purpose) {
+                case SDPStreamMetadataPurpose.Usermedia:
+                    this.client.getMediaHandler().stopUserMediaStream(feed.stream);
+                    break;
+
+                case SDPStreamMetadataPurpose.Screenshare:
+                    this.client.getMediaHandler().stopScreensharingStream(feed.stream);
+                    break;
             }
         }
 
-        if (callFeed.purpose === SDPStreamMetadataPurpose.Screenshare && callFeed.stream) {
-            this.client.getMediaHandler().stopScreensharingStream(callFeed.stream);
-        }
-
-        this.deleteFeed(callFeed);
+        this.removeFeed(feed);
     }
 
     private deleteAllFeeds(): void {
         for (const feed of this.feeds) {
-            if (!feed.isLocal()) {
+            if (!feed.isLocal) {
                 feed.removeListener(CallFeedEvent.SizeChanged, this.onCallFeedSizeChanged);
                 if (!this.groupCallId) {
                     feed.dispose();
@@ -1042,17 +824,23 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     }
 
     private deleteFeedByStream(stream: MediaStream): void {
-        const feed = this.getFeedById(stream.id);
+        const feed = this.getLocalFeedById(stream.id);
         if (!feed) {
             logger.warn(
                 `Call ${this.callId} deleteFeedByStream() didn't find the feed to delete (streamId=${stream.id})`,
             );
             return;
         }
-        this.deleteFeed(feed);
+        this.removeFeed(feed);
     }
 
-    private addRemoteFeed(feed: CallFeed, emit = true): void {
+    private addRemoteFeed(feed: RemoteCallFeed, emit = true): void {
+        if (!this.opponentSupportsSDPStreamMetadata() && this.getRemoteFeeds().length > 0) {
+            throw new Error(
+                "MatrixCall addRemoteFeed() cannot add multiple remote feeds if opponent does not support sdp_stream_metadata",
+            );
+        }
+
         this.feeds.push(feed);
         feed.addListener(CallFeedEvent.SizeChanged, this.onCallFeedSizeChanged);
 
@@ -1061,7 +849,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         }
     }
 
-    private deleteFeed(feed: CallFeed, emit = true): void {
+    private removeFeed(feed: CallFeed, emit = true): void {
         feed.dispose();
         this.feeds.splice(this.feeds.indexOf(feed), 1);
         feed.removeListener(CallFeedEvent.SizeChanged, this.onCallFeedSizeChanged);
@@ -1113,12 +901,19 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
         const sdpStreamMetadata = invite[SDPStreamMetadataKey];
         if (sdpStreamMetadata) {
-            this.updateRemoteSDPStreamMetadata(sdpStreamMetadata);
+            this.onMetadata(sdpStreamMetadata);
         } else if (!this.isFocus) {
             logger.debug(
                 `Call ${this.callId} initWithInvite() did not get any SDPStreamMetadata! Can not send/receive multiple streams`,
             );
         }
+
+        //const trackInfo = invite.track_info;
+        //if (trackInfo) {
+        //    this.onTrackInfo(trackInfo);
+        //} else {
+        //    logger.info(`Call ${this.callId} initWithInvite() did not get any track_info`);
+        //}
 
         this.peerConn = this.createPeerConnection();
         // we must set the party ID before await-ing on anything: the call event
@@ -1135,7 +930,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             return;
         }
 
-        const remoteStream = this.feeds.find((feed) => !feed.isLocal())?.stream;
+        const remoteStream = this.feeds.find((feed) => !feed.isLocal)?.stream;
 
         // According to previous comments in this file, firefox at some point did not
         // add streams until media started arriving on them. Testing latest firefox
@@ -1229,12 +1024,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             try {
                 const stream = await this.client.getMediaHandler().getUserMediaStream(answerWithAudio, answerWithVideo);
                 this.waitForLocalAVStream = false;
-                const usermediaFeed = new CallFeed({
+                const usermediaFeed = new LocalCallFeed({
                     client: this.client,
                     roomId: this.roomId,
-                    userId: this.client.getUserId()!,
-                    deviceId: this.client.getDeviceId() ?? undefined,
-                    feedId: stream.id,
                     stream,
                     purpose: SDPStreamMetadataPurpose.Usermedia,
                     audioMuted: false,
@@ -1267,7 +1059,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         }
     }
 
-    public answerWithCallFeeds(callFeeds: CallFeed[]): void {
+    public answerWithCallFeeds(callFeeds: LocalCallFeed[]): void {
         if (this.inviteOrAnswerSent) return;
 
         this.queueGotCallFeedsForAnswer(callFeeds);
@@ -1418,28 +1210,16 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             try {
                 const stream = await this.client.getMediaHandler().getScreensharingStream(opts);
                 if (!stream) return false;
-                this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare);
+                this.addLocalFeedFromStream(stream, SDPStreamMetadataPurpose.Screenshare);
                 return true;
             } catch (err) {
                 logger.error(`Call ${this.callId} setScreensharingEnabled() failed to get screen-sharing stream:`, err);
                 return false;
             }
         } else {
-            const audioTransceiver = this.transceivers.get(
-                getTransceiverKey(SDPStreamMetadataPurpose.Screenshare, "audio"),
-            );
-            const videoTransceiver = this.transceivers.get(
-                getTransceiverKey(SDPStreamMetadataPurpose.Screenshare, "video"),
-            );
-
-            for (const transceiver of [audioTransceiver, videoTransceiver]) {
-                // this is slightly mixing the track and transceiver API but is basically just shorthand
-                // for removing the sender.
-                if (transceiver && transceiver.sender) this.peerConn!.removeTrack(transceiver.sender);
+            if (this.localScreensharingFeed) {
+                this.removeLocalFeed(this.localScreensharingFeed);
             }
-
-            this.client.getMediaHandler().stopScreensharingStream(this.localScreensharingStream!);
-            this.deleteFeedByStream(this.localScreensharingStream!);
             return false;
         }
     }
@@ -1460,18 +1240,15 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         );
         if (enabled) {
             try {
-                const stream = await this.client.getMediaHandler().getScreensharingStream(opts);
-                if (!stream) return false;
+                const screensharingStream = await this.client.getMediaHandler().getScreensharingStream(opts);
+                if (!screensharingStream) return false;
+                const screensharingTrack = screensharingStream.getTracks().find((track) => track.kind === "video");
+                if (!screensharingTrack) return false;
+                const usermediaTrack = this.localUsermediaFeed?.tracks?.find((track) => track.kind === "video");
+                if (!usermediaTrack) return false;
 
-                const track = stream.getTracks().find((track) => track.kind === "video");
-
-                const sender = this.transceivers.get(
-                    getTransceiverKey(SDPStreamMetadataPurpose.Usermedia, "video"),
-                )?.sender;
-
-                sender?.replaceTrack(track ?? null);
-
-                this.pushNewLocalFeed(stream, SDPStreamMetadataPurpose.Screenshare, false);
+                usermediaTrack?.setNewTrack(screensharingTrack);
+                this.addLocalFeedFromStream(screensharingStream, SDPStreamMetadataPurpose.Screenshare, false);
 
                 return true;
             } catch (err) {
@@ -1482,12 +1259,13 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 return false;
             }
         } else {
-            const track = this.localUsermediaStream?.getTracks().find((track) => track.kind === "video");
-            const sender = this.transceivers.get(
-                getTransceiverKey(SDPStreamMetadataPurpose.Usermedia, "video"),
-            )?.sender;
-            sender?.replaceTrack(track ?? null);
+            const usermediaTrack = this.localUsermediaStream?.getTracks().find((track) => track.kind === "video");
+            if (!usermediaTrack) return true;
+            // We get the screensharing track here from the USERMEDIA feed
+            const screensharingTrack = this.localUsermediaFeed?.tracks?.find((track) => track.kind === "video");
+            if (!screensharingTrack) return true;
 
+            screensharingTrack.setNewTrack(usermediaTrack);
             this.client.getMediaHandler().stopScreensharingStream(this.localScreensharingStream!);
             this.deleteFeedByStream(this.localScreensharingStream!);
 
@@ -1521,6 +1299,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             `Call ${this.callId} updateLocalUsermediaStream() running (streamId=${newStream.id}, audio=${audioEnabled}, video=${videoEnabled})`,
         );
 
+        this.localUsermediaFeed?.setNewStream(newStream);
         // Firstly, make sure we keep the mute state
         setTracksEnabled(newStream.getAudioTracks(), audioEnabled);
         setTracksEnabled(newStream.getVideoTracks(), videoEnabled);
@@ -1531,12 +1310,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             oldStream.removeTrack(track);
             track.stop();
         }
-        for (const track of newStream.getTracks()) {
-            oldStream.addTrack(track);
-        }
-
-        // Then, we add the feed's tracks to the peer connection
-        this.addTracksOfFeedToPeerConnection(feed);
     }
 
     /**
@@ -1545,7 +1318,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * @returns the new mute state
      */
     public async setLocalVideoMuted(muted: boolean): Promise<boolean> {
-        logger.log(`Call ${this.callId} setLocalVideoMuted() running ${muted}`);
+        logger.log(`Call ${this.callId} setLocalVideoMuted() running (muted=${muted})`);
 
         // if we were still thinking about stopping and removing the video
         // track: don't, because we want it back.
@@ -1706,9 +1479,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         const vidShouldBeMuted = this.isLocalVideoMuted() || this.remoteOnHold;
 
         logger.log(
-            `Call ${this.callId} updateMuteStatus stream ${
+            `Call ${this.callId} updateMuteStatus (streamId=${
                 this.localUsermediaStream!.id
-            } micShouldBeMuted ${micShouldBeMuted} vidShouldBeMuted ${vidShouldBeMuted}`,
+            }, micShouldBeMuted=${micShouldBeMuted}, vidShouldBeMuted=${vidShouldBeMuted})`,
         );
 
         setTracksEnabled(this.localUsermediaStream!.getAudioTracks(), !micShouldBeMuted);
@@ -1720,12 +1493,12 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             this.sendFocusEvent(EventType.CallSDPStreamMetadataChanged);
         } else {
             await this.sendVoipEvent(EventType.CallSDPStreamMetadataChangedPrefix, {
-                [SDPStreamMetadataKey]: this.getLocalSDPStreamMetadata(),
+                [SDPStreamMetadataKey]: this.metadata,
             });
         }
     }
 
-    private gotCallFeedsForInvite(callFeeds: CallFeed[], requestScreenshareFeed = false): void {
+    private gotCallFeedsForInvite(callFeeds: LocalCallFeed[], requestScreenshareFeed = false): void {
         if (this.successor) {
             this.successor.queueGotCallFeedsForAnswer(callFeeds);
             return;
@@ -1759,7 +1532,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 // required to still be sent for backwards compat
                 type: this.peerConn!.localDescription!.type,
             },
-            [SDPStreamMetadataKey]: this.getLocalSDPStreamMetadata(),
+            [SDPStreamMetadataKey]: this.metadata,
         } as MCallAnswer;
 
         answerContent.capabilities = {
@@ -1800,7 +1573,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         this.sendCandidateQueue();
     }
 
-    private queueGotCallFeedsForAnswer(callFeeds: CallFeed[]): void {
+    private queueGotCallFeedsForAnswer(callFeeds: LocalCallFeed[]): void {
         // Ensure only one negotiate/answer event is being processed at a time.
         if (this.responsePromiseChain) {
             this.responsePromiseChain = this.responsePromiseChain.then(() => this.gotCallFeedsForAnswer(callFeeds));
@@ -1871,7 +1644,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         return answer;
     }
 
-    private async gotCallFeedsForAnswer(callFeeds: CallFeed[]): Promise<void> {
+    private async gotCallFeedsForAnswer(callFeeds: LocalCallFeed[]): Promise<void> {
         if (this.callHasEnded()) return;
 
         this.waitForLocalAVStream = false;
@@ -2020,12 +1793,19 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
         const sdpStreamMetadata = content[SDPStreamMetadataKey];
         if (sdpStreamMetadata) {
-            this.updateRemoteSDPStreamMetadata(sdpStreamMetadata);
+            this.onMetadata(sdpStreamMetadata);
         } else if (!this.isFocus) {
             logger.warn(
                 `Call ${this.callId} onAnswerReceived() did not get any SDPStreamMetadata! Can not send/receive multiple streams`,
             );
         }
+
+        //const trackInfo = content.track_info;
+        //if (trackInfo) {
+        //    this.onTrackInfo(trackInfo);
+        //} else {
+        //    logger.info(`Call ${this.callId} onAnswerReceived() did not get any track_info`);
+        //}
 
         try {
             await this.peerConn!.setRemoteDescription(content.answer);
@@ -2111,7 +1891,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         const prevLocalOnHold = this.isLocalOnHold();
 
         if (sdpStreamMetadata) {
-            this.updateRemoteSDPStreamMetadata(sdpStreamMetadata);
+            this.onMetadata(sdpStreamMetadata);
         } else {
             logger.warn(
                 `Call ${this.callId} onNegotiateReceived() received negotiation event without SDPStreamMetadata!`,
@@ -2141,7 +1921,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 } else {
                     this.sendVoipEvent(EventType.CallNegotiate, {
                         description: this.peerConn!.localDescription?.toJSON(),
-                        [SDPStreamMetadataKey]: this.getLocalSDPStreamMetadata(),
+                        [SDPStreamMetadataKey]: this.metadata,
                     });
                 }
             }
@@ -2164,11 +1944,11 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         try {
             json = JSON.parse(event.data);
         } catch (e) {
-            logger.warn("Ignoring non-JSON DC event:", event.data);
+            logger.warn(`Call ${this.callId} onDataChannelMessage() ignoring non-JSON message:"`, event.data);
             return;
         }
 
-        logger.info(`Received DC ${json.type} event`, json);
+        logger.info(`Call ${this.callId} onDataChannelMessage() received event (type=${json.type})`, json);
 
         switch (json.type) {
             case EventType.CallNegotiate:
@@ -2180,7 +1960,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             case EventType.CallSDPStreamMetadataChanged:
                 {
                     const metadata = json.content as FocusSDPStreamMetadataChangedEvent;
-                    this.updateRemoteSDPStreamMetadata(metadata[SDPStreamMetadataKeyStable]!);
+                    this.onMetadata(metadata[SDPStreamMetadataKeyStable]!);
                 }
                 break;
             case EventType.CallPing:
@@ -2189,7 +1969,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 }
                 break;
             default:
-                logger.warn("Ignoring unrecognized DC event op ", json.type);
+                logger.warn(
+                    `Call ${this.callId} onDataChannelMessage() received event of unknown type (type=${json.type})`,
+                );
 
                 break;
         }
@@ -2233,14 +2015,20 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     private sendSubscriptionFocusEvent(): void {
         const subscribe: FocusTrackDescription[] = [];
         const unsubscribe: FocusTrackDescription[] = [];
-        for (const { feedId, tracksMetadata, isVisible, width, height } of this.getRemoteFeeds()) {
-            for (const [trackId, trackMetadata] of Object.entries(tracksMetadata)) {
+        for (const { streamId, tracks, isVisible, width, height } of this.getRemoteFeeds()) {
+            if (!streamId) continue;
+            if (!tracks) continue;
+            if (!Object.keys(tracks).length) continue;
+
+            for (const { trackId, isAudio } of tracks) {
+                if (!trackId) continue;
+
                 const trackDescription: FocusTrackDescription = {
                     track_id: trackId,
-                    stream_id: feedId,
+                    stream_id: streamId,
                 };
 
-                if (trackMetadata.kind === "audio") {
+                if (isAudio) {
                     // We want audio from everyone
                     subscribe.push(trackDescription);
                 } else if (isVisible && width !== 0 && height !== 0) {
@@ -2270,40 +2058,63 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         this.subscribeToFocus();
     };
 
-    public updateRemoteSDPStreamMetadata(metadata: SDPStreamMetadata): void {
+    /**
+     * If the opponent
+     */
+    private addRemoteFeedWithoutMetadata(stream: MediaStream): void {
+        if (this.opponentSupportsSDPStreamMetadata()) {
+            throw new Error("createRemoteFeedWithoutMetadata() called with sdp_stream_metadata support");
+        }
+
+        logger.info(`Call ${this.callId} addRemoteFeedWithoutMetadata() running`);
+
+        this.addRemoteFeed(
+            new RemoteCallFeed({
+                client: this.client,
+                call: this,
+                roomId: this.roomId,
+                stream: stream,
+                streamId: stream.id,
+                audioMuted: false,
+                videoMuted: false,
+            }),
+        );
+    }
+
+    private onMetadata(metadata: SDPStreamMetadata): void {
         this._opponentSupportsSDPStreamMetadata = true;
 
         let feedsChanged = false;
 
         // Add new feeds and update existing ones
         for (const [streamId, streamMetadata] of Object.entries(metadata)) {
-            let feed = this.getRemoteFeeds().find((f) => f.feedId === streamId);
+            const feed = this.getRemoteFeeds().find((f) => f.streamId === streamId);
             if (feed) {
-                feed.purpose = streamMetadata.purpose;
-                feed.tracksMetadata = streamMetadata.tracks;
-            } else {
-                feed = new CallFeed({
+                feed.metadata = streamMetadata;
+                continue;
+            }
+
+            // We don't emit here and only emit at the end of onMetadata to
+            // avoid spam
+            this.addRemoteFeed(
+                new RemoteCallFeed({
                     client: this.client,
                     call: this,
                     roomId: this.roomId,
-                    userId: this.isFocus ? streamMetadata.user_id : this.getOpponentMember()!.userId,
-                    deviceId: this.isFocus ? streamMetadata.device_id : this.getOpponentDeviceId()!,
-                    feedId: streamId,
-                    purpose: streamMetadata.purpose,
-                    audioMuted: streamMetadata.audio_muted,
-                    videoMuted: streamMetadata.video_muted,
-                    tracksMetadata: streamMetadata.tracks,
-                });
-                this.addRemoteFeed(feed, false);
-                feedsChanged = true;
-            }
-            feed.setAudioVideoMuted(streamMetadata.audio_muted, streamMetadata.video_muted);
+                    streamId: streamId,
+                    metadata: streamMetadata,
+                    audioMuted: streamMetadata.audio_muted ?? false,
+                    videoMuted: streamMetadata.video_muted ?? false,
+                }),
+                false,
+            );
+            feedsChanged = true;
         }
 
         // Remove old feeds
         for (const feed of this.getRemoteFeeds()) {
-            if (!Object.keys(metadata).includes(feed.feedId)) {
-                this.deleteFeed(feed, false);
+            if (!Object.keys(metadata).includes(feed.streamId ?? "")) {
+                this.removeFeed(feed, false);
                 feedsChanged = true;
             }
         }
@@ -2319,7 +2130,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     public onSDPStreamMetadataChangedReceived(event: MatrixEvent): void {
         const metadata = event.getContent<MCallSDPStreamMetadataChanged>()?.[SDPStreamMetadataKey];
         if (metadata) {
-            this.updateRemoteSDPStreamMetadata(metadata);
+            this.onMetadata(metadata);
         }
     }
 
@@ -2435,7 +2246,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             "m.call.dtmf": false,
         };
 
-        content[SDPStreamMetadataKey] = this.getLocalSDPStreamMetadata();
+        content[SDPStreamMetadataKey] = this.metadata;
 
         // Get rid of any candidates waiting to be sent: they'll be included in the local
         // description we just got and will send in the offer.
@@ -2568,28 +2379,50 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     };
 
     private onTrack = (ev: RTCTrackEvent): void => {
-        if (ev.streams.length === 0) {
-            logger.warn(
-                `Call ${this.callId} onTrack() called with streamless track streamless (kind=${ev.track.kind})`,
-            );
+        const stream = ev.streams[0];
+        const transceiver = ev.transceiver;
+
+        if (!stream) {
+            logger.warn(`Call ${this.callId} onTrack() called with streamless track (kind=${ev.track.kind})`);
+            return;
+        }
+        if (!transceiver?.mid) {
+            logger.warn(`Call ${this.callId} onTrack() called with transceiver without an mid (kind=${ev.track.kind})`);
+            return;
+        }
+        if (!this.opponentSupportsSDPStreamMetadata()) {
+            this.addRemoteFeedWithoutMetadata(stream);
+            if (!this.removeTrackListeners.has(stream)) {
+                const onRemoveTrack = (): void => {
+                    if (stream.getTracks().length === 0) {
+                        logger.info(`Call ${this.callId} onTrack() removing track (streamId=${stream.id})`);
+                        this.deleteFeedByStream(stream);
+                        stream.removeEventListener("removetrack", onRemoveTrack);
+                        this.removeTrackListeners.delete(stream);
+                    }
+                };
+                stream.addEventListener("removetrack", onRemoveTrack);
+                this.removeTrackListeners.set(stream, onRemoveTrack);
+            }
             return;
         }
 
-        const stream = ev.streams[0];
-        this.pushRemoteStream(stream);
+        logger.log(
+            `Call ${this.callId} onTrack() running  (mid=${transceiver.mid}, kind=${transceiver.receiver.track.kind})`,
+        );
 
-        if (!this.removeTrackListeners.has(stream)) {
-            const onRemoveTrack = (): void => {
-                if (stream.getTracks().length === 0) {
-                    logger.info(`Call ${this.callId} onTrack() removing track (streamId=${stream.id})`);
-                    this.deleteFeedByStream(stream);
-                    stream.removeEventListener("removetrack", onRemoveTrack);
-                    this.removeTrackListeners.delete(stream);
-                }
-            };
-            stream.addEventListener("removetrack", onRemoveTrack);
-            this.removeTrackListeners.set(stream, onRemoveTrack);
+        const feed = this.getRemoteFeeds().find((feed) => feed.canAddTransceiver(transceiver));
+        if (!feed) {
+            logger.warn(
+                `Call ${
+                    this.callId
+                } onTrack() did not find feed for transceiver (streamId=${this.getRemoteStreamIdByMid(
+                    transceiver.mid,
+                )}, trackId=${this.getRemoteTrackIdByMid(transceiver.mid)} kind=${transceiver.receiver.track.kind})`,
+            );
+            return;
         }
+        feed.addTransceiver(transceiver);
     };
 
     private onDataChannel = (ev: RTCDataChannelEvent): void => {
@@ -2630,10 +2463,8 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             }
         }
 
-        const screenshareVideoTransceiver = this.transceivers.get(
-            getTransceiverKey(SDPStreamMetadataPurpose.Screenshare, "video"),
-        );
-        if (screenshareVideoTransceiver) screenshareVideoTransceiver.setCodecPreferences(codecs);
+        const screensharingVideoTransceiver = this.localScreensharingFeed?.videoTrack?.transceiver;
+        if (screensharingVideoTransceiver) screensharingVideoTransceiver.setCodecPreferences(codecs);
     }
 
     private onNegotiationNeeded = async (): Promise<void> => {
@@ -2772,12 +2603,12 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         };
 
         if ([EventType.CallNegotiate, EventType.CallSDPStreamMetadataChanged].includes(type)) {
-            event.content[SDPStreamMetadataKeyStable] = this.getLocalSDPStreamMetadata();
+            event.content[SDPStreamMetadataKeyStable] = this.metadata;
         }
 
         // FIXME: RPC reliability over DC
         this.dataChannel!.send(JSON.stringify(event));
-        logger.info(`Sent ${event.type} over DC:`, event);
+        logger.info(`Call ${this.callId} sendFocusEvent() sent event (type=${event.type}):`, event);
     }
 
     /**
@@ -2964,11 +2795,11 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             // NB. We clone local streams when passing them to individual calls in a group
             // call, so we can (and should) stop the clones once we no longer need them:
             // the other clones will continue fine.
-            if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Usermedia) {
+            if (feed.isLocal && feed.purpose === SDPStreamMetadataPurpose.Usermedia) {
                 this.client.getMediaHandler().stopUserMediaStream(feed.stream);
-            } else if (feed.isLocal() && feed.purpose === SDPStreamMetadataPurpose.Screenshare) {
+            } else if (feed.isLocal && feed.purpose === SDPStreamMetadataPurpose.Screenshare) {
                 this.client.getMediaHandler().stopScreensharingStream(feed.stream);
-            } else if (!feed.isLocal()) {
+            } else if (!feed.isLocal) {
                 logger.debug(`Call ${this.callId} stopAllMedia() stopping stream (streamId=${feed.stream.id})`);
                 for (const track of feed.stream.getTracks()) {
                     track.stop();
@@ -3061,12 +2892,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             setTracksEnabled(stream.getAudioTracks(), true);
             setTracksEnabled(stream.getVideoTracks(), true);
 
-            const callFeed = new CallFeed({
+            const callFeed = new LocalCallFeed({
                 client: this.client,
                 roomId: this.roomId,
-                userId: this.client.getUserId()!,
-                deviceId: this.client.getDeviceId() ?? undefined,
-                feedId: stream.id,
                 stream,
                 purpose: SDPStreamMetadataPurpose.Usermedia,
                 audioMuted: false,
@@ -3085,7 +2913,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
      * @throws if you have not specified a listener for 'error' events.
      * @throws if have passed audio=false.
      */
-    public async placeCallWithCallFeeds(callFeeds: CallFeed[], requestScreenshareFeed = false): Promise<void> {
+    public async placeCallWithCallFeeds(callFeeds: LocalCallFeed[], requestScreenshareFeed = false): Promise<void> {
         this.checkForErrorListener();
         this.direction = CallDirection.Outbound;
 

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -24,12 +24,12 @@ export interface SDPStreamMetadataTracks {
 }
 
 export interface SDPStreamMetadataObject {
-    user_id: string;
-    device_id: string;
+    user_id?: string;
+    device_id?: string;
     purpose: SDPStreamMetadataPurpose;
-    audio_muted: boolean;
-    video_muted: boolean;
-    tracks: SDPStreamMetadataTracks;
+    audio_muted?: boolean;
+    video_muted?: boolean;
+    tracks?: SDPStreamMetadataTracks;
 }
 
 export interface SDPStreamMetadata {

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -32,14 +32,6 @@ const SPEAKING_SAMPLE_COUNT = 8; // samples
 export interface ICallFeedOpts {
     client: MatrixClient;
     roomId?: string;
-    /**
-     * Whether or not the remote SDPStreamMetadata says audio is muted
-     */
-    audioMuted: boolean;
-    /**
-     * Whether or not the remote SDPStreamMetadata says video is muted
-     */
-    videoMuted: boolean;
 }
 
 export enum CallFeedEvent {
@@ -65,12 +57,12 @@ type EventHandlerMap = {
 };
 
 export abstract class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> {
-    public abstract readonly id?: string;
-    public abstract readonly streamId?: string;
-    public abstract readonly purpose: SDPStreamMetadataPurpose;
-    public abstract readonly connected: boolean;
-    public abstract readonly userId: string;
-    public abstract readonly deviceId?: string;
+    public abstract get id(): string | undefined;
+    public abstract get streamId(): string | undefined;
+    public abstract get purpose(): SDPStreamMetadataPurpose;
+    public abstract get connected(): boolean;
+    public abstract get userId(): string;
+    public abstract get deviceId(): string | undefined;
 
     public abstract isLocal: boolean;
     public abstract isRemote: boolean;
@@ -83,8 +75,8 @@ export abstract class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHan
     protected call?: MatrixCall;
     protected roomId?: string;
     protected client: MatrixClient;
-    protected audioMuted: boolean;
-    protected videoMuted: boolean;
+    protected audioMuted = false;
+    protected videoMuted = false;
 
     private localVolume = 1;
     private measuringVolumeActivity = false;
@@ -105,8 +97,6 @@ export abstract class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHan
         this._id = randomString(32);
         this.client = opts.client;
         this.roomId = opts.roomId;
-        this.audioMuted = opts.audioMuted;
-        this.videoMuted = opts.videoMuted;
         this.speakingVolumeSamples = new Array(SPEAKING_SAMPLE_COUNT).fill(-Infinity);
 
         if (this.hasAudioTrack) {

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -57,7 +57,7 @@ type EventHandlerMap = {
 };
 
 export abstract class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> {
-    public abstract get id(): string | undefined;
+    public abstract get id(): string;
     public abstract get streamId(): string | undefined;
     public abstract get purpose(): SDPStreamMetadataPurpose;
     public abstract get connected(): boolean;

--- a/src/webrtc/callTrack.ts
+++ b/src/webrtc/callTrack.ts
@@ -20,10 +20,11 @@ import { SDPStreamMetadataTrack } from "./callEventTypes";
 export interface CallTrackOpts {}
 
 export abstract class CallTrack {
-    public abstract readonly id?: string;
-    public abstract readonly track?: MediaStreamTrack;
-    public abstract readonly trackId?: string;
-    public abstract metadata?: SDPStreamMetadataTrack;
+    public abstract get id(): string | undefined;
+    public abstract get track(): MediaStreamTrack | undefined;
+    public abstract get trackId(): string | undefined;
+    public abstract get metadata(): SDPStreamMetadataTrack | undefined;
+    public abstract get kind(): string | undefined;
 
     protected readonly _id: string;
     protected _transceiver?: RTCRtpTransceiver;
@@ -34,10 +35,6 @@ export abstract class CallTrack {
 
     public get transceiver(): RTCRtpTransceiver | undefined {
         return this._transceiver;
-    }
-
-    public get kind(): string | undefined {
-        return this.track?.kind;
     }
 
     public get isAudio(): boolean {

--- a/src/webrtc/callTrack.ts
+++ b/src/webrtc/callTrack.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { randomString } from "../randomstring";
+import { SDPStreamMetadataTrack } from "./callEventTypes";
+
+export interface CallTrackOpts {}
+
+export abstract class CallTrack {
+    public abstract readonly id?: string;
+    public abstract readonly track?: MediaStreamTrack;
+    public abstract readonly trackId?: string;
+    public abstract metadata?: SDPStreamMetadataTrack;
+
+    protected readonly _id: string;
+    protected _transceiver?: RTCRtpTransceiver;
+
+    public constructor(opts: CallTrackOpts) {
+        this._id = randomString(32);
+    }
+
+    public get transceiver(): RTCRtpTransceiver | undefined {
+        return this._transceiver;
+    }
+
+    public get kind(): string | undefined {
+        return this.track?.kind;
+    }
+
+    public get isAudio(): boolean {
+        return this.kind === "audio";
+    }
+
+    public get isVideo(): boolean {
+        return this.kind === "video";
+    }
+}

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -406,9 +406,11 @@ export class GroupCall extends TypedEventEmitter<
             roomId: this.room.roomId,
             stream,
             purpose: SDPStreamMetadataPurpose.Usermedia,
-            audioMuted: this.initWithAudioMuted || stream.getAudioTracks().length === 0 || this.isPtt,
-            videoMuted: this.initWithVideoMuted || stream.getVideoTracks().length === 0,
         });
+        callFeed.setAudioVideoMuted(
+            this.initWithAudioMuted || stream.getAudioTracks().length === 0 || this.isPtt,
+            this.initWithVideoMuted || stream.getVideoTracks().length === 0,
+        );
 
         setTracksEnabled(stream.getAudioTracks(), !callFeed.isAudioMuted());
         setTracksEnabled(stream.getVideoTracks(), !callFeed.isVideoMuted());
@@ -730,8 +732,6 @@ export class GroupCall extends TypedEventEmitter<
                     roomId: this.room.roomId,
                     stream,
                     purpose: SDPStreamMetadataPurpose.Screenshare,
-                    audioMuted: false,
-                    videoMuted: false,
                 });
                 this.addScreenshareFeed(this.localScreenshareFeed);
 

--- a/src/webrtc/localCallFeed.ts
+++ b/src/webrtc/localCallFeed.ts
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "../logger";
+import { MatrixCall } from "./call";
+import { SDPStreamMetadataObject, SDPStreamMetadataPurpose, SDPStreamMetadataTracks } from "./callEventTypes";
+import { CallFeed, ICallFeedOpts } from "./callFeed";
+import { LocalCallTrack } from "./localCallTrack";
+
+export interface LocalCallFeedOpts extends ICallFeedOpts {
+    purpose: SDPStreamMetadataPurpose;
+    stream: MediaStream;
+}
+
+export class LocalCallFeed extends CallFeed {
+    protected _tracks: LocalCallTrack[] = [];
+    private _purpose: SDPStreamMetadataPurpose;
+
+    protected _stream: MediaStream;
+
+    public readonly connected = true;
+    public readonly isLocal = true;
+    public readonly isRemote = false;
+
+    public constructor(opts: LocalCallFeedOpts) {
+        super(opts);
+
+        this._purpose = opts.purpose;
+
+        this.updateStream(undefined, opts.stream);
+        // updateStream() already did the job, but this shuts up typescript from
+        // complaining about it not being set in the constructor
+        this._stream = opts.stream;
+    }
+
+    public get id(): string {
+        return this._id;
+    }
+
+    public get tracks(): LocalCallTrack[] {
+        return super.tracks as LocalCallTrack[];
+    }
+
+    public get metadata(): SDPStreamMetadataObject {
+        return {
+            user_id: this.userId,
+            device_id: this.deviceId,
+            purpose: this.purpose,
+            audio_muted: this.isAudioMuted(),
+            video_muted: this.isVideoMuted(),
+            tracks: this._tracks.reduce((metadata: SDPStreamMetadataTracks, track: LocalCallTrack) => {
+                if (!track.trackId) return metadata;
+
+                metadata[track.trackId] = track.metadata;
+                return metadata;
+            }, {}),
+        };
+    }
+
+    public get purpose(): SDPStreamMetadataPurpose {
+        return this._purpose;
+    }
+
+    public get userId(): string {
+        return this.client.getUserId()!;
+    }
+
+    public get deviceId(): string | undefined {
+        return this.client.getDeviceId() ?? undefined;
+    }
+
+    public get streamId(): string | undefined {
+        return this._tracks[0]?.streamId;
+    }
+
+    public clone(): LocalCallFeed {
+        const mediaHandler = this.client.getMediaHandler();
+        const stream = this._stream.clone();
+        logger.log(
+            `CallFeed ${this.id} clone() cloning stream (originalStreamId=${this._stream.id}, newStreamId=${stream.id})`,
+        );
+
+        if (this.purpose === SDPStreamMetadataPurpose.Usermedia) {
+            mediaHandler.userMediaStreams.push(stream);
+        } else if (this.purpose === SDPStreamMetadataPurpose.Screenshare) {
+            mediaHandler.screensharingStreams.push(stream);
+        }
+
+        return new LocalCallFeed({
+            client: this.client,
+            roomId: this.roomId,
+            stream,
+            purpose: this.purpose,
+            audioMuted: this.audioMuted,
+            videoMuted: this.videoMuted,
+        });
+    }
+
+    public setNewStream(newStream: MediaStream): void {
+        this.updateStream(this.stream, newStream);
+    }
+
+    protected updateStream(oldStream?: MediaStream, newStream?: MediaStream): void {
+        super.updateStream(oldStream, newStream);
+
+        if (!newStream) return;
+
+        // First, remove tracks which won't be used anymore
+        for (const track of this._tracks) {
+            if (!newStream.getTracks().some((streamTrack) => streamTrack.kind === track.kind)) {
+                this._tracks.splice(this._tracks.indexOf(track), 1);
+                if (track.published) {
+                    track.unpublish();
+                }
+            }
+        }
+
+        // Then, replace old track where we can and add new tracks
+        for (const streamTrack of newStream.getTracks()) {
+            let track = this._tracks.find((track) => track.kind === streamTrack.kind);
+            if (track) {
+                track.setNewTrack(streamTrack);
+                continue;
+            }
+
+            track = new LocalCallTrack({
+                feed: this,
+                track: streamTrack,
+            });
+            this._tracks.push(track);
+
+            if (this.call) {
+                track.publish(this.call);
+            }
+        }
+    }
+
+    public publish(call: MatrixCall): void {
+        this.call = call;
+        for (const track of this._tracks) {
+            track.publish(call);
+        }
+    }
+
+    public unpublish(): void {
+        this.call = undefined;
+        for (const track of this._tracks) {
+            track.unpublish();
+        }
+    }
+}

--- a/src/webrtc/localCallFeed.ts
+++ b/src/webrtc/localCallFeed.ts
@@ -99,14 +99,14 @@ export class LocalCallFeed extends CallFeed {
             mediaHandler.screensharingStreams.push(stream);
         }
 
-        return new LocalCallFeed({
+        const feed = new LocalCallFeed({
             client: this.client,
             roomId: this.roomId,
             stream,
             purpose: this.purpose,
-            audioMuted: this.audioMuted,
-            videoMuted: this.videoMuted,
         });
+        feed.setAudioVideoMuted(this.audioMuted, this.videoMuted);
+        return feed;
     }
 
     public setNewStream(newStream: MediaStream): void {

--- a/src/webrtc/localCallTrack.ts
+++ b/src/webrtc/localCallTrack.ts
@@ -1,0 +1,261 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "../logger";
+import { MatrixCall } from "./call";
+import { SDPStreamMetadataPurpose, SDPStreamMetadataTrack } from "./callEventTypes";
+import { CallTrack, CallTrackOpts } from "./callTrack";
+import { LocalCallFeed } from "./localCallFeed";
+
+export enum SimulcastResolution {
+    Full = "f",
+    Half = "h",
+    Quarter = "q",
+}
+
+// Order is important here: some browsers (e.g.
+// Chrome) will only send some of the encodings, if
+// the track has a resolution to low for it to send
+// all, in that case the encoding higher in the list
+// has priority and therefore we put full as first
+// as we always want to send the full resolution
+const SIMULCAST_USERMEDIA_ENCODINGS: RTCRtpEncodingParameters[] = [
+    {
+        // 720p (base)
+        maxFramerate: 30,
+        maxBitrate: 1_700_000,
+        rid: SimulcastResolution.Full,
+    },
+    {
+        // 360p
+        maxFramerate: 20,
+        maxBitrate: 300_000,
+        rid: SimulcastResolution.Half,
+        scaleResolutionDownBy: 2.0,
+    },
+    {
+        // 180p
+        maxFramerate: 15,
+        maxBitrate: 120_000,
+
+        rid: SimulcastResolution.Quarter,
+        scaleResolutionDownBy: 4.0,
+    },
+];
+
+const SIMULCAST_SCREENSHARING_ENCODINGS: RTCRtpEncodingParameters[] = [
+    {
+        // 1080p (base)
+        maxFramerate: 30,
+        maxBitrate: 3_000_000,
+        rid: SimulcastResolution.Full,
+    },
+    {
+        // 720p
+        maxFramerate: 15,
+        maxBitrate: 1_000_000,
+        rid: SimulcastResolution.Half,
+        scaleResolutionDownBy: 1.5,
+    },
+    {
+        // 360p
+        maxFramerate: 3,
+        maxBitrate: 200_000,
+        rid: SimulcastResolution.Quarter,
+        scaleResolutionDownBy: 3,
+    },
+];
+
+export const getSimulcastEncodings = (purpose: SDPStreamMetadataPurpose): RTCRtpEncodingParameters[] => {
+    if (purpose === SDPStreamMetadataPurpose.Usermedia) {
+        return SIMULCAST_USERMEDIA_ENCODINGS;
+    }
+    if (purpose === SDPStreamMetadataPurpose.Screenshare) {
+        return SIMULCAST_SCREENSHARING_ENCODINGS;
+    }
+
+    // Fallback to usermedia encodings
+    return SIMULCAST_USERMEDIA_ENCODINGS;
+};
+
+export interface LocalCallTrackOpts extends CallTrackOpts {
+    feed: LocalCallFeed;
+    track: MediaStreamTrack;
+}
+
+export class LocalCallTrack extends CallTrack {
+    private _track: MediaStreamTrack;
+    private feed: LocalCallFeed;
+    private call?: MatrixCall;
+
+    public constructor(opts: LocalCallTrackOpts) {
+        super(opts);
+
+        this._track = opts.track;
+        this.feed = opts.feed;
+    }
+
+    private get logInfo(): string {
+        return `streamId=${this.streamId}, trackId=${this.trackId}, mid=${this.mid} kind=${this.kind}`;
+    }
+
+    public get id(): string | undefined {
+        return this._id;
+    }
+
+    public get metadata(): SDPStreamMetadataTrack {
+        const trackMetadata: SDPStreamMetadataTrack = {
+            kind: this.track.kind,
+        };
+
+        if (this.isVideo) {
+            trackMetadata.width = this.track.getSettings().width;
+            trackMetadata.height = this.track.getSettings().height;
+        }
+
+        return trackMetadata;
+    }
+
+    public get mid(): string | undefined {
+        return this._transceiver?.mid ?? undefined;
+    }
+
+    public get trackId(): string | undefined {
+        const mid = this._transceiver?.mid;
+        return mid ? this.call?.getLocalTrackIdByMid(mid) : undefined;
+    }
+
+    public get streamId(): string | undefined {
+        const mid = this._transceiver?.mid;
+        return mid ? this.call?.getLocalStreamIdByMid(mid) : undefined;
+    }
+
+    public get track(): MediaStreamTrack {
+        return this._track;
+    }
+
+    public get kind(): string {
+        return this.track.kind;
+    }
+
+    public get purpose(): SDPStreamMetadataPurpose {
+        return this.feed.purpose;
+    }
+
+    public get stream(): MediaStream | undefined {
+        return this.feed.stream;
+    }
+
+    public get sender(): RTCRtpSender | undefined {
+        return this._transceiver?.sender;
+    }
+
+    public get encodings(): RTCRtpEncodingParameters[] {
+        return getSimulcastEncodings(this.purpose);
+    }
+
+    public get published(): boolean {
+        if (!this._transceiver?.sender) return false;
+        if (!this.call) return false;
+
+        return true;
+    }
+
+    public publish(call: MatrixCall): void {
+        if (this.published) {
+            throw new Error("Cannot publish already published track");
+        }
+
+        try {
+            this._transceiver = call.publishTrack(this);
+        } finally {
+            this.call = call;
+        }
+    }
+
+    public unpublish(): void {
+        const call = this.call;
+        if (!this.published || !call) {
+            throw new Error("Cannot unpublish track that is not published");
+        }
+
+        try {
+            call.unpublishTrack(this);
+        } finally {
+            this.call = undefined;
+            this._transceiver = undefined;
+        }
+    }
+
+    public setNewTrack(track: MediaStreamTrack): void {
+        this._track = track;
+        const stream = this.stream;
+        const sender = this.sender;
+        const transceiver = this._transceiver;
+
+        logger.log(`LocalCallTrack ${this.id} setNewTrack() running (${this.logInfo})`);
+
+        if (!this.call) return;
+        // XXX: We don't re-use transceivers with the SFU: this is to work around
+        // https://github.com/matrix-org/waterfall/issues/98 - see the bug for more.
+        // Since we use WebRTC data channels to renegotiate with the SFU, we're not
+        // limited to the size of a Matrix event, so it's 'ok' if the SDP grows
+        // indefinitely (although presumably this would break if we tried to do
+        // an ICE restart over to-device messages after you'd turned screen sharing
+        // on & off too many times...)
+        if (!transceiver || !sender || (this.call.isFocus && this.purpose === SDPStreamMetadataPurpose.Screenshare)) {
+            const call = this.call;
+            this.unpublish();
+            this.publish(call);
+            return;
+        }
+
+        logger.log(`LocalCallTrack LocalCallTrack ${this.id} setNewTrack() replacing track (${this.logInfo})`);
+
+        try {
+            // We already have a sender, so we re-use it. We try to
+            // re-use transceivers as much as possible because they
+            // can't be removed once added, so otherwise they just
+            // accumulate which makes the SDP very large very quickly:
+            // in fact it only takes about 6 video tracks to exceed the
+            // maximum size of an Olm-encrypted Matrix event - Dave
+
+            // setStreams() is currently not supported by Firefox but we
+            // try to use it at least in other browsers (once we switch
+            // to using mids and throw away streamIds we will be able to
+            // throw this away)
+            if (sender.setStreams && stream) sender.setStreams(stream);
+
+            sender.replaceTrack(track);
+
+            // We don't need to set simulcast encodings in here since we
+            // have already done that the first time we added the
+            // transceiver
+
+            // Set the direction of the transceiver to indicate we're
+            // going to be sending. This may trigger re-negotiation, if
+            // we weren't sending until now
+            transceiver.direction = transceiver.direction === "inactive" ? "sendonly" : "sendrecv";
+        } catch (error) {
+            logger.warn(
+                `LocalCallTrack ${this.id} setNewTrack() failed to replace track: falling back to publishing a new one (${this.logInfo})`,
+            );
+            if (this.call) {
+                this.publish(this.call);
+            }
+        }
+    }
+}

--- a/src/webrtc/remoteCallFeed.ts
+++ b/src/webrtc/remoteCallFeed.ts
@@ -1,0 +1,228 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "../logger";
+import { CallEvent, CallState, MatrixCall } from "./call";
+import { SDPStreamMetadataObject, SDPStreamMetadataPurpose } from "./callEventTypes";
+import { CallFeed, CallFeedEvent, ICallFeedOpts } from "./callFeed";
+import { RemoteCallTrack } from "./remoteCallTrack";
+
+export interface RemoteCallFeedOpts extends ICallFeedOpts {
+    streamId: string;
+    metadata?: SDPStreamMetadataObject;
+    call: MatrixCall;
+
+    /**
+     * @deprecated addTransceiver() should be used instead
+     */
+    stream?: MediaStream;
+}
+
+export class RemoteCallFeed extends CallFeed {
+    private _connected = false;
+    private _metadata?: SDPStreamMetadataObject;
+
+    protected _tracks: RemoteCallTrack[] = [];
+    protected call: MatrixCall;
+    protected _stream: MediaStream;
+
+    public readonly streamId: string;
+    public readonly isLocal = false;
+    public readonly isRemote = true;
+
+    public constructor(opts: RemoteCallFeedOpts) {
+        super(opts);
+
+        if (!opts.metadata && opts.call.opponentSupportsSDPStreamMetadata()) {
+            throw new Error(
+                "Cannot create RemoteCallFeed without metadata if the opponents supports sending sdp_stream_metadata",
+            );
+        }
+
+        this.streamId = opts.streamId;
+        this.call = opts.call;
+        this.metadata = opts.metadata;
+
+        this._stream = opts.stream || new MediaStream();
+
+        if (opts.call) {
+            opts.call.addListener(CallEvent.State, this.onCallState);
+        }
+        this.updateConnected();
+    }
+
+    public get id(): string | undefined {
+        return this.streamId;
+    }
+
+    public get metadata(): SDPStreamMetadataObject | undefined {
+        return this._metadata;
+    }
+
+    public set metadata(metadata: SDPStreamMetadataObject | undefined) {
+        if (!metadata) return;
+
+        this.setAudioVideoMuted(metadata.audio_muted ?? false, metadata.video_muted ?? false);
+        this._metadata = metadata;
+
+        if (!metadata.tracks) return;
+        for (const [metadataTrackId, metadataTrack] of Object.entries(metadata.tracks)) {
+            const track = this._tracks.find((track) => track.trackId === metadataTrackId);
+            if (track) {
+                track.metadata = metadataTrack;
+                continue;
+            }
+
+            logger.info(
+                `RemoteCallFeed ${this.id} set metadata() adding track (streamId=${this.streamId} trackId=${metadataTrackId}, kind=${metadataTrack.kind})`,
+            );
+            this._tracks.push(
+                new RemoteCallTrack({
+                    call: this.call,
+                    trackId: metadataTrackId,
+                    metadata: metadataTrack,
+                }),
+            );
+        }
+
+        for (const track of this._tracks) {
+            if (!track.trackId) continue;
+            if (!Object.keys(metadata.tracks).includes(track.trackId)) {
+                logger.info(
+                    `RemoteCallFeed ${this.id} set metadata() removing track (streamId=${this.streamId} trackId=${track.trackId}, kind=${track.kind})`,
+                );
+                this._tracks.splice(this._tracks.indexOf(track), 1);
+                if (track.track) {
+                    this.stream?.removeTrack(track.track);
+                }
+            }
+        }
+    }
+
+    public get purpose(): SDPStreamMetadataPurpose {
+        // If the opponent did not send a purpose, they probably don't support
+        // sdp_stream_metadata, so we can assume they're only sending usermedia
+        return this._metadata?.purpose ?? SDPStreamMetadataPurpose.Usermedia;
+    }
+
+    public get userId(): string {
+        const metadataUserId = this._metadata?.user_id;
+        return this.call.isFocus && metadataUserId
+            ? metadataUserId
+            : (this.call.invitee ?? this.call.getOpponentMember()?.userId)!;
+    }
+
+    public get deviceId(): string | undefined {
+        return this.call.isFocus ? this._metadata?.device_id : this.call.getOpponentDeviceId();
+    }
+
+    public get tracks(): RemoteCallTrack[] {
+        return [...this._tracks];
+    }
+
+    public get connected(): boolean {
+        return this._connected;
+    }
+
+    private set connected(connected: boolean) {
+        this._connected = connected;
+        this.emit(CallFeedEvent.ConnectedChanged, this.connected);
+    }
+
+    private onCallState = (): void => {
+        this.updateConnected();
+    };
+
+    private updateConnected(): void {
+        if (this.call?.state === CallState.Connecting) {
+            this.connected = false;
+        } else if (!this.stream) {
+            this.connected = false;
+        } else if (this.stream.getTracks().length === 0) {
+            this.connected = false;
+        } else if (this.call?.state === CallState.Connected) {
+            this.connected = true;
+        }
+    }
+
+    private streamIdMatches(transceiver: RTCRtpTransceiver): boolean {
+        if (!transceiver.mid) return false;
+        if (this.streamId !== this.call.getRemoteStreamIdByMid(transceiver.mid)) return false;
+
+        return true;
+    }
+
+    public canAddTransceiver(transceiver: RTCRtpTransceiver): boolean {
+        if (!transceiver.mid) return false;
+
+        // If the opponent does not support sdp_stream_metadata at all, we
+        // always allow adding transceivers
+        if (!this._metadata) return true;
+        // If the opponent does not support tracks on sdp_stream_metadata, we
+        // just check the streamId
+        if (!this._metadata.tracks && this.streamIdMatches(transceiver)) return true;
+
+        if (!this._tracks.some((track) => track.canSetTransceiver(transceiver))) return false;
+        if (!this.streamIdMatches(transceiver)) return false;
+
+        return true;
+    }
+
+    public addTransceiver(transceiver: RTCRtpTransceiver): void {
+        if (!transceiver.mid) {
+            throw new Error("RemoteCallFeed addTransceiver() called with transceiver without an mid");
+        }
+        if (!transceiver.receiver?.track) {
+            throw new Error("RemoteCallFeed addTransceiver() called with transceiver without a receiver or track");
+        }
+        if (!this.canAddTransceiver(transceiver)) {
+            throw new Error("RemoteCallFeed addTransceiver() called with wrong trackId or streamId");
+        }
+
+        const track = this._tracks.find((t) => t.canSetTransceiver(transceiver));
+        const trackId = this.call.getRemoteTrackIdByMid(transceiver.mid);
+
+        const trackInfo = `streamId=${this.streamId}, trackId=${trackId}, kind=${transceiver.receiver.track.kind}`;
+        logger.log(`RemoteCallFeed ${this.id} addTransceiver() running (${trackInfo})`);
+
+        if (!track && !this._metadata?.tracks) {
+            // If the opponent does not support tracks on sdp_stream_metadata or
+            // it does not support sdp_stream_metadata at all, we simply create
+            // new tracks
+            logger.info(`RemoteCallFeed ${this.id} addTransceiver() adding track (${trackInfo})`);
+            const track = new RemoteCallTrack({
+                call: this.call,
+                trackId,
+            });
+            track.setTransceiver(transceiver);
+            this._tracks.push(track);
+        } else if (!track) {
+            logger.warn(`RemoteCallFeed ${this.id} addTransceiver() did not find track for transceiver (${trackInfo})`);
+            return;
+        } else {
+            track.setTransceiver(transceiver);
+        }
+
+        this.stream?.addTrack(transceiver.receiver.track);
+        this.updateConnected();
+        this.emit(CallFeedEvent.NewStream, this.stream);
+    }
+
+    public dispose(): void {
+        super.dispose();
+        this.call?.removeListener(CallEvent.State, this.onCallState);
+    }
+}

--- a/src/webrtc/remoteCallFeed.ts
+++ b/src/webrtc/remoteCallFeed.ts
@@ -138,6 +138,7 @@ export class RemoteCallFeed extends CallFeed {
     }
 
     private set connected(connected: boolean) {
+        if (this._connected === connected) return;
         this._connected = connected;
         this.emit(CallFeedEvent.ConnectedChanged, this.connected);
     }

--- a/src/webrtc/remoteCallFeed.ts
+++ b/src/webrtc/remoteCallFeed.ts
@@ -56,7 +56,7 @@ export class RemoteCallFeed extends CallFeed {
         this.call = opts.call;
         this.metadata = opts.metadata;
 
-        this._stream = opts.stream || new MediaStream();
+        this._stream = opts.stream || new window.MediaStream();
 
         if (opts.call) {
             opts.call.addListener(CallEvent.State, this.onCallState);

--- a/src/webrtc/remoteCallFeed.ts
+++ b/src/webrtc/remoteCallFeed.ts
@@ -64,7 +64,7 @@ export class RemoteCallFeed extends CallFeed {
         this.updateConnected();
     }
 
-    public get id(): string | undefined {
+    public get id(): string {
         return this.streamId;
     }
 

--- a/src/webrtc/remoteCallTrack.ts
+++ b/src/webrtc/remoteCallTrack.ts
@@ -26,19 +26,23 @@ export interface RemoteCallTrackOpts extends CallTrackOpts {
 }
 
 export class RemoteCallTrack extends CallTrack {
+    private readonly _trackId?: string;
     private _metadata?: SDPStreamMetadataTrack;
     private call: MatrixCall;
-    public readonly trackId?: string;
 
     public constructor(opts: RemoteCallTrackOpts) {
         super(opts);
 
         this.call = opts.call;
-        this.trackId = opts.trackId;
+        this._trackId = opts.trackId;
     }
 
     public get id(): string | undefined {
-        return this.trackId;
+        return this._trackId;
+    }
+
+    public get trackId(): string | undefined {
+        return this._trackId;
     }
 
     public get metadata(): SDPStreamMetadataTrack | undefined {
@@ -55,14 +59,14 @@ export class RemoteCallTrack extends CallTrack {
     }
 
     public get kind(): string | undefined {
-        return super.kind ?? this._metadata?.kind;
+        return this.track?.kind ?? this._metadata?.kind;
     }
 
     public canSetTransceiver(transceiver: RTCRtpTransceiver): boolean {
-        if (!this.trackId) return true;
+        if (!this._trackId) return true;
 
         if (!transceiver.mid) return false;
-        if (this.call.getRemoteTrackIdByMid(transceiver.mid) !== this.trackId) return false;
+        if (this.call.getRemoteTrackIdByMid(transceiver.mid) !== this._trackId) return false;
 
         return true;
     }

--- a/src/webrtc/remoteCallTrack.ts
+++ b/src/webrtc/remoteCallTrack.ts
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logger } from "../logger";
+import { MatrixCall } from "./call";
+import { SDPStreamMetadataTrack } from "./callEventTypes";
+import { CallTrack, CallTrackOpts } from "./callTrack";
+
+export interface RemoteCallTrackOpts extends CallTrackOpts {
+    call: MatrixCall;
+    trackId?: string;
+    metadata?: SDPStreamMetadataTrack;
+}
+
+export class RemoteCallTrack extends CallTrack {
+    private _metadata?: SDPStreamMetadataTrack;
+    private call: MatrixCall;
+    public readonly trackId?: string;
+
+    public constructor(opts: RemoteCallTrackOpts) {
+        super(opts);
+
+        this.call = opts.call;
+        this.trackId = opts.trackId;
+    }
+
+    public get id(): string | undefined {
+        return this.trackId;
+    }
+
+    public get metadata(): SDPStreamMetadataTrack | undefined {
+        return this._metadata;
+    }
+
+    public set metadata(metadata: SDPStreamMetadataTrack | undefined) {
+        if (!metadata) return;
+        this._metadata = metadata;
+    }
+
+    public get track(): MediaStreamTrack | undefined {
+        return this._transceiver?.receiver?.track;
+    }
+
+    public get kind(): string | undefined {
+        return super.kind ?? this._metadata?.kind;
+    }
+
+    public canSetTransceiver(transceiver: RTCRtpTransceiver): boolean {
+        if (!this.trackId) return true;
+
+        if (!transceiver.mid) return false;
+        if (this.call.getRemoteTrackIdByMid(transceiver.mid) !== this.trackId) return false;
+
+        return true;
+    }
+
+    public setTransceiver(transceiver: RTCRtpTransceiver): void {
+        if (!this.canSetTransceiver(transceiver)) {
+            throw new Error("Wrong track_id");
+        }
+        if (!transceiver.receiver.track) {
+            throw new Error("No receiver or track");
+        }
+        if (!transceiver.mid) {
+            throw new Error("No mid");
+        }
+
+        logger.log(
+            `RemoteCallTrack ${this.id} setTransceiver() running (${this.call.getRemoteTrackInfoByMid(
+                transceiver.mid,
+            )})`,
+        );
+
+        this._transceiver = transceiver;
+    }
+}


### PR DESCRIPTION
Todos:
- [ ] Fix tests
- [ ] Perform further tests
- [ ] Draw a diagram of the thing, somehow

Follow up work
- Move mute handling into `CallTrack`s
- Possibly abstract publishing into a  class
- Possibly abstract subscribing into a class
- Possibly abstract different `CallFeed` purposes into separate classes


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->