### PR TITLE
Room call push rule should be an underride, not an override.

### DIFF
--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -180,11 +180,11 @@ describe("NotificationService", function () {
                         enabled: true,
                         rule_id: ".m.rule.room_one_to_one",
                     },
-                    msc3914RoomCallRule,
                 ],
                 room: [],
                 sender: [],
                 underride: [
+                    msc3914RoomCallRule,
                     {
                         actions: ["dont-notify"],
                         conditions: [
@@ -569,7 +569,7 @@ describe("NotificationService", function () {
 
         it("returns push rule when it is found in rule set", () => {
             expect(pushProcessor.getPushRuleAndKindById(".org.matrix.msc3914.rule.room.call")).toEqual({
-                kind: "override",
+                kind: "underride",
                 rule: msc3914RoomCallRule,
             });
         });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

#3181 added some tests which broke when #3179 merged in `develop`; I'm not really sure *why* that broke things, but it seems to be something about overriding the `matrixClient.pushRules`.

Anyway, consistently using this push rule as an underride rule, which is how it is already defined (and how [MSC3914](https://github.com/matrix-org/matrix-spec-proposals/pull/3914) defines it) fixes it:

https://github.com/matrix-org/matrix-js-sdk/blob/933a0c9909d691ae0f9fafa03377dbcaa38a6024/src/pushprocessor.ts#L92-L110

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->