### PR TITLE
Export thread-related types from SDK

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -37,6 +37,7 @@ export * from "./models/event-timeline-set";
 export * from "./models/poll";
 export * from "./models/room-member";
 export * from "./models/room-state";
+export * from "./models/thread";
 export * from "./models/typed-event-emitter";
 export * from "./models/user";
 export * from "./models/device";

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -37,7 +37,7 @@ export * from "./models/event-timeline-set";
 export * from "./models/poll";
 export * from "./models/room-member";
 export * from "./models/room-state";
-export * from "./models/thread";
+export { ThreadEvent, ThreadEmittedEvents, ThreadEventHandlerMap, Thread } from "./models/thread";
 export * from "./models/typed-event-emitter";
 export * from "./models/user";
 export * from "./models/device";

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -34,7 +34,7 @@ import {
 import { Crypto } from "../crypto";
 import { deepSortedObjectEntries, internaliseString } from "../utils";
 import { RoomMember } from "./room-member";
-import { Thread, ThreadEvent, EventHandlerMap as ThreadEventHandlerMap, THREAD_RELATION_TYPE } from "./thread";
+import { Thread, ThreadEvent, ThreadEventHandlerMap, THREAD_RELATION_TYPE } from "./thread";
 import { IActionsObject } from "../pushprocessor";
 import { TypedReEmitter } from "../ReEmitter";
 import { MatrixError } from "../http-api";

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -49,7 +49,7 @@ import { BeaconEvent, BeaconEventHandlerMap } from "./beacon";
 import {
     Thread,
     ThreadEvent,
-    EventHandlerMap as ThreadHandlerMap,
+    ThreadEventHandlerMap as ThreadHandlerMap,
     FILTER_RELATED_BY_REL_TYPES,
     THREAD_RELATION_TYPE,
     FILTER_RELATED_BY_SENDERS,

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -47,6 +47,11 @@ export type ThreadEventHandlerMap = {
     [ThreadEvent.Delete]: (thread: Thread) => void;
 } & EventTimelineSetHandlerMap;
 
+/**
+ * @deprecated please use ThreadEventHandlerMap instead
+ */
+export type EventHandlerMap = ThreadEventHandlerMap;
+
 interface IThreadOpts {
     room: Room;
     client: MatrixClient;

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -38,9 +38,9 @@ export enum ThreadEvent {
     Delete = "Thread.delete",
 }
 
-type EmittedEvents = Exclude<ThreadEvent, ThreadEvent.New> | RoomEvent.Timeline | RoomEvent.TimelineReset;
+export type ThreadEmittedEvents = Exclude<ThreadEvent, ThreadEvent.New> | RoomEvent.Timeline | RoomEvent.TimelineReset;
 
-export type EventHandlerMap = {
+export type ThreadEventHandlerMap = {
     [ThreadEvent.Update]: (thread: Thread) => void;
     [ThreadEvent.NewReply]: (thread: Thread, event: MatrixEvent) => void;
     [ThreadEvent.ViewThread]: () => void;
@@ -70,7 +70,7 @@ export function determineFeatureSupport(stable: boolean, unstable: boolean): Fea
     }
 }
 
-export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
+export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerMap> {
     public static hasServerSideSupport = FeatureSupport.None;
     public static hasServerSideListSupport = FeatureSupport.None;
     public static hasServerSideFwdPaginationSupport = FeatureSupport.None;
@@ -83,7 +83,7 @@ export class Thread extends ReadReceipt<EmittedEvents, EventHandlerMap> {
 
     private _currentUserParticipated = false;
 
-    private reEmitter: TypedReEmitter<EmittedEvents, EventHandlerMap>;
+    private reEmitter: TypedReEmitter<ThreadEmittedEvents, ThreadEventHandlerMap>;
 
     private lastEvent: MatrixEvent | undefined;
     private replyCount = 0;


### PR DESCRIPTION
Export types related to threads from SDK so consumers who also use typescript can easily consume them

Signed-off-by: Stanislav Demydiuk [s.demydiuk@gmail.com](mailto:s.demydiuk@gmail.com)

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Export thread-related types from SDK ([\#3447](https://github.com/matrix-org/matrix-js-sdk/pull/3447)). Contributed by @stas-demydiuk.<!-- CHANGELOG_PREVIEW_END -->