### PR TITLE
Factor out ReceiptAccumulator

### DIFF
--- a/src/receipt-accumulator.ts
+++ b/src/receipt-accumulator.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AccumulatedReceipt } from "./sync-accumulator";
+import { MapWithDefault } from "./utils";
+
+export class ReceiptAccumulator {
+    private readReceipts: Map<string, AccumulatedReceipt> = new Map();
+    private threadedReadReceipts: MapWithDefault<string, Map<string, AccumulatedReceipt>> = new MapWithDefault(
+        () => new Map(),
+    );
+
+    public setUnthreaded(userId: string, receipt: AccumulatedReceipt): void {
+        this.readReceipts.set(userId, receipt);
+    }
+
+    public setThreaded(threadId: string, userId: string, receipt: AccumulatedReceipt): void {
+        this.threadedReadReceipts.getOrCreate(threadId).set(userId, receipt);
+    }
+
+    /**
+     * @returns an iterator of pairs of [userId, AccumulatedReceipt] - all the
+     *          unthreaded receipts for each user.
+     */
+    public allUnthreaded(): IterableIterator<[string, AccumulatedReceipt]> {
+        return this.readReceipts.entries();
+    }
+
+    /**
+     * @returns an iterator of pairs of [userId, AccumulatedReceipt] - all the
+     *          threaded receipts for each user, in all threads.
+     */
+    public *allThreaded(): IterableIterator<[string, AccumulatedReceipt]> {
+        for (const receiptsForThread of this.threadedReadReceipts.values()) {
+            for (const e of receiptsForThread.entries()) {
+                yield e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24629

In order to allow us to write simple unit tests, factor out the part of the sync accumulator that does receipt handling. Later changes may well make this more self-contained. This change is intended to be simple enough that we can convince ourselves by examining it that it has the same behaviour as before.

This code is performance-critical, so I added a couple of tests. When I increased the `testSize` in those tests to 10 million and 1 million, I got these results:

With the old code:

    ✓ can handle large numbers of identical receipts (8760 ms)
    ✓ can handle large numbers of receipts for different users and events (12123 ms)


With the new code:

    ✓ can handle large numbers of identical receipts (9035 ms)
    ✓ can handle large numbers of receipts for different users and events (10800 ms)

So this change appears to slow us slightly when we have lots of redundant receipts, and speed us up when we have lots of receipts that we want to keep around.

I expect the speed changes are due to the use of a `Map` instead of an object.

I think the this change is acceptable, and I think using a Map is better generally, but am interested in others' opinions.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->