### PR TITLE
Fix twice time renegotiation handling if reuse a transceiver

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -814,10 +814,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                     // Matrix event.
                     const transceiver = this.transceivers.get(tKey)!;
 
-                    // this is what would allow us to use addTransceiver(), but it's not available
-                    // on Firefox yet. We call it anyway if we have it.
-                    if (transceiver.sender.setStreams) transceiver.sender.setStreams(callFeed.stream);
-
                     transceiver.sender.replaceTrack(track);
                     // set the direction to indicate we're going to start sending again
                     // (this will trigger the re-negotiation)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

If we use a new transceiver and attach a new track, then we should not swap the stream because that will trigger additional negotiation. Please check description: See: https://github.com/vector-im/element-call/issues/944

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
