### PR TITLE
Make webrtc stats collection optional

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -1650,33 +1650,35 @@ describe("Group Call", function () {
             );
         });
         it("should be undefined if not get stats", async () => {
-            // noinspection TypeScriptUnresolvedVariable
+            // @ts-ignore
             const stats = groupCall.stats;
             expect(stats).toBeUndefined();
         });
 
         it("should be defined after first access", async () => {
             groupCall.getGroupCallStats();
-            // noinspection TypeScriptUnresolvedVariable
+            // @ts-ignore
             const stats = groupCall.stats;
             expect(stats).toBeDefined();
         });
 
         it("with every number should do nothing if no stats exists.", async () => {
             groupCall.setGroupCallStatsInterval(0);
-            // noinspection TypeScriptUnresolvedVariable
+            // @ts-ignore
             let stats = groupCall.stats;
             expect(stats).toBeUndefined();
 
             groupCall.setGroupCallStatsInterval(10000);
-            // noinspection TypeScriptUnresolvedVariable
+            // @ts-ignore
             stats = groupCall.stats;
             expect(stats).toBeUndefined();
         });
 
         it("with number should stop existing stats", async () => {
             const stats = groupCall.getGroupCallStats();
+            // @ts-ignore
             const stop = jest.spyOn(stats, "stop");
+            // @ts-ignore
             const start = jest.spyOn(stats, "start");
             groupCall.setGroupCallStatsInterval(0);
 
@@ -1686,7 +1688,9 @@ describe("Group Call", function () {
 
         it("with number should restart existing stats", async () => {
             const stats = groupCall.getGroupCallStats();
+            // @ts-ignore
             const stop = jest.spyOn(stats, "stop");
+            // @ts-ignore
             const start = jest.spyOn(stats, "start");
             groupCall.setGroupCallStatsInterval(10000);
 

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -1625,4 +1625,73 @@ describe("Group Call", function () {
             expect(room.currentState.getStateEvents(EventType.GroupCallMemberPrefix, FAKE_USER_ID_2)).toBe(null);
         });
     });
+
+    describe("collection stats", () => {
+        let groupCall: GroupCall;
+
+        beforeAll(() => {
+            jest.useFakeTimers();
+            jest.setSystemTime(0);
+        });
+
+        afterAll(() => jest.useRealTimers());
+
+        beforeEach(async () => {
+            const typedMockClient = new MockCallMatrixClient(FAKE_USER_ID_1, FAKE_DEVICE_ID_1, FAKE_SESSION_ID_1);
+            const mockClient = typedMockClient.typed();
+            const room = new Room(FAKE_ROOM_ID, mockClient, FAKE_USER_ID_1);
+            groupCall = new GroupCall(
+                mockClient,
+                room,
+                GroupCallType.Video,
+                false,
+                GroupCallIntent.Prompt,
+                FAKE_CONF_ID,
+            );
+        });
+        it("should be undefined if not get stats", async () => {
+            // noinspection TypeScriptUnresolvedVariable
+            const stats = groupCall.stats;
+            expect(stats).toBeUndefined();
+        });
+
+        it("should be defined after first access", async () => {
+            groupCall.getGroupCallStats();
+            // noinspection TypeScriptUnresolvedVariable
+            const stats = groupCall.stats;
+            expect(stats).toBeDefined();
+        });
+
+        it("with every number should do nothing if no stats exists.", async () => {
+            groupCall.setGroupCallStatsInterval(0);
+            // noinspection TypeScriptUnresolvedVariable
+            let stats = groupCall.stats;
+            expect(stats).toBeUndefined();
+
+            groupCall.setGroupCallStatsInterval(10000);
+            // noinspection TypeScriptUnresolvedVariable
+            stats = groupCall.stats;
+            expect(stats).toBeUndefined();
+        });
+
+        it("with number should stop existing stats", async () => {
+            const stats = groupCall.getGroupCallStats();
+            const stop = jest.spyOn(stats, "stop");
+            const start = jest.spyOn(stats, "start");
+            groupCall.setGroupCallStatsInterval(0);
+
+            expect(stop).toHaveBeenCalled();
+            expect(start).not.toHaveBeenCalled();
+        });
+
+        it("with number should restart existing stats", async () => {
+            const stats = groupCall.getGroupCallStats();
+            const stop = jest.spyOn(stats, "stop");
+            const start = jest.spyOn(stats, "start");
+            groupCall.setGroupCallStatsInterval(10000);
+
+            expect(stop).toHaveBeenCalled();
+            expect(start).toHaveBeenCalled();
+        });
+    });
 });

--- a/spec/unit/webrtc/stats/groupCallStats.spec.ts
+++ b/spec/unit/webrtc/stats/groupCallStats.spec.ts
@@ -68,13 +68,23 @@ describe("GroupCallStats", () => {
             jest.useRealTimers();
         });
 
-        it("starting processing as well without stats collectors", async () => {
+        it("starting processing stats as well without stats collectors", async () => {
             // @ts-ignore
             stats.processStats = jest.fn();
             stats.start();
             jest.advanceTimersByTime(TIME_INTERVAL);
             // @ts-ignore
             expect(stats.processStats).toHaveBeenCalled();
+        });
+
+        it("not starting processing stats if interval 0", async () => {
+            const statsDisabled = new GroupCallStats(GROUP_CALL_ID, LOCAL_USER_ID, 0);
+            // @ts-ignore
+            statsDisabled.processStats = jest.fn();
+            statsDisabled.start();
+            jest.advanceTimersByTime(TIME_INTERVAL);
+            // @ts-ignore
+            expect(statsDisabled.processStats).not.toHaveBeenCalled();
         });
 
         it("starting processing and calling the collectors", async () => {

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -213,11 +213,6 @@ export class GroupCall extends TypedEventEmitter<
     public retryCallInterval = 5000;
     public participantTimeout = 1000 * 15;
     public pttMaxTransmitTime = 1000 * 20;
-    /**
-     * Configure default webrtc stats collection interval in ms
-     * Disable collecting webrtc stats by setting interval to 0
-     */
-    public statsCollectIntervalTime = 0;
 
     public activeSpeaker?: CallFeed;
     public localCallFeed?: CallFeed;
@@ -242,6 +237,11 @@ export class GroupCall extends TypedEventEmitter<
     private initCallFeedPromise?: Promise<void>;
 
     private stats: GroupCallStats | undefined;
+    /**
+     * Configure default webrtc stats collection interval in ms
+     * Disable collecting webrtc stats by setting interval to 0
+     */
+    private statsCollectIntervalTime = 0;
 
     public constructor(
         private client: MatrixClient,
@@ -1605,5 +1605,16 @@ export class GroupCall extends TypedEventEmitter<
             this.stats.reports.on(StatsReport.SUMMARY_STATS, this.onSummaryStats);
         }
         return this.stats;
+    }
+
+    public setGroupCallStatsInterval(interval: number): void {
+        this.statsCollectIntervalTime = interval;
+        if (this.stats !== undefined) {
+            this.stats.stop();
+            this.stats.setInterval(interval);
+            if (interval > 0) {
+                this.stats.start();
+            }
+        }
     }
 }

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -213,7 +213,11 @@ export class GroupCall extends TypedEventEmitter<
     public retryCallInterval = 5000;
     public participantTimeout = 1000 * 15;
     public pttMaxTransmitTime = 1000 * 20;
-    public statsCollectIntervalTime = 10000;
+    /**
+     * Configure default webrtc stats collection interval in ms
+     * Disable collecting webrtc stats by setting interval to 0
+     */
+    public statsCollectIntervalTime = 0;
 
     public activeSpeaker?: CallFeed;
     public localCallFeed?: CallFeed;

--- a/src/webrtc/stats/groupCallStats.ts
+++ b/src/webrtc/stats/groupCallStats.ts
@@ -69,4 +69,8 @@ export class GroupCallStats {
 
         Promise.all(summary).then((s: Awaited<SummaryStats>[]) => this.summaryStatsReporter.build(s));
     }
+
+    public setInterval(interval: number): void {
+        this.interval = interval;
+    }
 }

--- a/src/webrtc/stats/groupCallStats.ts
+++ b/src/webrtc/stats/groupCallStats.ts
@@ -27,7 +27,7 @@ export class GroupCallStats {
     public constructor(private groupCallId: string, private userId: string, private interval: number = 10000) {}
 
     public start(): void {
-        if (this.timer === undefined) {
+        if (this.timer === undefined && this.interval > 0) {
             this.timer = setInterval(() => {
                 this.processStats();
             }, this.interval);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Build a group call property to enable stats collecting

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->