### PR TITLE
Update MSC3912 implementation to use `with_rel_type` instead of `with_relations`

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -340,7 +340,7 @@ describe("MatrixClient", function () {
         store.storeClientOptions = jest.fn().mockReturnValue(Promise.resolve(null));
         store.isNewlyCreated = jest.fn().mockReturnValue(Promise.resolve(true));
 
-        // set unstableFeatures to a defined state before reach test
+        // set unstableFeatures to a defined state before each test
         unstableFeatures = {
             "org.matrix.msc3440.stable": true,
         };

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -340,6 +340,7 @@ describe("MatrixClient", function () {
         store.storeClientOptions = jest.fn().mockReturnValue(Promise.resolve(null));
         store.isNewlyCreated = jest.fn().mockReturnValue(Promise.resolve(true));
 
+        // set unstableFeatures to a defined state before reach test
         unstableFeatures = {
             "org.matrix.msc3440.stable": true,
         };

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -172,7 +172,7 @@ export const UNSTABLE_MSC2716_MARKER = new UnstableValue("m.room.marker", "org.m
  * {@link https://github.com/matrix-org/matrix-spec-proposals/pull/3912}
  */
 export const MSC3912_RELATION_BASED_REDACTIONS_PROP = new UnstableValue(
-    "with_relations",
+    "with_rel_types",
     "org.matrix.msc3912.with_relations",
 );
 

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -168,7 +168,7 @@ export const UNSTABLE_MSC3089_BRANCH = new UnstableValue("m.branch", "org.matrix
 export const UNSTABLE_MSC2716_MARKER = new UnstableValue("m.room.marker", "org.matrix.msc2716.marker");
 
 /**
- * Name of the "with_relations" request property for relation based redactions.
+ * Name of the request property for relation based redactions.
  * {@link https://github.com/matrix-org/matrix-spec-proposals/pull/3912}
  */
 export const MSC3912_RELATION_BASED_REDACTIONS_PROP = new UnstableValue(

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -48,17 +48,21 @@ export interface IJoinRoomOpts {
 export interface IRedactOpts {
     reason?: string;
     /**
-     * Whether events related to the redacted event should be redacted.
-     *
+     * @deprecated Use with_rel_types instead.
+     *             Will be removed at the latest when MSC3912 becomes stable.
+     */
+    with_relations?: Array<RelationType | string>;
+    /**
      * If specified, then any events which relate to the event being redacted with
      * any of the relationship types listed will also be redacted.
+     * Provide an "*" list item to tell the server to redact relations of any type.
      *
      * <b>Raises an Error if the server does not support it.</b>
      * Check for server-side support before using this param with
      * <code>client.canSupport.get(Feature.RelationBasedRedactions)</code>.
      * {@link https://github.com/matrix-org/matrix-spec-proposals/pull/3912}
      */
-    with_relations?: Array<RelationType | string>;
+    with_rel_types?: Array<RelationType | "*">;
 }
 
 export interface ISendEventResponse {

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -55,7 +55,7 @@ export interface IRedactOpts {
     /**
      * If specified, then any events which relate to the event being redacted with
      * any of the relationship types listed will also be redacted.
-     * Provide an "*" list item to tell the server to redact relations of any type.
+     * Provide a "*" list item to tell the server to redact relations of any type.
      *
      * <b>Raises an Error if the server does not support it.</b>
      * Check for server-side support before using this param with

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -48,11 +48,6 @@ export interface IJoinRoomOpts {
 export interface IRedactOpts {
     reason?: string;
     /**
-     * @deprecated Use with_rel_types instead.
-     *             Will be removed at the latest when MSC3912 becomes stable.
-     */
-    with_relations?: Array<RelationType | string>;
-    /**
      * If specified, then any events which relate to the event being redacted with
      * any of the relationship types listed will also be redacted.
      * Provide a "*" list item to tell the server to redact relations of any type.

--- a/src/client.ts
+++ b/src/client.ts
@@ -4627,26 +4627,26 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId = null;
         }
         const reason = opts?.reason;
-        let withRelTypes = opts?.with_rel_types ?? opts?.with_relations;
 
-        if (typeof withRelTypes === "string") {
-            withRelTypes = [withRelTypes];
+        let withRelTypesContent = {};
+
+        if (opts?.with_rel_types) {
+            if (this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Unsupported) {
+                throw new Error(
+                    "Server does not support relation based redactions " +
+                        `roomId ${roomId} eventId ${eventId} txnId: ${txnId} threadId ${threadId}`,
+                );
+            }
+
+            const withRelTypesPropName =
+                this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Stable
+                    ? MSC3912_RELATION_BASED_REDACTIONS_PROP.stable!
+                    : MSC3912_RELATION_BASED_REDACTIONS_PROP.unstable!;
+
+            withRelTypesContent = {
+                [withRelTypesPropName]: opts.with_rel_types,
+            };
         }
-
-        if (withRelTypes && this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Unsupported) {
-            throw new Error(
-                "Server does not support relation based redactions " +
-                    `roomId ${roomId} eventId ${eventId} txnId: ${txnId} threadId ${threadId}`,
-            );
-        }
-
-        const withRelTypesContent = withRelTypes
-            ? {
-                  [this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Stable
-                      ? MSC3912_RELATION_BASED_REDACTIONS_PROP.stable!
-                      : MSC3912_RELATION_BASED_REDACTIONS_PROP.unstable!]: withRelTypes,
-              }
-            : {};
 
         return this.sendCompleteEvent(
             roomId,

--- a/src/client.ts
+++ b/src/client.ts
@@ -4627,10 +4627,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId = null;
         }
         const reason = opts?.reason;
+        const content: IContent = { reason };
 
-        let withRelTypesContent = {};
-
-        if (opts?.with_rel_types) {
+        if (opts?.with_rel_types !== undefined) {
             if (this.canSupport.get(Feature.RelationBasedRedactions) === ServerSupport.Unsupported) {
                 throw new Error(
                     "Server does not support relation based redactions " +
@@ -4643,9 +4642,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                     ? MSC3912_RELATION_BASED_REDACTIONS_PROP.stable!
                     : MSC3912_RELATION_BASED_REDACTIONS_PROP.unstable!;
 
-            withRelTypesContent = {
-                [withRelTypesPropName]: opts.with_rel_types,
-            };
+            content[withRelTypesPropName] = opts.with_rel_types;
         }
 
         return this.sendCompleteEvent(
@@ -4653,10 +4650,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             threadId,
             {
                 type: EventType.RoomRedaction,
-                content: {
-                    ...withRelTypesContent,
-                    reason,
-                },
+                content,
                 redacts: eventId,
             },
             txnId as string,


### PR DESCRIPTION
Adapts the implementation to the latest version of [MSC3912](https://github.com/matrix-org/matrix-spec-proposals/pull/3912#issuecomment-1567173949)

- `with_relations` → `with_rel_types`
- `with_rel_types` is now always a list of strings incl. `*`
- I decided to keep `with_relations` and mark it as deprecated. It should be removed once the MSC becomes stable.

Part of https://github.com/vector-im/element-web/issues/25471

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Update MSC3912 implementation to use `with_rel_type` instead of `with_relations` ([\#3420](https://github.com/matrix-org/matrix-js-sdk/pull/3420)).<!-- CHANGELOG_PREVIEW_END -->