### PR TITLE
Remove spec non-compliant extended glob format

### DIFF
--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -97,51 +97,6 @@ describe("NotificationService", function () {
                         pattern: "foo*bar",
                         rule_id: "foobar",
                     },
-                    {
-                        actions: [
-                            "notify",
-                            {
-                                set_tweak: "sound",
-                                value: "default",
-                            },
-                            {
-                                set_tweak: "highlight",
-                            },
-                        ],
-                        enabled: true,
-                        pattern: "p[io]ng",
-                        rule_id: "pingpong",
-                    },
-                    {
-                        actions: [
-                            "notify",
-                            {
-                                set_tweak: "sound",
-                                value: "default",
-                            },
-                            {
-                                set_tweak: "highlight",
-                            },
-                        ],
-                        enabled: true,
-                        pattern: "I ate [0-9] pies",
-                        rule_id: "pies",
-                    },
-                    {
-                        actions: [
-                            "notify",
-                            {
-                                set_tweak: "sound",
-                                value: "default",
-                            },
-                            {
-                                set_tweak: "highlight",
-                            },
-                        ],
-                        enabled: true,
-                        pattern: "b[!ai]ke",
-                        rule_id: "bakebike",
-                    },
                 ],
                 override: [
                     {

--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -289,39 +289,6 @@ describe("NotificationService", function () {
         expect(actions.tweaks.highlight).toEqual(true);
     });
 
-    // TODO: This is not spec compliant behaviour.
-    //
-    // See https://spec.matrix.org/v1.5/client-server-api/#conditions-1 which
-    // describes pattern should glob:
-    //
-    // 1. * matches 0 or more characters;
-    // 2. ? matches exactly one character
-    it("should bing on character group ([abc]) bing words.", function () {
-        testEvent.event.content!.body = "Ping!";
-        let actions = pushProcessor.actionsForEvent(testEvent);
-        expect(actions.tweaks.highlight).toEqual(true);
-        testEvent.event.content!.body = "Pong!";
-        actions = pushProcessor.actionsForEvent(testEvent);
-        expect(actions.tweaks.highlight).toEqual(true);
-    });
-
-    // TODO: This is not spec compliant behaviour. (See above.)
-    it("should bing on character range ([a-z]) bing words.", function () {
-        testEvent.event.content!.body = "I ate 6 pies";
-        const actions = pushProcessor.actionsForEvent(testEvent);
-        expect(actions.tweaks.highlight).toEqual(true);
-    });
-
-    // TODO: This is not spec compliant behaviour. (See above.)
-    it("should bing on character negation ([!a]) bing words.", function () {
-        testEvent.event.content!.body = "boke";
-        let actions = pushProcessor.actionsForEvent(testEvent);
-        expect(actions.tweaks.highlight).toEqual(true);
-        testEvent.event.content!.body = "bake";
-        actions = pushProcessor.actionsForEvent(testEvent);
-        expect(actions.tweaks.highlight).toEqual(false);
-    });
-
     it("should not bing on room server ACL changes", function () {
         testEvent = utils.mkEvent({
             type: EventType.RoomServerAcl,

--- a/spec/unit/utils.spec.ts
+++ b/spec/unit/utils.spec.ts
@@ -30,6 +30,8 @@ import {
     sortEventsByLatestContentTimestamp,
     safeSet,
     MapWithDefault,
+    globToRegexp,
+    escapeRegExp,
 } from "../../src/utils";
 import { logger } from "../../src/logger";
 import { mkMessage } from "../test-utils/test-utils";
@@ -723,6 +725,21 @@ describe("utils", function () {
     describe("immediate", () => {
         it("resolves", async () => {
             await utils.immediate();
+        });
+    });
+
+    describe("escapeRegExp", () => {
+        it("should escape XYZ", () => {
+            expect(escapeRegExp("[FIT-Connect Zustelldienst \\(Testumgebung\\)]")).toMatchInlineSnapshot(
+                `"\\[FIT-Connect Zustelldienst \\\\\\(Testumgebung\\\\\\)\\]"`,
+            );
+        });
+    });
+
+    describe("globToRegexp", () => {
+        it("should not explode when given regexes as globs", () => {
+            const result = globToRegexp("[FIT-Connect Zustelldienst \\(Testumgebung\\)]");
+            expect(result).toMatchInlineSnapshot(`"\\[FIT-Connect Zustelldienst \\\\\\(Testumgebung\\\\\\)\\]"`);
         });
     });
 });

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -186,7 +186,7 @@ export class IgnoredInvites {
                     }
                     let regexp: RegExp;
                     try {
-                        regexp = new RegExp(globToRegexp(glob, false));
+                        regexp = new RegExp(globToRegexp(glob));
                     } catch (ex) {
                         // Assume invalid event.
                         continue;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -357,21 +357,14 @@ export function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Converts Matrix glob-style string to a regular expression
+ * https://spec.matrix.org/v1.7/appendices/#glob-style-matching
+ * @param glob - Matrix glob-style string
+ * @returns regular expression
+ */
 export function globToRegexp(glob: string): string {
-    // From
-    // https://github.com/matrix-org/synapse/blob/abbee6b29be80a77e05730707602f3bbfc3f38cb/synapse/push/__init__.py#L132
-    // Because micromatch is about 130KB with dependencies,
-    // and minimatch is not much better.
-    const replacements: [RegExp, string | ((substring: string, ...args: any[]) => string)][] = [
-        [/\\\*/g, ".*"],
-        [/\?/g, "."],
-    ];
-
-    return replacements.reduce(
-        // https://github.com/microsoft/TypeScript/issues/30134
-        (pat, args) => (args ? pat.replace(args[0], args[1] as any) : pat),
-        escapeRegExp(glob),
-    );
+    return escapeRegExp(glob).replace(/\\\*/g, ".*").replace(/\?/g, ".");
 }
 
 export function ensureNoTrailingSlash(url: string): string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -357,7 +357,7 @@ export function escapeRegExp(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function globToRegexp(glob: string, extended = false): string {
+export function globToRegexp(glob: string): string {
     // From
     // https://github.com/matrix-org/synapse/blob/abbee6b29be80a77e05730707602f3bbfc3f38cb/synapse/push/__init__.py#L132
     // Because micromatch is about 130KB with dependencies,
@@ -366,13 +366,7 @@ export function globToRegexp(glob: string, extended = false): string {
         [/\\\*/g, ".*"],
         [/\?/g, "."],
     ];
-    if (!extended) {
-        replacements.push([
-            /\\\[(!|)(.*)\\]/g,
-            (_match: string, neg: string, pat: string): string =>
-                ["[", neg ? "^" : "", pat.replace(/\\-/, "-"), "]"].join(""),
-        ]);
-    }
+
     return replacements.reduce(
         // https://github.com/microsoft/TypeScript/issues/30134
         (pat, args) => (args ? pat.replace(args[0], args[1] as any) : pat),


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25474
https://spec.matrix.org/v1.7/appendices/#glob-style-matching has no mention of the extended format, Synapse lost support for it in 2021, the extra replacements were meant to be added if extended=true, extended used to default to true, this method was subject to many fat fingers.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove spec non-compliant extended glob format ([\#3423](https://github.com/matrix-org/matrix-js-sdk/pull/3423)). Fixes vector-im/element-web#25474.<!-- CHANGELOG_PREVIEW_END -->