### PR TITLE
Allow via_servers property in findPredecessor (update to MSC3946)

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3343,11 +3343,16 @@ describe("Room", function () {
             newRoomId: string,
             predecessorRoomId: string,
             tombstoneEventId: string | null = null,
+            viaServers: string[] = [],
         ): MatrixEvent {
             const content =
                 tombstoneEventId === null
-                    ? { predecessor_room_id: predecessorRoomId }
-                    : { predecessor_room_id: predecessorRoomId, last_known_event_id: tombstoneEventId };
+                    ? { predecessor_room_id: predecessorRoomId, via_servers: viaServers }
+                    : {
+                          predecessor_room_id: predecessorRoomId,
+                          last_known_event_id: tombstoneEventId,
+                          via_servers: viaServers,
+                      };
 
             return new MatrixEvent({
                 content,
@@ -3387,6 +3392,7 @@ describe("Room", function () {
             expect(room.findPredecessor(useMsc3946)).toEqual({
                 roomId: "otherreplacedroomid",
                 eventId: undefined, // m.predecessor did not include an event_id
+                viaServers: [],
             });
         });
 
@@ -3394,12 +3400,13 @@ describe("Room", function () {
             const room = new Room("roomid", client!, "@u:example.com");
             room.addLiveEvents([
                 roomCreateEvent("roomid", "replacedroomid"),
-                predecessorEvent("roomid", "otherreplacedroomid", "lstevtid"),
+                predecessorEvent("roomid", "otherreplacedroomid", "lstevtid", ["one.example.com", "two.example.com"]),
             ]);
             const useMsc3946 = true;
             expect(room.findPredecessor(useMsc3946)).toEqual({
                 roomId: "otherreplacedroomid",
                 eventId: "lstevtid",
+                viaServers: ["one.example.com", "two.example.com"],
             });
         });
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3057,13 +3057,21 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @param msc3946ProcessDynamicPredecessor - if true, look for an
      * m.room.predecessor state event and use it if found (MSC3946).
      * @returns null if this room has no predecessor. Otherwise, returns
-     * the roomId and last eventId of the predecessor room.
+     * the roomId, last eventId and viaServers of the predecessor room.
+     *
      * If msc3946ProcessDynamicPredecessor is true, use m.predecessor events
      * as well as m.room.create events to find predecessors.
+     *
      * Note: if an m.predecessor event is used, eventId may be undefined
      * since last_known_event_id is optional.
+     *
+     * Note: viaServers may be undefined, and will definitely be undefined if
+     * this predecessor comes from a RoomCreate event (rather than a
+     * RoomPredecessor, which has the optional via_servers property).
      */
-    public findPredecessor(msc3946ProcessDynamicPredecessor = false): { roomId: string; eventId?: string } | null {
+    public findPredecessor(
+        msc3946ProcessDynamicPredecessor = false,
+    ): { roomId: string; eventId?: string; viaServers?: string[] } | null {
         const currentState = this.getLiveTimeline().getState(EventTimeline.FORWARDS);
         if (!currentState) {
             return null;


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow via_servers property in findPredecessor (update to MSC3946) ([\#3240](https://github.com/matrix-org/matrix-js-sdk/pull/3240)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->