### PR TITLE
Polls: count undecryptable poll relations

### DIFF
--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -28,6 +28,7 @@ export enum PollEvent {
     Update = "Poll.update",
     Responses = "Poll.Responses",
     Destroy = "Poll.Destroy",
+    UndecryptableRelations = "Poll.UndecryptableRelations"
 }
 
 export type PollEventHandlerMap = {
@@ -35,6 +36,7 @@ export type PollEventHandlerMap = {
     [PollEvent.Destroy]: (pollIdentifier: string) => void;
     [PollEvent.End]: () => void;
     [PollEvent.Responses]: (responses: Relations) => void;
+    [PollEvent.UndecryptableRelations]: (count: number) => void;
 };
 
 const filterResponseRelations = (
@@ -45,7 +47,6 @@ const filterResponseRelations = (
 } => {
     const responseEvents = relationEvents.filter((event) => {
         if (event.isDecryptionFailure()) {
-            // @TODO(kerrya) PSG-1023 track and return these
             return;
         }
         return (
@@ -66,6 +67,11 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
     private relationsNextBatch: string | undefined;
     private responses: null | Relations = null;
     private endEvent: MatrixEvent | undefined;
+    /**
+     * Keep track of undecryptable relations
+     * As incomplete result sets affect poll results
+     */
+    private undecryptableRelationEventIds = new Set<string>();
 
     public constructor(public readonly rootEvent: MatrixEvent, private matrixClient: MatrixClient, private room: Room) {
         super();
@@ -80,12 +86,20 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         return this.rootEvent.getId()!;
     }
 
+    public get endEventId(): string | undefined {
+        return this.endEvent?.getId();
+    }
+
     public get isEnded(): boolean {
         return !!this.endEvent;
     }
 
     public get isFetchingResponses(): boolean {
         return this._isFetchingResponses;
+    }
+
+    public get undecryptableRelationsCount(): number {
+        return this.undecryptableRelationEventIds.size;
     }
 
     public async getResponses(): Promise<Relations> {
@@ -124,12 +138,17 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         const pollEndTimestamp = this.endEvent?.getTs() || Number.MAX_SAFE_INTEGER;
         const { responseEvents } = filterResponseRelations([event], pollEndTimestamp);
 
+        this.countUndecryptableEvents([event]);
+
         if (responseEvents.length) {
             responseEvents.forEach((event) => {
                 this.responses!.addEvent(event);
             });
+
+
             this.emit(PollEvent.Responses, this.responses);
         }
+
     }
 
     private async fetchResponses(): Promise<void> {
@@ -173,6 +192,7 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
 
         this.relationsNextBatch = allRelations.nextBatch ?? undefined;
         this.responses = responses;
+        this.countUndecryptableEvents(allRelations.events);
 
         // while there are more pages of relations
         // fetch them
@@ -207,6 +227,17 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         });
 
         this.emit(PollEvent.Responses, this.responses);
+    }
+
+    private countUndecryptableEvents = (events: MatrixEvent[]) => {
+        const undecryptableEventIds = events.filter(event => event.isDecryptionFailure()).map(event => event.getId()!);
+
+        const previousCount = this.undecryptableRelationsCount;
+        this.undecryptableRelationEventIds = new Set([...this.undecryptableRelationEventIds, ...undecryptableEventIds]);
+
+        if (this.undecryptableRelationsCount !== previousCount) {
+            this.emit(PollEvent.UndecryptableRelations, this.undecryptableRelationsCount);
+        }
     }
 
     private validateEndEvent(endEvent?: MatrixEvent): boolean {

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -28,7 +28,7 @@ export enum PollEvent {
     Update = "Poll.update",
     Responses = "Poll.Responses",
     Destroy = "Poll.Destroy",
-    UndecryptableRelations = "Poll.UndecryptableRelations"
+    UndecryptableRelations = "Poll.UndecryptableRelations",
 }
 
 export type PollEventHandlerMap = {
@@ -145,10 +145,8 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
                 this.responses!.addEvent(event);
             });
 
-
             this.emit(PollEvent.Responses, this.responses);
         }
-
     }
 
     private async fetchResponses(): Promise<void> {
@@ -229,8 +227,10 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         this.emit(PollEvent.Responses, this.responses);
     }
 
-    private countUndecryptableEvents = (events: MatrixEvent[]) => {
-        const undecryptableEventIds = events.filter(event => event.isDecryptionFailure()).map(event => event.getId()!);
+    private countUndecryptableEvents = (events: MatrixEvent[]): void => {
+        const undecryptableEventIds = events
+            .filter((event) => event.isDecryptionFailure())
+            .map((event) => event.getId()!);
 
         const previousCount = this.undecryptableRelationsCount;
         this.undecryptableRelationEventIds = new Set([...this.undecryptableRelationEventIds, ...undecryptableEventIds]);
@@ -238,7 +238,7 @@ export class Poll extends TypedEventEmitter<Exclude<PollEvent, PollEvent.New>, P
         if (this.undecryptableRelationsCount !== previousCount) {
             this.emit(PollEvent.UndecryptableRelations, this.undecryptableRelationsCount);
         }
-    }
+    };
 
     private validateEndEvent(endEvent?: MatrixEvent): boolean {
         if (!endEvent) {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Keep track of undecryptable poll relations to communicate to users that their vote count may be inaccurate:
<img width="626" alt="Screenshot 2023-02-17 at 11 38 23" src="https://user-images.githubusercontent.com/3055605/219503049-330409e4-ed18-4d2d-8753-89dc6168f694.png">


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Polls: count undecryptable poll relations ([\#3163](https://github.com/matrix-org/matrix-js-sdk/pull/3163)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->