### PR TITLE
Exporting live WebRTC metric as GroupCall Event from SDK #3220

### DIFF
--- a/spec/unit/webrtc/stats/statsCollector.spec.ts
+++ b/spec/unit/webrtc/stats/statsCollector.spec.ts
@@ -54,5 +54,15 @@ describe("StatsCollector", () => {
             expect(getStats).toHaveBeenCalled();
             expect(collector.getActive()).toBeFalsy();
         });
+
+        it("if active an RTCStatsReport not a promise the collector becomes inactive", async () => {
+            const getStats = jest.spyOn(rtcSpy, "getStats");
+            // @ts-ignore
+            getStats.mockReturnValue({});
+            const actual = await collector.processStats("GROUP_CALL_ID", "LOCAL_USER_ID");
+            expect(actual).toBeFalsy();
+            expect(getStats).toHaveBeenCalled();
+            expect(collector.getActive()).toBeFalsy();
+        });
     });
 });

--- a/spec/unit/webrtc/stats/statsReportEmitter.spec.ts
+++ b/spec/unit/webrtc/stats/statsReportEmitter.spec.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { StatsReportEmitter } from "../../../../src/webrtc/stats/statsReportEmitter";
-import { ByteSendStatsReport, ConnectionStatsReport, StatsReport } from "../../../../src/webrtc/stats/statsReport";
+import { ByteSentStatsReport, ConnectionStatsReport, StatsReport } from "../../../../src/webrtc/stats/statsReport";
 
 describe("StatsReportEmitter", () => {
     let emitter: StatsReportEmitter;
@@ -23,7 +23,7 @@ describe("StatsReportEmitter", () => {
     });
 
     it("should emit and receive ByteSendStatsReport", async () => {
-        const report = {} as ByteSendStatsReport;
+        const report = {} as ByteSentStatsReport;
         return new Promise((resolve, _) => {
             emitter.on(StatsReport.BYTE_SENT_STATS, (r) => {
                 expect(r).toBe(report);

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -3118,6 +3118,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
     public initStats(stats: GroupCallStats, peerId = "unknown"): void {
         this.stats = stats;
+        this.stats.start();
     }
 }
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -310,6 +310,15 @@ function isFirefox(): boolean {
     return navigator.userAgent.indexOf("Firefox") !== -1;
 }
 
+export interface VoipEvent {
+    type: "toDevice" | "sendEvent";
+    eventType: string;
+    userId?: string;
+    opponentDeviceId?: string;
+    roomId?: string;
+    content: Record<string, unknown>;
+}
+
 export type CallEventHandlerMap = {
     [CallEvent.DataChannel]: (channel: RTCDataChannel) => void;
     [CallEvent.FeedsChanged]: (feeds: CallFeed[]) => void;
@@ -323,7 +332,7 @@ export type CallEventHandlerMap = {
     [CallEvent.AssertedIdentityChanged]: () => void;
     /* @deprecated */
     [CallEvent.HoldUnhold]: (onHold: boolean) => void;
-    [CallEvent.SendVoipEvent]: (event: Record<string, any>) => void;
+    [CallEvent.SendVoipEvent]: (event: VoipEvent) => void;
 };
 
 export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap> {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -26,7 +26,7 @@ import { IScreensharingOpts } from "./mediaHandler";
 import { mapsEqual } from "../utils";
 import { LocalCallFeed } from "./localCallFeed";
 import { GroupCallStats } from "./stats/groupCallStats";
-import { ByteSendStatsReport, ConnectionStatsReport, StatsReport } from "./stats/statsReport";
+import { ByteSentStatsReport, ConnectionStatsReport, StatsReport } from "./stats/statsReport";
 
 export enum GroupCallIntent {
     Ring = "m.ring",
@@ -86,10 +86,24 @@ export type GroupCallEventHandlerMap = {
     [GroupCallEvent.Error]: (error: GroupCallError) => void;
 };
 
+export enum GroupCallStatsReportEvent {
+    ConnectionStats = "GroupCall.connection_stats",
+    ByteSentStats = "GroupCall.byte_sent_stats",
+}
+
+export type GroupCallStatsReportEventHandlerMap = {
+    [GroupCallStatsReportEvent.ConnectionStats]: (report: GroupCallStatsReport<ConnectionStatsReport>) => void;
+    [GroupCallStatsReportEvent.ByteSentStats]: (report: GroupCallStatsReport<ByteSentStatsReport>) => void;
+};
+
 export enum GroupCallErrorCode {
     NoUserMedia = "no_user_media",
     UnknownDevice = "unknown_device",
     PlaceCallFailed = "place_call_failed",
+}
+
+export interface GroupCallStatsReport<T extends ConnectionStatsReport | ByteSentStatsReport> {
+    report: T;
 }
 
 export class GroupCallError extends Error {
@@ -185,8 +199,8 @@ function getCallUserId(call: MatrixCall): string | null {
 }
 
 export class GroupCall extends TypedEventEmitter<
-    GroupCallEvent | CallEvent,
-    GroupCallEventHandlerMap & CallEventHandlerMap
+    GroupCallEvent | CallEvent | GroupCallStatsReportEvent,
+    GroupCallEventHandlerMap & CallEventHandlerMap & GroupCallStatsReportEventHandlerMap
 > {
     // Config
     public activeSpeakerInterval = 1000;
@@ -239,6 +253,7 @@ export class GroupCall extends TypedEventEmitter<
         this.on(GroupCallEvent.ParticipantsChanged, this.onParticipantsChanged);
         this.on(GroupCallEvent.GroupCallStateChanged, this.onStateChanged);
         this.on(GroupCallEvent.LocalScreenshareStateChanged, this.onLocalFeedsChanged);
+
         const userID = this.client.getUserId() || "unknown";
         this.stats = new GroupCallStats(this.groupCallId, userID);
         this.stats.reports.on(StatsReport.CONNECTION_STATS, this.onConnectionStats);

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -257,16 +257,18 @@ export class GroupCall extends TypedEventEmitter<
         const userID = this.client.getUserId() || "unknown";
         this.stats = new GroupCallStats(this.groupCallId, userID);
         this.stats.reports.on(StatsReport.CONNECTION_STATS, this.onConnectionStats);
-        this.stats.reports.on(StatsReport.BYTE_SENT_STATS, this.onByteSendStats);
+        this.stats.reports.on(StatsReport.BYTE_SENT_STATS, this.onByteSentStats);
     }
 
-    private onConnectionStats(_: ConnectionStatsReport): void {
-        // @TODO: Implement data argumentation and event broadcasting please
-    }
+    private onConnectionStats = (report: ConnectionStatsReport): void => {
+        // @TODO: Implement data argumentation
+        this.emit(GroupCallStatsReportEvent.ConnectionStats, { report });
+    };
 
-    private onByteSendStats(_: ByteSendStatsReport): void {
-        // @TODO: Implement data argumentation and event broadcasting please
-    }
+    private onByteSentStats = (report: ByteSentStatsReport): void => {
+        // @TODO: Implement data argumentation
+        this.emit(GroupCallStatsReportEvent.ByteSentStats, { report });
+    };
 
     public async create(): Promise<GroupCall> {
         this.creationTs = Date.now();

--- a/src/webrtc/stats/statsCollector.ts
+++ b/src/webrtc/stats/statsCollector.ts
@@ -70,6 +70,7 @@ export class StatsCollector {
                         return false;
                     });
             }
+            this.isActive = false;
             return Promise.resolve(false);
         }
         return Promise.resolve(false);

--- a/src/webrtc/stats/statsCollector.ts
+++ b/src/webrtc/stats/statsCollector.ts
@@ -51,7 +51,7 @@ export class StatsCollector {
         if (this.isActive) {
             const statsPromise = this.pc.getStats();
             if (typeof statsPromise?.then === "function") {
-                statsPromise
+                return statsPromise
                     .then((report) => {
                         // @ts-ignore
                         this.currentStatsReport = typeof report?.result === "function" ? report.result() : report;
@@ -71,7 +71,6 @@ export class StatsCollector {
                     });
             }
             this.isActive = false;
-            return Promise.resolve(false);
         }
         return Promise.resolve(false);
     }

--- a/src/webrtc/stats/statsCollector.ts
+++ b/src/webrtc/stats/statsCollector.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { ConnectionStats } from "./connectionStats";
 import { StatsReportEmitter } from "./statsReportEmitter";
-import { ByteSend, ByteSendStatsReport, TrackID } from "./statsReport";
+import { ByteSend, ByteSentStatsReport, TrackID } from "./statsReport";
 import { ConnectionStatsReporter } from "./connectionStatsReporter";
 import { TransportStatsReporter } from "./transportStatsReporter";
 import { MediaSsrcHandler } from "./media/mediaSsrcHandler";
@@ -74,7 +74,7 @@ export class StatsCollector {
     }
 
     private processStatsReport(groupCallId: string, localUserId: string): void {
-        const byteSentStats: ByteSendStatsReport = new Map<TrackID, ByteSend>();
+        const byteSentStats: ByteSentStatsReport = new Map<TrackID, ByteSend>();
 
         this.currentStatsReport?.forEach((now) => {
             const before = this.previousStatsReport ? this.previousStatsReport.get(now.id) : null;

--- a/src/webrtc/stats/statsCollector.ts
+++ b/src/webrtc/stats/statsCollector.ts
@@ -49,26 +49,28 @@ export class StatsCollector {
 
     public async processStats(groupCallId: string, localUserId: string): Promise<boolean> {
         if (this.isActive) {
-            return this.pc
-                .getStats()
-                .then((report) => {
-                    // @ts-ignore
-                    this.currentStatsReport = typeof report?.result === "function" ? report.result() : report;
-                    try {
-                        this.processStatsReport(groupCallId, localUserId);
-                    } catch (error) {
-                        this.isActive = false;
-                        return false;
-                        // logger.error('Processing of RTP stats failed:', error);
-                    }
+            const statsPromise = this.pc.getStats();
+            if (typeof statsPromise?.then === "function") {
+                statsPromise
+                    .then((report) => {
+                        // @ts-ignore
+                        this.currentStatsReport = typeof report?.result === "function" ? report.result() : report;
+                        try {
+                            this.processStatsReport(groupCallId, localUserId);
+                        } catch (error) {
+                            this.isActive = false;
+                            return false;
+                        }
 
-                    this.previousStatsReport = this.currentStatsReport;
-                    return true;
-                })
-                .catch((error) => {
-                    this.handleError(error);
-                    return false;
-                });
+                        this.previousStatsReport = this.currentStatsReport;
+                        return true;
+                    })
+                    .catch((error) => {
+                        this.handleError(error);
+                        return false;
+                    });
+            }
+            return Promise.resolve(false);
         }
         return Promise.resolve(false);
     }

--- a/src/webrtc/stats/statsReport.ts
+++ b/src/webrtc/stats/statsReport.ts
@@ -19,14 +19,14 @@ import { TransportStats } from "./transportStats";
 import { Resolution } from "./media/mediaTrackStats";
 
 export enum StatsReport {
-    CONNECTION_STATS = "connection_stats",
-    BYTE_SENT_STATS = "byte_sent_stats",
+    CONNECTION_STATS = "StatsReport.connection_stats",
+    BYTE_SENT_STATS = "StatsReport.byte_sent_stats",
 }
 
 export type TrackID = string;
 export type ByteSend = number;
 
-export interface ByteSendStatsReport extends Map<TrackID, ByteSend> {
+export interface ByteSentStatsReport extends Map<TrackID, ByteSend> {
     // is a map: `local trackID` => byte send
 }
 

--- a/src/webrtc/stats/statsReportEmitter.ts
+++ b/src/webrtc/stats/statsReportEmitter.ts
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 import { TypedEventEmitter } from "../../models/typed-event-emitter";
-import { ByteSendStatsReport, ConnectionStatsReport, StatsReport } from "./statsReport";
+import { ByteSentStatsReport, ConnectionStatsReport, StatsReport } from "./statsReport";
 
 export type StatsReportHandlerMap = {
-    [StatsReport.BYTE_SENT_STATS]: (report: ByteSendStatsReport) => void;
+    [StatsReport.BYTE_SENT_STATS]: (report: ByteSentStatsReport) => void;
     [StatsReport.CONNECTION_STATS]: (report: ConnectionStatsReport) => void;
 };
 
 export class StatsReportEmitter extends TypedEventEmitter<StatsReport, StatsReportHandlerMap> {
-    public emitByteSendReport(byteSentStats: ByteSendStatsReport): void {
+    public emitByteSendReport(byteSentStats: ByteSentStatsReport): void {
         this.emit(StatsReport.BYTE_SENT_STATS, byteSentStats);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Export WebRTC stats metrics as GroupCall Event.

This is a cleanup for: https://github.com/matrix-org/matrix-js-sdk/pull/3220

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->