### PR TITLE
Pin versions of third-party github actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
               )
             )
         steps:
-            - uses: tibdex/backport@v2
+            - uses: tibdex/backport@2e217641d82d02ba0603f46b1aeedefb258890ac # v2
               with:
                   labels_template: "<%= JSON.stringify([...labels, 'X-Release-Blocker']) %>"
                   # We can't use GITHUB_TOKEN here or CI won't run on the new PR

--- a/.github/workflows/docs-pr-netlify.yaml
+++ b/.github/workflows/docs-pr-netlify.yaml
@@ -14,7 +14,7 @@ jobs:
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
-              uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2.26.0
+              uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   workflow: static_analysis.yml
                   run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/notify-downstream.yaml
+++ b/.github/workflows/notify-downstream.yaml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Notify matrix-react-sdk repo that a new SDK build is on develop so it can CI against it
-              uses: peter-evans/repository-dispatch@v2
+              uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # v2
               with:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
                   repository: ${{ matrix.repo }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.event.action == 'opened'
         steps:
             - name: Check membership
-              uses: tspascoal/get-user-teams-membership@v2
+              uses: tspascoal/get-user-teams-membership@37c08f7b52a72ca95d12af2e7ab2553ca9adf13b # v2
               id: teams
               with:
                   username: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: 🚀 Publish to npm
               id: npm-publish
-              uses: JS-DevTools/npm-publish@v1
+              uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939 # v1
               with:
                   token: ${{ secrets.NPM_TOKEN }}
                   access: public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
                   fi
 
             - name: 🚀 Deploy
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # v3
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   keep_files: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
         steps:
             # We create the status here and then update it to success/failure in the `report` stage
             # This provides an easy link to this workflow_run from the PR before Cypress is done.
-            - uses: Sibz/github-status-action@v1
+            - uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
                   state: pending
@@ -42,7 +42,7 @@ jobs:
                   coverage_extract_path: coverage
                   extra_args: ${{ inputs.extra_args }}
 
-            - uses: Sibz/github-status-action@v1
+            - uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               if: always()
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -19,7 +19,7 @@ jobs:
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
-              uses: dawidd6/action-download-artifact@v2
+              uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   workflow: tests.yaml
                   run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Get number of CPU cores
               id: cpu-cores
-              uses: SimenB/github-actions-cpu-cores@v1
+              uses: SimenB/github-actions-cpu-cores@410541432439795d30db6501fb1d8178eb41e502 # v1
 
             - name: Load metrics reporter
               id: metrics

--- a/.github/workflows/upgrade_dependencies.yml
+++ b/.github/workflows/upgrade_dependencies.yml
@@ -20,7 +20,7 @@ jobs:
 
             - name: Create Pull Request
               id: cpr
-              uses: peter-evans/create-pull-request@v4
+              uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4
               with:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
                   branch: actions/upgrade-deps
@@ -31,7 +31,7 @@ jobs:
                       T-Task
 
             - name: Enable automerge
-              uses: peter-evans/enable-pull-request-automerge@v2
+              uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2
               if: steps.cpr.outputs.pull-request-operation == 'created'
               with:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
Type: Task
Related: https://github.com/matrix-org/matrix-js-sdk/pull/3208
Related: https://github.com/matrix-org/matrix-react-sdk/pull/10351
Related: https://github.com/vector-im/element-web/pull/24786

Previously, we used tags to version third-party actions. t3chguy suggested we should pin them to specific commit hashes by default.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->