### PR TITLE
Upgrade JS-DevTools/npm-publish to v2.2.0

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,18 +24,16 @@ jobs:
 
             - name: 🚀 Publish to npm
               id: npm-publish
-              uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939 # v1
+              uses: JS-DevTools/npm-publish@a25b4180b728b0279fca97d4e5bccf391685aead # v2.2.0
               with:
                   token: ${{ secrets.NPM_TOKEN }}
                   access: public
                   tag: next
+                  ignore-scripts: false
 
             - name: 🎖️ Add `latest` dist-tag to final releases
-              if: github.event.release.prerelease == false
-              run: |
-                  package=$(cat package.json | jq -er .name)
-                  npm dist-tag add "$package@$release" latest
+              if: github.event.release.prerelease == false && steps.npm-publish.outputs.id
+              run: npm dist-tag add "$release" latest
               env:
-                  # JS-DevTools/npm-publish overrides `NODE_AUTH_TOKEN` with `INPUT_TOKEN` in .npmrc
-                  INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  release: ${{ steps.npm-publish.outputs.version }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  release: ${{ steps.npm-publish.outputs.id }}


### PR DESCRIPTION
## Overview

Hi! I was checking in on closed issues in JS-DevTools/npm-publish and noticed a link-back in JS-DevTools/npm-publish#15 to #3350.

Since `npm-publish@v1` uses deprecated GitHub Actions APIs that could stop working at any point, I wanted to help y'all get on v2. There seemed to be two breaking changes that affected your repository:

- v1 modifies `.npmrc` by replacing `NODE_AUTH_TOKEN` (added by `actions/setup-node`) with `INPUT_TOKEN`, v2 no longer makes this modification
- v1 calls `npm publish`, v2 calls `npm publish --ignore-scripts`

This PR upgrades the npm-publish package to v2 and modifies the publish workflow accordingly.

## Change log

- Upgrade JS-DevTools/npm-publish to [v2.2.0](https://github.com/JS-DevTools/npm-publish/releases/tag/v2.2.0)
- Remove workaround for JS-DevTools/npm-publish#15
- Remove usage of `jq` in favor of npm-publish output

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
    - Note: unsure how you'd like this tested
    - One method would be to see if I can publish my own scoped version on my fork, if you're interested
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->