### PR TITLE
Typescript fix to `AccountDataClient`

### DIFF
--- a/spec/unit/secret-storage.spec.ts
+++ b/spec/unit/secret-storage.spec.ts
@@ -103,7 +103,7 @@ describe("ServerSideSecretStorageImpl", function () {
             const secretStorage = new ServerSideSecretStorageImpl(accountDataAdapter, {});
 
             const storedKey = { iv: "iv", mac: "mac" } as SecretStorageKeyDescriptionAesV1;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T> {
+            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
                 if (eventType === "m.secret_storage.key.my_key") {
                     return storedKey as unknown as T;
                 } else {
@@ -121,7 +121,7 @@ describe("ServerSideSecretStorageImpl", function () {
             const secretStorage = new ServerSideSecretStorageImpl(accountDataAdapter, {});
 
             const storedKey = { iv: "iv", mac: "mac" } as SecretStorageKeyDescriptionAesV1;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T> {
+            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
                 if (eventType === "m.secret_storage.default_key") {
                     return { key: "default_key_id" } as unknown as T;
                 } else if (eventType === "m.secret_storage.key.default_key_id") {
@@ -222,7 +222,7 @@ describe("ServerSideSecretStorageImpl", function () {
 
             // stub out getAccountData to return a key with an unknown algorithm
             const storedKey = { algorithm: "badalg" } as SecretStorageKeyDescriptionCommon;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T> {
+            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
                 if (eventType === "m.secret_storage.key.keyid") {
                     return storedKey as unknown as T;
                 } else {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { logger } from "../logger";
-import { IContent, MatrixEvent } from "../models/event";
+import { MatrixEvent } from "../models/event";
 import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
 import { Method, ClientPrefix } from "../http-api";
@@ -252,21 +252,21 @@ class AccountDataClientAdapter
     /**
      * @returns the content of the account data
      */
-    public getAccountDataFromServer<T extends { [k: string]: any }>(type: string): Promise<T> {
-        return Promise.resolve(this.getAccountData(type) as T);
+    public getAccountDataFromServer<T extends { [k: string]: any }>(type: string): Promise<T | null> {
+        return Promise.resolve(this.getAccountData(type));
     }
 
     /**
      * @returns the content of the account data
      */
-    public getAccountData(type: string): IContent | null {
+    public getAccountData<T extends { [k: string]: any }>(type: string): T | null {
         const modifiedValue = this.values.get(type);
         if (modifiedValue) {
-            return modifiedValue;
+            return modifiedValue as unknown as T;
         }
         const existingValue = this.existingValues.get(type);
         if (existingValue) {
-            return existingValue.getContent();
+            return existingValue.getContent<T>();
         }
         return null;
     }

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -132,9 +132,9 @@ export interface AccountDataClient extends TypedEventEmitter<ClientEvent.Account
      * ready, which can be useful very early in startup before the initial sync.
      *
      * @param eventType - The type of account data
-     * @returns The contents of the given account data event.
+     * @returns The contents of the given account data event, or `null` if the event is not found
      */
-    getAccountDataFromServer: <T extends Record<string, any>>(eventType: string) => Promise<T>;
+    getAccountDataFromServer: <T extends Record<string, any>>(eventType: string) => Promise<T | null>;
 
     /**
      * Set account data event for the current user, with retries
@@ -531,7 +531,7 @@ export class ServerSideSecretStorageImpl implements ServerSideSecretStorage {
             );
             const encInfo = secretInfo.encrypted[keyId];
             // only use keys we understand the encryption algorithm of
-            if (keyInfo.algorithm === SECRET_STORAGE_ALGORITHM_V1_AES) {
+            if (keyInfo !== null && keyInfo.algorithm === SECRET_STORAGE_ALGORITHM_V1_AES) {
                 if (encInfo.iv && encInfo.ciphertext && encInfo.mac) {
                     keys[keyId] = keyInfo;
                 }

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -531,7 +531,7 @@ export class ServerSideSecretStorageImpl implements ServerSideSecretStorage {
             );
             const encInfo = secretInfo.encrypted[keyId];
             // only use keys we understand the encryption algorithm of
-            if (keyInfo !== null && keyInfo.algorithm === SECRET_STORAGE_ALGORITHM_V1_AES) {
+            if (keyInfo?.algorithm === SECRET_STORAGE_ALGORITHM_V1_AES) {
                 if (encInfo.iv && encInfo.ciphertext && encInfo.mac) {
                     keys[keyId] = keyInfo;
                 }


### PR DESCRIPTION
Obviously, `getAccountDataFromServer` can return null.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->