### PR TITLE
Skip sonarcloud & coverage in merge_queue

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -11,26 +11,15 @@ jobs:
     # This is a workaround for https://github.com/SonarSource/SonarJS/issues/578
     prepare:
         name: Prepare
+        if: github.event.workflow_run.event != 'merge_group'
         runs-on: ubuntu-latest
         outputs:
             reportPaths: ${{ steps.extra_args.outputs.reportPaths }}
             testExecutionReportPaths: ${{ steps.extra_args.outputs.testExecutionReportPaths }}
         steps:
-            - name: Skip on merge queue
-              if: github.event.workflow_run.event == 'merge_group'
-              uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
-              with:
-                  authToken: ${{ secrets.GITHUB_TOKEN }}
-                  state: success
-                  description: SonarCloud skipped
-                  context: SonarCloud Code Analysis
-                  sha: ${{ github.event.workflow_run.head_sha }}
-                  target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
-              if: github.event.workflow_run.event != 'merge_group'
               uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   workflow: tests.yaml
@@ -39,7 +28,6 @@ jobs:
                   path: coverage
 
             - id: extra_args
-              if: github.event.workflow_run.event != 'merge_group'
               run: |
                   coverage=$(find coverage -type f -name '*lcov.info' | tr '\n' ',' | sed 's/,$//g')
                   echo "reportPaths=$coverage" >> $GITHUB_OUTPUT

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,9 +16,21 @@ jobs:
             reportPaths: ${{ steps.extra_args.outputs.reportPaths }}
             testExecutionReportPaths: ${{ steps.extra_args.outputs.testExecutionReportPaths }}
         steps:
+            - name: Skip on merge queue
+              if: github.event.workflow_run.event == 'merge_group'
+              uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
+              with:
+                  authToken: ${{ secrets.GITHUB_TOKEN }}
+                  state: success
+                  description: SonarCloud skipped
+                  context: SonarCloud Code Analysis
+                  sha: ${{ github.event.workflow_run.head_sha }}
+                  target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
             # There's a 'download artifact' action, but it hasn't been updated for the workflow_run action
             # (https://github.com/actions/download-artifact/issues/60) so instead we get this mess:
             - name: 📥 Download artifact
+              if: github.event.workflow_run.event != 'merge_group'
               uses: dawidd6/action-download-artifact@5e780fc7bbd0cac69fc73271ed86edf5dcb72d67 # v2
               with:
                   workflow: tests.yaml
@@ -27,6 +39,7 @@ jobs:
                   path: coverage
 
             - id: extra_args
+              if: github.event.workflow_run.event != 'merge_group'
               run: |
                   coverage=$(find coverage -type f -name '*lcov.info' | tr '\n' ',' | sed 's/,$//g')
                   echo "reportPaths=$coverage" >> $GITHUB_OUTPUT
@@ -35,6 +48,7 @@ jobs:
 
     sonarqube:
         name: 🩻 SonarQube
+        if: github.event.workflow_run.event != 'merge_group'
         needs: prepare
         uses: matrix-org/matrix-js-sdk/.github/workflows/sonarcloud.yml@develop
         secrets:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
             - name: Run tests
               run: |
-                  yarn coverage \
+                  yarn ${{ github.event_name == 'merge_group' && 'test' || 'coverage' }} \
                       --ci \
                       --reporters github-actions ${{ steps.metrics.outputs.extra-reporter }} \
                       --max-workers ${{ steps.cpu-cores.outputs.count }} \
@@ -56,6 +56,7 @@ jobs:
                   JEST_SONAR_UNIQUE_OUTPUT_NAME: true
 
             - name: Upload Artifact
+              if: github.event_name != 'merge_group'
               uses: actions/upload-artifact@v3
               with:
                   name: coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,22 @@ jobs:
                       coverage
                       !coverage/lcov-report
 
+    skip_sonar:
+        name: Skip SonarCloud on merge_queue
+        if: github.event_name == 'merge_group'
+        runs-on: ubuntu-latest
+        needs: jest
+        steps:
+            - name: Skip on merge queue
+              uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
+              with:
+                  authToken: ${{ secrets.GITHUB_TOKEN }}
+                  state: success
+                  description: SonarCloud skipped
+                  context: SonarCloud Code Analysis
+                  sha: ${{ github.event.workflow_run.head_sha }}
+                  target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     matrix-react-sdk:
         name: Downstream test matrix-react-sdk
         if: github.event_name == 'merge_group'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,12 @@ jobs:
                       --reporters github-actions ${{ steps.metrics.outputs.extra-reporter }} \
                       --max-workers ${{ steps.cpu-cores.outputs.count }} \
                       ./spec/${{ matrix.specs }}
-                  mv coverage/lcov.info coverage/${{ matrix.node }}-${{ matrix.specs }}.lcov.info
               env:
                   JEST_SONAR_UNIQUE_OUTPUT_NAME: true
+
+            - name: Move coverage files into place
+              if: github.event_name != 'merge_group'
+              run: mv coverage/lcov.info coverage/${{ matrix.node }}-${{ matrix.specs }}.lcov.info
 
             - name: Upload Artifact
               if: github.event_name != 'merge_group'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,14 +70,14 @@ jobs:
         runs-on: ubuntu-latest
         needs: jest
         steps:
-            - name: Skip on merge queue
+            - name: Skip SonarCloud
               uses: Sibz/github-status-action@faaa4d96fecf273bd762985e0e7f9f933c774918 # v1
               with:
                   authToken: ${{ secrets.GITHUB_TOKEN }}
                   state: success
                   description: SonarCloud skipped
                   context: SonarCloud Code Analysis
-                  sha: ${{ github.event.workflow_run.head_sha }}
+                  sha: ${{ github.sha }}
                   target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     matrix-react-sdk:


### PR DESCRIPTION
They're already checked on the PR

Fixes issue with merge queue always failing if new code coverage on develop < 80%

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->