### PR TITLE
Polls: expose end event id on poll model

### DIFF
--- a/spec/unit/models/poll.spec.ts
+++ b/spec/unit/models/poll.spec.ts
@@ -76,6 +76,7 @@ describe("Poll", () => {
         expect(poll.pollId).toEqual(basePollStartEvent.getId());
         expect(poll.pollEvent).toEqual(basePollStartEvent.unstableExtensibleEvent);
         expect(poll.isEnded).toBe(false);
+        expect(poll.endEventId).toBe(undefined);
     });
 
     it("throws when poll start has no room id", () => {
@@ -208,6 +209,7 @@ describe("Poll", () => {
 
                 expect(maySendRedactionForEventSpy).toHaveBeenCalledWith(basePollStartEvent, "@bob@server.org");
                 expect(poll.isEnded).toBe(true);
+                expect(poll.endEventId).toBe(stablePollEndEvent.getId()!);
                 expect(poll.emit).toHaveBeenCalledWith(PollEvent.End);
             });
 

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -80,6 +80,10 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         return this.rootEvent.getId()!;
     }
 
+    public get endEventId(): string | undefined {
+        return this.endEvent?.getId();
+    }
+
     public get isEnded(): boolean {
         return !!this.endEvent;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Polls: expose end event id on poll model ([\#3160](https://github.com/matrix-org/matrix-js-sdk/pull/3160)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->