### PR TITLE
Fix spec compliance issue around encrypted `m.relates_to`

### DIFF
--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { MatrixEvent, MatrixEventEvent } from "../../../src/models/event";
 import { emitPromise } from "../../test-utils/test-utils";
-import { Crypto } from "../../../src/crypto";
+import { Crypto, IEventDecryptionResult } from "../../../src/crypto";
 
 describe("MatrixEvent", () => {
     it("should create copies of itself", () => {
@@ -180,6 +180,40 @@ describe("MatrixEvent", () => {
             expect(eventAttemptDecryptionSpy).toHaveBeenCalledTimes(2);
             expect(crypto.decryptEvent).toHaveBeenCalledTimes(2);
             expect(encryptedEvent.getType()).toEqual("m.room.message");
+        });
+    });
+
+    describe("replyEventId", () => {
+        it("should ignore 'm.relates_to' from encrypted content even if cleartext lacks one", async () => {
+            const eventId = "test_encrypted_event";
+            const encryptedEvent = new MatrixEvent({
+                event_id: eventId,
+                type: "m.room.encrypted",
+                content: {
+                    ciphertext: "secrets",
+                },
+            });
+
+            const crypto = {
+                decryptEvent: jest.fn().mockImplementationOnce(() => {
+                    return Promise.resolve<IEventDecryptionResult>({
+                        clearEvent: {
+                            type: "m.room.message",
+                            content: {
+                                "m.relates_to": {
+                                    "m.in_reply_to": {
+                                        event_id: "!anotherEvent",
+                                    },
+                                },
+                            },
+                        },
+                    });
+                }),
+            } as unknown as Crypto;
+
+            await encryptedEvent.attemptDecryption(crypto);
+            expect(encryptedEvent.getType()).toEqual("m.room.message");
+            expect(encryptedEvent.replyEventId).toBeUndefined();
         });
     });
 });

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -576,13 +576,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
     }
 
     public get replyEventId(): string | undefined {
-        // We're prefer ev.getContent() over ev.getWireContent() to make sure
-        // we grab the latest edit with potentially new relations. But we also
-        // can't just rely on ev.getContent() by itself because historically we
-        // still show the reply from the original message even though the edit
-        // event does not include the relation reply.
-        const mRelatesTo = this.getContent()["m.relates_to"] || this.getWireContent()["m.relates_to"];
-        return mRelatesTo?.["m.in_reply_to"]?.event_id;
+        return this.getWireContent()["m.relates_to"]?.["m.in_reply_to"]?.event_id;
     }
 
     public get relationEventId(): string | undefined {


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/10248

![image](https://user-images.githubusercontent.com/2403652/221628457-9b9762e9-0a0b-4440-a420-956db58d232b.png)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix spec compliance issue around encrypted `m.relates_to` ([\#3178](https://github.com/matrix-org/matrix-js-sdk/pull/3178)).<!-- CHANGELOG_PREVIEW_END -->