### PR TITLE
Always show a summary after Jest tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,11 +23,19 @@ const config: Config = {
     collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts}"],
     coverageReporters: ["text-summary", "lcov"],
     testResultsProcessor: "@casualbot/jest-sonar-reporter",
+
+    // Always print out a summary if there are any failing tests. Normally
+    // a summary is only printed if there are more than 20 test *suites*.
+    reporters: [["default", { summaryThreshold: 0 }]],
 };
 
 // if we're running under GHA, enable the GHA reporter
 if (env["GITHUB_ACTIONS"] !== undefined) {
-    const reporters: Config["reporters"] = [["github-actions", { silent: false }], "summary"];
+    const reporters: Config["reporters"] = [
+        ["github-actions", { silent: false }],
+        // as above: always show a summary if there were any failing tests.
+        ["summary", { summaryThreshold: 0 }],
+    ];
 
     // if we're running against the develop branch, also enable the slow test reporter
     if (env["GITHUB_REF"] == "refs/heads/develop") {


### PR DESCRIPTION
... because it is otherwise impossible to see what failed.

This ensures that Jest prints out a list of the failed tests at the end of a test run; by default it will only do so if more than 20 test suites were run.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->