### PR TITLE
use cli.canSupport to determine intentional mentions support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9630,7 +9630,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * A helper to determine intentional mentions support
-     * @returns a boolean to determine if intentional mentions are enabled
+     * @returns a boolean to determine if intentional mentions are enabled on the server
      * @experimental
      */
     public supportsIntentionalMentions(): boolean {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9634,7 +9634,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @experimental
      */
     public supportsIntentionalMentions(): boolean {
-        return this.canSupport.get(Feature.IntentionalMentions) !== ServerSupport.Unsupported || false;
+        return this.canSupport.get(Feature.IntentionalMentions) !== ServerSupport.Unsupported;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -469,11 +469,6 @@ export interface IStartClientOpts {
      * @experimental
      */
     slidingSync?: SlidingSync;
-
-    /**
-     * @experimental
-     */
-    intentionalMentions?: boolean;
 }
 
 export interface IStoredClientOpts extends IStartClientOpts {}
@@ -9639,7 +9634,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @experimental
      */
     public supportsIntentionalMentions(): boolean {
-        return this.clientOpts?.intentionalMentions || false;
+        return this.canSupport.get(Feature.IntentionalMentions) !== ServerSupport.Unsupported || false;
     }
 
     /**

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -32,6 +32,7 @@ export enum Feature {
     RelationBasedRedactions = "RelationBasedRedactions",
     AccountDataDeletion = "AccountDataDeletion",
     RelationsRecursion = "RelationsRecursion",
+    IntentionalMentions = "IntentionalMentions",
 }
 
 type FeatureSupportCondition = {
@@ -59,6 +60,9 @@ const featureSupportResolver: Record<string, FeatureSupportCondition> = {
     },
     [Feature.RelationsRecursion]: {
         unstablePrefixes: ["org.matrix.msc3981"],
+    },
+    [Feature.IntentionalMentions]: {
+        unstablePrefixes: ["org.matrix.msc3952_intentional_mentions"],
     },
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes: https://github.com/vector-im/element-web/issues/25497

`supportsIntentionalMentions` was being set using a client option set on client start. react-sdk set this value using a setting with an unstable version controller. react-sdk's `ServerSupportUnstableFeatureController` uses the matrix client to determine support, and is only initialised **after** the client is started. So, intentional mention support in matrix-js-sdk was always falsy.

`supportsIntentionalMentions` is used in react-sdk during client-side notification creation.

Now, intentional mention support uses the client's `canSupport` map. 
This means the user's lab setting does not affect `supportsIntentionalMentions`. Intentional mentions is moving out of labs soon after these bugs are fixed so the impact will be minimal.
Users will be impacted where:
1. Server supports IM and
2. Sender has IM labs enabled and
3. Recipient has IM labs disabled and
4. Message includes a plaintext mention of the recipient

If the sender Alice includes a plaintext mention of Bob, (ie 'Bob' without any pillification), recipient Bob may expect a ping for this message and will not get one.
If the sender includes an intentional mention of Bob, Bob will be pinged.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * use cli.canSupport to determine intentional mentions support ([\#3445](https://github.com/matrix-org/matrix-js-sdk/pull/3445)). Fixes vector-im/element-web#25497. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->