### PR TITLE
Enable the `prepareToEncrypt` test for Element-R

### DIFF
--- a/spec/integ/crypto.spec.ts
+++ b/spec/integ/crypto.spec.ts
@@ -755,7 +755,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         expect(event.getContent().body).toEqual("42");
     });
 
-    oldBackendOnly("prepareToEncrypt", async () => {
+    it("prepareToEncrypt", async () => {
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();
         aliceClient.setGlobalErrorOnUnknownDevices(false);


### PR DESCRIPTION
This Just Works, so I don't know why I didn't enable the test sooner.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->