### PR TITLE
Add an event emitted when a Call creates a PeerConnection

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -152,6 +152,10 @@ export enum CallEvent {
     DataChannel = "datachannel",
 
     SendVoipEvent = "send_voip_event",
+
+    // When the call instantiates its peer connection
+    // For apps that want to access the underlying peer connection, eg for debugging
+    PeerConnectionCreated = "peer_connection_created",
 }
 
 export enum CallErrorCode {
@@ -325,6 +329,7 @@ export type CallEventHandlerMap = {
     /* @deprecated */
     [CallEvent.HoldUnhold]: (onHold: boolean) => void;
     [CallEvent.SendVoipEvent]: (event: VoipEvent, call: MatrixCall) => void;
+    [CallEvent.PeerConnectionCreated]: (peerConn: RTCPeerConnection, call: MatrixCall) => void;
 };
 
 // The key of the transceiver map (purpose + media type, separated by ':')
@@ -951,6 +956,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         }
 
         this.peerConn = this.createPeerConnection();
+        this.emit(CallEvent.PeerConnectionCreated, this.peerConn, this);
         // we must set the party ID before await-ing on anything: the call event
         // handler will start giving us more call events (eg. candidates) so if
         // we haven't set the party ID, we'll ignore them.
@@ -2785,6 +2791,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         // create the peer connection now so it can be gathering candidates while we get user
         // media (assuming a candidate pool size is configured)
         this.peerConn = this.createPeerConnection();
+        this.emit(CallEvent.PeerConnectionCreated, this.peerConn, this);
         this.gotCallFeedsForInvite(callFeeds, requestScreenshareFeed);
     }
 


### PR DESCRIPTION
For apps that need acces to the per connection as soon as it's created for debugging etc.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->