### PR TITLE
Add typedoc-plugin-coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
         "ts-node": "^10.9.1",
         "tsify": "^5.0.2",
         "typedoc": "^0.24.0",
+        "typedoc-plugin-coverage": "^2.1.0",
         "typedoc-plugin-mdn-links": "^3.0.3",
         "typedoc-plugin-missing-exports": "^2.0.0",
         "typedoc-plugin-versions": "^0.2.3",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,8 @@
 {
-    "plugin": ["typedoc-plugin-mdn-links", "typedoc-plugin-missing-exports", "typedoc-plugin-versions"]
+    "plugin": [
+        "typedoc-plugin-mdn-links",
+        "typedoc-plugin-missing-exports",
+        "typedoc-plugin-versions",
+        "typedoc-plugin-coverage"
+    ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,5 +4,6 @@
         "typedoc-plugin-missing-exports",
         "typedoc-plugin-versions",
         "typedoc-plugin-coverage"
-    ]
+    ],
+    "coverageLabel": "TypeDoc"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7421,6 +7421,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+typedoc-plugin-coverage@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-coverage/-/typedoc-plugin-coverage-2.1.0.tgz#619bf10853c5851c47dc17585e14385647bbb754"
+  integrity sha512-d0Lc/aOPRAMnfABCW2cQqCQdzLUzadeq62r4DBrSchcfzx1X8nOvhXK/n4mVAO4wQQUchTm2ZGAzTtiAc2nl0A==
+
 typedoc-plugin-mdn-links@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-3.0.3.tgz#da8d1a9750d57333e6c21717b38bfc13d4058de2"


### PR DESCRIPTION
Lets us monitor documentation coverage over time

Example https://pr3379--js-sdk-docs-previews.netlify.app/stable/coverage.svg

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->