### PR TITLE
Add new methods to VerificationRequest

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -129,9 +129,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expectSendToDeviceMessage("m.key.verification.request"),
             aliceClient.requestVerification(TEST_USER_ID, [TEST_DEVICE_ID]),
         ]);
-        const transactionId = request.channel.transactionId;
+        const transactionId = request.transactionId;
         expect(transactionId).toBeDefined();
         expect(request.phase).toEqual(Phase.Requested);
+        expect(request.roomId).toBeUndefined();
 
         let toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
         expect(toDeviceMessage.methods).toContain("m.sas.v1");
@@ -149,6 +150,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
         });
         await waitForVerificationRequestChanged(request);
         expect(request.phase).toEqual(Phase.Ready);
+        expect(request.otherDeviceId).toEqual(TEST_DEVICE_ID);
 
         // ... and picks a method with m.key.verification.start
         returnToDeviceMessageFromSync({
@@ -265,7 +267,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
                 expectSendToDeviceMessage("m.key.verification.request"),
                 aliceClient.requestVerification(TEST_USER_ID, [TEST_DEVICE_ID]),
             ]);
-            const transactionId = request.channel.transactionId;
+            const transactionId = request.transactionId;
 
             const toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
             expect(toDeviceMessage.methods).toContain("m.qr_code.show.v1");
@@ -287,9 +289,9 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(request.phase).toEqual(Phase.Ready);
 
             // we should now have QR data we can display
-            const qrCodeData = request.qrCodeData!;
-            expect(qrCodeData).toBeTruthy();
-            const qrCodeBuffer = qrCodeData.getBuffer();
+            const qrCodeBuffer = request.getQRCodeBytes()!;
+            expect(qrCodeBuffer).toBeTruthy();
+
             // https://spec.matrix.org/v1.7/client-server-api/#qr-code-format
             expect(qrCodeBuffer.subarray(0, 6).toString("latin1")).toEqual("MATRIX");
             expect(qrCodeBuffer.readUint8(6)).toEqual(0x02); // version

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -163,6 +163,22 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
         return true;
     }
 
+    /**
+     * Unique ID for this verification request.
+     *
+     * An ID isn't assigned until the first message is sent, so this may be `undefined` in the early phases.
+     */
+    public get transactionId(): string | undefined {
+        return this.channel.transactionId;
+    }
+
+    /**
+     * For an in-room verification, the ID of the room.
+     */
+    public get roomId(): string | undefined {
+        return this.channel.roomId;
+    }
+
     public get invalid(): boolean {
         return this.phase === PHASE_UNSENT;
     }

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -359,6 +359,11 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
         return this.channel.userId!;
     }
 
+    /** The device id of the other party in this request, for requests happening over to-device messages only. */
+    public get otherDeviceId(): string | undefined {
+        return this.channel.deviceId;
+    }
+
     public get isSelfVerification(): boolean {
         return this.client.getUserId() === this.otherUserId;
     }

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -257,9 +257,21 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
         return !this.observeOnly && this._phase !== PHASE_DONE && this._phase !== PHASE_CANCELLED;
     }
 
-    /** Only set after a .ready if the other party can scan a QR code */
+    /** Only set after a .ready if the other party can scan a QR code
+     *
+     * @deprecated Prefer `getQRCodeBytes`.
+     */
     public get qrCodeData(): QRCodeData | null {
         return this._qrCodeData;
+    }
+
+    /**
+     * Get the data for a QR code allowing the other device to verify this one, if it supports it.
+     *
+     * Only set after a .ready if the other party can scan a QR code, otherwise undefined.
+     */
+    public getQRCodeBytes(): Buffer | undefined {
+        return this._qrCodeData?.getBuffer();
     }
 
     /** Checks whether the other party supports a given verification method.


### PR DESCRIPTION
I'm trying to pull out an interface from `VerificationRequest`, so that I can replace it with a Rust implementation without changes to the application (vector-im/crypto-internal#96).

Currently it exposes `channel` and `qrCodeData` which are entire objects of which only one or two fields are used. By adding more specific methods, we can reduce the amount of stuff that has to be implemented considerably.

Based on #3439 

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->