### PR TITLE
Handle group call redaction

### DIFF
--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -585,6 +585,7 @@ export function makeMockGroupCallStateEvent(
         "m.type": GroupCallType.Video,
         "m.intent": GroupCallIntent.Prompt,
     },
+    redacted?: boolean,
 ): MatrixEvent {
     return {
         getType: jest.fn().mockReturnValue(EventType.GroupCallPrefix),
@@ -592,6 +593,7 @@ export function makeMockGroupCallStateEvent(
         getTs: jest.fn().mockReturnValue(0),
         getContent: jest.fn().mockReturnValue(content),
         getStateKey: jest.fn().mockReturnValue(groupCallId),
+        isRedacted: jest.fn().mockReturnValue(redacted ?? false),
     } as unknown as MatrixEvent;
 }
 

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -118,7 +118,7 @@ export class GroupCallEventHandler {
         for (const callEvent of sortedCallEvents) {
             const content = callEvent.getContent();
 
-            if (content["m.terminated"]) {
+            if (content["m.terminated"] || callEvent.isRedacted()) {
                 continue;
             }
 
@@ -210,10 +210,10 @@ export class GroupCallEventHandler {
 
             const currentGroupCall = this.groupCalls.get(state.roomId);
 
-            if (!currentGroupCall && !content["m.terminated"]) {
+            if (!currentGroupCall && !content["m.terminated"] && !event.isRedacted()) {
                 this.createGroupCallFromRoomStateEvent(event);
             } else if (currentGroupCall && currentGroupCall.groupCallId === groupCallId) {
-                if (content["m.terminated"]) {
+                if (content["m.terminated"] || event.isRedacted()) {
                     currentGroupCall.terminate(false);
                 } else if (content["m.type"] !== currentGroupCall.type) {
                     // TODO: Handle the callType changing when the room state changes


### PR DESCRIPTION
Redacted group call events should be interpreted as terminated calls.

Closes https://github.com/vector-im/voip-internal/issues/128

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Handle group call redaction ([\#3231](https://github.com/matrix-org/matrix-js-sdk/pull/3231)). Fixes vector-im/voip-internal#128.<!-- CHANGELOG_PREVIEW_END -->