### PR TITLE
Move receipt-specific logic into ReceiptAccumulator

### DIFF
--- a/src/receipt-accumulator.ts
+++ b/src/receipt-accumulator.ts
@@ -14,11 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AccumulatedReceipt, IMinimalEvent } from "./sync-accumulator";
+import { IMinimalEvent } from "./sync-accumulator";
 import { EventType } from "./@types/event";
 import { MapWithDefault, recursiveMapToObject } from "./utils";
 import { IContent } from "./models/event";
 import { ReceiptType } from "./@types/read_receipts";
+
+interface AccumulatedReceipt {
+    data: IMinimalEvent;
+    type: ReceiptType;
+    eventId: string;
+}
 
 /**
  * Summarises the read receipts within a room. Used by the sync accumulator.

--- a/src/receipt-accumulator.ts
+++ b/src/receipt-accumulator.ts
@@ -33,7 +33,7 @@ import { ReceiptType } from "./@types/read_receipts";
  */
 export class ReceiptAccumulator {
     /** user_id -\> most-recently-received unthreaded receipt */
-    private readReceipts: Map<string, AccumulatedReceipt> = new Map();
+    private unthreadedReadReceipts: Map<string, AccumulatedReceipt> = new Map();
 
     /** thread_id -\> user_id -\> most-recently-received receipt for this thread */
     private threadedReadReceipts: MapWithDefault<string, Map<string, AccumulatedReceipt>> = new MapWithDefault(
@@ -45,7 +45,7 @@ export class ReceiptAccumulator {
      * unthreaded receipt we have for this user.
      */
     public setUnthreaded(userId: string, receipt: AccumulatedReceipt): void {
-        this.readReceipts.set(userId, receipt);
+        this.unthreadedReadReceipts.set(userId, receipt);
     }
 
     /**
@@ -61,7 +61,7 @@ export class ReceiptAccumulator {
      *          most recently-received unthreaded receipts for each user.
      */
     private allUnthreaded(): IterableIterator<[string, AccumulatedReceipt]> {
-        return this.readReceipts.entries();
+        return this.unthreadedReadReceipts.entries();
     }
 
     /**

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -19,11 +19,10 @@ limitations under the License.
  */
 
 import { logger } from "./logger";
-import { deepCopy, isSupportedReceiptType } from "./utils";
+import { deepCopy } from "./utils";
 import { IContent, IUnsigned } from "./models/event";
 import { IRoomSummary } from "./models/room-summary";
 import { EventType } from "./@types/event";
-import { MAIN_ROOM_TIMELINE, ReceiptContent, ReceiptType } from "./@types/read_receipts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
 import { ReceiptAccumulator } from "./receipt-accumulator";
 
@@ -405,52 +404,17 @@ export class SyncAccumulator {
             acc[INVITED_COUNT_KEY] = sum[INVITED_COUNT_KEY] || acc[INVITED_COUNT_KEY];
         }
 
-        data.ephemeral?.events?.forEach((e) => {
-            // We purposefully do not persist m.typing events.
-            // Technically you could refresh a browser before the timer on a
-            // typing event is up, so it'll look like you aren't typing when
-            // you really still are. However, the alternative is worse. If
-            // we do persist typing events, it will look like people are
-            // typing forever until someone really does start typing (which
-            // will prompt Synapse to send down an actual m.typing event to
-            // clobber the one we persisted).
-            if (e.type !== EventType.Receipt || !e.content) {
-                // This means we'll drop unknown ephemeral events but that
-                // seems okay.
-                return;
-            }
-            // Handle m.receipt events. They clobber based on:
-            //   (user_id, receipt_type)
-            // but they are keyed in the event as:
-            //   content:{ $event_id: { $receipt_type: { $user_id: {json} }}}
-            // so store them in the former so we can accumulate receipt deltas
-            // quickly and efficiently (we expect a lot of them). Fold the
-            // receipt type into the key name since we only have 1 at the
-            // moment (m.read) and nested JSON objects are slower and more
-            // of a hassle to work with. We'll inflate this back out when
-            // getJSON() is called.
-            Object.keys(e.content).forEach((eventId) => {
-                Object.entries<ReceiptContent>(e.content[eventId]).forEach(([key, value]) => {
-                    if (!isSupportedReceiptType(key)) return;
+        // We purposefully do not persist m.typing events.
+        // Technically you could refresh a browser before the timer on a
+        // typing event is up, so it'll look like you aren't typing when
+        // you really still are. However, the alternative is worse. If
+        // we do persist typing events, it will look like people are
+        // typing forever until someone really does start typing (which
+        // will prompt Synapse to send down an actual m.typing event to
+        // clobber the one we persisted).
 
-                    for (const userId of Object.keys(value)) {
-                        const data = e.content[eventId][key][userId];
-
-                        const receipt = {
-                            data: e.content[eventId][key][userId],
-                            type: key as ReceiptType,
-                            eventId,
-                        };
-
-                        if (!data.thread_id || data.thread_id === MAIN_ROOM_TIMELINE) {
-                            currentData._receipts.setUnthreaded(userId, receipt);
-                        } else {
-                            currentData._receipts.setThreaded(data.thread_id, userId, receipt);
-                        }
-                    }
-                });
-            });
-        });
+        // Persist the receipts
+        currentData._receipts.consumeEphemeralEvents(data.ephemeral?.events);
 
         // if we got a limited sync, we need to remove all timeline entries or else
         // we will have gaps in the timeline.

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -45,12 +45,6 @@ export interface IMinimalEvent {
     unsigned?: IUnsigned;
 }
 
-export interface AccumulatedReceipt {
-    data: IMinimalEvent;
-    type: ReceiptType;
-    eventId: string;
-}
-
 export interface IEphemeral {
     events: IMinimalEvent[];
 }


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/24629

Move all the logic for processing receipts into the ReceiptAccumulator, so we can create simpler tests, and so it's easier to deal with when we start fixing bugs in it.

It's probably worth looking at this commit-by-commit.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->