### PR TITLE
Add getLastUnthreadedReceiptFor utility to Thread delegating to the underlying Room

### DIFF
--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -778,7 +778,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
      */
     public insertEventIntoTimeline(event: MatrixEvent, timeline: EventTimeline, roomState: RoomState): void {
         if (timeline.getTimelineSet() !== this) {
-            throw new Error(`EventTimelineSet.addEventToTimeline: Timeline=${timeline.toString()} does not belong " +
+            throw new Error(`EventTimelineSet.insertEventIntoTimeline: Timeline=${timeline.toString()} does not belong " +
                 "in timelineSet(threadId=${this.thread?.id})`);
         }
 
@@ -793,7 +793,7 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
                 eventDebugString += `(belongs to thread=${event.threadRootId})`;
             }
             logger.warn(
-                `EventTimelineSet.addEventToTimeline: Ignoring ${eventDebugString} that does not belong ` +
+                `EventTimelineSet.insertEventIntoTimeline: Ignoring ${eventDebugString} that does not belong ` +
                     `in timeline=${timeline.toString()} timelineSet(threadId=${this.thread?.id})`,
             );
             return;

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -309,4 +309,13 @@ export abstract class ReadReceipt<
         // We don't know if the user has read it, so assume not.
         return false;
     }
+
+    /**
+     * Returns the most recent unthreaded receipt for a given user
+     * @param userId - the MxID of the User
+     * @returns an unthreaded Receipt. Can be undefined if receipts have been disabled
+     * or a user chooses to use private read receipts (or we have simply not received
+     * a receipt from this user yet).
+     */
+    public abstract getLastUnthreadedReceiptFor(userId: string): Receipt | undefined;
 }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -27,7 +27,7 @@ import { RoomState } from "./room-state";
 import { ServerControlledNamespacedValue } from "../NamespacedValue";
 import { logger } from "../logger";
 import { ReadReceipt } from "./read-receipt";
-import { CachedReceiptStructure, ReceiptType } from "../@types/read_receipts";
+import { CachedReceiptStructure, Receipt, ReceiptType } from "../@types/read_receipts";
 import { Feature, ServerSupport } from "../feature";
 
 export enum ThreadEvent {
@@ -710,6 +710,17 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
 
     public setUnread(type: NotificationCountType, count: number): void {
         return this.room.setThreadUnreadNotificationCount(this.id, type, count);
+    }
+
+    /**
+     * Returns the most recent unthreaded receipt for a given user
+     * @param userId - the MxID of the User
+     * @returns an unthreaded Receipt. Can be undefined if receipts have been disabled
+     * or a user chooses to use private read receipts (or we have simply not received
+     * a receipt from this user yet).
+     */
+    public getLastUnthreadedReceiptFor(userId: string): Receipt | undefined {
+        return this.room.getLastUnthreadedReceiptFor(userId);
     }
 }
 


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add getLastUnthreadedReceiptFor utility to Thread delegating to the underlying Room ([\#3493](https://github.com/matrix-org/matrix-js-sdk/pull/3493)).<!-- CHANGELOG_PREVIEW_END -->