### PR TITLE
OutgoingRoomKeyRequest is only a type

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -47,7 +47,7 @@ export * from "./store/memory";
 export * from "./store/indexeddb";
 export * from "./crypto/store/memory-crypto-store";
 export * from "./crypto/store/indexeddb-crypto-store";
-export { OutgoingRoomKeyRequest } from "./crypto/store/base";
+export type { OutgoingRoomKeyRequest } from "./crypto/store/base";
 export * from "./content-repo";
 export * from "./@types/event";
 export * from "./@types/PushRules";


### PR DESCRIPTION
Followup to #3275

Fixes a warning from webpack:

    [element-js] WARNING in ../matrix-js-sdk/src/matrix.ts 46:0-61
    [element-js] "export 'OutgoingRoomKeyRequest' was not found in './crypto/store/base'

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->