### PR TITLE
DeviceVerificationStatus: take a param object

### DIFF
--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -106,29 +106,41 @@ export interface CryptoApi {
 }
 
 export class DeviceVerificationStatus {
+    /**
+     * True if this device has been verified via cross signing.
+     *
+     * This does *not* take into account `trustCrossSignedDevices`.
+     */
+    public readonly crossSigningVerified: boolean;
+
+    /**
+     * TODO: tofu magic wtf does this do?
+     */
+    public readonly tofu: boolean;
+
+    /**
+     * True if the device has been marked as locally verified.
+     */
+    public readonly localVerified: boolean;
+
+    /**
+     * True if the client has been configured to trust cross-signed devices via {@link CryptoApi#setTrustCrossSignedDevices}.
+     */
+    private readonly trustCrossSignedDevices: boolean;
+
     public constructor(
-        /**
-         * True if this device has been verified via cross signing.
-         *
-         * This does *not* take into account `trustCrossSignedDevices`.
-         */
-        public readonly crossSigningVerified: boolean,
-
-        /**
-         * TODO: tofu magic wtf does this do?
-         */
-        public readonly tofu: boolean,
-
-        /**
-         * True if the device has been marked as locally verified.
-         */
-        public readonly localVerified: boolean,
-
-        /**
-         * True if the client has been configured to trust cross-signed devices via {@link CryptoApi#setTrustCrossSignedDevices}.
-         */
-        private readonly trustCrossSignedDevices: boolean,
-    ) {}
+        opts: Partial<DeviceVerificationStatus> & {
+            /**
+             * True if cross-signed devices should be considered verified for {@link DeviceVerificationStatus#isVerified}.
+             */
+            trustCrossSignedDevices?: boolean;
+        },
+    ) {
+        this.crossSigningVerified = opts.crossSigningVerified ?? false;
+        this.tofu = opts.tofu ?? false;
+        this.localVerified = opts.localVerified ?? false;
+        this.trustCrossSignedDevices = opts.trustCrossSignedDevices ?? false;
+    }
 
     /**
      * Check if we should consider this device "verified".

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -634,6 +634,15 @@ export class UserTrustLevel {
  * @deprecated Use {@link DeviceVerificationStatus}.
  */
 export class DeviceTrustLevel extends DeviceVerificationStatus {
+    public constructor(
+        crossSigningVerified: boolean,
+        tofu: boolean,
+        localVerified: boolean,
+        trustCrossSignedDevices: boolean,
+    ) {
+        super({ crossSigningVerified, tofu, localVerified, trustCrossSignedDevices });
+    }
+
     public static fromUserTrustLevel(
         userTrustLevel: UserTrustLevel,
         localVerified: boolean,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -192,12 +192,11 @@ export class RustCrypto implements CryptoBackend {
 
         if (!device) return null;
 
-        return new DeviceVerificationStatus(
-            device.isCrossSigningTrusted(),
-            false, // tofu
-            device.isLocallyTrusted(),
-            this._trustCrossSignedDevices,
-        );
+        return new DeviceVerificationStatus({
+            crossSigningVerified: device.isCrossSigningTrusted(),
+            localVerified: device.isLocallyTrusted(),
+            trustCrossSignedDevices: this._trustCrossSignedDevices,
+        });
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
An update to https://github.com/matrix-org/matrix-js-sdk/pull/3287 in which I realise I should have used a parameter object for the constructor rather than a long list of arguments.

This only landed yesterday so hopefully it's safe to assume nobody is using it yet!