### PR TITLE
Remove `eventNames` from `TypedEventEmitter`

### DIFF
--- a/src/models/typed-event-emitter.ts
+++ b/src/models/typed-event-emitter.ts
@@ -59,10 +59,6 @@ export class TypedEventEmitter<
         return super.emit(event, ...args);
     }
 
-    public eventNames(): (Events | EventEmitterEvents)[] {
-        return super.eventNames() as Array<Events | EventEmitterEvents>;
-    }
-
     public listenerCount(event: Events | EventEmitterEvents): number {
         return super.listenerCount(event);
     }


### PR DESCRIPTION
I'm not 100% sure that this is the right thing to do, but...

Currently, `TypedEventEmitter<Events>` overrides `eventNames()` to say that it can only return events of type `Events`. This is problematic, because of the following situation:

Suppose you have a method which wants to register a listener for `FooEvent`s. To do so, it needs an event emitter which is a known source of `FooEvent`s. In other words, it takes an `eventEmitter` parameter of type `TypedEventEmitter<FooEvent>`.

But now suppose we have a class which can emit all sorts of different events, *including*, but not limited to, `FooEvent`. This class extends `TypedEventEmitter<FooEvent|BarEvent|BazEvent>`, which is great as far as the `emit` and `addListener` methods go, and should be fine for our method's needs. However, we can't use it where we need the `TypedEventEmitter<FooEvent>`, because its `eventNames` method is not compliant.

Basically, given the way that we use `TypedEventEmitter`, I don't think it's correct to say that `eventNames` will only ever return the restricted list of event names we instantiate the class with. We may as well just remove the override and use the definition from the base type, which is `eventNames(): Array<string | symbol>`.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->