### PR TITLE
Improve types and their safety

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ import { Filter, IFilterDefinition, IRoomEventFilter } from "./filter";
 import { CallEventHandlerEvent, CallEventHandler, CallEventHandlerEventHandlerMap } from "./webrtc/callEventHandler";
 import { GroupCallEventHandlerEvent, GroupCallEventHandlerEventHandlerMap } from "./webrtc/groupCallEventHandler";
 import * as utils from "./utils";
-import { replaceParam, QueryDict, sleep, noUnsafeEventProps } from "./utils";
+import { replaceParam, QueryDict, sleep, noUnsafeEventProps, safeSet } from "./utils";
 import { Direction, EventTimeline } from "./models/event-timeline";
 import { IActionsObject, PushProcessor } from "./pushprocessor";
 import { AutoDiscovery, AutoDiscoveryAction } from "./autodiscovery";
@@ -8787,8 +8787,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         for (const [userId, deviceId] of devices) {
             const query = queries[userId] || {};
-            queries[userId] = query;
-            query[deviceId] = keyAlgorithm;
+            safeSet(queries, userId, query);
+            safeSet(query, deviceId, keyAlgorithm);
         }
         const content: IClaimKeysRequest = { one_time_keys: queries };
         if (timeout) {

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -338,7 +338,7 @@ export class MemoryCryptoStore implements CryptoStore {
             deviceSessions = {};
             this.sessions[deviceKey] = deviceSessions;
         }
-        deviceSessions[sessionId] = sessionInfo;
+        safeSet(deviceSessions, sessionId, sessionInfo);
     }
 
     public async storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -720,7 +720,7 @@ function processMapToObjectValue(value: any): any {
  * Recursively converts Maps to plain objects.
  * Also supports sub-lists of Maps.
  */
-export function recursiveMapToObject(map: Map<any, any>): any {
+export function recursiveMapToObject<K extends string | number | symbol, V>(map: Map<K, V>): Partial<Record<K, V>> {
     const targetMap = new Map();
 
     for (const [key, value] of map) {
@@ -734,7 +734,7 @@ export function unsafeProp<K extends keyof any | undefined>(prop: K): boolean {
     return prop === "__proto__" || prop === "prototype" || prop === "constructor";
 }
 
-export function safeSet<K extends keyof any>(obj: Record<any, any>, prop: K, value: any): void {
+export function safeSet<O extends Record<any, any>, K extends keyof O>(obj: O, prop: K, value: O[K]): void {
     if (unsafeProp(prop)) {
         throw new Error("Trying to modify prototype or constructor");
     }


### PR DESCRIPTION
The generic `safeSet` was allowing any value type to be passed allowing for developer mistakes