### PR TITLE
Adjust negotiation process for pending answer process

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1945,6 +1945,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
     }
 
     public async onNegotiateReceived(event: MatrixEvent): Promise<void> {
+        window.console.log('####### onNegotiateReceived', event);
         const content = event.getContent<MCallInviteNegotiate>();
         const description = content.description;
         if (!description || !description.sdp || !description.type) {
@@ -1996,12 +1997,14 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
 
                 await this.peerConn!.setLocalDescription(answer);
 
+                window.console.log('####### send NegotiateReceived', event);
                 this.sendVoipEvent(EventType.CallNegotiate, {
                     description: this.peerConn!.localDescription?.toJSON(),
                     [SDPStreamMetadataKey]: this.getLocalSDPStreamMetadata(true),
                 });
             }
         } catch (err) {
+            window.console.log('####### fail', event);
             logger.warn(`Call ${this.callId} onNegotiateReceived() failed to complete negotiation`, err);
         }
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -1900,6 +1900,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             await this.peerConn!.setRemoteDescription(content.answer);
             this.isSettingRemoteAnswerPending = false;
         } catch (e) {
+            this.isSettingRemoteAnswerPending = false;
             logger.debug(`Call ${this.callId} onAnswerReceived() failed to set remote description`, e);
             this.terminate(CallParty.Local, CallErrorCode.SetRemoteDescription, false);
             return;
@@ -2009,6 +2010,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 });
             }
         } catch (err) {
+            this.isSettingRemoteAnswerPending = false;
             logger.warn(`Call ${this.callId} onNegotiateReceived() failed to complete negotiation`, err);
         }
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2093,10 +2093,8 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
             return;
         }
 
-        let offer: RTCSessionDescriptionInit;
         try {
             this.getRidOfRTXCodecs();
-            offer = await this.createOffer();
         } catch (err) {
             logger.debug(`Call ${this.callId} gotLocalOffer() failed to create offer: `, err);
             this.terminate(CallParty.Local, CallErrorCode.CreateOffer, true);
@@ -2104,7 +2102,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         }
 
         try {
-            await this.peerConn!.setLocalDescription(offer);
+            await this.peerConn!.setLocalDescription();
         } catch (err) {
             logger.debug(`Call ${this.callId} gotLocalOffer() error setting local description!`, err);
             this.terminate(CallParty.Local, CallErrorCode.SetLocalDescription, true);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Note that an answer operation pending process is not treated as an unstable negotiation state and an offer will not rejected from impolite peer. The PR fixes the issue  adding an answer is not in race with renegotiation.'

We not using `await this.peerConn!.setLocalDescription(offer);` parameter less. We would also like to adjust this. Unfortunately, we munging the local SDP before adding it. That needs to be adjust first.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->