### PR TITLE
Fix downstream-artifacts build

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
     cypress:
         name: Cypress
-        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@HEAD
+        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@develop
         permissions:
             actions: read
             issues: read

--- a/.github/workflows/downstream-artifacts.yml
+++ b/.github/workflows/downstream-artifacts.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
     build-element-web:
         name: Build element-web
-        uses: matrix-org/matrix-react-sdk/.github/workflows/element-web.yaml@HEAD
+        uses: matrix-org/matrix-react-sdk/.github/workflows/element-web.yaml@develop
         with:
             matrix-js-sdk-sha: ${{ github.sha }}
             react-sdk-repository: matrix-org/matrix-react-sdk


### PR DESCRIPTION
Fixes:

> ```
> error parsing called workflow ".github/workflows/downstream-artifacts.yml" -> "matrix-org/matrix-react-sdk/.github/workflows/element-web.yaml@HEAD" : failed to fetch workflow: reference to workflow should be either a valid branch, tag, or commit
> ```

Fixes to #3412 

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->