### PR TITLE
Export type for return of getCapabilities()

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
         secrets:
             ELEMENT_BOT_TOKEN:
                 required: true
-concurrency: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     changelog:
         name: Preview Changelog

--- a/src/client.ts
+++ b/src/client.ts
@@ -492,7 +492,11 @@ export interface IMSC3882GetLoginTokenCapability extends ICapability {}
 
 export const UNSTABLE_MSC3882_CAPABILITY = new UnstableValue("m.get_login_token", "org.matrix.msc3882.get_login_token");
 
-interface ICapabilities {
+/**
+ * A representation of the capabilities advertised by a homeserver as defined by
+ * [Capabilities negotiation](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv3capabilities).
+ */
+export interface ICapabilitiesAdvertised {
     [key: string]: any;
     "m.change_password"?: IChangePasswordCapability;
     "m.room_versions"?: IRoomVersionsCapability;
@@ -1231,7 +1235,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected serverVersionsPromise?: Promise<IServerVersions>;
 
     public cachedCapabilities?: {
-        capabilities: ICapabilities;
+        capabilities: ICapabilitiesAdvertised;
         expiration: number;
     };
     protected clientWellKnown?: IClientWellKnown;
@@ -2050,7 +2054,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves to the capabilities of the homeserver
      * @returns Rejects: with an error response.
      */
-    public getCapabilities(fresh = false): Promise<ICapabilities> {
+    public getCapabilities(fresh = false): Promise<ICapabilitiesAdvertised> {
         const now = new Date().getTime();
 
         if (this.cachedCapabilities && !fresh) {
@@ -2061,7 +2065,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         type Response = {
-            capabilities?: ICapabilities;
+            capabilities?: ICapabilitiesAdvertised;
         };
         return this.http
             .authedRequest<Response>(Method.Get, "/capabilities")

--- a/src/client.ts
+++ b/src/client.ts
@@ -496,7 +496,7 @@ export const UNSTABLE_MSC3882_CAPABILITY = new UnstableValue("m.get_login_token"
  * A representation of the capabilities advertised by a homeserver as defined by
  * [Capabilities negotiation](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv3capabilities).
  */
-export interface ICapabilitiesAdvertised {
+export interface Capabilities {
     [key: string]: any;
     "m.change_password"?: IChangePasswordCapability;
     "m.room_versions"?: IRoomVersionsCapability;
@@ -1235,7 +1235,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     protected serverVersionsPromise?: Promise<IServerVersions>;
 
     public cachedCapabilities?: {
-        capabilities: ICapabilitiesAdvertised;
+        capabilities: Capabilities;
         expiration: number;
     };
     protected clientWellKnown?: IClientWellKnown;
@@ -2054,7 +2054,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves to the capabilities of the homeserver
      * @returns Rejects: with an error response.
      */
-    public getCapabilities(fresh = false): Promise<ICapabilitiesAdvertised> {
+    public getCapabilities(fresh = false): Promise<Capabilities> {
         const now = new Date().getTime();
 
         if (this.cachedCapabilities && !fresh) {
@@ -2065,7 +2065,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         type Response = {
-            capabilities?: ICapabilitiesAdvertised;
+            capabilities?: Capabilities;
         };
         return this.http
             .authedRequest<Response>(Method.Get, "/capabilities")


### PR DESCRIPTION
Renamed because it clashes with ICapabilities from embedded. I would happily take alternative naming suggestions.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->