### PR TITLE
Element-R: fix to device list change notifications

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -238,7 +238,10 @@ export class RustCrypto implements CryptoBackend {
      * @param deviceLists - device_lists field from /sync
      */
     public async processDeviceLists(deviceLists: IDeviceLists): Promise<void> {
-        const devices = new RustSdkCryptoJs.DeviceLists(deviceLists.changed, deviceLists.left);
+        const devices = new RustSdkCryptoJs.DeviceLists(
+            deviceLists.changed?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
+            deviceLists.left?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
+        );
         await this.receiveSyncChanges({ devices });
     }
 


### PR DESCRIPTION
The rust crypto-sdk expects `UserId`s, not raw strings.

Follow-up to #3254

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->