### PR TITLE
Fix racing between one-time-keys processing and sync

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1525,7 +1525,7 @@ export class SyncApi {
         }
 
         // Handle one_time_keys_count and unused fallback keys
-        this.syncOpts.cryptoCallbacks?.processKeyCounts(
+        await this.syncOpts.cryptoCallbacks?.processKeyCounts(
             data.device_one_time_keys_count,
             data.device_unused_fallback_key_types ?? data["org.matrix.msc2732.device_unused_fallback_key_types"],
         );


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Closes https://github.com/vector-im/element-web/issues/25214

Notes: Fix racing between one-time-keys processing and sync

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix racing between one-time-keys processing and sync ([\#3327](https://github.com/matrix-org/matrix-js-sdk/pull/3327)). Fixes vector-im/element-web#25214. Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->