### PR TITLE
Fix lack of media when a user reconnects

### DIFF
--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -388,6 +388,10 @@ describe("Group Call", function () {
                 call = new MockMatrixCall(room.roomId, groupCall.groupCallId);
 
                 await groupCall.create();
+
+                const deviceCallMap = new Map<string, MatrixCall>();
+                deviceCallMap.set(FAKE_DEVICE_ID_1, call.typed());
+                (groupCall as any).calls.set(FAKE_USER_ID_1, deviceCallMap);
             });
 
             it("ignores changes, if we can't get user id of opponent", async () => {


### PR DESCRIPTION
This fixes broken media when someone reconnects to the call after a forced disconnect (when their old call gets replaced immediately by a new call). We listen for changes in the call feeds and the tearing down of the feeds for the old call caused us to remove the feed for the new call.

Also adds the call to the calls map before it'as initialised, such that it's the active call for the user/device when the feedsChanged event arrives, otherwise we'll ignore the event.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix lack of media when a user reconnects ([\#3318](https://github.com/matrix-org/matrix-js-sdk/pull/3318)).<!-- CHANGELOG_PREVIEW_END -->