### PR TITLE
add client method to remove pusher

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -2909,4 +2909,43 @@ describe("MatrixClient", function () {
             });
         });
     });
+
+    describe("pushers", () => {
+        const pusher = {
+            app_id: "test",
+            app_display_name: "Test App",
+            data: {},
+            device_display_name: "test device",
+            kind: "http",
+            lang: "en-NZ",
+            pushkey: "1234",
+        };
+
+        beforeEach(() => {
+            makeClient();
+            const response: HttpLookup = {
+                method: Method.Post,
+                path: "/pushers/set",
+                data: {},
+            };
+            httpLookups = [response];
+            jest.spyOn(client.http, "authedRequest").mockClear();
+        });
+
+        it("should make correct request to set pusher", async () => {
+            const result = await client.setPusher(pusher);
+            expect(client.http.authedRequest).toHaveBeenCalledWith(Method.Post, "/pushers/set", undefined, pusher);
+            expect(result).toEqual({});
+        });
+
+        it("should make correct request to remove pusher", async () => {
+            const result = await client.removePusher(pusher.pushkey, pusher.app_id);
+            expect(client.http.authedRequest).toHaveBeenCalledWith(Method.Post, "/pushers/set", undefined, {
+                pushkey: pusher.pushkey,
+                app_id: pusher.app_id,
+                kind: null,
+            });
+            expect(result).toEqual({});
+        });
+    });
 });

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -206,8 +206,4 @@ export interface IPusherRequest extends Omit<IPusher, "device_id" | "org.matrix.
     append?: boolean;
 }
 
-export interface IPusherRemoveRequest extends Pick<IPusher, "app_id" | "pushkey"> {
-    kind: null;
-}
-
 /* eslint-enable camelcase */

--- a/src/@types/PushRules.ts
+++ b/src/@types/PushRules.ts
@@ -206,4 +206,8 @@ export interface IPusherRequest extends Omit<IPusher, "device_id" | "org.matrix.
     append?: boolean;
 }
 
+export interface IPusherRemoveRequest extends Pick<IPusher, "app_id" | "pushkey"> {
+    kind: null;
+}
+
 /* eslint-enable camelcase */

--- a/src/client.ts
+++ b/src/client.ts
@@ -8621,6 +8621,23 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
+     * Removes an existing pusher
+     * @param pushKey - pushkey of pusher to remove
+     * @param appId - app_id of pusher to remove
+     * @returns Promise which resolves: Empty json object on success
+     * @returns Rejects: with an error response.
+     */
+    public removePusher(pushKey: string, appId: string): Promise<{}> {
+        const path = "/pushers/set";
+        const body = {
+            pushkey: pushKey,
+            app_id: appId,
+            kind: null, // marks pusher for removal
+        };
+        return this.http.authedRequest(Method.Post, path, undefined, body);
+    }
+
+    /**
      * Persists local notification settings
      * @returns Promise which resolves: an empty object
      * @returns Rejects: with an error response.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Removing a pusher [is a bit opaque](https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/components/views/settings/Notifications.tsx#L444) and violates types
Adds a nice method to MatrixClient to remove a pusher.

Used https://github.com/matrix-org/matrix-react-sdk/pull/10724
For https://github.com/vector-im/element-web/issues/25217

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * add client method to remove pusher ([\#3324](https://github.com/matrix-org/matrix-js-sdk/pull/3324)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->