### PR TITLE
Pass SecretStorage into RustCrypto

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -27,6 +27,7 @@ import { mkEvent } from "../../test-utils/test-utils";
 import { CryptoBackend } from "../../../src/common-crypto/CryptoBackend";
 import { IEventDecryptionResult } from "../../../src/@types/crypto";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+import { ServerSideSecretStorage } from "../../../src/secret-storage";
 
 afterEach(() => {
     // reset fake-indexeddb after each test, to make sure we don't leak connections
@@ -44,7 +45,12 @@ describe("RustCrypto", () => {
 
         beforeEach(async () => {
             const mockHttpApi = {} as MatrixClient["http"];
-            rustCrypto = (await initRustCrypto(mockHttpApi, TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
+            rustCrypto = (await initRustCrypto(
+                mockHttpApi,
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            )) as RustCrypto;
         });
 
         it("should return a list", async () => {
@@ -58,7 +64,12 @@ describe("RustCrypto", () => {
 
         beforeEach(async () => {
             const mockHttpApi = {} as MatrixClient["http"];
-            rustCrypto = (await initRustCrypto(mockHttpApi, TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
+            rustCrypto = (await initRustCrypto(
+                mockHttpApi,
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            )) as RustCrypto;
         });
 
         it("should pass through unencrypted to-device messages", async () => {
@@ -141,7 +152,13 @@ describe("RustCrypto", () => {
                 makeOutgoingRequest: jest.fn(),
             } as unknown as Mocked<OutgoingRequestProcessor>;
 
-            rustCrypto = new RustCrypto(olmMachine, {} as MatrixHttpApi<any>, TEST_USER, TEST_DEVICE_ID);
+            rustCrypto = new RustCrypto(
+                olmMachine,
+                {} as MatrixHttpApi<any>,
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            );
             rustCrypto["outgoingRequestProcessor"] = outgoingRequestProcessor;
         });
 
@@ -207,7 +224,12 @@ describe("RustCrypto", () => {
 
         beforeEach(async () => {
             const mockHttpApi = {} as MatrixClient["http"];
-            rustCrypto = (await initRustCrypto(mockHttpApi, TEST_USER, TEST_DEVICE_ID)) as RustCrypto;
+            rustCrypto = (await initRustCrypto(
+                mockHttpApi,
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            )) as RustCrypto;
         });
 
         it("should handle unencrypted events", () => {
@@ -235,7 +257,12 @@ describe("RustCrypto", () => {
         let rustCrypto: RustCrypto;
 
         beforeEach(async () => {
-            rustCrypto = await initRustCrypto({} as MatrixClient["http"], TEST_USER, TEST_DEVICE_ID);
+            rustCrypto = await initRustCrypto(
+                {} as MatrixClient["http"],
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            );
         });
 
         it("should be true by default", () => {
@@ -258,7 +285,13 @@ describe("RustCrypto", () => {
             olmMachine = {
                 getDevice: jest.fn(),
             } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
-            rustCrypto = new RustCrypto(olmMachine, {} as MatrixClient["http"], TEST_USER, TEST_DEVICE_ID);
+            rustCrypto = new RustCrypto(
+                olmMachine,
+                {} as MatrixClient["http"],
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+            );
         });
 
         it("should call getDevice", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -2228,7 +2228,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // importing rust-crypto will download the webassembly, so we delay it until we know it will be
         // needed.
         const RustCrypto = await import("./rust-crypto");
-        const rustCrypto = await RustCrypto.initRustCrypto(this.http, userId, deviceId);
+        const rustCrypto = await RustCrypto.initRustCrypto(this.http, userId, deviceId, this.secretStorage);
         this.cryptoBackend = rustCrypto;
 
         // attach the event listeners needed by RustCrypto

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -74,7 +74,7 @@ export class RustCrypto implements CryptoBackend {
         _deviceId: string,
 
         /** Interface to server-side secret storage */
-        private readonly secretStorage: ServerSideSecretStorage,
+        _secretStorage: ServerSideSecretStorage,
     ) {
         this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
         this.keyClaimManager = new KeyClaimManager(olmMachine, this.outgoingRequestProcessor);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -34,6 +34,7 @@ import { DeviceVerificationStatus } from "../crypto-api";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client";
 import { Device, DeviceMap } from "../models/device";
+import { ServerSideSecretStorage } from "../secret-storage";
 
 /**
  * An implementation of {@link CryptoBackend} using the Rust matrix-sdk-crypto.
@@ -56,10 +57,24 @@ export class RustCrypto implements CryptoBackend {
     private outgoingRequestProcessor: OutgoingRequestProcessor;
 
     public constructor(
+        /** The `OlmMachine` from the underlying rust crypto sdk. */
         private readonly olmMachine: RustSdkCryptoJs.OlmMachine,
+
+        /**
+         * Low-level HTTP interface: used to make outgoing requests required by the rust SDK.
+         *
+         * We expect it to set the access token, etc.
+         */
         private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+
+        /** The local user's User ID. */
         _userId: string,
+
+        /** The local user's Device ID. */
         _deviceId: string,
+
+        /** Interface to server-side secret storage */
+        private readonly secretStorage: ServerSideSecretStorage,
     ) {
         this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
         this.keyClaimManager = new KeyClaimManager(olmMachine, this.outgoingRequestProcessor);


### PR DESCRIPTION
Our new crypto impl is going to need access to the secret storage, to store the cross signing keys, and do key backup

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->