### PR TITLE
Fix: handle `baseUrl` with trailing slash in `fetch.getUrl`

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -18,6 +18,7 @@ import { FetchHttpApi } from "../../../src/http-api/fetch";
 import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
 import { ClientPrefix, HttpApiEvent, HttpApiEventHandlerMap, IdentityPrefix, IHttpOpts, Method } from "../../../src";
 import { emitPromise } from "../../test-utils/test-utils";
+import { QueryDict } from "../../../src/utils";
 
 describe("FetchHttpApi", () => {
     const baseUrl = "http://baseUrl";
@@ -233,6 +234,60 @@ describe("FetchHttpApi", () => {
             const api = new FetchHttpApi(emitter, { baseUrl, prefix, fetchFn });
             api.authedRequest(Method.Post, "/account/password");
             expect(fetchFn.mock.calls[0][1].headers.Authorization).toBeUndefined();
+        });
+    });
+
+    describe("getUrl()", () => {
+        const localBaseUrl = "http://baseurl";
+        const baseUrlWithTrailingSlash = "http://baseurl/";
+        const makeApi = (thisBaseUrl = baseUrl): FetchHttpApi<any> => {
+            const fetchFn = jest.fn();
+            const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
+            return new FetchHttpApi(emitter, { baseUrl: thisBaseUrl, prefix, fetchFn });
+        };
+
+        type TestParams = {
+            path: string;
+            queryParams?: QueryDict;
+            prefix?: string;
+            baseUrl?: string;
+        };
+        type TestCase = [TestParams, string];
+        const queryParams: QueryDict = {
+            test1: 99,
+            test2: ["a", "b"],
+        };
+        const testPrefix = "/just/testing";
+        const testUrl = "http://justtesting.com";
+        const testUrlWithTrailingSlash = "http://justtesting.com/";
+
+        const testCases: TestCase[] = [
+            [{ path: "/terms" }, `${localBaseUrl}${prefix}/terms`],
+            [{ path: "/terms", queryParams }, `${localBaseUrl}${prefix}/terms?test1=99&test2=a&test2=b`],
+            [{ path: "/terms", prefix: testPrefix }, `${localBaseUrl}${testPrefix}/terms`],
+            [{ path: "/terms", baseUrl: testUrl }, `${testUrl}${prefix}/terms`],
+            [{ path: "/terms", baseUrl: testUrlWithTrailingSlash }, `${testUrl}${prefix}/terms`],
+            [
+                { path: "/terms", queryParams, prefix: testPrefix, baseUrl: testUrl },
+                `${testUrl}${testPrefix}/terms?test1=99&test2=a&test2=b`,
+            ],
+        ];
+        const runTests = (fetchBaseUrl: string) => {
+            it.each<TestCase>(testCases)(
+                "creates url with params %s",
+                ({ path, queryParams, prefix, baseUrl }, result) => {
+                    const api = makeApi(fetchBaseUrl);
+
+                    expect(api.getUrl(path, queryParams, prefix, baseUrl)).toEqual(new URL(result));
+                },
+            );
+        };
+
+        describe("when fetch.opts.baseUrl does not have a trailing slash", () => {
+            runTests(localBaseUrl);
+        });
+        describe("when fetch.opts.baseUrl does have a trailing slash", () => {
+            runTests(baseUrlWithTrailingSlash);
         });
     });
 });

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -298,11 +298,12 @@ export class FetchHttpApi<O extends IHttpOpts> {
      * @param path - The HTTP path <b>after</b> the supplied prefix e.g. "/createRoom".
      * @param queryParams - A dict of query params (these will NOT be urlencoded).
      * @param prefix - The full prefix to use e.g. "/_matrix/client/v2_alpha", defaulting to this.opts.prefix.
-     * @param baseUrl - The baseUrl to use e.g. "https://matrix.org/", defaulting to this.opts.baseUrl.
+     * @param baseUrl - The baseUrl to use e.g. "https://matrix.org", defaulting to this.opts.baseUrl.
      * @returns URL
      */
     public getUrl(path: string, queryParams?: QueryDict, prefix?: string, baseUrl?: string): URL {
-        const url = new URL((baseUrl ?? this.opts.baseUrl) + (prefix ?? this.opts.prefix) + path);
+        const baseUrlWithoutTrailingSlash = (baseUrl ?? this.opts.baseUrl).replace(/\/+$/, "");
+        const url = new URL(baseUrlWithoutTrailingSlash + (prefix ?? this.opts.prefix) + path);
         if (queryParams) {
             encodeParams(queryParams, url.searchParams);
         }

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -302,7 +302,10 @@ export class FetchHttpApi<O extends IHttpOpts> {
      * @returns URL
      */
     public getUrl(path: string, queryParams?: QueryDict, prefix?: string, baseUrl?: string): URL {
-        const baseUrlWithoutTrailingSlash = (baseUrl ?? this.opts.baseUrl).replace(/\/+$/, "");
+        const baseUrlWithFallback = baseUrl ?? this.opts.baseUrl;
+        const baseUrlWithoutTrailingSlash = baseUrlWithFallback.endsWith("/")
+            ? baseUrlWithFallback.slice(0, -1)
+            : baseUrlWithFallback;
         const url = new URL(baseUrlWithoutTrailingSlash + (prefix ?? this.opts.prefix) + path);
         if (queryParams) {
             encodeParams(queryParams, url.searchParams);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes: https://github.com/vector-im/element-web/issues/25526

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix: handle `baseUrl` with trailing slash in `fetch.getUrl` ([\#3455](https://github.com/matrix-org/matrix-js-sdk/pull/3455)). Fixes vector-im/element-web#25526. Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->