### PR TITLE
Add `Room.getLastLiveEvent` and `Room.getLastThread`

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3547,46 +3547,26 @@ describe("Room", function () {
             expect(room.getLastLiveEvent()).toBeUndefined();
         });
 
-        describe("when there is only an event in the main timeline and there are no threads", () => {
-            beforeEach(() => {
-                lastEventInMainTimeline = addRoomMainAndThreadMessages(room, 23).mainEvent!;
-                room.addLiveEvents([lastEventInMainTimeline]);
-            });
-
-            it("should return the last event from the main timeline", () => {
-                expect(room.getLastLiveEvent()).toBe(lastEventInMainTimeline);
-            });
+        it("when there is only an event in the main timeline and there are no threads, it should return the last event from the main timeline", () => {
+            lastEventInMainTimeline = addRoomMainAndThreadMessages(room, 23).mainEvent!;
+            room.addLiveEvents([lastEventInMainTimeline]);
+            expect(room.getLastLiveEvent()).toBe(lastEventInMainTimeline);
         });
 
-        describe("when there is no event in the room live timeline, but in a thread", () => {
-            beforeEach(() => {
-                lastEventInThread = addRoomMainAndThreadMessages(room, undefined, 42).threadEvent!;
-            });
-
-            it("should return the last event from the thread", () => {
-                expect(room.getLastLiveEvent()).toBe(lastEventInThread);
-            });
+        it("when there is no event in the room live timeline but in a thread, it should return the last event from the thread", () => {
+            lastEventInThread = addRoomMainAndThreadMessages(room, undefined, 42).threadEvent!;
+            expect(room.getLastLiveEvent()).toBe(lastEventInThread);
         });
 
         describe("when there are events in both, the main timeline and threads", () => {
-            describe("and the last event is in a thread", () => {
-                beforeEach(() => {
-                    lastEventInThread = addRoomMainAndThreadMessages(room, 23, 42).threadEvent!;
-                });
-
-                it("should return the last event from the thread", () => {
-                    expect(room.getLastLiveEvent()).toBe(lastEventInThread);
-                });
+            it("and the last event is in a thread, it should return the last event from the thread", () => {
+                lastEventInThread = addRoomMainAndThreadMessages(room, 23, 42).threadEvent!;
+                expect(room.getLastLiveEvent()).toBe(lastEventInThread);
             });
 
-            describe("and the last event is in the main timeline", () => {
-                beforeEach(() => {
-                    lastEventInMainTimeline = addRoomMainAndThreadMessages(room, 42, 23).mainEvent!;
-                });
-
-                it("should return the last event from the main timeline", () => {
-                    expect(room.getLastLiveEvent()).toBe(lastEventInMainTimeline);
-                });
+            it("and the last event is in the main timeline, it should return the last event from the main timeline", () => {
+                lastEventInMainTimeline = addRoomMainAndThreadMessages(room, 42, 23).mainEvent!;
+                expect(room.getLastLiveEvent()).toBe(lastEventInMainTimeline);
             });
         });
     });

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -792,6 +792,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     /**
      * Returns the last live event of this room.
      * "last" means latest timestamp.
+     * Instead of using timestamps, it would be better to do the comparison based on the order of the homeserver DAG.
+     * Unfortunately, this information is currently not available in the client.
+     * See {@link https://github.com/matrix-org/matrix-js-sdk/issues/3325}.
      * "live of this room" means from all live timelines: the room and the threads.
      *
      * @returns MatrixEvent if there is a last event; else undefined.
@@ -809,6 +812,12 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
+     * Returns the last thread of this room.
+     * "last" means latest timestamp of the last thread event.
+     * Instead of using timestamps, it would be better to do the comparison based on the order of the homeserver DAG.
+     * Unfortunately, this information is currently not available in the client.
+     * See {@link https://github.com/matrix-org/matrix-js-sdk/issues/3325}.
+     *
      * @returns the thread with the most recent event in its live time line. undefined if there is no thread.
      */
     public getLastThread(): Thread | undefined {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -398,7 +398,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private threads = new Map<string, Thread>();
 
     /**
-     * @deprecated use {@link Room.getLastThread} instead
+     * @deprecated This value is unreliable. It may not contain the last thread.
+     *             Use {@link Room.getLastThread} instead.
      */
     public lastThread?: Thread;
 


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/25207

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

Notes: Added `Room.getLastLiveEvent` and `Room.getLastThread`. Deprecated `Room.lastThread` in favour of `Room.getLastThread`.

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Added `Room.getLastLiveEvent` and `Room.getLastThread`. Deprecated `Room.lastThread` in favour of `Room.getLastThread`. ([\#3321](https://github.com/matrix-org/matrix-js-sdk/pull/3321)).<!-- CHANGELOG_PREVIEW_END -->