### PR TITLE
GHA: build and cypress-test a copy of element-web after each push

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,29 @@
+# Triggers after the "Downstream artifacts" build has finished, to run the
+# cypress tests (with access to repo secrets)
+
+name: matrix-react-sdk Cypress End to End Tests
+on:
+    workflow_run:
+        workflows: ["Build downstream artifacts"]
+        types:
+            - completed
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.run_id }}
+    cancel-in-progress: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+jobs:
+    cypress:
+        name: Cypress
+        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@HEAD
+        permissions:
+            actions: read
+            issues: read
+            statuses: write
+            pull-requests: read
+        secrets:
+            # secrets are not automatically shared with called workflows, so share the cypress dashboard key
+            CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        with:
+            react-sdk-repository: matrix-org/matrix-react-sdk
+            rust-crypto: true

--- a/.github/workflows/downstream-artifacts.yml
+++ b/.github/workflows/downstream-artifacts.yml
@@ -1,0 +1,17 @@
+name: Build downstream artifacts
+on:
+    pull_request: {}
+    merge_group:
+        types: [checks_requested]
+    push:
+        branches: [develop, master]
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+jobs:
+    build-element-web:
+        name: Build element-web
+        uses: matrix-org/matrix-react-sdk/.github/workflows/element-web.yaml@HEAD
+        with:
+            matrix-js-sdk-sha: ${{ github.sha }}
+            react-sdk-repository: matrix-org/matrix-react-sdk


### PR DESCRIPTION
Part of vector-im/element-web#25313.

Fires off a Cypress test run against a rust-crypto-enabled Element Web R after each js-sdk PR.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/10969.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->