### PR TITLE
Keep measuring a call feed's volume after a stream replacement

### DIFF
--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -135,6 +135,8 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
     private updateStream(oldStream: MediaStream | null, newStream: MediaStream): void {
         if (newStream === oldStream) return;
 
+        const wasMeasuringVolumeActivity = this.measuringVolumeActivity;
+
         if (oldStream) {
             oldStream.removeEventListener("addtrack", this.onAddTrack);
             this.measureVolumeActivity(false);
@@ -145,6 +147,7 @@ export class CallFeed extends TypedEventEmitter<CallFeedEvent, EventHandlerMap> 
 
         if (this.hasAudioTrack) {
             this.initVolumeMeasuring();
+            if (wasMeasuringVolumeActivity) this.measureVolumeActivity(true);
         } else {
             this.measureVolumeActivity(false);
         }


### PR DESCRIPTION
Closes https://github.com/vector-im/element-call/issues/1051

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Keep measuring a call feed's volume after a stream replacement ([\#3361](https://github.com/matrix-org/matrix-js-sdk/pull/3361)). Fixes vector-im/element-call#1051.<!-- CHANGELOG_PREVIEW_END -->