### PR TITLE
Fix verification bug with `pendingEventOrdering: "chronological"`

### DIFF
--- a/src/crypto/verification/request/InRoomChannel.ts
+++ b/src/crypto/verification/request/InRoomChannel.ts
@@ -208,10 +208,17 @@ export class InRoomChannel implements IVerificationChannel {
             this.requestEventId = InRoomChannel.getTransactionId(event);
         }
 
+        // With pendingEventOrdering: "chronological", we will see events that have been sent but not yet reflected
+        // back via /sync. These are "local echoes" and are identifiable by their txnId
+        const isLocalEcho = !!event.getTxnId();
+
+        // Alternatively, we may see an event that we sent that is reflected back via /sync. These are "remote echoes"
+        // and have a transaction ID in the "unsigned" data
         const isRemoteEcho = !!event.getUnsigned().transaction_id;
+
         const isSentByUs = event.getSender() === this.client.getUserId();
 
-        return request.handleEvent(type, event, isLiveEvent, isRemoteEcho, isSentByUs);
+        return request.handleEvent(type, event, isLiveEvent, isLocalEcho || isRemoteEcho, isSentByUs);
     }
 
     /**


### PR DESCRIPTION
There exists a bug (in the legacy `Crypto` implementation), in which in-room verifications-via-emoji will fail for applications which use the default `pendingEventOrdering` setting.

The basis of the problem is that the verifier sees a local echo of our own outgoing `m.key.verification.mac`. It tries to verify the MAC in that message, which of course fails.

The solution is to treat such local echoes in the same way as remote echoes.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix verification bug with `pendingEventOrdering: "chronological"` ([\#3382](https://github.com/matrix-org/matrix-js-sdk/pull/3382)).<!-- CHANGELOG_PREVIEW_END -->