### PR TITLE
ElementR: Add `rust-crypto#createRecoveryKeyFromPassphrase` implementation

### DIFF
--- a/spec/setupTests.ts
+++ b/spec/setupTests.ts
@@ -15,12 +15,8 @@ limitations under the License.
 */
 
 import DOMException from "domexception";
-import * as crypto from "crypto";
 
 global.DOMException = DOMException as typeof global.DOMException;
-// Set node crypto into global.crypto
-// Needed in `CryptoApi#createRecoveryKeyFromPassphrase` and `crypto/crypto.ts`
-global.crypto = crypto.webcrypto as typeof global.crypto;
 
 jest.mock("../src/http-api/utils", () => ({
     ...jest.requireActual("../src/http-api/utils"),

--- a/spec/setupTests.ts
+++ b/spec/setupTests.ts
@@ -15,8 +15,12 @@ limitations under the License.
 */
 
 import DOMException from "domexception";
+import * as crypto from "crypto";
 
 global.DOMException = DOMException as typeof global.DOMException;
+// Set node crypto into global.crypto
+// Needed in `CryptoApi#createRecoveryKeyFromPassphrase` and `crypto/crypto.ts`
+global.crypto = crypto.webcrypto as typeof global.crypto;
 
 jest.mock("../src/http-api/utils", () => ({
     ...jest.requireActual("../src/http-api/utils"),

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -356,6 +356,39 @@ describe("RustCrypto", () => {
             expect(res).toBe(null);
         });
     });
+
+    describe("createRecoveryKeyFromPassphrase", () => {
+        let rustCrypto: RustCrypto;
+
+        beforeEach(async () => {
+            rustCrypto = await makeTestRustCrypto();
+        });
+
+        it("should create a recovery key without password", async () => {
+            const recoveryKey = await rustCrypto.createRecoveryKeyFromPassphrase();
+
+            // Expected the encoded private key to have 59 chars
+            expect(recoveryKey.encodedPrivateKey?.length).toBe(59);
+            // Expect the private key to be an Uint8Array with a length of 32
+            expect(recoveryKey.privateKey).toBeInstanceOf(Uint8Array);
+            expect(recoveryKey.privateKey.length).toBe(32);
+            // Expect keyInfo to be empty
+            expect(Object.keys(recoveryKey.keyInfo!).length).toBe(0);
+        });
+
+        it("should create a recovery key with password", async () => {
+            const recoveryKey = await rustCrypto.createRecoveryKeyFromPassphrase("my password");
+
+            // Expected the encoded private key to have 59 chars
+            expect(recoveryKey.encodedPrivateKey?.length).toBe(59);
+            // Expect the private key to be an Uint8Array with a length of 32
+            expect(recoveryKey.privateKey).toBeInstanceOf(Uint8Array);
+            expect(recoveryKey.privateKey.length).toBe(32);
+            // Expect keyInfo.passphrase to be filled
+            expect(recoveryKey.keyInfo?.passphrase?.algorithm).toBe("m.pbkdf2");
+            expect(recoveryKey.keyInfo?.passphrase?.iterations).toBe(500000);
+        });
+    });
 });
 
 /** build a basic RustCrypto instance for testing

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -30,7 +30,7 @@ export enum CrossSigningKey {
 /**
  * Recovery key created by {@link CryptoApi#createRecoveryKeyFromPassphrase}
  */
-export interface IRecoveryKey {
+export interface GeneratedSecretStorageKey {
     keyInfo?: AddSecretStorageKeyOpts;
     /* Generated private key Uint8Array(32) */
     privateKey: Uint8Array;
@@ -223,7 +223,7 @@ export interface CryptoApi {
      *     recovery key which should be disposed of after displaying to the user,
      *     and raw private key to avoid round tripping if needed.
      */
-    createRecoveryKeyFromPassphrase(password?: string): Promise<IRecoveryKey>;
+    createRecoveryKeyFromPassphrase(password?: string): Promise<GeneratedSecretStorageKey>;
 }
 
 /**

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -32,8 +32,9 @@ export enum CrossSigningKey {
  */
 export interface GeneratedSecretStorageKey {
     keyInfo?: AddSecretStorageKeyOpts;
-    /* Generated private key Uint8Array(32) */
+    /** The raw generated private key. */
     privateKey: Uint8Array;
+    /** The generated key, encoded for display to the user per https://spec.matrix.org/v1.7/client-server-api/#key-representation. */
     encodedPrivateKey?: string;
 }
 
@@ -214,14 +215,16 @@ export interface CryptoApi {
     getCrossSigningStatus(): Promise<CrossSigningStatus>;
 
     /**
-     * Create a recovery key from a user-supplied passphrase.
+     * Create a recovery key (ie, a key suitable for use with server-side secret storage).
      *
-     * @param password - Passphrase string that can be entered by the user
-     *     when restoring the backup as an alternative to entering the recovery key.
-     *     Optional.
-     * @returns Object with encoded private
-     *     recovery key which should be disposed of after displaying to the user,
-     *     and raw private key to avoid round tripping if needed.
+     * The key can either be based on a user-supplied passphrase, or just created randomly.
+     *
+     * @param password - Optional passphrase string to use to derive the key,
+     *      which can later be entered by the user as an alternative to entering the
+     *      recovery key itself. If omitted, a key is generated randomly.
+     *
+     * @returns Object including recovery key and server upload parameters.
+     *      The private key should be disposed of after displaying to the use.
      */
     createRecoveryKeyFromPassphrase(password?: string): Promise<GeneratedSecretStorageKey>;
 }

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -18,12 +18,23 @@ import type { IMegolmSessionData } from "./@types/crypto";
 import { Room } from "./models/room";
 import { DeviceMap } from "./models/device";
 import { UIAuthCallback } from "./interactive-auth";
+import { AddSecretStorageKeyOpts } from "./secret-storage";
 
 /** Types of cross-signing key */
 export enum CrossSigningKey {
     Master = "master",
     SelfSigning = "self_signing",
     UserSigning = "user_signing",
+}
+
+/**
+ * Recovery key created by {@link CryptoApi#createRecoveryKeyFromPassphrase}
+ */
+export interface IRecoveryKey {
+    keyInfo?: AddSecretStorageKeyOpts;
+    /* Generated private key Uint8Array(32) */
+    privateKey: Uint8Array;
+    encodedPrivateKey?: string;
 }
 
 /**
@@ -201,6 +212,18 @@ export interface CryptoApi {
      * @returns The current status of cross-signing keys: whether we have public and private keys cached locally, and whether the private keys are in secret storage.
      */
     getCrossSigningStatus(): Promise<CrossSigningStatus>;
+
+    /**
+     * Create a recovery key from a user-supplied passphrase.
+     *
+     * @param password - Passphrase string that can be entered by the user
+     *     when restoring the backup as an alternative to entering the recovery key.
+     *     Optional.
+     * @returns Object with encoded private
+     *     recovery key which should be disposed of after displaying to the user,
+     *     and raw private key to avoid round tripping if needed.
+     */
+    createRecoveryKeyFromPassphrase(password?: string): Promise<IRecoveryKey>;
 }
 
 /**

--- a/src/crypto/api.ts
+++ b/src/crypto/api.ts
@@ -16,10 +16,10 @@ limitations under the License.
 
 import { DeviceInfo } from "./deviceinfo";
 import { IKeyBackupInfo } from "./keybackup";
-import { IRecoveryKey } from "../crypto-api";
+import { GeneratedSecretStorageKey } from "../crypto-api";
 
 /* re-exports for backwards compatibility. */
-export { CrossSigningKey, IRecoveryKey } from "../crypto-api";
+export { CrossSigningKey, GeneratedSecretStorageKey as IRecoveryKey } from "../crypto-api";
 
 export type {
     ImportRoomKeyProgressData as IImportOpts,
@@ -73,7 +73,7 @@ export interface ICreateSecretStorageOpts {
      *     recovery key which should be disposed of after displaying to the user,
      *     and raw private key to avoid round tripping if needed.
      */
-    createSecretStorageKey?: () => Promise<IRecoveryKey>;
+    createSecretStorageKey?: () => Promise<GeneratedSecretStorageKey>;
 
     /**
      * The current key backup object. If passed,

--- a/src/crypto/api.ts
+++ b/src/crypto/api.ts
@@ -16,10 +16,10 @@ limitations under the License.
 
 import { DeviceInfo } from "./deviceinfo";
 import { IKeyBackupInfo } from "./keybackup";
-import type { AddSecretStorageKeyOpts } from "../secret-storage";
+import { IRecoveryKey } from "../crypto-api";
 
 /* re-exports for backwards compatibility. */
-export { CrossSigningKey } from "../crypto-api";
+export { CrossSigningKey, IRecoveryKey } from "../crypto-api";
 
 export type {
     ImportRoomKeyProgressData as IImportOpts,
@@ -64,12 +64,6 @@ export interface IEncryptedEventInfo {
      * if the event's ed25519 and curve25519 keys don't match (only meaningful if `sender` is set)
      */
     mismatchedSender: boolean;
-}
-
-export interface IRecoveryKey {
-    keyInfo?: AddSecretStorageKeyOpts;
-    privateKey: Uint8Array;
-    encodedPrivateKey?: string;
 }
 
 export interface ICreateSecretStorageOpts {

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -46,6 +46,7 @@ import { CrossSigningIdentity } from "./CrossSigningIdentity";
 import { secretStorageContainsCrossSigningKeys } from "./secret-storage";
 import { keyFromPassphrase } from "../crypto/key_passphrase";
 import { encodeRecoveryKey } from "../crypto/recoverykey";
+import { crypto } from "../crypto/crypto";
 
 /**
  * An implementation of {@link CryptoBackend} using the Rust matrix-sdk-crypto.
@@ -426,7 +427,7 @@ export class RustCrypto implements CryptoBackend {
         } else {
             // Using the navigator crypto API to generate the private key
             privateKey = new Uint8Array(32);
-            global.crypto.getRandomValues(privateKey);
+            crypto.getRandomValues(privateKey);
         }
 
         const encodedPrivateKey = encodeRecoveryKey(privateKey);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -417,7 +417,7 @@ export class RustCrypto implements CryptoBackend {
 
         const keyInfo: Partial<GeneratedSecretStorageKey["keyInfo"]> = {};
         if (password) {
-            // Get the private key from the passphrase
+            // Generate the key from the passphrase
             const derivation = await keyFromPassphrase(password);
             keyInfo.passphrase = {
                 algorithm: "m.pbkdf2",

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -42,7 +42,7 @@ import {
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client";
 import { Device, DeviceMap } from "../models/device";
-import { ServerSideSecretStorage } from "../secret-storage";
+import { AddSecretStorageKeyOpts, ServerSideSecretStorage } from "../secret-storage";
 import { CrossSigningIdentity } from "./CrossSigningIdentity";
 import { secretStorageContainsCrossSigningKeys } from "./secret-storage";
 import { keyFromPassphrase } from "../crypto/key_passphrase";
@@ -413,9 +413,9 @@ export class RustCrypto implements CryptoBackend {
      * Implementation of {@link CryptoApi#createRecoveryKeyFromPassphrase}
      */
     public async createRecoveryKeyFromPassphrase(password?: string): Promise<GeneratedSecretStorageKey> {
-        let privateKey: Uint8Array;
+        let key: Uint8Array;
 
-        const keyInfo: Partial<GeneratedSecretStorageKey["keyInfo"]> = {};
+        const keyInfo: AddSecretStorageKeyOpts = {};
         if (password) {
             // Generate the key from the passphrase
             const derivation = await keyFromPassphrase(password);
@@ -424,18 +424,18 @@ export class RustCrypto implements CryptoBackend {
                 iterations: derivation.iterations,
                 salt: derivation.salt,
             };
-            privateKey = derivation.key;
+            key = derivation.key;
         } else {
             // Using the navigator crypto API to generate the private key
-            privateKey = new Uint8Array(32);
-            crypto.getRandomValues(privateKey);
+            key = new Uint8Array(32);
+            crypto.getRandomValues(key);
         }
 
-        const encodedPrivateKey = encodeRecoveryKey(privateKey);
+        const encodedPrivateKey = encodeRecoveryKey(key);
         return {
-            keyInfo: keyInfo as GeneratedSecretStorageKey["keyInfo"],
+            keyInfo,
             encodedPrivateKey,
-            privateKey,
+            privateKey: key,
         };
     }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -34,14 +34,15 @@ import {
     BootstrapCrossSigningOpts,
     CrossSigningStatus,
     DeviceVerificationStatus,
+    GeneratedSecretStorageKey,
     ImportRoomKeyProgressData,
     ImportRoomKeysOpts,
+    CrossSigningKey,
 } from "../crypto-api";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client";
 import { Device, DeviceMap } from "../models/device";
 import { ServerSideSecretStorage } from "../secret-storage";
-import { CrossSigningKey, IRecoveryKey } from "../crypto/api";
 import { CrossSigningIdentity } from "./CrossSigningIdentity";
 import { secretStorageContainsCrossSigningKeys } from "./secret-storage";
 import { keyFromPassphrase } from "../crypto/key_passphrase";
@@ -411,10 +412,10 @@ export class RustCrypto implements CryptoBackend {
     /**
      * Implementation of {@link CryptoApi#createRecoveryKeyFromPassphrase}
      */
-    public async createRecoveryKeyFromPassphrase(password?: string): Promise<IRecoveryKey> {
+    public async createRecoveryKeyFromPassphrase(password?: string): Promise<GeneratedSecretStorageKey> {
         let privateKey: Uint8Array;
 
-        const keyInfo: Partial<IRecoveryKey["keyInfo"]> = {};
+        const keyInfo: Partial<GeneratedSecretStorageKey["keyInfo"]> = {};
         if (password) {
             // Get the private key from the passphrase
             const derivation = await keyFromPassphrase(password);
@@ -432,7 +433,7 @@ export class RustCrypto implements CryptoBackend {
 
         const encodedPrivateKey = encodeRecoveryKey(privateKey);
         return {
-            keyInfo: keyInfo as IRecoveryKey["keyInfo"],
+            keyInfo: keyInfo as GeneratedSecretStorageKey["keyInfo"],
             encodedPrivateKey,
             privateKey,
         };


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

- Related to https://github.com/vector-im/crypto-internal/issues/120
- Already implemented in the old crypto
- Add a new implementation in the new crypto which is not using Olm.
- I'm using `crypto.getRandomValues` from `crypto/crypto.ts` instead of `global.crypto` because:
   - `crypto/crypto.ts` is doing all the job to check into the global variable
   - We are calling `subtleCrypto` underneath (`keyFromPassphrase` -> `deviveKey`) which is imported from `crypto/crypto.ts`
   - In the test, `global.crypto` can't be override directly (TypeError...). I used `Object.defineProperty(global, "crypto", crypto.webcrypto)` where `crypto.webcrypto` is imported from node but without success

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * ElementR: Add `rust-crypto#createRecoveryKeyFromPassphrase` implementation ([\#3472](https://github.com/matrix-org/matrix-js-sdk/pull/3472)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->