### PR TITLE
Fix issues with implementation for MSC3981

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -1046,16 +1046,20 @@ describe("MatrixClient event timelines", function () {
                 return request;
             }
 
-            function respondToThread(root: Partial<IEvent>, replies: Partial<IEvent>[], limit?: number): ExpectedHttpRequest {
+            function respondToThread(
+                root: Partial<IEvent>,
+                replies: Partial<IEvent>[],
+                limit?: number,
+            ): ExpectedHttpRequest {
                 const request = httpBackend.when(
                     "GET",
                     "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                    encodeURIComponent(root.event_id!) +
-                    buildRelationPaginationQuery(client, {
-                        dir: Direction.Backward,
-                        limit: limit,
-                        recurse: true,
-                    }),
+                        encodeURIComponent(root.event_id!) +
+                        buildRelationPaginationQuery(client, {
+                            dir: Direction.Backward,
+                            limit: limit,
+                            recurse: true,
+                        }),
                 );
                 request.respond(200, function () {
                     return {

--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -29,6 +29,7 @@ import {
     PendingEventOrdering,
     RelationType,
     Room,
+    UNSIGNED_THREAD_ID_FIELD,
 } from "../../src/matrix";
 import { logger } from "../../src/logger";
 import { encodeParams, encodeUri, QueryDict, replaceParam } from "../../src/utils";
@@ -178,6 +179,9 @@ const THREAD_REPLY = utils.mkEvent({
             rel_type: "io.element.thread",
             event_id: THREAD_ROOT.event_id,
         },
+    },
+    unsigned: {
+        [UNSIGNED_THREAD_ID_FIELD.name]: THREAD_ROOT.event_id,
     },
     event: false,
 });
@@ -1091,6 +1095,9 @@ describe("MatrixClient event timelines", function () {
                     event_id: THREAD_ROOT.event_id,
                 },
             },
+            unsigned: {
+                [UNSIGNED_THREAD_ID_FIELD.name]: THREAD_ROOT.event_id,
+            },
             event: true,
         });
         THREAD_REPLY2.localTimestamp += 1000;
@@ -1108,6 +1115,9 @@ describe("MatrixClient event timelines", function () {
                     rel_type: "io.element.thread",
                     event_id: THREAD_ROOT.event_id,
                 },
+            },
+            unsigned: {
+                [UNSIGNED_THREAD_ID_FIELD.name]: THREAD_ROOT.event_id,
             },
             event: true,
         });
@@ -1182,6 +1192,9 @@ describe("MatrixClient event timelines", function () {
                     event_id: THREAD_ROOT.event_id,
                 },
             },
+            unsigned: {
+                [UNSIGNED_THREAD_ID_FIELD.name]: THREAD_ROOT.event_id,
+            },
             event: true,
         });
         THREAD_REPLY2.localTimestamp += 1000;
@@ -1213,6 +1226,9 @@ describe("MatrixClient event timelines", function () {
                     rel_type: "io.element.thread",
                     event_id: THREAD_ROOT.event_id,
                 },
+            },
+            unsigned: {
+                [UNSIGNED_THREAD_ID_FIELD.name]: THREAD_ROOT.event_id,
             },
             event: true,
         });
@@ -1254,8 +1270,6 @@ describe("MatrixClient event timelines", function () {
                 "GET",
                 "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
                     encodeURIComponent(THREAD_ROOT_UPDATED.event_id!) +
-                    "/" +
-                    encodeURIComponent(THREAD_RELATION_TYPE.name) +
                     buildRelationPaginationQuery({
                         dir: Direction.Backward,
                         limit: 3,

--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -1101,6 +1101,12 @@ describe("MatrixClient event timelines", function () {
             respondToEvent();
             respondToThread(THREAD_ROOT, [THREAD_REPLY], 1);
             await flushHttp(room.fetchRoomThreads());
+            const thread = room.getThread(THREAD_ROOT.event_id!)!;
+            expect(thread).not.toBeNull();
+            respondToThread(THREAD_ROOT, [THREAD_REPLY], 1);
+            expect(thread.timelineSet.thread).toBe(thread);
+            expect(Thread.hasServerSideSupport).toBe(FeatureSupport.Stable);
+            await flushHttp(client.getLatestTimeline(thread.timelineSet));
         });
 
         it("should create threads for thread roots discovered", function () {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -42,6 +42,7 @@ import {
     RelationType,
     RoomEvent,
     RoomMember,
+    UNSIGNED_THREAD_ID_FIELD,
 } from "../../src";
 import { EventTimeline } from "../../src/models/event-timeline";
 import { NotificationCountType, Room } from "../../src/models/room";
@@ -132,6 +133,9 @@ describe("Room", function () {
                         },
                         "rel_type": "m.thread",
                     },
+                },
+                unsigned: {
+                    [UNSIGNED_THREAD_ID_FIELD.name]: root.getId(),
                 },
             },
             room.client,

--- a/src/client.ts
+++ b/src/client.ts
@@ -5778,7 +5778,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 for (const event of events) {
                     event.setUnsigned({
                         ...event.getUnsigned(),
-                         [UNSIGNED_THREAD_ID_FIELD.name]: timelineSet.thread.id,
+                        [UNSIGNED_THREAD_ID_FIELD.name]: timelineSet.thread.id,
                     });
                     await timelineSet.thread?.processEvent(event);
                 }
@@ -5813,13 +5813,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 const thread = timelineSet.thread;
                 const relType = recurse ? null : THREAD_RELATION_TYPE.name;
 
-                const resOlder = await this.fetchRelations(
-                    timelineSet.room.roomId,
-                    thread.id,
-                    relType,
-                    null,
-                    { dir: Direction.Backward, from: res.start, recurse: recurse || undefined },
-                );
+                const resOlder = await this.fetchRelations(timelineSet.room.roomId, thread.id, relType, null, {
+                    dir: Direction.Backward,
+                    from: res.start,
+                    recurse: recurse || undefined,
+                });
                 const eventsNewer: IEvent[] = [];
                 let nextBatch: Optional<string> = res.end;
                 while (nextBatch) {
@@ -5908,13 +5906,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             event = res.chunk?.[0];
         } else if (timelineSet.thread && Thread.hasServerSideSupport) {
             const recurse = this.canSupport.get(Feature.RelationsRecursion) !== ServerSupport.Unsupported;
-            const res = await this.fetchRelations(
-                timelineSet.room.roomId,
-                timelineSet.thread.id,
-                relType,
-                null,
-                { dir: Direction.Backward, limit: 1, recurse: recurse || undefined },
-            );
+            const res = await this.fetchRelations(timelineSet.room.roomId, timelineSet.thread.id, relType, null, {
+                dir: Direction.Backward,
+                limit: 1,
+                recurse: recurse || undefined,
+            });
             event = res.chunk?.[0];
             // Fallback to set unsigned thread id if the server doesn't support it
             // We know the thread id because we just requested this event via /relations

--- a/src/client.ts
+++ b/src/client.ts
@@ -5751,18 +5751,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                     throw new Error("could not get thread timeline: not a thread timeline");
                 }
 
+                const relType = recurse ? null : THREAD_RELATION_TYPE.name;
                 const thread = timelineSet.thread;
                 const resOlder: IRelationsResponse = await this.fetchRelations(
                     timelineSet.room.roomId,
                     thread.id,
-                    THREAD_RELATION_TYPE.name,
+                    relType,
                     null,
                     { dir: Direction.Backward, from: res.start, recurse: recurse || undefined },
                 );
                 const resNewer: IRelationsResponse = await this.fetchRelations(
                     timelineSet.room.roomId,
                     thread.id,
-                    THREAD_RELATION_TYPE.name,
+                    relType,
                     null,
                     { dir: Direction.Forward, from: res.end, recurse: recurse || undefined },
                 );
@@ -5810,11 +5811,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 // XXX: workaround for https://github.com/vector-im/element-meta/issues/150
 
                 const thread = timelineSet.thread;
+                const relType = recurse ? null : THREAD_RELATION_TYPE.name;
 
                 const resOlder = await this.fetchRelations(
                     timelineSet.room.roomId,
                     thread.id,
-                    THREAD_RELATION_TYPE.name,
+                    relType,
                     null,
                     { dir: Direction.Backward, from: res.start, recurse: recurse || undefined },
                 );
@@ -5824,7 +5826,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                     const resNewer: IRelationsResponse = await this.fetchRelations(
                         timelineSet.room.roomId,
                         thread.id,
-                        THREAD_RELATION_TYPE.name,
+                        relType,
                         null,
                         { dir: Direction.Forward, from: nextBatch, recurse: recurse || undefined },
                     );
@@ -5892,10 +5894,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         let event;
+        const recurse = this.canSupport.get(Feature.RelationsRecursion) !== ServerSupport.Unsupported;
+        const relType = recurse ? null : THREAD_RELATION_TYPE.name;
         if (timelineSet.threadListType !== null) {
             const res = await this.createThreadListMessagesRequest(
                 timelineSet.room.roomId,
-                null,
+                relType,
                 1,
                 Direction.Backward,
                 timelineSet.threadListType,
@@ -5907,7 +5911,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             const res = await this.fetchRelations(
                 timelineSet.room.roomId,
                 timelineSet.thread.id,
-                THREAD_RELATION_TYPE.name,
+                relType,
                 null,
                 { dir: Direction.Backward, limit: 1, recurse: recurse || undefined },
             );
@@ -6191,7 +6195,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
 
             const recurse = this.canSupport.get(Feature.RelationsRecursion) !== ServerSupport.Unsupported;
-            promise = this.fetchRelations(eventTimeline.getRoomId() ?? "", thread.id, THREAD_RELATION_TYPE.name, null, {
+            const relType = recurse ? null : THREAD_RELATION_TYPE.name;
+            promise = this.fetchRelations(eventTimeline.getRoomId() ?? "", thread.id, relType, null, {
                 dir,
                 limit: opts.limit,
                 from: token ?? undefined,


### PR DESCRIPTION
Type: Defect
Uses: https://github.com/matrix-org/matrix-spec-proposals/pull/3981
Uses: https://github.com/matrix-org/matrix-spec-proposals/pull/4023
Related: https://github.com/matrix-org/matrix-js-sdk/pull/3248
Related: https://github.com/matrix-org/matrix-js-sdk/pull/3427

1. Fixes an issue where messages discovered via recursive relations would not be accurately reported as belonging to the thread via eventShouldLiveIn. This was fixed by setting the unsigned thread id field for thread timeline pagination calls if it's not yet set by the server.
3. Fixes an issue where reactions were not included in thread timelines. This was fixed by disabling the "only return m.thread events" filter on those calls if recursive relations is available.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix issues with implementation for MSC3981 ([\#3448](https://github.com/matrix-org/matrix-js-sdk/pull/3448)). Contributed by @justjanne.<!-- CHANGELOG_PREVIEW_END -->