### PR TITLE
Mark room version 10 as safe

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -72,8 +72,8 @@ import { isPollEvent, Poll, PollEvent } from "./poll";
 // room versions which are considered okay for people to run without being asked
 // to upgrade (ie: "stable"). Eventually, we should remove these when all homeservers
 // return an m.room_versions capability.
-export const KNOWN_SAFE_ROOM_VERSION = "9";
-const SAFE_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+export const KNOWN_SAFE_ROOM_VERSION = "10";
+const SAFE_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
 
 interface IOpts {
     /**


### PR DESCRIPTION
As should have been done a year ago.

See https://github.com/vector-im/element-web/issues/16068

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Mark room version 10 as safe ([\#3425](https://github.com/matrix-org/matrix-js-sdk/pull/3425)).<!-- CHANGELOG_PREVIEW_END -->