### PR TITLE
Revert "Update JS-DevTools/npm-publish action to v2 (#3336)"

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: 🚀 Publish to npm
               id: npm-publish
-              uses: JS-DevTools/npm-publish@0be441d808570461daedc3fb178405dbcac54de0 # v2
+              uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939 # v1
               with:
                   token: ${{ secrets.NPM_TOKEN }}
                   access: public


### PR DESCRIPTION
Attempting to fix failure to publish to NPM due to an "invalid token" error https://github.com/matrix-org/matrix-js-sdk/actions/runs/4926808655/jobs/8819822367 .

This reverts commit ca9263fa647e4cfc581a137c389ea646bcf71ce6.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->