### PR TITLE
Element-R: handle events which arrive before their keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.5",
+        "@matrix-org/matrix-sdk-crypto-js": "^0.1.0-alpha.6",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/integ/crypto.spec.ts
+++ b/spec/integ/crypto.spec.ts
@@ -624,7 +624,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         expect(decryptedEvent.getContent().body).toEqual("42");
     });
 
-    oldBackendOnly("Alice receives a megolm message before the session keys", async () => {
+    it("Alice receives a megolm message before the session keys", async () => {
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();
 

--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -375,17 +375,17 @@ export async function awaitDecryption(
     // already
     if (event.getClearContent() !== null) {
         if (waitOnDecryptionFailure && event.isDecryptionFailure()) {
-            logger.log(`${Date.now()} event ${event.getId()} got decryption error; waiting`);
+            logger.log(`${Date.now()}: event ${event.getId()} got decryption error; waiting`);
         } else {
             return event;
         }
     } else {
-        logger.log(`${Date.now()} event ${event.getId()} is not yet decrypted; waiting`);
+        logger.log(`${Date.now()}: event ${event.getId()} is not yet decrypted; waiting`);
     }
 
     return new Promise((resolve) => {
-        event.once(MatrixEventEvent.Decrypted, (ev) => {
-            logger.log(`${Date.now()} event ${event.getId()} now decrypted`);
+        event.once(MatrixEventEvent.Decrypted, (ev, err) => {
+            logger.log(`${Date.now()}: MatrixEventEvent.Decrypted for event ${event.getId()}: ${err ?? "success"}`);
             resolve(ev);
         });
     });

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -39,6 +39,9 @@ export async function initRustCrypto(
     // TODO: use the pickle key for the passphrase
     const olmMachine = await RustSdkCryptoJs.OlmMachine.initialize(u, d, RUST_SDK_STORE_PREFIX, "test pass");
     const rustCrypto = new RustCrypto(olmMachine, http, userId, deviceId);
+    await olmMachine.registerRoomKeyUpdatedCallback((sessions: RustSdkCryptoJs.RoomKeyInfo[]) =>
+        rustCrypto.onRoomKeysUpdated(sessions),
+    );
 
     logger.info("Completed rust crypto-sdk setup");
     return rustCrypto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,10 +1494,10 @@
   dependencies:
     lodash "^4.17.21"
 
-"@matrix-org/matrix-sdk-crypto-js@^0.1.0-alpha.5":
-  version "0.1.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.5.tgz#60ede2c43b9d808ba8cf46085a3b347b290d9658"
-  integrity sha512-2KjAgWNGfuGLNjJwsrs6gGX157vmcTfNrA4u249utgnMPbJl7QwuUqh1bGxQ0PpK06yvZjgPlkna0lTbuwtuQw==
+"@matrix-org/matrix-sdk-crypto-js@^0.1.0-alpha.6":
+  version "0.1.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.0-alpha.6.tgz#c0bdb9ab0d30179b8ef744d1b4010b0ad0ab9c3a"
+  integrity sha512-7hMffzw7KijxDyyH/eUyTfrLeCQHuyU3kaPOKGhcl3DZ3vx7bCncqjGMGTnxNPoP23I6gosvKSbO+3wYOT24Xg==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
Currently, any event which is received before the decryption keys will not be decrypted. We can fix this by retrying decryption after keys are received.

Fixes https://github.com/vector-im/element-web/issues/24489
~~Requires https://github.com/matrix-org/matrix-rust-sdk/pull/1704~~

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Element-R: handle events which arrive before their keys ([\#3230](https://github.com/matrix-org/matrix-js-sdk/pull/3230)). Fixes vector-im/element-web#24489.<!-- CHANGELOG_PREVIEW_END -->