### PR TITLE
Stop doing O(n^2) work to find event's home

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2028,8 +2028,11 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             };
         }
 
-        const parentEventId = event.getAssociatedId()!;
-        const parentEvent = this.findEventById(parentEventId) ?? events?.find((e) => e.getId() === parentEventId);
+        const parentEventId = event.getAssociatedId();
+        let parentEvent;
+        if (parentEventId) {
+            parentEvent = this.findEventById(parentEventId) ?? events?.find((e) => e.getId() === parentEventId);
+        }
 
         // Treat relations and redactions as extensions of their parents so evaluate parentEvent instead
         if (parentEvent && (event.isRelation() || event.isRedaction())) {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2029,7 +2029,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         }
 
         const parentEventId = event.getAssociatedId();
-        let parentEvent;
+        let parentEvent: MatrixEvent | undefined;
         if (parentEventId) {
             parentEvent = this.findEventById(parentEventId) ?? events?.find((e) => e.getId() === parentEventId);
         }


### PR DESCRIPTION
In certain rooms (e.g. with many state changes hidden via user preferences), the events array presented to `eventShouldLiveIn` may contain 100s of events. As part of its various checks, `eventShouldLiveIn` would get an event's associated ID (reply / relation / redaction parent). It would then use `events.find` to search the entire (possibly large) `events` array to look for the parent. (This by itself seems sub-optimal and should probably change to use a map.)

For many events in a room, there is no associated ID. Unfortunately, `eventShouldLiveIn` did not check whether the associated ID actually exists before running off to search all of `events`, resulting in O(n^2) work.

This changes `eventShouldLiveIn` to first check that there is an associated ID before proceeding with its (slow) search. For some rooms, this change drastically improves performance from ~100% CPU usage to nearly idle.

## Profile before

![image](https://user-images.githubusercontent.com/279572/227318324-83c37731-9014-4d05-9512-406dc9d688d7.png)

## Profile after

![image](https://user-images.githubusercontent.com/279572/227318500-f5276e47-751c-4178-baea-5f99d02577a8.png)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Stop doing O(n^2) work to find event's home ([\#3227](https://github.com/matrix-org/matrix-js-sdk/pull/3227)). Contributed by @jryans.<!-- CHANGELOG_PREVIEW_END -->