### PR TITLE
Pull out a new `VerificationRequest` interface

### DIFF
--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -36,6 +36,27 @@ export type VerificationRequestEventHandlerMap = {
     [VerificationRequestEvent.Change]: () => void;
 };
 
+/** The current phase of a verification request. */
+export enum VerificationPhase {
+    /** Initial state: no event yet exchanged */
+    Unsent = 1,
+
+    /** An `m.key.verification.request` event has been sent or received */
+    Requested,
+
+    /** An `m.key.verification.ready` event has been sent or received, indicating the verification request is accepted. */
+    Ready,
+
+    /** An `m.key.verification.start` event has been sent or received, choosing a verification method */
+    Started,
+
+    /** An `m.key.verification.cancel` event has been sent or received at any time before the `done` event, cancelling the verification request */
+    Cancelled,
+
+    /** An `m.key.verification.done` event has been **sent**, completing the verification request. */
+    Done,
+}
+
 /**
  * A `Verifier` is responsible for performing the verification using a particular method, such as via QR code or SAS
  * (emojis).

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -350,3 +350,11 @@ export interface GeneratedSas {
  * English name.
  */
 export type EmojiMapping = [emoji: string, name: string];
+
+/**
+ * True if the request is in a state where it can be accepted (ie, that we're in phases {@link VerificationPhase.Unsent}
+ * or {@link VerificationPhase.Requested}, and that we're not in the process of sending a `ready` or `cancel`).
+ */
+export function canAcceptVerificationRequest(req: VerificationRequest): boolean {
+    return req.phase < VerificationPhase.Ready && !req.accepting && !req.declining;
+}

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -17,6 +17,25 @@ limitations under the License.
 import { MatrixEvent } from "../models/event";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 
+/** Events emitted by `VerificationRequest` */
+export enum VerificationRequestEvent {
+    /**
+     * Fires whenever the state of the request object has changed.
+     *
+     * There is no payload to the event.
+     */
+    Change = "change",
+}
+
+/**
+ * Listener type map for {@link VerificationRequestEvent}s.
+ *
+ * @internal
+ */
+export type VerificationRequestEventHandlerMap = {
+    [VerificationRequestEvent.Change]: () => void;
+};
+
 /**
  * A `Verifier` is responsible for performing the verification using a particular method, such as via QR code or SAS
  * (emojis).

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -17,7 +17,148 @@ limitations under the License.
 import { MatrixEvent } from "../models/event";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 
-/** Events emitted by `VerificationRequest` */
+/**
+ * An incoming, or outgoing, request to verify a user or a device via cross-signing.
+ */
+export interface VerificationRequest
+    extends TypedEventEmitter<VerificationRequestEvent, VerificationRequestEventHandlerMap> {
+    /**
+     * Unique ID for this verification request.
+     *
+     * An ID isn't assigned until the first message is sent, so this may be `undefined` in the early phases.
+     */
+    get transactionId(): string | undefined;
+
+    /**
+     * For an in-room verification, the ID of the room.
+     *
+     * For to-device verifictions, `undefined`.
+     */
+    get roomId(): string | undefined;
+
+    /**
+     * True if this request was initiated by the local client.
+     *
+     * For in-room verifications, the initiator is who sent the `m.key.verification.request` event.
+     * For to-device verifications, the initiator is who sent the `m.key.verification.start` event.
+     */
+    get initiatedByMe(): boolean;
+
+    /** The user id of the other party in this request */
+    get otherUserId(): string;
+
+    /** For verifications via to-device messages: the ID of the other device. Otherwise, undefined. */
+    get otherDeviceId(): string | undefined;
+
+    /** True if the other party in this request is one of this user's own devices. */
+    get isSelfVerification(): boolean;
+
+    /** current phase of the request. */
+    get phase(): VerificationPhase;
+
+    /** True if the request has sent its initial event and needs more events to complete
+     * (ie it is in phase `Requested`, `Ready` or `Started`).
+     */
+    get pending(): boolean;
+
+    /**
+     * True if we have started the process of sending an `m.key.verification.ready` (but have not necessarily received
+     * the remote echo which causes a transition to {@link VerificationPhase.Ready}.
+     */
+    get accepting(): boolean;
+
+    /**
+     * True if we have started the process of sending an `m.key.verification.cancel` (but have not necessarily received
+     * the remote echo which causes a transition to {@link VerificationPhase.Cancelled}).
+     */
+    get declining(): boolean;
+
+    /**
+     * The remaining number of ms before the request will be automatically cancelled.
+     *
+     * `null` indicates that there is no timeout
+     */
+    get timeout(): number | null;
+
+    /** once the phase is Started (and !initiatedByMe) or Ready: common methods supported by both sides */
+    get methods(): string[];
+
+    /** the method picked in the .start event */
+    get chosenMethod(): string | null;
+
+    /**
+     * Checks whether the other party supports a given verification method.
+     * This is useful when setting up the QR code UI, as it is somewhat asymmetrical:
+     * if the other party supports SCAN_QR, we should show a QR code in the UI, and vice versa.
+     * For methods that need to be supported by both ends, use the `methods` property.
+     *
+     * @param method - the method to check
+     * @returns true if the other party said they supported the method
+     */
+    otherPartySupportsMethod(method: string): boolean;
+
+    /**
+     * Accepts the request, sending a .ready event to the other party
+     *
+     * @returns Promise which resolves when the event has been sent.
+     */
+    accept(): Promise<void>;
+
+    /**
+     * Cancels the request, sending a cancellation to the other party
+     *
+     * @param params - Details for the cancellation, including `reason` (defaults to "User declined"), and `code`
+     *    (defaults to `m.user`).
+     *
+     * @returns Promise which resolves when the event has been sent.
+     */
+    cancel(params?: { reason?: string; code?: string }): Promise<void>;
+
+    /**
+     * Create a {@link Verifier} to do this verification via a particular method.
+     *
+     * If a verifier has already been created for this request, returns that verifier.
+     *
+     * This does *not* send the `m.key.verification.start` event - to do so, call {@link Crypto.Verifier#verify} on the
+     * returned verifier.
+     *
+     * If no previous events have been sent, pass in `targetDevice` to set who to direct this request to.
+     *
+     * @param method - the name of the verification method to use.
+     * @param targetDevice - details of where to send the request to.
+     *
+     * @returns The verifier which will do the actual verification.
+     */
+    beginKeyVerification(method: string, targetDevice?: { userId?: string; deviceId?: string }): Verifier;
+
+    /**
+     * The verifier which is doing the actual verification, once the method has been established.
+     * Only defined when the `phase` is Started.
+     */
+    get verifier(): Verifier | undefined;
+
+    /**
+     * Get the data for a QR code allowing the other device to verify this one, if it supports it.
+     *
+     * Only set after a .ready if the other party can scan a QR code, otherwise undefined.
+     */
+    getQRCodeBytes(): Buffer | undefined;
+
+    /**
+     * If this request has been cancelled, the cancellation code (e.g `m.user`) which is responsible for cancelling
+     * this verification.
+     */
+    get cancellationCode(): string | null;
+
+    /**
+     * The id of the user that cancelled the request.
+     *
+     * Only defined when phase is Cancelled
+     */
+    get cancellingUserId(): string | undefined;
+}
+
+/** Events emitted by {@link VerificationRequest}. */
 export enum VerificationRequestEvent {
     /**
      * Fires whenever the state of the request object has changed.

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -26,6 +26,7 @@ import { VerificationMethod } from "../../index";
 import { TypedEventEmitter } from "../../../models/typed-event-emitter";
 import {
     VerificationPhase as Phase,
+    VerificationRequest as IVerificationRequest,
     VerificationRequestEvent,
     VerificationRequestEventHandlerMap,
 } from "../../../crypto-api/verification";
@@ -74,11 +75,13 @@ interface ITransition {
  * State machine for verification requests.
  * Things that differ based on what channel is used to
  * send and receive verification events are put in `InRoomChannel` or `ToDeviceChannel`.
+ *
+ * @deprecated Avoid direct references: instead prefer {@link Crypto.VerificationRequest}.
  */
-export class VerificationRequest<C extends IVerificationChannel = IVerificationChannel> extends TypedEventEmitter<
-    VerificationRequestEvent,
-    VerificationRequestEventHandlerMap
-> {
+export class VerificationRequest<C extends IVerificationChannel = IVerificationChannel>
+    extends TypedEventEmitter<VerificationRequestEvent, VerificationRequestEventHandlerMap>
+    implements IVerificationRequest
+{
     private eventsByUs = new Map<string, MatrixEvent>();
     private eventsByThem = new Map<string, MatrixEvent>();
     private _observeOnly = false;

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -24,10 +24,14 @@ import { EventType } from "../../../@types/event";
 import { VerificationBase } from "../Base";
 import { VerificationMethod } from "../../index";
 import { TypedEventEmitter } from "../../../models/typed-event-emitter";
-import { VerificationRequestEvent, VerificationRequestEventHandlerMap } from "../../../crypto-api/verification";
+import {
+    VerificationPhase as Phase,
+    VerificationRequestEvent,
+    VerificationRequestEventHandlerMap,
+} from "../../../crypto-api/verification";
 
 // backwards-compatibility exports
-export { VerificationRequestEvent } from "../../../crypto-api/verification";
+export { VerificationPhase as Phase, VerificationRequestEvent } from "../../../crypto-api/verification";
 
 // How long after the event's timestamp that the request times out
 const TIMEOUT_FROM_EVENT_TS = 10 * 60 * 1000; // 10 minutes
@@ -47,15 +51,6 @@ export const START_TYPE = EVENT_PREFIX + "start";
 export const CANCEL_TYPE = EVENT_PREFIX + "cancel";
 export const DONE_TYPE = EVENT_PREFIX + "done";
 export const READY_TYPE = EVENT_PREFIX + "ready";
-
-export enum Phase {
-    Unsent = 1,
-    Requested,
-    Ready,
-    Started,
-    Cancelled,
-    Done,
-}
 
 // Legacy export fields
 export const PHASE_UNSENT = Phase.Unsent;

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -24,6 +24,10 @@ import { EventType } from "../../../@types/event";
 import { VerificationBase } from "../Base";
 import { VerificationMethod } from "../../index";
 import { TypedEventEmitter } from "../../../models/typed-event-emitter";
+import { VerificationRequestEvent, VerificationRequestEventHandlerMap } from "../../../crypto-api/verification";
+
+// backwards-compatibility exports
+export { VerificationRequestEvent } from "../../../crypto-api/verification";
 
 // How long after the event's timestamp that the request times out
 const TIMEOUT_FROM_EVENT_TS = 10 * 60 * 1000; // 10 minutes
@@ -71,17 +75,6 @@ interface ITransition {
     event?: MatrixEvent;
 }
 
-export enum VerificationRequestEvent {
-    Change = "change",
-}
-
-type EventHandlerMap = {
-    /**
-     * Fires whenever the state of the request object has changed.
-     */
-    [VerificationRequestEvent.Change]: () => void;
-};
-
 /**
  * State machine for verification requests.
  * Things that differ based on what channel is used to
@@ -89,7 +82,7 @@ type EventHandlerMap = {
  */
 export class VerificationRequest<C extends IVerificationChannel = IVerificationChannel> extends TypedEventEmitter<
     VerificationRequestEvent,
-    EventHandlerMap
+    VerificationRequestEventHandlerMap
 > {
     private eventsByUs = new Map<string, MatrixEvent>();
     private eventsByThem = new Map<string, MatrixEvent>();

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -25,6 +25,7 @@ import { VerificationBase } from "../Base";
 import { VerificationMethod } from "../../index";
 import { TypedEventEmitter } from "../../../models/typed-event-emitter";
 import {
+    canAcceptVerificationRequest,
     VerificationPhase as Phase,
     VerificationRequest as IVerificationRequest,
     VerificationRequestEvent,
@@ -248,7 +249,7 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
     }
 
     public get canAccept(): boolean {
-        return this.phase < PHASE_READY && !this._accepting && !this._declining;
+        return canAcceptVerificationRequest(this);
     }
 
     public get accepting(): boolean {


### PR DESCRIPTION
Notes: Introduce a new `Crypto.VerificationRequest` interface, and deprecate direct access to the old `VerificationRequest` class. Also deprecate some related classes that were exported from `src/crypto/verification/request/VerificationRequest`: `VerificationRequestEvent`, `Phase`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Introduce a new `Crypto.VerificationRequest` interface, and deprecate direct access to the old `VerificationRequest` class. Also deprecate some related classes that were exported from `src/crypto/verification/request/VerificationRequest` ([\#3449](https://github.com/matrix-org/matrix-js-sdk/pull/3449)).<!-- CHANGELOG_PREVIEW_END -->