### PR TITLE
Use stricter types on login functions

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -26,6 +26,7 @@ import { IFilterDefinition } from "../../src/filter";
 import { ISearchResults } from "../../src/@types/search";
 import { IStore } from "../../src/store";
 import { CryptoBackend } from "../../src/common-crypto/CryptoBackend";
+import { LoginType } from "../../src/@types/auth";
 
 describe("MatrixClient", function () {
     const userId = "@alice:localhost";
@@ -1326,7 +1327,7 @@ describe("MatrixClient", function () {
                 access_token: token,
                 user_id: userId,
             });
-            const prom = client!.login("fake.login", {});
+            const prom = client!.login("fake.login" as unknown as LoginType, {});
             await httpBackend!.flushAllExpected();
             const resp = await prom;
             expect(resp.access_token).toBe(token);

--- a/spec/unit/login.spec.ts
+++ b/spec/unit/login.spec.ts
@@ -26,7 +26,7 @@ describe("Login request", function () {
 
         client.httpBackend.when("POST", "/login").respond(200, response);
         client.httpBackend.flush("/login", 1, 100);
-        await client.client.login("m.login.any", { user: "test", password: "12312za" });
+        await client.client.login("m.login.password", { user: "test", password: "12312za" });
 
         expect(client.client.getAccessToken()).toBe(response.access_token);
         expect(client.client.getUserId()).toBe(response.user_id);

--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { IClientWellKnown } from "../client";
 import { UnstableValue } from "../NamespacedValue";
 
 // disable lint because these are wire responses
@@ -36,6 +37,8 @@ export interface IRefreshTokenResponse {
 export interface ILoginFlowsResponse {
     flows: LoginFlow[];
 }
+
+export type LoginType = "m.login.password" | "m.login.token" | "m.login.saml2";
 
 export type LoginFlow = ISSOFlow | IPasswordFlow | ILoginFlow;
 
@@ -121,3 +124,59 @@ export interface LoginTokenPostResponse {
      */
     expires_in_ms: number;
 }
+
+/**
+ * Response from a successful /login
+ * See spec: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3login
+ */
+export interface LoginResponse {
+    access_token: string;
+    device_id: string;
+    expires_in_ms?: number;
+    refresh_token?: string;
+    user_id: string;
+    well_known?: IClientWellKnown;
+}
+
+// https://spec.matrix.org/v1.7/client-server-api/#identifier-types
+export type UserIdentifier = "m.id.user" | "m.id.thirdparty" | "m.id.phone";
+
+/**
+ * Params passed to /login request
+ * https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3login
+ */
+interface LoginCoreParams {
+    device_id?: string;
+    identifier?: {
+        type: UserIdentifier;
+    };
+    initial_device_display_name?: string;
+    refresh_token?: boolean;
+    // @deprecated, use `identifier`
+    user?: string;
+    // @deprecated, use `identifier`
+    address?: string;
+}
+
+export interface ThirdPartyLoginParams extends LoginCoreParams {
+    // @deprecated, use `identifier`
+    medium?: "email";
+}
+
+export interface PasswordLoginParams extends LoginCoreParams {
+    password: string;
+}
+
+export interface TokenLoginParams extends LoginCoreParams {
+    token: string;
+}
+
+export interface Saml2LoginParams {
+    relay_state: string;
+}
+
+export type LoginParams = ThirdPartyLoginParams | PasswordLoginParams | TokenLoginParams | Saml2LoginParams;
+
+export type LoginRequestBody = (ThirdPartyLoginParams | PasswordLoginParams | TokenLoginParams | Saml2LoginParams) & {
+    type: LoginType;
+};

--- a/src/client.ts
+++ b/src/client.ts
@@ -7798,7 +7798,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Rejects: with an error response.
      */
     public loginWithPassword(user: string, password: string): Promise<LoginResponse> {
-        // TODO: Types
         return this.login("m.login.password", {
             user: user,
             password: password,
@@ -7811,7 +7810,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Rejects: with an error response.
      */
     public loginWithSAML2(relayState: string): Promise<LoginResponse> {
-        // TODO: Types
         return this.login("m.login.saml2", {
             relay_state: relayState,
         });
@@ -7855,7 +7853,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Rejects: with an error response.
      */
     public loginWithToken(token: string): Promise<LoginResponse> {
-        // TODO: Types
         return this.login("m.login.token", {
             token: token,
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -209,6 +209,7 @@ import {
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
 } from "./secret-storage";
+import { LoginResponse, LoginType, LoginRequestBody, LoginParams } from "./@types/auth";
 
 export type Store = IStore;
 
@@ -7770,39 +7771,33 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * @returns Promise which resolves: TODO
+     * @param loginType - password or token login
+     * @param data - request params for given login type
+     * @returns Promise which resolves with LoginResponse
      * @returns Rejects: with an error response.
      */
-    public login(loginType: string, data: any): Promise<any> {
-        // TODO: Types
-        const loginData = {
+    public login(loginType: LoginType, data: LoginParams): Promise<LoginResponse> {
+        const loginData: LoginRequestBody = {
             type: loginType,
+            ...data,
         };
 
-        // merge data into loginData
-        Object.assign(loginData, data);
-
-        return this.http
-            .authedRequest<{
-                access_token?: string;
-                user_id?: string;
-            }>(Method.Post, "/login", undefined, loginData)
-            .then((response) => {
-                if (response.access_token && response.user_id) {
-                    this.http.opts.accessToken = response.access_token;
-                    this.credentials = {
-                        userId: response.user_id,
-                    };
-                }
-                return response;
-            });
+        return this.http.authedRequest<LoginResponse>(Method.Post, "/login", undefined, loginData).then((response) => {
+            if (response.access_token && response.user_id) {
+                this.http.opts.accessToken = response.access_token;
+                this.credentials = {
+                    userId: response.user_id,
+                };
+            }
+            return response;
+        });
     }
 
     /**
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
      */
-    public loginWithPassword(user: string, password: string): Promise<any> {
+    public loginWithPassword(user: string, password: string): Promise<LoginResponse> {
         // TODO: Types
         return this.login("m.login.password", {
             user: user,
@@ -7815,7 +7810,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
      */
-    public loginWithSAML2(relayState: string): Promise<any> {
+    public loginWithSAML2(relayState: string): Promise<LoginResponse> {
         // TODO: Types
         return this.login("m.login.saml2", {
             relay_state: relayState,
@@ -7859,7 +7854,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
      */
-    public loginWithToken(token: string): Promise<any> {
+    public loginWithToken(token: string): Promise<LoginResponse> {
         // TODO: Types
         return this.login("m.login.token", {
             token: token,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/21967

Pulling the loose string from strictification work in `AddThreepid` I found these untyped functions.
There is some distance between the spec and js-sdk's current implementation, for example the login type "m.login.saml2"

Breaking as far as types, no changes to logic.

With 

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
