### PR TITLE
Fix an instance of failed to decrypt error when an in flight `/keys/query` fails.

### DIFF
--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -210,8 +210,8 @@ class OlmDecryption extends DecryptionAlgorithm {
         // In practice, it's not clear that the js-sdk would behave that way, so this may be only a defence in depth.
 
         let senderKeyUser = this.crypto.deviceList.getUserByIdentityKey(olmlib.OLM_ALGORITHM, deviceKey);
-        if (senderKeyUser == undefined) {
-            // Await for any ongoing key query fetches for the user before trying the lookup again.
+        if (senderKeyUser === undefined) {
+            // Wait for any pending key query fetches for the user to complete before trying the lookup again.
             try {
                 await this.crypto.deviceList.downloadKeys([event.getSender()!], false);
             } catch (e) {

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -225,7 +225,7 @@ class OlmDecryption extends DecryptionAlgorithm {
             senderKeyUser = this.crypto.deviceList.getUserByIdentityKey(olmlib.OLM_ALGORITHM, deviceKey);
         }
 
-        if (senderKeyUser !== event.getSender() && senderKeyUser != undefined) {
+        if (senderKeyUser !== event.getSender() && senderKeyUser !== undefined) {
             throw new DecryptionError("OLM_BAD_SENDER", "Message claimed to be from " + event.getSender(), {
                 real_sender: senderKeyUser,
             });

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -194,7 +194,7 @@ class OlmDecryption extends DecryptionAlgorithm {
 
         // check that the device that encrypted the event belongs to the user that the event claims it's from.
         //
-        // If the device is unknown then we check that we're not in the process of fetching the keys. If after that the
+        // If the device is unknown then we check that we don't have any pending key-query requests for the sender. If after that the
         // device is still unknown, then we can only assume that the device logged out and accept it anyway. Some event
         // handlers, such as secret sharing, may be more strict and reject events that come from unknown devices.
         //

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -211,7 +211,7 @@ class OlmDecryption extends DecryptionAlgorithm {
         // In practice, it's not clear that the js-sdk would behave that way, so this may be only a defence in depth.
 
         let senderKeyUser = this.crypto.deviceList.getUserByIdentityKey(olmlib.OLM_ALGORITHM, deviceKey);
-        if (senderKeyUser === undefined) {
+        if (senderKeyUser === undefined || senderKeyUser === null) {
             // Wait for any pending key query fetches for the user to complete before trying the lookup again.
             try {
                 await this.crypto.deviceList.downloadKeys([event.getSender()!], false);
@@ -224,8 +224,7 @@ class OlmDecryption extends DecryptionAlgorithm {
 
             senderKeyUser = this.crypto.deviceList.getUserByIdentityKey(olmlib.OLM_ALGORITHM, deviceKey);
         }
-
-        if (senderKeyUser !== event.getSender() && senderKeyUser !== undefined) {
+        if (senderKeyUser !== event.getSender() && senderKeyUser !== undefined && senderKeyUser !== null) {
             throw new DecryptionError("OLM_BAD_SENDER", "Message claimed to be from " + event.getSender(), {
                 real_sender: senderKeyUser,
             });

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -194,9 +194,10 @@ class OlmDecryption extends DecryptionAlgorithm {
 
         // check that the device that encrypted the event belongs to the user that the event claims it's from.
         //
-        // If the device is unknown then we check that we don't have any pending key-query requests for the sender. If after that the
-        // device is still unknown, then we can only assume that the device logged out and accept it anyway. Some event
-        // handlers, such as secret sharing, may be more strict and reject events that come from unknown devices.
+        // If the device is unknown then we check that we don't have any pending key-query requests for the sender. If
+        // after that the device is still unknown, then we can only assume that the device logged out and accept it
+        // anyway. Some event handlers, such as secret sharing, may be more strict and reject events that come from
+        // unknown devices.
         //
         // This is a defence against the following scenario:
         //
@@ -204,8 +205,8 @@ class OlmDecryption extends DecryptionAlgorithm {
         //   * Mallory gets control of Alice's server, and sends a megolm session to Alice using her (Mallory's)
         //     senderkey, but claiming to be from Bob.
         //   * Mallory sends more events using that session, claiming to be from Bob.
-        //   * Alice sees that the senderkey is verified (since she verified Mallory) so marks events those
-        //     events as verified even though the sender is forged.
+        //   * Alice sees that the senderkey is verified (since she verified Mallory) so marks events those events as
+        //     verified even though the sender is forged.
         //
         // In practice, it's not clear that the js-sdk would behave that way, so this may be only a defence in depth.
 


### PR DESCRIPTION
Specifically, when checking the event sender matches who sent us the session keys we skip waiting for pending device list updates if we already know who owns the session key.

This mitigates some of https://github.com/vector-im/element-web/issues/24682.

I've also stuck an try/catch across the `downloadKeys(..)` call, on the assumption that it would make it easier to track this failure mode down. I've completely made up the new `OLM_BAD_SENDER_CHECK_FAILED` error code.

Ideally, I think instead of doing it like this we'd instead specifically track who sent us the session keys (or at least, who we believe session keys should be from), and match against those when we do the decryption. But that's a bigger job and I think this should help a bunch while this gets fixed properly.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix an instance of failed to decrypt error when an in flight `/keys/query` fails. ([\#3486](https://github.com/matrix-org/matrix-js-sdk/pull/3486)).<!-- CHANGELOG_PREVIEW_END -->