### PR TITLE
Check permission on mute mic, only if no audio track exists.

### DIFF
--- a/spec/unit/webrtc/call.spec.ts
+++ b/spec/unit/webrtc/call.spec.ts
@@ -25,6 +25,7 @@ import {
     CallType,
     CallState,
     CallParty,
+    CallDirection,
 } from "../../../src/webrtc/call";
 import {
     MCallAnswer,
@@ -1710,6 +1711,112 @@ describe("Call", function () {
             call.replacedBy(call2);
 
             expect(onReplace).toHaveBeenCalled();
+        });
+    });
+    describe("should handle glare in negotiation process", () => {
+        beforeEach(async () => {
+            // cut methods not want to test
+            call.hangup = () => null;
+            call.isLocalOnHold = () => true;
+            // @ts-ignore
+            call.updateRemoteSDPStreamMetadata = jest.fn();
+            // @ts-ignore
+            call.getRidOfRTXCodecs = jest.fn();
+            // @ts-ignore
+            call.createAnswer = jest.fn().mockResolvedValue({});
+            // @ts-ignore
+            call.sendVoipEvent = jest.fn();
+        });
+
+        it("and reject remote offer if not polite and have pending local offer", async () => {
+            // not polite user == CallDirection.Outbound
+            call.direction = CallDirection.Outbound;
+            // have already a local offer
+            // @ts-ignore
+            call.makingOffer = true;
+            const offerEvent = makeMockEvent("@test:foo", {
+                description: {
+                    type: "offer",
+                    sdp: DUMMY_SDP,
+                },
+            });
+            // @ts-ignore
+            call.peerConn = {
+                signalingState: "have-local-offer",
+                setRemoteDescription: jest.fn(),
+            };
+            await call.onNegotiateReceived(offerEvent);
+            expect(call.peerConn?.setRemoteDescription).not.toHaveBeenCalled();
+        });
+
+        it("and not reject remote offer if not polite and do have pending answer", async () => {
+            // not polite user == CallDirection.Outbound
+            call.direction = CallDirection.Outbound;
+            // have not a local offer
+            // @ts-ignore
+            call.makingOffer = false;
+
+            // If we have a setRemoteDescription() answer operation pending, then
+            // we will be "stable" by the time the next setRemoteDescription() is
+            // executed, so we count this being readyForOffer when deciding whether to
+            // ignore the offer.
+            // @ts-ignore
+            call.isSettingRemoteAnswerPending = true;
+            const offerEvent = makeMockEvent("@test:foo", {
+                description: {
+                    type: "offer",
+                    sdp: DUMMY_SDP,
+                },
+            });
+            // @ts-ignore
+            call.peerConn = {
+                signalingState: "have-local-offer",
+                setRemoteDescription: jest.fn(),
+            };
+            await call.onNegotiateReceived(offerEvent);
+            expect(call.peerConn?.setRemoteDescription).toHaveBeenCalled();
+        });
+
+        it("and not reject remote offer if not polite and do not have pending local offer", async () => {
+            // not polite user == CallDirection.Outbound
+            call.direction = CallDirection.Outbound;
+            // have no local offer
+            // @ts-ignore
+            call.makingOffer = false;
+            const offerEvent = makeMockEvent("@test:foo", {
+                description: {
+                    type: "offer",
+                    sdp: DUMMY_SDP,
+                },
+            });
+            // @ts-ignore
+            call.peerConn = {
+                signalingState: "stable",
+                setRemoteDescription: jest.fn(),
+            };
+            await call.onNegotiateReceived(offerEvent);
+            expect(call.peerConn?.setRemoteDescription).toHaveBeenCalled();
+        });
+
+        it("and if polite do rollback pending local offer", async () => {
+            // polite user == CallDirection.Inbound
+            call.direction = CallDirection.Inbound;
+            // have already a local offer
+            // @ts-ignore
+            call.makingOffer = true;
+            const offerEvent = makeMockEvent("@test:foo", {
+                description: {
+                    type: "offer",
+                    sdp: DUMMY_SDP,
+                },
+            });
+            // @ts-ignore
+            call.peerConn = {
+                signalingState: "have-local-offer",
+                setRemoteDescription: jest.fn(),
+            };
+            await call.onNegotiateReceived(offerEvent);
+            expect(call.peerConn?.setRemoteDescription).toHaveBeenCalled();
         });
     });
 });

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -915,7 +915,7 @@ describe("Group Call", function () {
                 jest.spyOn(groupCall.localCallFeed, "hasAudioTrack", "get").mockReturnValue(false);
                 // @ts-ignore
                 jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue(
-                    new MockMediaStream("new"),
+                    {} as MediaStream,
                 );
                 expect(await groupCall.setMicrophoneMuted(false)).toBe(false);
             });

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -914,9 +914,7 @@ describe("Group Call", function () {
                 // @ts-ignore
                 jest.spyOn(groupCall.localCallFeed, "hasAudioTrack", "get").mockReturnValue(false);
                 // @ts-ignore
-                jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue(
-                    {} as MediaStream,
-                );
+                jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue({} as MediaStream);
                 expect(await groupCall.setMicrophoneMuted(false)).toBe(false);
             });
 

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -909,6 +909,14 @@ describe("Group Call", function () {
                 expect(await groupCall.setMicrophoneMuted(false)).toBe(false);
             });
 
+            it("returns false when user media stream null", async () => {
+                const groupCall = await createAndEnterGroupCall(mockClient, room);
+                // @ts-ignore
+                jest.spyOn(groupCall.localCallFeed, "hasAudioTrack", "get").mockReturnValue(false);
+                jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue(null);
+                expect(await groupCall.setMicrophoneMuted(false)).toBe(false);
+            });
+
             it("returns true when no permission for audio stream but localCallFeed has a audio track already", async () => {
                 const groupCall = await createAndEnterGroupCall(mockClient, room);
                 // @ts-ignore

--- a/spec/unit/webrtc/groupCall.spec.ts
+++ b/spec/unit/webrtc/groupCall.spec.ts
@@ -913,7 +913,10 @@ describe("Group Call", function () {
                 const groupCall = await createAndEnterGroupCall(mockClient, room);
                 // @ts-ignore
                 jest.spyOn(groupCall.localCallFeed, "hasAudioTrack", "get").mockReturnValue(false);
-                jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue(null);
+                // @ts-ignore
+                jest.spyOn(mockClient.getMediaHandler(), "getUserMediaStream").mockResolvedValue(
+                    new MockMediaStream("new"),
+                );
                 expect(await groupCall.setMicrophoneMuted(false)).toBe(false);
             });
 

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -128,7 +128,7 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
         this.emit(CallFeedEvent.ConnectedChanged, this.connected);
     }
 
-    private get hasAudioTrack(): boolean {
+    public get hasAudioTrack(): boolean {
         return this.stream.getAudioTracks().length > 0;
     }
 

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -625,9 +625,8 @@ export class GroupCall extends TypedEventEmitter<
         if (this.isPtt) {
             // Set or clear the max transmit timer
             if (!muted && this.isMicrophoneMuted()) {
-                const slf = this;
                 this.transmitTimer = setTimeout(() => {
-                    slf.setMicrophoneMuted(true);
+                    this.setMicrophoneMuted(true);
                 }, this.pttMaxTransmitTime);
             } else if (muted && !this.isMicrophoneMuted()) {
                 if (this.transmitTimer !== null) clearTimeout(this.transmitTimer);
@@ -691,8 +690,6 @@ export class GroupCall extends TypedEventEmitter<
      * `this.client.getMediaHandler().getUserMediaStream` clones the current stream, so it only wanted to be called when
      * not Audio Track exists.
      * As such, this is a compromise, because, the access rights should always be queried before the call.
-     * @param muted
-     * @private
      */
     private async checkAudioPermissionIfNecessary(muted: boolean): Promise<boolean> {
         // We needed this here to avoid an error in case user join a call without a device.

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -698,7 +698,7 @@ export class GroupCall extends TypedEventEmitter<
                 const stream = await this.client
                     .getMediaHandler()
                     .getUserMediaStream(true, !this.localCallFeed.isVideoMuted());
-                if (stream === null) {
+                if (stream?.getTracks().length === 0) {
                     // if case permission denied to get a stream stop this here
                     /* istanbul ignore next */
                     logger.log(

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -625,8 +625,9 @@ export class GroupCall extends TypedEventEmitter<
         if (this.isPtt) {
             // Set or clear the max transmit timer
             if (!muted && this.isMicrophoneMuted()) {
+                const slf = this;
                 this.transmitTimer = setTimeout(() => {
-                    this.setMicrophoneMuted(true);
+                    slf.setMicrophoneMuted(true);
                 }, this.pttMaxTransmitTime);
             } else if (muted && !this.isMicrophoneMuted()) {
                 if (this.transmitTimer !== null) clearTimeout(this.transmitTimer);
@@ -655,27 +656,9 @@ export class GroupCall extends TypedEventEmitter<
                 `GroupCall ${this.groupCallId} setMicrophoneMuted() (streamId=${this.localCallFeed.stream.id}, muted=${muted})`,
             );
 
-            // We needed this here to avoid an error in case user join a call without a device.
-            // I can not use .then .catch functions because linter :-(
-            try {
-                if (!muted) {
-                    const stream = await this.client
-                        .getMediaHandler()
-                        .getUserMediaStream(true, !this.localCallFeed.isVideoMuted());
-                    if (stream === null) {
-                        // if case permission denied to get a stream stop this here
-                        /* istanbul ignore next */
-                        logger.log(
-                            `GroupCall ${this.groupCallId} setMicrophoneMuted() no device to receive local stream, muted=${muted}`,
-                        );
-                        return false;
-                    }
-                }
-            } catch (e) {
-                /* istanbul ignore next */
-                logger.log(
-                    `GroupCall ${this.groupCallId} setMicrophoneMuted() no device or permission to receive local stream, muted=${muted}`,
-                );
+            const hasPermission = await this.checkAudioPermissionIfNecessary(muted);
+
+            if (!hasPermission) {
                 return false;
             }
 
@@ -696,6 +679,44 @@ export class GroupCall extends TypedEventEmitter<
         this.emit(GroupCallEvent.LocalMuteStateChanged, muted, this.isLocalVideoMuted());
 
         if (!sendUpdatesBefore) await sendUpdates();
+
+        return true;
+    }
+
+    /**
+     * If we allow entering a call without a camera and without video, it can happen that the access rights to the
+     * devices have not yet been queried. If a stream does not yet have an audio track, we assume that the rights have
+     * not yet been checked.
+     *
+     * `this.client.getMediaHandler().getUserMediaStream` clones the current stream, so it only wanted to be called when
+     * not Audio Track exists.
+     * As such, this is a compromise, because, the access rights should always be queried before the call.
+     * @param muted
+     * @private
+     */
+    private async checkAudioPermissionIfNecessary(muted: boolean): Promise<boolean> {
+        // We needed this here to avoid an error in case user join a call without a device.
+        try {
+            if (!muted && this.localCallFeed && !this.localCallFeed.hasAudioTrack) {
+                const stream = await this.client
+                    .getMediaHandler()
+                    .getUserMediaStream(true, !this.localCallFeed.isVideoMuted());
+                if (stream === null) {
+                    // if case permission denied to get a stream stop this here
+                    /* istanbul ignore next */
+                    logger.log(
+                        `GroupCall ${this.groupCallId} setMicrophoneMuted() no device to receive local stream, muted=${muted}`,
+                    );
+                    return false;
+                }
+            }
+        } catch (e) {
+            /* istanbul ignore next */
+            logger.log(
+                `GroupCall ${this.groupCallId} setMicrophoneMuted() no device or permission to receive local stream, muted=${muted}`,
+            );
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Sometimes when audio and video are muted in an awkward order then the local media stream will be duplicated. 
Then there is a ghost reference to the old stream that is not cleaned up.

Bug Fix for:
https://github.com/vector-im/element-call/issues/1044

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->