### PR TITLE
Revert "decrypt poll relations before processing (#3148)"

### DIFF
--- a/spec/unit/models/poll.spec.ts
+++ b/spec/unit/models/poll.spec.ts
@@ -20,7 +20,6 @@ import { M_POLL_END, M_POLL_KIND_DISCLOSED, M_POLL_RESPONSE } from "../../../src
 import { PollStartEvent } from "../../../src/extensible_events_v1/PollStartEvent";
 import { Poll } from "../../../src/models/poll";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../test-utils/client";
-import { flushPromises } from "../../test-utils/flushPromises";
 
 jest.useFakeTimers();
 
@@ -28,7 +27,6 @@ describe("Poll", () => {
     const userId = "@alice:server.org";
     const mockClient = getMockClientWithEventEmitter({
         ...mockClientMethodsUser(userId),
-        decryptEventIfNeeded: jest.fn().mockResolvedValue(true),
         relations: jest.fn(),
     });
     const roomId = "!room:server";
@@ -173,8 +171,6 @@ describe("Poll", () => {
                 const poll = new Poll(basePollStartEvent, mockClient, room);
                 jest.spyOn(poll, "emit");
                 const responses = await poll.getResponses();
-
-                await flushPromises();
 
                 expect(mockClient.relations.mock.calls).toEqual([
                     [roomId, basePollStartEvent.getId(), "m.reference", undefined, { from: undefined }],

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -149,14 +149,11 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
             },
         );
 
-        await Promise.all(allRelations.events.map((event) => this.matrixClient.decryptEventIfNeeded(event)));
-
         const responses =
             this.responses ||
             new Relations("m.reference", M_POLL_RESPONSE.name, this.matrixClient, [M_POLL_RESPONSE.altName!]);
 
         const pollEndEvent = allRelations.events.find((event) => M_POLL_END.matches(event.getType()));
-
         if (this.validateEndEvent(pollEndEvent)) {
             this.endEvent = pollEndEvent;
             this.refilterResponsesOnEnd();


### PR DESCRIPTION
Type: Defect

This reverts commit cdd7dbbb2b12ba97e8d0a6368f7ca42be5131a62.
Fixes build failure of https://github.com/matrix-org/matrix-react-sdk/actions/runs/4183372993/jobs/7247645153 caused by tests not adapting to new, changed timing of poll relation decryption

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "decrypt poll relations before processing (#3148)" ([\#3158](https://github.com/matrix-org/matrix-js-sdk/pull/3158)). Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->