### PR TITLE
Remove redundant "default" module in generated typedoc.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     },
     "include": ["./src/**/*.ts", "./spec/**/*.ts"],
     "typedocOptions": {
-        "entryPoints": ["src/index.ts"],
+        "entryPoints": ["src/matrix.ts"],
         "excludeExternals": true,
         "out": "_docs"
     }


### PR DESCRIPTION
For "reasons", `index.ts` exports everything twice: both directly, and as a "default" object. So, pointing `typedoc` at it means we get a rather redundant "default" module which is just re-exports of everything (see http://matrix-org.github.io/matrix-js-sdk/24.0.0/modules/default.html).

If we point it instead directly at `matrix.ts`, we get rid of the "default" module and everything else continues to work.


---

Some background on those "reasons". It seems to be so that you can do either:

```javascript
// import a specific identifier
import {createClient} from "matrix-js-sdk";  // ES module
var {createClient} = require("matrix-js-sdk"); // CommonJS equivalent
var client = createClient({/* ... */});
```

or:

```javascript
// import default object as 'sdk'
import sdk from "matrix-js-sdk";  // ES module
var sdk = require("matrix-js-sdk").default; // CommonJS equivalent, not that it is useful
var client = sdk.createClient({/* ... */});
```

I'm not *really* sure why that `default` property is useful. It's way more cumbersome to use in CommonJS, and in ES modules you can get much the same effect with `import * as sdk from "matrix-js-sdk"`.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->