### PR TITLE
Fix: braking changes with GroupCall and ensure backwards-compatibility

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -109,7 +109,7 @@ const mockGetStateEvents = (type: EventType, userId?: string): MatrixEvent[] | M
 const ONE_HOUR = 1000 * 60 * 60;
 
 const createAndEnterGroupCall = async (cli: MatrixClient, room: Room): Promise<GroupCall> => {
-    const groupCall = new GroupCall(cli, room, GroupCallType.Video, false, GroupCallIntent.Prompt, false, FAKE_CONF_ID);
+    const groupCall = new GroupCall(cli, room, GroupCallType.Video, false, GroupCallIntent.Prompt, FAKE_CONF_ID);
 
     await groupCall.create();
     await groupCall.enter();
@@ -135,7 +135,7 @@ describe("Group Call", function () {
             mockClient = typedMockClient as unknown as MatrixClient;
 
             room = new Room(FAKE_ROOM_ID, mockClient, FAKE_USER_ID_1);
-            groupCall = new GroupCall(mockClient, room, GroupCallType.Video, false, GroupCallIntent.Prompt, false);
+            groupCall = new GroupCall(mockClient, room, GroupCallType.Video, false, GroupCallIntent.Prompt);
             room.currentState.members[FAKE_USER_ID_1] = {
                 userId: FAKE_USER_ID_1,
                 membership: "join",
@@ -484,7 +484,7 @@ describe("Group Call", function () {
         describe("PTT calls", () => {
             beforeEach(async () => {
                 // replace groupcall with a PTT one
-                groupCall = new GroupCall(mockClient, room, GroupCallType.Video, true, GroupCallIntent.Prompt, false);
+                groupCall = new GroupCall(mockClient, room, GroupCallType.Video, true, GroupCallIntent.Prompt);
 
                 await groupCall.create();
 
@@ -647,7 +647,6 @@ describe("Group Call", function () {
                 GroupCallType.Video,
                 false,
                 GroupCallIntent.Prompt,
-                false,
                 FAKE_CONF_ID,
             );
 
@@ -657,7 +656,6 @@ describe("Group Call", function () {
                 GroupCallType.Video,
                 false,
                 GroupCallIntent.Prompt,
-                false,
                 FAKE_CONF_ID,
             );
         });
@@ -1483,7 +1481,6 @@ describe("Group Call", function () {
                 GroupCallType.Video,
                 false,
                 GroupCallIntent.Prompt,
-                false,
                 FAKE_CONF_ID,
             );
             await groupCall.create();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1897,10 +1897,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             type,
             isPtt,
             intent,
-            this.isVoipWithNoMediaAllowed,
             undefined,
             dataChannelsEnabled || this.isVoipWithNoMediaAllowed,
             dataChannelOptions,
+            this.isVoipWithNoMediaAllowed,
         ).create();
     }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -196,6 +196,7 @@ export class GroupCall extends TypedEventEmitter<
     public readonly userMediaFeeds: CallFeed[] = [];
     public readonly screenshareFeeds: CallFeed[] = [];
     public groupCallId: string;
+    public readonly allowCallWithoutVideoAndAudio: boolean;
 
     private readonly calls = new Map<string, Map<string, MatrixCall>>(); // user_id -> device_id -> MatrixCall
     private callHandlers = new Map<string, Map<string, ICallHandlers>>(); // user_id -> device_id -> ICallHandlers
@@ -216,10 +217,10 @@ export class GroupCall extends TypedEventEmitter<
         public type: GroupCallType,
         public isPtt: boolean,
         public intent: GroupCallIntent,
-        public readonly allowCallWithoutVideoAndAudio: boolean,
         groupCallId?: string,
         private dataChannelsEnabled?: boolean,
         private dataChannelOptions?: IGroupCallDataChannelOptions,
+        isCallWithoutVideoAndAudio?: boolean,
     ) {
         super();
         this.reEmitter = new ReEmitter(this);
@@ -232,6 +233,7 @@ export class GroupCall extends TypedEventEmitter<
         this.on(GroupCallEvent.ParticipantsChanged, this.onParticipantsChanged);
         this.on(GroupCallEvent.GroupCallStateChanged, this.onStateChanged);
         this.on(GroupCallEvent.LocalScreenshareStateChanged, this.onLocalFeedsChanged);
+        this.allowCallWithoutVideoAndAudio = !!isCallWithoutVideoAndAudio;
     }
 
     public async create(): Promise<GroupCall> {

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -183,12 +183,12 @@ export class GroupCallEventHandler {
             callType,
             isPtt,
             callIntent,
-            this.client.isVoipWithNoMediaAllowed,
             groupCallId,
             // Because without Media section a WebRTC connection is not possible, so need a RTCDataChannel to set up a
             // no media WebRTC connection anyway.
             content?.dataChannelsEnabled || this.client.isVoipWithNoMediaAllowed,
             dataChannelOptions,
+            this.client.isVoipWithNoMediaAllowed,
         );
 
         this.groupCalls.set(room.roomId, groupCall);


### PR DESCRIPTION
- ensure group call backwards-compatibility and move `allowCallWithoutVideoAndAudio`to the end of the `CroupCall` constructor

- The changes in PR https://github.com/matrix-org/matrix-js-sdk/pull/3162#event-8651860750 brakes with the `matrix-react-sdk` because of using GroupCall there: https://github.com/matrix-org/matrix-react-sdk/blob/2d2b40ddac5fa1adb12b34eea436e0b70e8a9857/src/models/Call.ts#L723
- The changes in PR `3162` leads to breaking dependencies: https://github.com/matrix-org/matrix-react-sdk/actions/runs/4316690112/jobs/7532790787

This PR is a fix for it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->