### PR TITLE
Implement MSC3966: a push rule condition to check if an array contains a value

### DIFF
--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -621,7 +621,7 @@ describe("NotificationService", function () {
                             actions: [PushRuleActionName.Notify],
                             conditions: [
                                 {
-                                    kind: ConditionKind.EventPropertyContainsPrefix,
+                                    kind: ConditionKind.EventPropertyContains,
                                     key: "content.foo",
                                     value: value,
                                 },

--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -641,11 +641,7 @@ describe("NotificationService", function () {
             });
 
             const actions = pushProcessor.actionsForEvent(testEvent);
-            if (expected) {
-                expect(actions?.notify).toBeTruthy();
-            } else {
-                expect(actions?.notify).toBeFalsy();
-            }
+            expect(actions?.notify).toBe(expected ? true : undefined);
         });
     });
 

--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -580,6 +580,79 @@ describe("NotificationService", function () {
         });
     });
 
+    describe("Test event property contains", () => {
+        it.each([
+            // Simple string matching.
+            { value: "bar", eventValue: ["bar"], expected: true },
+            // Matches are case-sensitive.
+            { value: "bar", eventValue: ["BAR"], expected: false },
+            // Values should not be type-coerced.
+            { value: "bar", eventValue: [true], expected: false },
+            { value: "bar", eventValue: [1], expected: false },
+            { value: "bar", eventValue: [false], expected: false },
+            // Boolean matching.
+            { value: true, eventValue: [true], expected: true },
+            { value: false, eventValue: [false], expected: true },
+            // Types should not be coerced.
+            { value: true, eventValue: ["true"], expected: false },
+            { value: true, eventValue: [1], expected: false },
+            { value: false, eventValue: [null], expected: false },
+            // Null matching.
+            { value: null, eventValue: [null], expected: true },
+            // Types should not be coerced
+            { value: null, eventValue: [false], expected: false },
+            { value: null, eventValue: [0], expected: false },
+            { value: null, eventValue: [""], expected: false },
+            { value: null, eventValue: [undefined], expected: false },
+            // Non-array or empty values should never be matched.
+            { value: "bar", eventValue: "bar", expected: false },
+            { value: "bar", eventValue: { bar: true }, expected: false },
+            { value: true, eventValue: { true: true }, expected: false },
+            { value: true, eventValue: true, expected: false },
+            { value: null, eventValue: [], expected: false },
+            { value: null, eventValue: {}, expected: false },
+            { value: null, eventValue: null, expected: false },
+            { value: null, eventValue: undefined, expected: false },
+        ])("test $value against $eventValue", ({ value, eventValue, expected }) => {
+            matrixClient.pushRules! = {
+                global: {
+                    override: [
+                        {
+                            actions: [PushRuleActionName.Notify],
+                            conditions: [
+                                {
+                                    kind: ConditionKind.EventPropertyContainsPrefix,
+                                    key: "content.foo",
+                                    value: value,
+                                },
+                            ],
+                            default: true,
+                            enabled: true,
+                            rule_id: ".m.rule.test",
+                        },
+                    ],
+                },
+            };
+
+            testEvent = utils.mkEvent({
+                type: "m.room.message",
+                room: testRoomId,
+                user: "@alfred:localhost",
+                event: true,
+                content: {
+                    foo: eventValue,
+                },
+            });
+
+            const actions = pushProcessor.actionsForEvent(testEvent);
+            if (expected) {
+                expect(actions?.notify).toBeTruthy();
+            } else {
+                expect(actions?.notify).toBeFalsy();
+            }
+        });
+    });
+
     it.each([
         // The properly escaped key works.
         { key: "content.m\\.test.foo", pattern: "bar", expected: true },

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -63,7 +63,7 @@ export function isDmMemberCountCondition(condition: AnyMemberCountCondition): bo
 export enum ConditionKind {
     EventMatch = "event_match",
     EventPropertyIs = "event_property_is",
-    EventPropertyContainsPrefix = "org.matrix.msc3966.exact_event_property_contains",
+    EventPropertyContains = "event_property_contains",
     ContainsDisplayName = "contains_display_name",
     RoomMemberCount = "room_member_count",
     SenderNotificationPermission = "sender_notification_permission",
@@ -89,8 +89,7 @@ export interface IEventPropertyIsCondition extends IPushRuleCondition<ConditionK
     value: string | boolean | null | number;
 }
 
-export interface IEventPropertyContainsPrefixCondition
-    extends IPushRuleCondition<ConditionKind.EventPropertyContainsPrefix> {
+export interface IEventPropertyContainsCondition extends IPushRuleCondition<ConditionKind.EventPropertyContains> {
     key: string;
     value: string | boolean | null | number;
 }
@@ -121,7 +120,7 @@ export interface ICallStartedPrefixCondition extends IPushRuleCondition<Conditio
 export type PushRuleCondition =
     | IEventMatchCondition
     | IEventPropertyIsCondition
-    | IEventPropertyContainsPrefixCondition
+    | IEventPropertyContainsCondition
     | IContainsDisplayNameCondition
     | IRoomMemberCountCondition
     | ISenderNotificationPermissionCondition

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -63,6 +63,7 @@ export function isDmMemberCountCondition(condition: AnyMemberCountCondition): bo
 export enum ConditionKind {
     EventMatch = "event_match",
     EventPropertyIs = "event_property_is",
+    EventPropertyContainsPrefix = "org.matrix.msc3966.exact_event_property_contains",
     ContainsDisplayName = "contains_display_name",
     RoomMemberCount = "room_member_count",
     SenderNotificationPermission = "sender_notification_permission",
@@ -84,6 +85,12 @@ export interface IEventMatchCondition extends IPushRuleCondition<ConditionKind.E
 }
 
 export interface IEventPropertyIsCondition extends IPushRuleCondition<ConditionKind.EventPropertyIs> {
+    key: string;
+    value: string | boolean | null | number;
+}
+
+export interface IEventPropertyContainsPrefixCondition
+    extends IPushRuleCondition<ConditionKind.EventPropertyContainsPrefix> {
     key: string;
     value: string | boolean | null | number;
 }
@@ -114,6 +121,7 @@ export interface ICallStartedPrefixCondition extends IPushRuleCondition<Conditio
 export type PushRuleCondition =
     | IEventMatchCondition
     | IEventPropertyIsCondition
+    | IEventPropertyContainsPrefixCondition
     | IContainsDisplayNameCondition
     | IRoomMemberCountCondition
     | ISenderNotificationPermissionCondition

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -26,6 +26,7 @@ import {
     IContainsDisplayNameCondition,
     IEventMatchCondition,
     IEventPropertyIsCondition,
+    IEventPropertyContainsPrefixCondition,
     IPushRule,
     IPushRules,
     IRoomMemberCountCondition,
@@ -340,6 +341,8 @@ export class PushProcessor {
                 return this.eventFulfillsEventMatchCondition(cond, ev);
             case ConditionKind.EventPropertyIs:
                 return this.eventFulfillsEventPropertyIsCondition(cond, ev);
+            case ConditionKind.EventPropertyContainsPrefix:
+                return this.eventFulfillsEventPropertyContains(cond, ev);
             case ConditionKind.ContainsDisplayName:
                 return this.eventFulfillsDisplayNameCondition(cond, ev);
             case ConditionKind.RoomMemberCount:
@@ -486,6 +489,24 @@ export class PushProcessor {
             return false;
         }
         return cond.value === this.valueForDottedKey(cond.key, ev);
+    }
+
+    /**
+     * Check whether the given event matches the push rule condition by fetching
+     * the property from the event and comparing exactly against the condition's
+     * value.
+     * @param cond - The push rule condition to check for a match.
+     * @param ev - The event to check for a match.
+     */
+    private eventFulfillsEventPropertyContains(cond: IEventPropertyContainsPrefixCondition, ev: MatrixEvent): boolean {
+        if (!cond.key || cond.value === undefined) {
+            return false;
+        }
+        const val = this.valueForDottedKey(cond.key, ev);
+        if (!Array.isArray(val)) {
+            return false;
+        }
+        return val.includes(cond.value);
     }
 
     private eventFulfillsCallStartedCondition(

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -26,7 +26,7 @@ import {
     IContainsDisplayNameCondition,
     IEventMatchCondition,
     IEventPropertyIsCondition,
-    IEventPropertyContainsPrefixCondition,
+    IEventPropertyContainsCondition,
     IPushRule,
     IPushRules,
     IRoomMemberCountCondition,
@@ -341,7 +341,7 @@ export class PushProcessor {
                 return this.eventFulfillsEventMatchCondition(cond, ev);
             case ConditionKind.EventPropertyIs:
                 return this.eventFulfillsEventPropertyIsCondition(cond, ev);
-            case ConditionKind.EventPropertyContainsPrefix:
+            case ConditionKind.EventPropertyContains:
                 return this.eventFulfillsEventPropertyContains(cond, ev);
             case ConditionKind.ContainsDisplayName:
                 return this.eventFulfillsDisplayNameCondition(cond, ev);
@@ -498,7 +498,7 @@ export class PushProcessor {
      * @param cond - The push rule condition to check for a match.
      * @param ev - The event to check for a match.
      */
-    private eventFulfillsEventPropertyContains(cond: IEventPropertyContainsPrefixCondition, ev: MatrixEvent): boolean {
+    private eventFulfillsEventPropertyContains(cond: IEventPropertyContainsCondition, ev: MatrixEvent): boolean {
         if (!cond.key || cond.value === undefined) {
             return false;
         }


### PR DESCRIPTION
Implements the **stable** version of [MSC3966](https://github.com/matrix-org/matrix-spec-proposals/pull/3966) which adds a push rule condition to check for a value in an array.

MSC3966 is in the final comment period, but not yet merged. We must wait until it finishes FCP before merging.

~~This is currently based on matrix-org/matrix-js-sdk#3179, I'll rebase once that is merged.~~

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Implement MSC3966: a push rule condition to check if an array contains a value ([\#3180](https://github.com/matrix-org/matrix-js-sdk/pull/3180)).<!-- CHANGELOG_PREVIEW_END -->