### PR TITLE
Element-R: implement `MatrixClient.isSecretStorageReady`

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -722,13 +722,8 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns True if secret storage is ready to be used on this device
      */
-    public async isSecretStorageReady(): Promise<boolean> {
-        const secretStorageKeyInAccount = await this.secretStorage.hasKey();
-        const privateKeysInStorage = await this.crossSigningInfo.isStoredInSecretStorage(this.secretStorage);
-        const sessionBackupInStorage =
-            !this.backupManager.getKeyBackupEnabled() || (await this.baseApis.isKeyBackupKeyStored());
-
-        return !!(secretStorageKeyInAccount && privateKeysInStorage && sessionBackupInStorage);
+    public isSecretStorageReady(): Promise<boolean> {
+        return this.baseApis.isSecretStorageReady();
     }
 
     /**


### PR DESCRIPTION
Most of this is actually independent of the crypto implementation, so let's
hoist its definition up to `MatrixClient`.