### PR TITLE
Allow disabling VoIP support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -342,6 +342,13 @@ export interface ICreateClientOpts {
     verificationMethods?: Array<VerificationMethod>;
 
     /**
+     * Set to false to disable the VoIP functionality of the client.
+     *
+     * Default true.
+     */
+    voipSupport?: boolean;
+
+    /**
      * Whether relaying calls through a TURN server should be forced. Default false.
      */
     forceTURN?: boolean;
@@ -1297,7 +1304,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             });
         }
 
-        if (supportsMatrixCall()) {
+        if (opts.voipSupport !== false && supportsMatrixCall()) {
             this.callEventHandler = new CallEventHandler(this);
             this.groupCallEventHandler = new GroupCallEventHandler(this);
             this.canSupportVoip = true;


### PR DESCRIPTION
Allow to manually disable VoIP support by passing a `{voipSupport: false}` option during matrix client initialization.

Signed-off-by: Stanislav Demydiuk <s.demydiuk@gmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->