### PR TITLE
Element-R: wait for OlmMachine on startup

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -19,16 +19,26 @@ import { IDBFactory } from "fake-indexeddb";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
 import { KeysQueryRequest, OlmMachine } from "@matrix-org/matrix-sdk-crypto-js";
 import { Mocked } from "jest-mock";
+import fetchMock from "fetch-mock-jest";
 
 import { RustCrypto } from "../../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../../src/rust-crypto";
-import { IHttpOpts, IToDeviceEvent, MatrixClient, MatrixHttpApi } from "../../../src";
+import {
+    HttpApiEvent,
+    HttpApiEventHandlerMap,
+    IHttpOpts,
+    IToDeviceEvent,
+    MatrixClient,
+    MatrixHttpApi,
+    TypedEventEmitter,
+} from "../../../src";
 import { mkEvent } from "../../test-utils/test-utils";
 import { CryptoBackend } from "../../../src/common-crypto/CryptoBackend";
 import { IEventDecryptionResult } from "../../../src/@types/crypto";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { ServerSideSecretStorage } from "../../../src/secret-storage";
 import { ImportRoomKeysOpts } from "../../../src/crypto-api";
+import * as testData from "../../test-utils/test-data";
 
 afterEach(() => {
     // reset fake-indexeddb after each test, to make sure we don't leak connections
@@ -388,6 +398,37 @@ describe("RustCrypto", () => {
             expect(recoveryKey.keyInfo?.passphrase?.algorithm).toBe("m.pbkdf2");
             expect(recoveryKey.keyInfo?.passphrase?.iterations).toBe(500000);
         });
+    });
+
+    it("should wait for a keys/query before returning devices", async () => {
+        jest.useFakeTimers();
+
+        const mockHttpApi = new MatrixHttpApi(new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>(), {
+            baseUrl: "http://server/",
+            prefix: "",
+            onlyData: true,
+        });
+        fetchMock.post("path:/_matrix/client/v3/keys/upload", { one_time_key_counts: {} });
+        fetchMock.post("path:/_matrix/client/v3/keys/query", {
+            device_keys: {
+                [testData.TEST_USER_ID]: {
+                    [testData.TEST_DEVICE_ID]: testData.SIGNED_TEST_DEVICE_DATA,
+                },
+            },
+        });
+
+        const rustCrypto = await makeTestRustCrypto(mockHttpApi, testData.TEST_USER_ID);
+
+        // an attempt to fetch the device list should block
+        const devicesPromise = rustCrypto.getUserDeviceInfo([testData.TEST_USER_ID]);
+
+        // ... until a /sync completes, and we trigger the outgoingRequests.
+        rustCrypto.onSyncCompleted({});
+
+        const deviceMap = (await devicesPromise).get(testData.TEST_USER_ID)!;
+        expect(deviceMap.has(TEST_DEVICE_ID)).toBe(true);
+        expect(deviceMap.has(testData.TEST_DEVICE_ID)).toBe(true);
+        rustCrypto.stop();
     });
 });
 

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -54,6 +54,17 @@ export async function initRustCrypto(
         rustCrypto.onRoomKeysUpdated(sessions),
     );
 
+    // Tell the OlmMachine to think about its outgoing requests before we hand control back to the application.
+    //
+    // This is primarily a fudge to get it to correctly populate the `users_for_key_query` list, so that future
+    // calls to getIdentity (etc) block until the key queries are performed.
+    //
+    // Note that we don't actually need to *make* any requests here; it is sufficient to tell the Rust side to think
+    // about them.
+    //
+    // XXX: find a less hacky way to do this.
+    await olmMachine.outgoingRequests();
+
     logger.info("Completed rust crypto-sdk setup");
     return rustCrypto;
 }


### PR DESCRIPTION
Previously, if you called `CryptoApi.getUserDeviceInfo()` before the first `/sync` request happened, it would return an empty list, which made a bunch of the tests racy. Add a hack to get the OlmMachine to think about its device lists during startup.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->