### PR TITLE
indexddb-local-backend - return the current sync to database promise …

### DIFF
--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -130,7 +130,7 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     private db?: IDBDatabase;
     private disconnected = true;
     private _isNewlyCreated = false;
-    private isPersisting = false;
+    private syncToDatabasePromise?: Promise<void>;
     private pendingUserPresenceData: UserTuple[] = [];
 
     /**
@@ -396,26 +396,34 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         });
     }
 
+    /**
+     * Sync users and all accumulated sync data to the database.
+     * If a previous sync is in flight, the new data will be added to the
+     * next sync and the current sync's promise will be returned.
+     * @param userTuples - The user tuples
+     * @returns Promise which resolves if the data was persisted.
+     */
     public async syncToDatabase(userTuples: UserTuple[]): Promise<void> {
-        if (this.isPersisting) {
+        if (this.syncToDatabasePromise) {
             logger.warn("Skipping syncToDatabase() as persist already in flight");
             this.pendingUserPresenceData.push(...userTuples);
-            return;
-        } else {
-            userTuples.unshift(...this.pendingUserPresenceData);
-            this.isPersisting = true;
+            return this.syncToDatabasePromise;
         }
+        userTuples.unshift(...this.pendingUserPresenceData);
+        this.syncToDatabasePromise = this.doSyncToDatabase(userTuples);
+        return this.syncToDatabasePromise;
+    }
 
+    private async doSyncToDatabase(userTuples: UserTuple[]): Promise<void> {
         try {
             const syncData = this.syncAccumulator.getJSON(true);
-
             await Promise.all([
                 this.persistUserPresenceEvents(userTuples),
                 this.persistAccountData(syncData.accountData),
                 this.persistSyncData(syncData.nextBatch, syncData.roomsData),
             ]);
         } finally {
-            this.isPersisting = false;
+            this.syncToDatabasePromise = undefined;
         }
     }
 


### PR DESCRIPTION
…if a sync is in flight

I’m trying to shutdown my matrix clients while using an indexdb, but awaiting the save() function has no effect because a previous sync was in flight. I ended up deleting the matrix client while the save was in flight and I saw a crash.

signed-off-by Austin Ellis <austin@hntlabs.com>

Type: defect

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * indexddb-local-backend - return the current sync to database promise … ([\#3222](https://github.com/matrix-org/matrix-js-sdk/pull/3222)). Contributed by @texuf.<!-- CHANGELOG_PREVIEW_END -->