### PR TITLE
Refactor the way group calls hang up

### DIFF
--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -504,6 +504,8 @@ export class MockMatrixCall extends TypedEventEmitter<CallEvent, CallEventHandle
     public callId = "1";
     public localUsermediaFeed = {
         setAudioVideoMuted: jest.fn<void, [boolean, boolean]>(),
+        isAudioMuted: jest.fn().mockReturnValue(false),
+        isVideoMuted: jest.fn().mockReturnValue(false),
         stream: new MockMediaStream("stream"),
     } as unknown as CallFeed;
     public remoteUsermediaFeed?: CallFeed;

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -144,6 +144,10 @@ describe("Group Call", function () {
             } as unknown as RoomMember;
         });
 
+        afterEach(() => {
+            groupCall.leave();
+        });
+
         it.each(Object.values(GroupCallState).filter((v) => v !== GroupCallState.LocalCallFeedUninitialized))(
             "throws when initializing local call feed in %s state",
             async (state: GroupCallState) => {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -495,6 +495,11 @@ export class GroupCall extends TypedEventEmitter<
             this.retryCallLoopInterval = undefined;
         }
 
+        if (this.participantsExpirationTimer !== null) {
+            clearTimeout(this.participantsExpirationTimer);
+            this.participantsExpirationTimer = null;
+        }
+
         if (this.state !== GroupCallState.Entered) {
             return;
         }

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -40,6 +40,8 @@ export enum GroupCallTerminationReason {
     CallEnded = "call_ended",
 }
 
+export type CallsByUserAndDevice = Map<string, Map<string, MatrixCall>>;
+
 /**
  * Because event names are just strings, they do need
  * to be unique over all event types of event emitter.
@@ -60,7 +62,7 @@ export enum GroupCallEvent {
 export type GroupCallEventHandlerMap = {
     [GroupCallEvent.GroupCallStateChanged]: (newState: GroupCallState, oldState: GroupCallState) => void;
     [GroupCallEvent.ActiveSpeakerChanged]: (activeSpeaker: CallFeed | undefined) => void;
-    [GroupCallEvent.CallsChanged]: (calls: Map<string, Map<string, MatrixCall>>) => void;
+    [GroupCallEvent.CallsChanged]: (calls: CallsByUserAndDevice) => void;
     [GroupCallEvent.UserMediaFeedsChanged]: (feeds: CallFeed[]) => void;
     [GroupCallEvent.ScreenshareFeedsChanged]: (feeds: CallFeed[]) => void;
     [GroupCallEvent.LocalScreenshareStateChanged]: (


### PR DESCRIPTION
We previously used disposeCall to terminate the call which meant that sometimes a call would never get a hangup event. This changes it so that we always end a call by calling hangup, then do the cleanup when the hangup event arrives, so the cleanup is the same whether we hang up or the other side does.

This means we have somewhere we can reliably end OpenTelemetry spans (we were seeing them sometimes close but other times not).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->