### PR TITLE
Implement MSC3758: a push rule condition to match event properties exactly

### DIFF
--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -546,7 +546,7 @@ describe("NotificationService", function () {
                             actions: [PushRuleActionName.Notify],
                             conditions: [
                                 {
-                                    kind: ConditionKind.ExactEventMatchPrefix,
+                                    kind: ConditionKind.EventPropertyIs,
                                     key: "content.foo",
                                     value: value,
                                 },

--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -1,6 +1,6 @@
 import * as utils from "../test-utils/test-utils";
 import { IActionsObject, PushProcessor } from "../../src/pushprocessor";
-import { ConditionKind, EventType, IContent, MatrixClient, MatrixEvent } from "../../src";
+import { ConditionKind, EventType, IContent, MatrixClient, MatrixEvent, PushRuleActionName } from "../../src";
 
 describe("NotificationService", function () {
     const testUserId = "@ali:matrix.org";
@@ -502,6 +502,79 @@ describe("NotificationService", function () {
                     ),
                 );
             });
+        });
+    });
+
+    describe("Test exact event matching", () => {
+        it.each([
+            // Simple string matching.
+            { value: "bar", eventValue: "bar", expected: true },
+            // Matches are case-sensitive.
+            { value: "bar", eventValue: "BAR", expected: false },
+            // Matches must match the full string.
+            { value: "bar", eventValue: "barbar", expected: false },
+            // Values should not be type-coerced.
+            { value: "bar", eventValue: true, expected: false },
+            { value: "bar", eventValue: 1, expected: false },
+            { value: "bar", eventValue: false, expected: false },
+            // Boolean matching.
+            { value: true, eventValue: true, expected: true },
+            { value: false, eventValue: false, expected: true },
+            // Types should not be coerced.
+            { value: true, eventValue: "true", expected: false },
+            { value: true, eventValue: 1, expected: false },
+            { value: false, eventValue: null, expected: false },
+            // Null matching.
+            { value: null, eventValue: null, expected: true },
+            // Types should not be coerced
+            { value: null, eventValue: false, expected: false },
+            { value: null, eventValue: 0, expected: false },
+            { value: null, eventValue: "", expected: false },
+            { value: null, eventValue: undefined, expected: false },
+            // Compound values should never be matched.
+            { value: "bar", eventValue: ["bar"], expected: false },
+            { value: "bar", eventValue: { bar: true }, expected: false },
+            { value: true, eventValue: [true], expected: false },
+            { value: true, eventValue: { true: true }, expected: false },
+            { value: null, eventValue: [], expected: false },
+            { value: null, eventValue: {}, expected: false },
+        ])("test $value against $eventValue", ({ value, eventValue, expected }) => {
+            matrixClient.pushRules! = {
+                global: {
+                    override: [
+                        {
+                            actions: [PushRuleActionName.Notify],
+                            conditions: [
+                                {
+                                    kind: ConditionKind.ExactEventMatchPrefix,
+                                    key: "content.foo",
+                                    value: value,
+                                },
+                            ],
+                            default: true,
+                            enabled: true,
+                            rule_id: ".m.rule.test",
+                        },
+                    ],
+                },
+            };
+
+            testEvent = utils.mkEvent({
+                type: "m.room.message",
+                room: testRoomId,
+                user: "@alfred:localhost",
+                event: true,
+                content: {
+                    foo: eventValue,
+                },
+            });
+
+            const actions = pushProcessor.actionsForEvent(testEvent);
+            if (expected) {
+                expect(actions?.notify).toBeTruthy();
+            } else {
+                expect(actions?.notify).toBeFalsy();
+            }
         });
     });
 

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -62,6 +62,7 @@ export function isDmMemberCountCondition(condition: AnyMemberCountCondition): bo
 
 export enum ConditionKind {
     EventMatch = "event_match",
+    ExactEventMatchPrefix = "com.beeper.msc3758.exact_event_match",
     ContainsDisplayName = "contains_display_name",
     RoomMemberCount = "room_member_count",
     SenderNotificationPermission = "sender_notification_permission",
@@ -80,6 +81,11 @@ export interface IEventMatchCondition extends IPushRuleCondition<ConditionKind.E
     // Note that value property is an optimization for patterns which do not do
     // any globbing and when the key is not "content.body".
     value?: string;
+}
+
+export interface IExactEventMatchPrefixCondition extends IPushRuleCondition<ConditionKind.ExactEventMatchPrefix> {
+    key: string;
+    value: string | boolean | null | number;
 }
 
 export interface IContainsDisplayNameCondition extends IPushRuleCondition<ConditionKind.ContainsDisplayName> {
@@ -107,6 +113,7 @@ export interface ICallStartedPrefixCondition extends IPushRuleCondition<Conditio
 // IPushRuleCondition<Exclude<string, ConditionKind>> unfortunately does not resolve this at the time of writing.
 export type PushRuleCondition =
     | IEventMatchCondition
+    | IExactEventMatchPrefixCondition
     | IContainsDisplayNameCondition
     | IRoomMemberCountCondition
     | ISenderNotificationPermissionCondition

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -77,6 +77,8 @@ export interface IPushRuleCondition<N extends ConditionKind | string> {
 export interface IEventMatchCondition extends IPushRuleCondition<ConditionKind.EventMatch> {
     key: string;
     pattern?: string;
+    // Note that value property is an optimization for patterns which do not do
+    // any globbing and when the key is not "content.body".
     value?: string;
 }
 

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -62,7 +62,7 @@ export function isDmMemberCountCondition(condition: AnyMemberCountCondition): bo
 
 export enum ConditionKind {
     EventMatch = "event_match",
-    ExactEventMatchPrefix = "com.beeper.msc3758.exact_event_match",
+    EventPropertyIs = "event_property_is",
     ContainsDisplayName = "contains_display_name",
     RoomMemberCount = "room_member_count",
     SenderNotificationPermission = "sender_notification_permission",
@@ -83,7 +83,7 @@ export interface IEventMatchCondition extends IPushRuleCondition<ConditionKind.E
     value?: string;
 }
 
-export interface IExactEventMatchPrefixCondition extends IPushRuleCondition<ConditionKind.ExactEventMatchPrefix> {
+export interface IEventPropertyIsCondition extends IPushRuleCondition<ConditionKind.EventPropertyIs> {
     key: string;
     value: string | boolean | null | number;
 }
@@ -113,7 +113,7 @@ export interface ICallStartedPrefixCondition extends IPushRuleCondition<Conditio
 // IPushRuleCondition<Exclude<string, ConditionKind>> unfortunately does not resolve this at the time of writing.
 export type PushRuleCondition =
     | IEventMatchCondition
-    | IExactEventMatchPrefixCondition
+    | IEventPropertyIsCondition
     | IContainsDisplayNameCondition
     | IRoomMemberCountCondition
     | ISenderNotificationPermissionCondition

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -435,6 +435,13 @@ export class PushProcessor {
         return content.body.search(pat) > -1;
     }
 
+    /**
+     * Check whether the given event matches the push rule condition by fetching
+     * the property from the event and comparing against the condition's glob-based
+     * pattern.
+     * @param cond - The push rule condition to check for a match.
+     * @param ev - The event to check for a match.
+     */
     private eventFulfillsEventMatchCondition(cond: IEventMatchCondition, ev: MatrixEvent): boolean {
         if (!cond.key) {
             return false;
@@ -445,6 +452,9 @@ export class PushProcessor {
             return false;
         }
 
+        // XXX This does not match in a case-insensitive manner.
+        //
+        // See https://spec.matrix.org/v1.5/client-server-api/#conditions-1
         if (cond.value) {
             return cond.value === val;
         }

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -25,7 +25,7 @@ import {
     ICallStartedPrefixCondition,
     IContainsDisplayNameCondition,
     IEventMatchCondition,
-    IExactEventMatchPrefixCondition,
+    IEventPropertyIsCondition,
     IPushRule,
     IPushRules,
     IRoomMemberCountCondition,
@@ -338,8 +338,8 @@ export class PushProcessor {
         switch (cond.kind) {
             case ConditionKind.EventMatch:
                 return this.eventFulfillsEventMatchCondition(cond, ev);
-            case ConditionKind.ExactEventMatchPrefix:
-                return this.eventFulfillsExactEventMatchCondition(cond, ev);
+            case ConditionKind.EventPropertyIs:
+                return this.eventFulfillsEventPropertyIsCondition(cond, ev);
             case ConditionKind.ContainsDisplayName:
                 return this.eventFulfillsDisplayNameCondition(cond, ev);
             case ConditionKind.RoomMemberCount:
@@ -481,7 +481,7 @@ export class PushProcessor {
      * @param cond - The push rule condition to check for a match.
      * @param ev - The event to check for a match.
      */
-    private eventFulfillsExactEventMatchCondition(cond: IExactEventMatchPrefixCondition, ev: MatrixEvent): boolean {
+    private eventFulfillsEventPropertyIsCondition(cond: IEventPropertyIsCondition, ev: MatrixEvent): boolean {
         if (!cond.key || cond.value === undefined) {
             return false;
         }


### PR DESCRIPTION
This implements the **stable** version of [MSC3758](https://github.com/matrix-org/matrix-spec-proposals/pull/3758) -- a new push rule condition to match an event property exactly (instead of globbing).

MSC3758 is in the final comment period, but not yet merged. We must wait until it finishes FCP before merging.

~~This is currently based on #3134, I'll rebase once that is merged.~~

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement MSC3758: a push rule condition to match event properties exactly ([\#3179](https://github.com/matrix-org/matrix-js-sdk/pull/3179)).<!-- CHANGELOG_PREVIEW_END -->