### PR TITLE
`DeviceVerificationStatus`: add new `signedByOwner` property

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -265,12 +265,14 @@ describe("RustCrypto", () => {
             olmMachine.getDevice.mockResolvedValue({
                 isCrossSigningTrusted: jest.fn().mockReturnValue(false),
                 isLocallyTrusted: jest.fn().mockReturnValue(false),
+                isCrossSignedByOwner: jest.fn().mockReturnValue(false),
             } as unknown as RustSdkCryptoJs.Device);
             const res = await rustCrypto.getDeviceVerificationStatus("@user:domain", "device");
             expect(olmMachine.getDevice.mock.calls[0][0].toString()).toEqual("@user:domain");
             expect(olmMachine.getDevice.mock.calls[0][1].toString()).toEqual("device");
             expect(res?.crossSigningVerified).toBe(false);
             expect(res?.localVerified).toBe(false);
+            expect(res?.signedByOwner).toBe(false);
         });
 
         it("should return null for unknown device", async () => {

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -107,6 +107,14 @@ export interface CryptoApi {
 
 export class DeviceVerificationStatus {
     /**
+     * True if this device has been signed by its owner (and that signature verified).
+     *
+     * This doesn't necessarily mean that we have verified the device, since we may not have verified the
+     * owner's cross-signing key.
+     */
+    public readonly signedByOwner: boolean;
+
+    /**
      * True if this device has been verified via cross signing.
      *
      * This does *not* take into account `trustCrossSignedDevices`.
@@ -136,6 +144,7 @@ export class DeviceVerificationStatus {
             trustCrossSignedDevices?: boolean;
         },
     ) {
+        this.signedByOwner = opts.signedByOwner ?? false;
         this.crossSigningVerified = opts.crossSigningVerified ?? false;
         this.tofu = opts.tofu ?? false;
         this.localVerified = opts.localVerified ?? false;

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -639,8 +639,9 @@ export class DeviceTrustLevel extends DeviceVerificationStatus {
         tofu: boolean,
         localVerified: boolean,
         trustCrossSignedDevices: boolean,
+        signedByOwner = false,
     ) {
-        super({ crossSigningVerified, tofu, localVerified, trustCrossSignedDevices });
+        super({ crossSigningVerified, tofu, localVerified, trustCrossSignedDevices, signedByOwner });
     }
 
     public static fromUserTrustLevel(
@@ -653,6 +654,7 @@ export class DeviceTrustLevel extends DeviceVerificationStatus {
             userTrustLevel.isTofu(),
             localVerified,
             trustCrossSignedDevices,
+            true,
         );
     }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -193,6 +193,7 @@ export class RustCrypto implements CryptoBackend {
         if (!device) return null;
 
         return new DeviceVerificationStatus({
+            signedByOwner: device.isCrossSignedByOwner(),
             crossSigningVerified: device.isCrossSigningTrusted(),
             localVerified: device.isLocallyTrusted(),
             trustCrossSignedDevices: this._trustCrossSignedDevices,


### PR DESCRIPTION
... which turns out to be useful

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->