### PR TITLE
correctly accumulate sync summaries.

### DIFF
--- a/spec/unit/sync-accumulator.spec.ts
+++ b/spec/unit/sync-accumulator.spec.ts
@@ -545,6 +545,23 @@ describe("SyncAccumulator", function () {
             expect(summary["m.heroes"]).toEqual(["@bob:bar"]);
         });
 
+        it("should reset summary properties", function () {
+            sa.accumulate(
+                createSyncResponseWithSummary({
+                    "m.heroes": ["@alice:bar"],
+                    "m.invited_member_count": 2,
+                }),
+            );
+            sa.accumulate(
+                createSyncResponseWithSummary({
+                    "m.heroes": ["@alice:bar"],
+                    "m.invited_member_count": 0,
+                }),
+            );
+            const summary = sa.getJSON().roomsData.join["!foo:bar"].summary;
+            expect(summary["m.invited_member_count"]).toEqual(0);
+        });
+
         it("should return correctly adjusted age attributes", () => {
             const delta = 1000;
             const startingTs = 1000;

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -399,9 +399,9 @@ export class SyncAccumulator {
 
             const acc = currentData._summary;
             const sum = data.summary;
-            acc[HEROES_KEY] = sum[HEROES_KEY] || acc[HEROES_KEY];
-            acc[JOINED_COUNT_KEY] = sum[JOINED_COUNT_KEY] || acc[JOINED_COUNT_KEY];
-            acc[INVITED_COUNT_KEY] = sum[INVITED_COUNT_KEY] || acc[INVITED_COUNT_KEY];
+            acc[HEROES_KEY] = sum[HEROES_KEY] ?? acc[HEROES_KEY];
+            acc[JOINED_COUNT_KEY] = sum[JOINED_COUNT_KEY] ?? acc[JOINED_COUNT_KEY];
+            acc[INVITED_COUNT_KEY] = sum[INVITED_COUNT_KEY] ?? acc[INVITED_COUNT_KEY];
         }
 
         // We purposefully do not persist m.typing events.


### PR DESCRIPTION
if a sync summary for (say) invited_member_count goes from 1 to 0, it should be accumluated as 0, rather than 1.

Fixes https://github.com/vector-im/element-web/issues/23345


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * correctly accumulate sync summaries. ([\#3366](https://github.com/matrix-org/matrix-js-sdk/pull/3366)). Fixes vector-im/element-web#23345.<!-- CHANGELOG_PREVIEW_END -->