### PR TITLE
Move `SecretStorage`-related interfaces out to new module

### DIFF
--- a/spec/unit/crypto/secrets.spec.ts
+++ b/spec/unit/crypto/secrets.spec.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import "../../olm-loader";
 import * as olmlib from "../../../src/crypto/olmlib";
 import { IObject } from "../../../src/crypto/olmlib";
-import { SECRET_STORAGE_ALGORITHM_V1_AES } from "../../../src/crypto/SecretStorage";
 import { MatrixEvent } from "../../../src/models/event";
 import { TestClient } from "../../TestClient";
 import { makeTestClients } from "./verification/util";
@@ -28,7 +27,7 @@ import { ClientEvent, ICreateClientOpts, ICrossSigningKey, MatrixClient } from "
 import { DeviceInfo } from "../../../src/crypto/deviceinfo";
 import { ISignatures } from "../../../src/@types/signed";
 import { ICurve25519AuthData } from "../../../src/crypto/keybackup";
-import { SecretStorageKeyDescription } from "../../../src/secret-storage";
+import { SecretStorageKeyDescription, SECRET_STORAGE_ALGORITHM_V1_AES } from "../../../src/secret-storage";
 
 async function makeTestClient(
     userInfo: { userId: string; deviceId: string },

--- a/src/client.ts
+++ b/src/client.ts
@@ -101,7 +101,6 @@ import { IAuthData, IAuthDict } from "./interactive-auth";
 import { IMinimalEvent, IRoomEvent, IStateEvent } from "./sync-accumulator";
 import {
     CrossSigningKey,
-    IAddSecretStorageKeyOpts,
     ICreateSecretStorageOpts,
     IEncryptedEventInfo,
     IImportRoomKeysOpts,
@@ -207,7 +206,7 @@ import { CryptoBackend } from "./common-crypto/CryptoBackend";
 import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants";
 import { CryptoApi } from "./crypto-api";
 import { DeviceInfoMap } from "./crypto/DeviceList";
-import { SecretStorageKeyDescription } from "./secret-storage";
+import { AddSecretStorageKeyOpts, SecretStorageKeyDescription } from "./secret-storage";
 
 export type Store = IStore;
 
@@ -2861,7 +2860,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      */
     public addSecretStorageKey(
         algorithm: string,
-        opts: IAddSecretStorageKeyOpts,
+        opts: AddSecretStorageKeyOpts,
         keyName?: string,
     ): Promise<{ keyId: string; keyInfo: SecretStorageKeyDescription }> {
         if (!this.crypto) {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -30,8 +30,7 @@ import {
 } from "../client";
 import { IKeyBackupInfo } from "./keybackup";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { IAccountDataClient } from "./SecretStorage";
-import { SecretStorageKeyDescription } from "../secret-storage";
+import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage";
 
 interface ICrossSigningKeys {
     authUpload: IBootstrapCrossSigningOpts["authUploadDeviceSigningKeys"];
@@ -238,7 +237,7 @@ export class EncryptionSetupOperation {
  */
 class AccountDataClientAdapter
     extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap>
-    implements IAccountDataClient
+    implements AccountDataClient
 {
     //
     public readonly values = new Map<string, MatrixEvent>();

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { v4 as uuidv4 } from "uuid";
 
-import { SecretStorageKeyTuple, SecretStorageKeyObject } from "../secret-storage";
 import { logger } from "../logger";
 import * as olmlib from "./olmlib";
 import { randomString } from "../randomstring";
@@ -24,11 +23,16 @@ import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./
 import { ICryptoCallbacks, IEncryptedContent } from ".";
 import { MatrixEvent } from "../models/event";
 import { ClientEvent, ClientEventHandlerMap, MatrixClient } from "../client";
-import { IAddSecretStorageKeyOpts } from "./api";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 import { defer, IDeferred } from "../utils";
 import { ToDeviceMessageId } from "../@types/event";
-import { SecretStorageKeyDescription, SecretStorageKeyDescriptionAesV1 } from "../secret-storage";
+import {
+    SecretStorageKeyDescription,
+    SecretStorageKeyDescriptionAesV1,
+    SecretStorageKeyTuple,
+    SecretStorageKeyObject,
+    AddSecretStorageKeyOpts,
+} from "../secret-storage";
 
 /* re-exports for backwards compatibility */
 export { SecretStorageKeyTuple, SecretStorageKeyObject } from "../secret-storage";
@@ -124,7 +128,7 @@ export class SecretStorage<B extends MatrixClient | undefined = MatrixClient> {
      */
     public async addKey(
         algorithm: string,
-        opts: IAddSecretStorageKeyOpts = {},
+        opts: AddSecretStorageKeyOpts = {},
         keyId?: string,
     ): Promise<SecretStorageKeyObject> {
         if (algorithm !== SECRET_STORAGE_ALGORITHM_V1_AES) {

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -21,7 +21,7 @@ import * as olmlib from "./olmlib";
 import { randomString } from "../randomstring";
 import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes";
 import { ICryptoCallbacks, IEncryptedContent } from ".";
-import { IContent, MatrixEvent } from "../models/event";
+import { MatrixEvent } from "../models/event";
 import { ClientEvent, ClientEventHandlerMap, MatrixClient } from "../client";
 import { IAddSecretStorageKeyOpts } from "./api";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
@@ -44,7 +44,6 @@ export interface ISecretRequest {
 export interface IAccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap> {
     // Subset of MatrixClient (which also uses any for the event content)
     getAccountDataFromServer: <T extends { [k: string]: any }>(eventType: string) => Promise<T>;
-    getAccountData: (eventType: string) => IContent | null;
     setAccountData: (eventType: string, content: any) => Promise<{}>;
 }
 

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -31,7 +31,7 @@ import {
     SecretStorageKeyTuple,
     SecretStorageKeyObject,
     AddSecretStorageKeyOpts,
-    AccountDataClient as IAccountDataClient,
+    AccountDataClient,
 } from "../secret-storage";
 
 /* re-exports for backwards compatibility */
@@ -81,7 +81,7 @@ export class SecretStorage<B extends MatrixClient | undefined = MatrixClient> {
     // A better solution would probably be to split this class up into secret storage and
     // secret sharing which are really two separate things, even though they share an MSC.
     public constructor(
-        private readonly accountDataAdapter: IAccountDataClient,
+        private readonly accountDataAdapter: AccountDataClient,
         private readonly cryptoCallbacks: ICryptoCallbacks,
         private readonly baseApis: B,
     ) {}

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -32,6 +32,7 @@ import {
     SecretStorageKeyObject,
     AddSecretStorageKeyOpts,
     AccountDataClient,
+    SECRET_STORAGE_ALGORITHM_V1_AES,
 } from "../secret-storage";
 
 /* re-exports for backwards compatibility */
@@ -39,9 +40,8 @@ export {
     AccountDataClient as IAccountDataClient,
     SecretStorageKeyTuple,
     SecretStorageKeyObject,
+    SECRET_STORAGE_ALGORITHM_V1_AES,
 } from "../secret-storage";
-
-export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
 
 export interface ISecretRequest {
     requestId: string;

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -22,8 +22,7 @@ import { randomString } from "../randomstring";
 import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes";
 import { ICryptoCallbacks, IEncryptedContent } from ".";
 import { MatrixEvent } from "../models/event";
-import { ClientEvent, ClientEventHandlerMap, MatrixClient } from "../client";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
+import { ClientEvent, MatrixClient } from "../client";
 import { defer, IDeferred } from "../utils";
 import { ToDeviceMessageId } from "../@types/event";
 import {
@@ -32,10 +31,15 @@ import {
     SecretStorageKeyTuple,
     SecretStorageKeyObject,
     AddSecretStorageKeyOpts,
+    AccountDataClient as IAccountDataClient,
 } from "../secret-storage";
 
 /* re-exports for backwards compatibility */
-export { SecretStorageKeyTuple, SecretStorageKeyObject } from "../secret-storage";
+export {
+    AccountDataClient as IAccountDataClient,
+    SecretStorageKeyTuple,
+    SecretStorageKeyObject,
+} from "../secret-storage";
 
 export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
 
@@ -43,12 +47,6 @@ export interface ISecretRequest {
     requestId: string;
     promise: Promise<string>;
     cancel: (reason: string) => void;
-}
-
-export interface IAccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap> {
-    // Subset of MatrixClient (which also uses any for the event content)
-    getAccountDataFromServer: <T extends { [k: string]: any }>(eventType: string) => Promise<T>;
-    setAccountData: (eventType: string, content: any) => Promise<{}>;
 }
 
 interface ISecretRequestInternal {

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { v4 as uuidv4 } from "uuid";
 
+import { SecretStorageKeyTuple, SecretStorageKeyObject } from "../secret-storage";
 import { logger } from "../logger";
 import * as olmlib from "./olmlib";
 import { randomString } from "../randomstring";
@@ -29,11 +30,10 @@ import { defer, IDeferred } from "../utils";
 import { ToDeviceMessageId } from "../@types/event";
 import { SecretStorageKeyDescription, SecretStorageKeyDescriptionAesV1 } from "../secret-storage";
 
-export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
+/* re-exports for backwards compatibility */
+export { SecretStorageKeyTuple, SecretStorageKeyObject } from "../secret-storage";
 
-// Some of the key functions use a tuple and some use an object...
-export type SecretStorageKeyTuple = [keyId: string, keyInfo: SecretStorageKeyDescription];
-export type SecretStorageKeyObject = { keyId: string; keyInfo: SecretStorageKeyDescription };
+export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
 
 export interface ISecretRequest {
     requestId: string;

--- a/src/crypto/api.ts
+++ b/src/crypto/api.ts
@@ -16,10 +16,11 @@ limitations under the License.
 
 import { DeviceInfo } from "./deviceinfo";
 import { IKeyBackupInfo } from "./keybackup";
-import { PassphraseInfo } from "../secret-storage";
+import { AddSecretStorageKeyOpts } from "../secret-storage";
 
 /* re-exports for backwards compatibility. */
 export {
+    AddSecretStorageKeyOpts as IAddSecretStorageKeyOpts,
     PassphraseInfo as IPassphraseInfo,
     SecretStorageKeyDescription as ISecretStorageKeyInfo,
 } from "../secret-storage";
@@ -65,7 +66,7 @@ export interface IEncryptedEventInfo {
 }
 
 export interface IRecoveryKey {
-    keyInfo?: IAddSecretStorageKeyOpts;
+    keyInfo?: AddSecretStorageKeyOpts;
     privateKey: Uint8Array;
     encodedPrivateKey?: string;
 }
@@ -103,13 +104,6 @@ export interface ICreateSecretStorageOpts {
      * containing the key, or rejects if the key cannot be obtained.
      */
     getKeyBackupPassphrase?: () => Promise<Uint8Array>;
-}
-
-export interface IAddSecretStorageKeyOpts {
-    pubkey?: string;
-    passphrase?: PassphraseInfo;
-    name?: string;
-    key?: Uint8Array;
 }
 
 export interface IImportOpts {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -34,7 +34,7 @@ import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms";
 import * as algorithms from "./algorithms";
 import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning";
 import { EncryptionSetupBuilder } from "./EncryptionSetup";
-import { ISecretRequest, SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorage } from "./SecretStorage";
+import { ISecretRequest, SecretStorage } from "./SecretStorage";
 import { ICreateSecretStorageOpts, IEncryptedEventInfo, IImportRoomKeysOpts, IRecoveryKey } from "./api";
 import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
@@ -83,6 +83,7 @@ import {
     SecretStorageKeyDescription,
     SecretStorageKeyObject,
     SecretStorageKeyTuple,
+    SECRET_STORAGE_ALGORITHM_V1_AES,
 } from "../secret-storage";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -34,21 +34,8 @@ import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms";
 import * as algorithms from "./algorithms";
 import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning";
 import { EncryptionSetupBuilder } from "./EncryptionSetup";
-import {
-    IAccountDataClient,
-    ISecretRequest,
-    SECRET_STORAGE_ALGORITHM_V1_AES,
-    SecretStorage,
-    SecretStorageKeyObject,
-    SecretStorageKeyTuple,
-} from "./SecretStorage";
-import {
-    IAddSecretStorageKeyOpts,
-    ICreateSecretStorageOpts,
-    IEncryptedEventInfo,
-    IImportRoomKeysOpts,
-    IRecoveryKey,
-} from "./api";
+import { IAccountDataClient, ISecretRequest, SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorage } from "./SecretStorage";
+import { ICreateSecretStorageOpts, IEncryptedEventInfo, IImportRoomKeysOpts, IRecoveryKey } from "./api";
 import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
 import { VerificationBase } from "./verification/Base";
@@ -90,7 +77,12 @@ import { IMessage } from "./algorithms/olm";
 import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
 import { RoomState, RoomStateEvent } from "../models/room-state";
 import { MapWithDefault, recursiveMapToObject } from "../utils";
-import { SecretStorageKeyDescription } from "../secret-storage";
+import {
+    AddSecretStorageKeyOpts,
+    SecretStorageKeyDescription,
+    SecretStorageKeyObject,
+    SecretStorageKeyTuple,
+} from "../secret-storage";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 
@@ -910,7 +902,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         let newKeyId: string | null = null;
 
         // create a new SSSS key and set it as default
-        const createSSSS = async (opts: IAddSecretStorageKeyOpts, privateKey?: Uint8Array): Promise<string> => {
+        const createSSSS = async (opts: AddSecretStorageKeyOpts, privateKey?: Uint8Array): Promise<string> => {
             if (privateKey) {
                 opts.key = privateKey;
             }
@@ -984,7 +976,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             // secrets using it, in theory. We could move them to the new key but a)
             // that would mean we'd need to prompt for the old passphrase, and b)
             // it's not clear that would be the right thing to do anyway.
-            const { keyInfo = {} as IAddSecretStorageKeyOpts, privateKey } = await createSecretStorageKey();
+            const { keyInfo = {} as AddSecretStorageKeyOpts, privateKey } = await createSecretStorageKey();
             newKeyId = await createSSSS(keyInfo, privateKey);
         } else if (!storageExists && keyBackupInfo) {
             // we have an existing backup, but no SSSS
@@ -995,7 +987,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             const backupKey = (await this.getSessionBackupPrivateKey()) || (await getKeyBackupPassphrase?.());
 
             // create a new SSSS key and use the backup key as the new SSSS key
-            const opts = {} as IAddSecretStorageKeyOpts;
+            const opts = {} as AddSecretStorageKeyOpts;
 
             if (keyBackupInfo.auth_data.private_key_salt && keyBackupInfo.auth_data.private_key_iterations) {
                 // FIXME: ???
@@ -1111,7 +1103,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
 
     public addSecretStorageKey(
         algorithm: string,
-        opts: IAddSecretStorageKeyOpts,
+        opts: AddSecretStorageKeyOpts,
         keyID?: string,
     ): Promise<SecretStorageKeyObject> {
         return this.secretStorage.addKey(algorithm, opts, keyID);

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -34,7 +34,7 @@ import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms";
 import * as algorithms from "./algorithms";
 import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning";
 import { EncryptionSetupBuilder } from "./EncryptionSetup";
-import { IAccountDataClient, ISecretRequest, SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorage } from "./SecretStorage";
+import { ISecretRequest, SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorage } from "./SecretStorage";
 import { ICreateSecretStorageOpts, IEncryptedEventInfo, IImportRoomKeysOpts, IRecoveryKey } from "./api";
 import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
@@ -78,6 +78,7 @@ import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBacke
 import { RoomState, RoomStateEvent } from "../models/room-state";
 import { MapWithDefault, recursiveMapToObject } from "../utils";
 import {
+    AccountDataClient,
     AddSecretStorageKeyOpts,
     SecretStorageKeyDescription,
     SecretStorageKeyObject,
@@ -521,7 +522,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
 
         this.crossSigningInfo = new CrossSigningInfo(userId, cryptoCallbacks, cacheCallbacks);
         // Yes, we pass the client twice here: see SecretStorage
-        this.secretStorage = new SecretStorage(baseApis as IAccountDataClient, cryptoCallbacks, baseApis);
+        this.secretStorage = new SecretStorage(baseApis as AccountDataClient, cryptoCallbacks, baseApis);
         this.dehydrationManager = new DehydrationManager(this);
 
         // Assuming no app-supplied callback, default to getting from SSSS.

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -125,7 +125,7 @@ export interface AccountDataClient extends TypedEventEmitter<ClientEvent.Account
      * @param eventType - The type of account data
      * @returns The contents of the given account data event.
      */
-    getAccountDataFromServer: <T extends { [k: string]: any }>(eventType: string) => Promise<T>;
+    getAccountDataFromServer: <T extends Record<string, any>>(eventType: string) => Promise<T>;
 
     /**
      * Set account data event for the current user, with retries

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -86,3 +86,23 @@ export interface PassphraseInfo {
     /** The number of bits to generate. Defaults to 256. */
     bits?: number;
 }
+
+/**
+ * Options for {@link SecretStorage#addKey}.
+ */
+export interface AddSecretStorageKeyOpts {
+    pubkey?: string;
+    passphrase?: PassphraseInfo;
+    name?: string;
+    key?: Uint8Array;
+}
+
+/**
+ * Return type for {@link SecretStorage#getKey}.
+ */
+export type SecretStorageKeyTuple = [keyId: string, keyInfo: SecretStorageKeyDescription];
+
+/**
+ * Return type for {@link SecretStorage#addKey}.
+ */
+export type SecretStorageKeyObject = { keyId: string; keyInfo: SecretStorageKeyDescription };

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -23,6 +23,8 @@ limitations under the License.
 import { TypedEventEmitter } from "./models/typed-event-emitter";
 import { ClientEvent, ClientEventHandlerMap } from "./client";
 
+export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
+
 /**
  * Common base interface for Secret Storage Keys.
  *

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -20,6 +20,9 @@ limitations under the License.
  * @see https://spec.matrix.org/v1.6/client-server-api/#storage
  */
 
+import { TypedEventEmitter } from "./models/typed-event-emitter";
+import { ClientEvent, ClientEventHandlerMap } from "./client";
+
 /**
  * Common base interface for Secret Storage Keys.
  *
@@ -106,3 +109,28 @@ export type SecretStorageKeyTuple = [keyId: string, keyInfo: SecretStorageKeyDes
  * Return type for {@link SecretStorage#addKey}.
  */
 export type SecretStorageKeyObject = { keyId: string; keyInfo: SecretStorageKeyDescription };
+
+/** Interface for managing account data on the server.
+ *
+ * A subset of {@link MatrixClient}.
+ */
+export interface AccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap> {
+    /**
+     * Get account data event of given type for the current user. This variant
+     * gets account data directly from the homeserver if the local store is not
+     * ready, which can be useful very early in startup before the initial sync.
+     *
+     * @param eventType - The type of account data
+     * @returns The contents of the given account data event.
+     */
+    getAccountDataFromServer: <T extends { [k: string]: any }>(eventType: string) => Promise<T>;
+
+    /**
+     * Set account data event for the current user, with retries
+     *
+     * @param eventType - The type of account data
+     * @param content - the content object to be set
+     * @returns an empty object
+     */
+    setAccountData: (eventType: string, content: any) => Promise<{}>;
+}


### PR DESCRIPTION
We have a number of interfaces related to SecretStorage defined either in `crypto/api` or `crypto/SecretStorage`. This isn't entirely appropriate, because the SecretStorage implementation is orthogonal to the E2EE implementation.

This PR moves those interfaces out to `secret-storage.ts`, which was started in #3242. It is part of a larger piece of work in refactoring the SecretStorage interface (vector-im/element-web#24982).

Suggest reviewing commit-by-commit

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->