### PR TITLE
New `CryptoApi.getDeviceVerificationStatus` api

### DIFF
--- a/spec/unit/crypto/verification/sas.spec.ts
+++ b/spec/unit/crypto/verification/sas.spec.ts
@@ -374,6 +374,12 @@ describe("SAS verification", function () {
             expect(bobDeviceTrust.isLocallyVerified()).toBeTruthy();
             expect(bobDeviceTrust.isCrossSigningVerified()).toBeFalsy();
 
+            const bobDeviceVerificationStatus = (await alice.client
+                .getCrypto()!
+                .getDeviceVerificationStatus("@bob:example.com", "Dynabook"))!;
+            expect(bobDeviceVerificationStatus.localVerified).toBe(true);
+            expect(bobDeviceVerificationStatus.crossSigningVerified).toBe(false);
+
             const aliceTrust = bob.client.checkUserTrust("@alice:example.com");
             expect(aliceTrust.isCrossSigningVerified()).toBeTruthy();
             expect(aliceTrust.isTofu()).toBeTruthy();
@@ -381,6 +387,17 @@ describe("SAS verification", function () {
             const aliceDeviceTrust = bob.client.checkDeviceTrust("@alice:example.com", "Osborne2");
             expect(aliceDeviceTrust.isLocallyVerified()).toBeTruthy();
             expect(aliceDeviceTrust.isCrossSigningVerified()).toBeFalsy();
+
+            const aliceDeviceVerificationStatus = (await bob.client
+                .getCrypto()!
+                .getDeviceVerificationStatus("@alice:example.com", "Osborne2"))!;
+            expect(aliceDeviceVerificationStatus.localVerified).toBe(true);
+            expect(aliceDeviceVerificationStatus.crossSigningVerified).toBe(false);
+
+            const unknownDeviceVerificationStatus = await bob.client
+                .getCrypto()!
+                .getDeviceVerificationStatus("@alice:example.com", "xyz");
+            expect(unknownDeviceVerificationStatus).toBe(null);
         });
     });
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022-2023 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -228,6 +228,25 @@ describe("RustCrypto", () => {
 
             const res = rustCrypto.getEventEncryptionInfo(event);
             expect(res.encrypted).toBeTruthy();
+        });
+    });
+
+    describe("get|setTrustCrossSignedDevices", () => {
+        let rustCrypto: RustCrypto;
+
+        beforeEach(async () => {
+            rustCrypto = await initRustCrypto({} as MatrixClient["http"], TEST_USER, TEST_DEVICE_ID);
+        });
+
+        it("should be true by default", () => {
+            expect(rustCrypto.getTrustCrossSignedDevices()).toBe(true);
+        });
+
+        it("should be easily turn-off-and-on-able", () => {
+            rustCrypto.setTrustCrossSignedDevices(false);
+            expect(rustCrypto.getTrustCrossSignedDevices()).toBe(false);
+            rustCrypto.setTrustCrossSignedDevices(true);
+            expect(rustCrypto.getTrustCrossSignedDevices()).toBe(true);
         });
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -2605,12 +2605,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param userId - The ID of the user whose devices is to be checked.
      * @param deviceId - The ID of the device to check
+     *
+     * @deprecated Use {@link CryptoApi.getDeviceVerificationStatus | `CryptoApi.getDeviceVerificationStatus`}
      */
     public checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel {
-        if (!this.cryptoBackend) {
+        if (!this.crypto) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.cryptoBackend.checkDeviceTrust(userId, deviceId);
+        return this.crypto.checkDeviceTrust(userId, deviceId);
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -2748,24 +2748,28 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * Default: true
      *
      * @returns True if trusting cross-signed devices
+     *
+     * @deprecated Prefer {@link CryptoApi.getTrustCrossSignedDevices | `CryptoApi.getTrustCrossSignedDevices`}.
      */
     public getCryptoTrustCrossSignedDevices(): boolean {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             throw new Error("End-to-end encryption disabled");
         }
-        return this.crypto.getCryptoTrustCrossSignedDevices();
+        return this.cryptoBackend.getTrustCrossSignedDevices();
     }
 
     /**
      * See getCryptoTrustCrossSignedDevices
      *
      * @param val - True to trust cross-signed devices
+     *
+     * @deprecated Prefer {@link CryptoApi.setTrustCrossSignedDevices | `CryptoApi.setTrustCrossSignedDevices`}.
      */
     public setCryptoTrustCrossSignedDevices(val: boolean): void {
-        if (!this.crypto) {
+        if (!this.cryptoBackend) {
             throw new Error("End-to-end encryption disabled");
         }
-        this.crypto.setCryptoTrustCrossSignedDevices(val);
+        this.cryptoBackend.setTrustCrossSignedDevices(val);
     }
 
     /**

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -18,7 +18,7 @@ import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
 import { MatrixEvent } from "../models/event";
 import { Room } from "../models/room";
 import { CryptoApi } from "../crypto-api";
-import { DeviceTrustLevel, UserTrustLevel } from "../crypto/CrossSigning";
+import { UserTrustLevel } from "../crypto/CrossSigning";
 import { IEncryptedEventInfo } from "../crypto/api";
 import { IEventDecryptionResult } from "../@types/crypto";
 
@@ -50,16 +50,6 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * @param userId - user to be checked
      */
     checkUserTrust(userId: string): UserTrustLevel;
-
-    /**
-     * Get the verification level for a given device
-     *
-     * TODO: define this better
-     *
-     * @param userId - user to be checked
-     * @param deviceId - device to be checked
-     */
-    checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel;
 
     /**
      * Encrypt an event according to the configuration of the room.

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -94,3 +94,43 @@ export interface CryptoApi {
      */
     getTrustCrossSignedDevices(): boolean;
 }
+
+export class DeviceVerificationStatus {
+    public constructor(
+        /**
+         * True if this device has been verified via cross signing.
+         *
+         * This does *not* take into account `trustCrossSignedDevices`.
+         */
+        public readonly crossSigningVerified: boolean,
+
+        /**
+         * TODO: tofu magic wtf does this do?
+         */
+        public readonly tofu: boolean,
+
+        /**
+         * True if the device has been marked as locally verified.
+         */
+        public readonly localVerified: boolean,
+
+        /**
+         * True if the client has been configured to trust cross-signed devices via {@link CryptoApi#setTrustCrossSignedDevices}.
+         */
+        private readonly trustCrossSignedDevices: boolean,
+    ) {}
+
+    /**
+     * Check if we should consider this device "verified".
+     *
+     * A device is "verified" if either:
+     *  * it has been manually marked as such via {@link MatrixClient#setDeviceVerified}.
+     *  * it has been cross-signed with a verified signing key, **and** the client has been configured to trust
+     *    cross-signed devices via {@link CryptoApi#setTrustCrossSignedDevices}.
+     *
+     * @returns true if this device is verified via any means.
+     */
+    public isVerified(): boolean {
+        return this.localVerified || (this.trustCrossSignedDevices && this.crossSigningVerified);
+    }
+}

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -93,6 +93,16 @@ export interface CryptoApi {
      * @returns `true` if we trust cross-signed devices, otherwise `false`.
      */
     getTrustCrossSignedDevices(): boolean;
+
+    /**
+     * Get the verification status of a given device.
+     *
+     * @param userId - The ID of the user whose device is to be checked.
+     * @param deviceId - The ID of the device to check
+     *
+     * @returns Verification status of the device, or `null` if the device is not known
+     */
+    getDeviceVerificationStatus(userId: string, deviceId: string): Promise<DeviceVerificationStatus | null>;
 }
 
 export class DeviceVerificationStatus {

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -72,4 +72,25 @@ export interface CryptoApi {
      *    session export objects
      */
     exportRoomKeys(): Promise<IMegolmSessionData[]>;
+
+    /**
+     * Set whether to trust other user's signatures of their devices.
+     *
+     * If false, devices will only be considered 'verified' if we have
+     * verified that device individually (effectively disabling cross-signing).
+     *
+     * `true` by default.
+     *
+     * @param val - the new value
+     */
+    setTrustCrossSignedDevices(val: boolean): void;
+
+    /**
+     * Return whether we trust other user's signatures of their devices.
+     *
+     * @see {@link CryptoApi#setTrustCrossSignedDevices}
+     *
+     * @returns `true` if we trust cross-signed devices, otherwise `false`.
+     */
+    getTrustCrossSignedDevices(): boolean;
 }

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -31,6 +31,7 @@ import { ICryptoCallbacks } from ".";
 import { ISignatures } from "../@types/signed";
 import { CryptoStore, SecretStorePrivateKeys } from "./store/base";
 import { ServerSideSecretStorage, SecretStorageKeyDescription } from "../secret-storage";
+import { DeviceVerificationStatus } from "../crypto-api";
 
 const KEY_REQUEST_TIMEOUT_MS = 1000 * 60;
 
@@ -628,16 +629,11 @@ export class UserTrustLevel {
 }
 
 /**
- * Represents the ways in which we trust a device
+ * Represents the ways in which we trust a device.
+ *
+ * @deprecated Use {@link DeviceVerificationStatus}.
  */
-export class DeviceTrustLevel {
-    public constructor(
-        public readonly crossSigningVerified: boolean,
-        public readonly tofu: boolean,
-        private readonly localVerified: boolean,
-        private readonly trustCrossSignedDevices: boolean,
-    ) {}
-
+export class DeviceTrustLevel extends DeviceVerificationStatus {
     public static fromUserTrustLevel(
         userTrustLevel: UserTrustLevel,
         localVerified: boolean,
@@ -649,13 +645,6 @@ export class DeviceTrustLevel {
             localVerified,
             trustCrossSignedDevices,
         );
-    }
-
-    /**
-     * @returns true if this device is verified via any means
-     */
-    public isVerified(): boolean {
-        return Boolean(this.isLocallyVerified() || (this.trustCrossSignedDevices && this.isCrossSigningVerified()));
     }
 
     /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -605,18 +605,23 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns True if trusting cross-signed devices
      */
+    public getTrustCrossSignedDevices(): boolean {
+        return this.trustCrossSignedDevices;
+    }
+
+    /**
+     * @deprecated Use {@link CryptoApi#getTrustCrossSignedDevices}.
+     */
     public getCryptoTrustCrossSignedDevices(): boolean {
         return this.trustCrossSignedDevices;
     }
 
     /**
      * See getCryptoTrustCrossSignedDevices
-
-     * This may be set before initCrypto() is called to ensure no races occur.
      *
      * @param val - True to trust cross-signed devices
      */
-    public setCryptoTrustCrossSignedDevices(val: boolean): void {
+    public setTrustCrossSignedDevices(val: boolean): void {
         this.trustCrossSignedDevices = val;
 
         for (const userId of this.deviceList.getKnownUserIds()) {
@@ -632,6 +637,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
                 }
             }
         }
+    }
+
+    /**
+     * @deprecated Use {@link CryptoApi#setTrustCrossSignedDevices}.
+     */
+    public setCryptoTrustCrossSignedDevices(val: boolean): void {
+        this.setTrustCrossSignedDevices(val);
     }
 
     /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -88,6 +88,7 @@ import {
     ServerSideSecretStorageImpl,
 } from "../secret-storage";
 import { ISecretRequest } from "./SecretSharing";
+import { DeviceVerificationStatus } from "../crypto-api";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1426,10 +1426,22 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Check whether a given device is trusted.
      *
-     * @param userId - The ID of the user whose devices is to be checked.
+     * @param userId - The ID of the user whose device is to be checked.
      * @param deviceId - The ID of the device to check
-     *
-     * @returns
+     */
+    public async getDeviceVerificationStatus(
+        userId: string,
+        deviceId: string,
+    ): Promise<DeviceVerificationStatus | null> {
+        const device = this.deviceList.getStoredDevice(userId, deviceId);
+        if (!device) {
+            return null;
+        }
+        return this.checkDeviceInfoTrust(userId, device);
+    }
+
+    /**
+     * @deprecated Use {@link CryptoApi.getDeviceVerificationStatus}.
      */
     public checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel {
         const device = this.deviceList.getStoredDevice(userId, deviceId);
@@ -1442,7 +1454,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * @param userId - The ID of the user whose devices is to be checked.
      * @param device - The device info object to check
      *
-     * @returns
+     * @deprecated Use {@link CryptoApi.getDeviceVerificationStatus}.
      */
     public checkDeviceInfoTrust(userId: string, device?: DeviceInfo): DeviceTrustLevel {
         const trustedLocally = !!device?.isVerified();

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -62,7 +62,7 @@ export { createNewMatrixCall } from "./webrtc/call";
 export type { MatrixCall } from "./webrtc/call";
 export { GroupCallEvent, GroupCallIntent, GroupCallState, GroupCallType } from "./webrtc/groupCall";
 export type { GroupCall } from "./webrtc/groupCall";
-export type { CryptoApi } from "./crypto-api";
+export type { CryptoApi, DeviceVerificationStatus } from "./crypto-api";
 export { CryptoEvent } from "./crypto";
 
 let cryptoStoreFactory = (): CryptoStore => new MemoryCryptoStore();

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -62,7 +62,8 @@ export { createNewMatrixCall } from "./webrtc/call";
 export type { MatrixCall } from "./webrtc/call";
 export { GroupCallEvent, GroupCallIntent, GroupCallState, GroupCallType } from "./webrtc/groupCall";
 export type { GroupCall } from "./webrtc/groupCall";
-export type { CryptoApi, DeviceVerificationStatus } from "./crypto-api";
+export type { CryptoApi } from "./crypto-api";
+export { DeviceVerificationStatus } from "./crypto-api";
 export { CryptoEvent } from "./crypto";
 
 let cryptoStoreFactory = (): CryptoStore => new MemoryCryptoStore();

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -36,6 +36,7 @@ import { MapWithDefault } from "../utils";
  */
 export class RustCrypto implements CryptoBackend {
     public globalErrorOnUnknownDevices = false;
+    private _trustCrossSignedDevices = true;
 
     /** whether {@link stop} has been called */
     private stopped = false;
@@ -163,6 +164,22 @@ export class RustCrypto implements CryptoBackend {
     public async exportRoomKeys(): Promise<IMegolmSessionData[]> {
         // TODO
         return [];
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#getTrustCrossSignedDevices}.
+     */
+    public getTrustCrossSignedDevices(): boolean {
+        return this._trustCrossSignedDevices;
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#setTrustCrossSignedDevices}.
+     */
+    public setTrustCrossSignedDevices(val: boolean): void {
+        this._trustCrossSignedDevices = val;
+        // TODO: legacy crypto goes through the list of known devices and emits DeviceVerificationChanged
+        //  events. Maybe we need to do the same?
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -25,11 +25,12 @@ import { RoomMember } from "../models/room-member";
 import { CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
 import { logger } from "../logger";
 import { IHttpOpts, MatrixHttpApi } from "../http-api";
-import { DeviceTrustLevel, UserTrustLevel } from "../crypto/CrossSigning";
+import { UserTrustLevel } from "../crypto/CrossSigning";
 import { RoomEncryptor } from "./RoomEncryptor";
 import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
 import { KeyClaimManager } from "./KeyClaimManager";
 import { MapWithDefault } from "../utils";
+import { DeviceVerificationStatus } from "../crypto-api";
 
 /**
  * An implementation of {@link CryptoBackend} using the Rust matrix-sdk-crypto.
@@ -131,11 +132,6 @@ export class RustCrypto implements CryptoBackend {
         return new UserTrustLevel(false, false, false);
     }
 
-    public checkDeviceTrust(userId: string, deviceId: string): DeviceTrustLevel {
-        // TODO
-        return new DeviceTrustLevel(false, false, false, false);
-    }
-
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //
     // CryptoApi implementation
@@ -180,6 +176,28 @@ export class RustCrypto implements CryptoBackend {
         this._trustCrossSignedDevices = val;
         // TODO: legacy crypto goes through the list of known devices and emits DeviceVerificationChanged
         //  events. Maybe we need to do the same?
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#getDeviceVerificationStatus}.
+     */
+    public async getDeviceVerificationStatus(
+        userId: string,
+        deviceId: string,
+    ): Promise<DeviceVerificationStatus | null> {
+        const device: RustSdkCryptoJs.Device | undefined = await this.olmMachine.getDevice(
+            new RustSdkCryptoJs.UserId(userId),
+            new RustSdkCryptoJs.DeviceId(deviceId),
+        );
+
+        if (!device) return null;
+
+        return new DeviceVerificationStatus(
+            device.isCrossSigningTrusted(),
+            false, // tofu
+            device.isLocallyTrusted(),
+            this._trustCrossSignedDevices,
+        );
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Define a new endpoint to replace the existing `checkDeviceTrust` which is awkward to implement in rust.

Review commit-by-commit.

Based on https://github.com/matrix-org/matrix-js-sdk/pull/3281.

Part of https://github.com/vector-im/element-web/issues/25092.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->