### PR TITLE
Minor fixes to CryptoApi doc comments

### DIFF
--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -126,7 +126,8 @@ export interface CryptoApi {
      * @param userId - The ID of the user whose device is to be checked.
      * @param deviceId - The ID of the device to check
      *
-     * @returns Verification status of the device, or `null` if the device is not known
+     * @returns `null` if the device is unknown, or has not published any encryption keys (implying it does not support
+     *     encryption); otherwise the verification status of the device.
      */
     getDeviceVerificationStatus(userId: string, deviceId: string): Promise<DeviceVerificationStatus | null>;
 
@@ -147,7 +148,7 @@ export interface CryptoApi {
     /**
      * Get the ID of one of the user's cross-signing keys.
      *
-     * @param type - The type of key to get the ID of.  One of `CrossSigningKey.Master`, `CrossSigngingKey.SelfSigning`,
+     * @param type - The type of key to get the ID of.  One of `CrossSigningKey.Master`, `CrossSigningKey.SelfSigning`,
      *     or `CrossSigningKey.UserSigning`.  Defaults to `CrossSigningKey.Master`.
      *
      * @returns If cross-signing has been initialised on this device, the ID of the given key. Otherwise, null


### PR DESCRIPTION
Followups to #3287 and #3360: minor clarifications to the doc-comments

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->