### PR TITLE
Element-R: Pull out an interface from `VerificationBase`

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -18,9 +18,8 @@ import fetchMock from "fetch-mock-jest";
 import { MockResponse } from "fetch-mock";
 
 import { createClient, MatrixClient } from "../../../src";
-import { ShowQrCodeCallbacks, ShowSasCallbacks, VerifierEvent } from "../../../src/crypto-api/verification";
+import { ShowQrCodeCallbacks, ShowSasCallbacks, Verifier, VerifierEvent } from "../../../src/crypto-api/verification";
 import { escapeRegExp } from "../../../src/utils";
-import { VerificationBase } from "../../../src/crypto/verification/Base";
 import { CRYPTO_BACKENDS, InitCrypto } from "../../test-utils/test-utils";
 import { SyncResponder } from "../../test-utils/SyncResponder";
 import {
@@ -170,7 +169,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
         expect(request.chosenMethod).toEqual("m.sas.v1");
 
         // there should now be a verifier
-        const verifier: VerificationBase = request.verifier!;
+        const verifier: Verifier = request.verifier!;
         expect(verifier).toBeDefined();
         expect(verifier.getShowSasCallbacks()).toBeNull();
 
@@ -325,7 +324,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(request.chosenMethod).toEqual("m.reciprocate.v1");
 
             // there should now be a verifier
-            const verifier: VerificationBase = request.verifier!;
+            const verifier: Verifier = request.verifier!;
             expect(verifier).toBeDefined();
             expect(verifier.getReciprocateQrCodeCallbacks()).toBeNull();
 

--- a/src/crypto/verification/Base.ts
+++ b/src/crypto/verification/Base.ts
@@ -32,6 +32,7 @@ import { TypedEventEmitter } from "../../models/typed-event-emitter";
 import {
     ShowQrCodeCallbacks,
     ShowSasCallbacks,
+    Verifier,
     VerifierEvent,
     VerifierEventHandlerMap,
 } from "../../crypto-api/verification";
@@ -59,11 +60,14 @@ export type VerificationEventHandlerMap = {
 // The type parameters of VerificationBase are no longer used, but we need some placeholders to maintain
 // backwards compatibility with applications that reference the class.
 export class VerificationBase<
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    Events extends string = VerifierEvent,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    Arguments = VerifierEventHandlerMap,
-> extends TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap> {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        Events extends string = VerifierEvent,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        Arguments = VerifierEventHandlerMap,
+    >
+    extends TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap>
+    implements Verifier
+{
     private cancelled = false;
     private _done = false;
     private promise: Promise<void> | null = null;

--- a/src/crypto/verification/Base.ts
+++ b/src/crypto/verification/Base.ts
@@ -57,6 +57,7 @@ export type VerificationEventHandlerMap = {
     [VerificationEvent.Cancel]: (e: Error | MatrixEvent) => void;
 };
 
+/** @deprecated Avoid referencing this class directly; instead use {@link Crypto.Verifier}. */
 // The type parameters of VerificationBase are no longer used, but we need some placeholders to maintain
 // backwards compatibility with applications that reference the class.
 export class VerificationBase<

--- a/src/crypto/verification/QRCode.ts
+++ b/src/crypto/verification/QRCode.ts
@@ -36,6 +36,7 @@ export type QrCodeEvent = VerifierEvent;
 /** @deprecated use VerifierEvent */
 export const QrCodeEvent = VerifierEvent;
 
+/** @deprecated Avoid referencing this class directly; instead use {@link Crypto.Verifier}. */
 export class ReciprocateQRCode extends Base {
     public reciprocateQREvent?: ShowQrCodeCallbacks;
 

--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -219,6 +219,7 @@ export type SasEvent = VerifierEvent;
 /** @deprecated use VerifierEvent */
 export const SasEvent = VerifierEvent;
 
+/** @deprecated Avoid referencing this class directly; instead use {@link Crypto.Verifier}. */
 export class SAS extends Base {
     private waitingForAccept?: boolean;
     public ourSASPubKey?: string;


### PR DESCRIPTION
The abstract base class `VerificationBase` (along with its two concrete subclasses `SAS` and `ReciprocateQRCode`) implement the logic for performing a device or user verification once a specific verification method has been agreed between the two parties.

We want to reimplement this in Rust, so as a first step, pull out an interface from the current Javascript implementation, which in future we can implement with a rust-backed implementation - and deprecate direct access to the old classes..

Notes: Introduce a new `Crypto.Verifier` interface, and deprecate direct access to `VerificationBase`, `SAS` and `ReciprocateQRCode`

Part of https://github.com/vector-im/crypto-internal/issues/95.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Introduce a new `Crypto.Verifier` interface, and deprecate direct access to `VerificationBase`, `SAS` and `ReciprocateQRCode` ([\#3414](https://github.com/matrix-org/matrix-js-sdk/pull/3414)).<!-- CHANGELOG_PREVIEW_END -->