### PR TITLE
Improve logging of http requests to aid debugging

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -300,9 +300,9 @@ describe("FetchHttpApi", () => {
         const fetchFn = jest.fn().mockReturnValue(deferred.promise);
         jest.spyOn(logger, "debug").mockImplementation(() => {});
         const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
-        const prom = api.requestOtherUrl(Method.Get, "https://server:1234/some/path#fragment?query=param");
+        const prom = api.requestOtherUrl(Method.Get, "https://server:8448/some/path#fragment?query=param");
         jest.advanceTimersByTime(1234);
-        deferred.resolve({ ok: true, text: () => Promise.resolve("RESPONSE") } as Response);
+        deferred.resolve({ ok: true, status: 200, text: () => Promise.resolve("RESPONSE") } as Response);
         await prom;
         expect(logger.debug).not.toHaveBeenCalledWith("fragment");
         expect(logger.debug).not.toHaveBeenCalledWith("query");
@@ -310,12 +310,12 @@ describe("FetchHttpApi", () => {
         expect(logger.debug).toHaveBeenCalledTimes(2);
         expect(mocked(logger.debug).mock.calls[0]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: --> GET https://server:1234/some/path",
+              "FetchHttpApi: --> GET https://server:8448/some/path",
             ]
         `);
         expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: <-- GET https://server:1234/some/path [1234ms undefined]",
+              "FetchHttpApi: <-- GET https://server:8448/some/path [1234ms undefined]",
             ]
         `);
     });

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -310,12 +310,12 @@ describe("FetchHttpApi", () => {
         expect(logger.debug).toHaveBeenCalledTimes(2);
         expect(mocked(logger.debug).mock.calls[0]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: GET --> /some/path",
+              "FetchHttpApi: --> GET https://server:1234/some/path",
             ]
         `);
         expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi:  <-- undefined 1234ms /some/path",
+              "FetchHttpApi: <-- undefined 1234ms GET https://server:1234/some/path",
             ]
         `);
     });

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -315,7 +315,7 @@ describe("FetchHttpApi", () => {
         `);
         expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: <-- GET https://server:8448/some/path [1234ms undefined]",
+              "FetchHttpApi: <-- GET https://server:8448/some/path [1234ms 200]",
             ]
         `);
     });

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -315,7 +315,7 @@ describe("FetchHttpApi", () => {
         `);
         expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: <-- undefined 1234ms GET https://server:1234/some/path",
+              "FetchHttpApi: <-- GET https://server:1234/some/path [1234ms undefined]",
             ]
         `);
     });

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { mocked } from "jest-mock";
+
 import { FetchHttpApi } from "../../../src/http-api/fetch";
 import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
 import { ClientPrefix, HttpApiEvent, HttpApiEventHandlerMap, IdentityPrefix, IHttpOpts, Method } from "../../../src";
 import { emitPromise } from "../../test-utils/test-utils";
-import { QueryDict } from "../../../src/utils";
+import { defer, QueryDict } from "../../../src/utils";
+import { logger } from "../../../src/logger";
 
 describe("FetchHttpApi", () => {
     const baseUrl = "http://baseUrl";
@@ -289,5 +292,31 @@ describe("FetchHttpApi", () => {
         describe("when fetch.opts.baseUrl does have a trailing slash", () => {
             runTests(baseUrlWithTrailingSlash);
         });
+    });
+
+    it("should not log query parameters", async () => {
+        jest.useFakeTimers();
+        const deferred = defer<Response>();
+        const fetchFn = jest.fn().mockReturnValue(deferred.promise);
+        jest.spyOn(logger, "debug").mockImplementation(() => {});
+        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
+        const prom = api.requestOtherUrl(Method.Get, "https://server:1234/some/path#fragment?query=param");
+        jest.advanceTimersByTime(1234);
+        deferred.resolve({ ok: true, text: () => Promise.resolve("RESPONSE") } as Response);
+        await prom;
+        expect(logger.debug).not.toHaveBeenCalledWith("fragment");
+        expect(logger.debug).not.toHaveBeenCalledWith("query");
+        expect(logger.debug).not.toHaveBeenCalledWith("param");
+        expect(logger.debug).toHaveBeenCalledTimes(2);
+        expect(mocked(logger.debug).mock.calls[0]).toMatchInlineSnapshot(`
+            [
+              "FetchHttpApi: GET --> /some/path",
+            ]
+        `);
+        expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
+            [
+              "FetchHttpApi:  <-- undefined 1234ms /some/path",
+            ]
+        `);
     });
 });

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -227,7 +227,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         opts: Pick<IRequestOpts, "headers" | "json" | "localTimeoutMs" | "keepAlive" | "abortSignal"> = {},
     ): Promise<ResponseType<T, O>> {
         const urlForLogs = this.clearUrlParamsForLogs(url);
-        logger.debug(`FetchHttpApi: ${method} --> ${urlForLogs}`);
+        logger.debug(`FetchHttpApi: --> ${method} ${urlForLogs}`);
 
         const headers = Object.assign({}, opts.headers || {});
         const json = opts.json ?? true;
@@ -280,9 +280,9 @@ export class FetchHttpApi<O extends IHttpOpts> {
                 keepalive: keepAlive,
             });
 
-            logger.debug(`FetchHttpApi:  <-- ${res.status} ${Date.now() - start}ms ${urlForLogs}`);
+            logger.debug(`FetchHttpApi: <-- ${res.status} ${Date.now() - start}ms ${method} ${urlForLogs}`);
         } catch (e) {
-            logger.debug(`FetchHttpApi:  <-- ${e} ${Date.now() - start}ms ${urlForLogs}`);
+            logger.debug(`FetchHttpApi: <-- ${e} ${Date.now() - start}ms ${method} ${urlForLogs}`);
             if ((<Error>e).name === "AbortError") {
                 throw e;
             }
@@ -311,7 +311,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
             }
             // get just the path to remove any potential url param that could have
             // some potential secrets
-            return asUrl.pathname;
+            return asUrl.origin + asUrl.pathname;
         } catch (error) {
             // defensive coding for malformed url
             return "??";

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -311,7 +311,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
             }
             // get just the path to remove any potential url param that could have
             // some potential secrets
-            return asUrl.pathname.toString();
+            return asUrl.pathname;
         } catch (error) {
             // defensive coding for malformed url
             return "??";

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -280,9 +280,9 @@ export class FetchHttpApi<O extends IHttpOpts> {
                 keepalive: keepAlive,
             });
 
-            logger.debug(`FetchHttpApi: <-- ${res.status} ${Date.now() - start}ms ${method} ${urlForLogs}`);
+            logger.debug(`FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${res.status}]`);
         } catch (e) {
-            logger.debug(`FetchHttpApi: <-- ${e} ${Date.now() - start}ms ${method} ${urlForLogs}`);
+            logger.debug(`FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${e}]`);
             if ((<Error>e).name === "AbortError") {
                 throw e;
             }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Added simple logging for all requests made from the js-sdk to ease rageshakes investigation.

~~Looks like that:~~
```
FetchHttpApi: GET --> http://localhost:8080/_matrix/client/r0/sync?filter=0&timeout=30000&since=s26_3787_3_8_29_1_12_38_0_1
```


udpated as per to remove url params that could contain secrets
```
FetchHttpApi: PUT --> /_matrix/client/v3/sendToDevice/m.room.encrypted/b8f4c87559504be794f3e1496a8970a5
rageshake.ts:77 FetchHttpApi:  <-- 200 8ms /_matrix/client/v3/sendToDevice/m.room.encrypted/b8f4c87559504be794f3e1496a8970a5
rageshake.ts:77 FetchHttpApi: PUT --> /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/typing/%40alice%3Alocalhost%3A8480
rageshake.ts:77 FetchHttpApi:  <-- 200 10ms /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/typing/%40alice%3Alocalhost%3A8480
rageshake.ts:77 FetchHttpApi:  <-- 200 2662ms /_matrix/client/r0/sync
rageshake.ts:77 FetchHttpApi: GET --> /_matrix/client/r0/sync
rageshake.ts:77 FetchHttpApi: PUT --> /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/typing/%40alice%3Alocalhost%3A8480
rageshake.ts:77 FetchHttpApi:  <-- 200 28ms /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/typing/%40alice%3Alocalhost%3A8480
rageshake.ts:77 FetchHttpApi:  <-- 200 247ms /_matrix/client/r0/sync
rageshake.ts:77 FetchHttpApi: GET --> /_matrix/client/r0/sync
rageshake.ts:77 FetchHttpApi: PUT --> /_matrix/client/v3/sendToDevice/m.room.encrypted/815dbfb5a7b54c9a9cfe09a8080a8704
rageshake.ts:77 FetchHttpApi:  <-- 200 10ms /_matrix/client/v3/sendToDevice/m.room.encrypted/815dbfb5a7b54c9a9cfe09a8080a8704
rageshake.ts:77 FetchHttpApi: PUT --> /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/send/m.room.encrypted/m1688377642353.0
rageshake.ts:77 FetchHttpApi:  <-- 200 30ms /_matrix/client/r0/rooms/!ZTAJxYLImTUucVDSZW%3Alocalhost%3A8480/send/m.room.encrypted/m1688377642353.0
```

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->