### PR TITLE
Change `Store.save()` to return a `Promise`

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -175,7 +175,7 @@ export interface IStore {
     /**
      * Save does nothing as there is no backing data store.
      */
-    save(force?: boolean): void;
+    save(force?: boolean): Promise<void>;
 
     /**
      * Startup does nothing.

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -329,7 +329,9 @@ export class MemoryStore implements IStore {
      * @param force - True to force a save (but the memory
      *     store still can't save anything)
      */
-    public save(force: boolean): void {}
+    public save(force: boolean): Promise<void> {
+        return Promise.resolve();
+    }
 
     /**
      * Startup does nothing as this store doesn't require starting up.

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -189,7 +189,9 @@ export class StubStore implements IStore {
     /**
      * Save does nothing as there is no backing data store.
      */
-    public save(): void {}
+    public save(): Promise<void> {
+        return Promise.resolve();
+    }
 
     /**
      * Startup does nothing.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -953,7 +953,7 @@ export class SyncApi {
                 }
 
                 // tell databases that everything is now in a consistent state and can be saved.
-                this.client.store.save();
+                await this.client.store.save();
             }
         }
 


### PR DESCRIPTION
The only implementation of this is an async function, but I can’t await it because the interface hides the return type.

signed-off-by austin ellis <austin@hntlabs.com>

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Change `Store.save()` to return a `Promise` ([\#3221](https://github.com/matrix-org/matrix-js-sdk/pull/3221)). Contributed by @texuf.<!-- CHANGELOG_PREVIEW_END -->