### PR TITLE
Use `processKeyCounts` in sliding sync

### DIFF
--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -671,32 +671,17 @@ describe("SlidingSyncSdk", () => {
             // TODO: more assertions?
         });
 
-        it("can update OTK counts", () => {
-            client!.crypto!.updateOneTimeKeyCount = jest.fn();
+        it("can update OTK counts and unused fallback keys", () => {
+            client!.crypto!.processKeyCounts = jest.fn();
             ext.onResponse({
                 device_one_time_keys_count: {
                     signed_curve25519: 42,
                 },
-            });
-            expect(client!.crypto!.updateOneTimeKeyCount).toHaveBeenCalledWith(42);
-            ext.onResponse({
-                device_one_time_keys_count: {
-                    not_signed_curve25519: 42,
-                    // missing field -> default to 0
-                },
-            });
-            expect(client!.crypto!.updateOneTimeKeyCount).toHaveBeenCalledWith(0);
-        });
-
-        it("can update fallback keys", () => {
-            ext.onResponse({
                 device_unused_fallback_key_types: ["signed_curve25519"],
             });
-            expect(client!.crypto!.getNeedsNewFallback()).toEqual(false);
-            ext.onResponse({
-                device_unused_fallback_key_types: ["not_signed_curve25519"],
-            });
-            expect(client!.crypto!.getNeedsNewFallback()).toEqual(true);
+            expect(client!.crypto!.processKeyCounts).toHaveBeenCalledWith({ signed_curve25519: 42 }, [
+                "signed_curve25519",
+            ]);
         });
     });
 

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -94,21 +94,12 @@ class ExtensionE2EE implements Extension<ExtensionE2EERequest, ExtensionE2EEResp
             );
         }
 
-        // Handle one_time_keys_count
-        if (data["device_one_time_keys_count"]) {
-            const currentCount = data["device_one_time_keys_count"].signed_curve25519 || 0;
-            this.crypto.updateOneTimeKeyCount(currentCount);
-        }
-        if (data["device_unused_fallback_key_types"] || data["org.matrix.msc2732.device_unused_fallback_key_types"]) {
-            // The presence of device_unused_fallback_key_types indicates that the
-            // server supports fallback keys. If there's no unused
-            // signed_curve25519 fallback key we need a new one.
-            const unusedFallbackKeys =
-                data["device_unused_fallback_key_types"] || data["org.matrix.msc2732.device_unused_fallback_key_types"];
-            this.crypto.setNeedsNewFallback(
-                Array.isArray(unusedFallbackKeys) && !unusedFallbackKeys.includes("signed_curve25519"),
-            );
-        }
+        // Handle one_time_keys_count and unused_fallback_key_types
+        await this.crypto.processKeyCounts(
+            data.device_one_time_keys_count,
+            data["device_unused_fallback_key_types"] || data["org.matrix.msc2732.device_unused_fallback_key_types"],
+        );
+
         this.crypto.onSyncCompleted({});
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Following comment about sliding sync in https://github.com/matrix-org/matrix-js-sdk/pull/3215#discussion_r1144640847

The purpose is to use the `processKeyCounts` method of the `CryptoBackend` interface  to process one time key counts and unused fall back keys after a `/sync` instead of using a duplicated behaviour

The sliding sync tests about it are eased because the `processKeyCounts` behaviour is already tested in https://github.com/matrix-org/matrix-js-sdk/blob/develop/spec/integ/crypto.spec.ts#L1966

Also
- `processKeyCounts` is implemented by old and new crypto (`CryptoBackend` interface) and should be used instead of `updateOneTimeKeyCount` for old crypto
- `updateOneTimeKeyCount` is only used by `processKeyCounts` so I made it private (sliding sync was the last one to use it)
- Same logic for `setNeedsNewFallback` but since the method has one line of code, I removed it.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->