### PR TITLE
OIDC: navigate to authorization endpoint

### DIFF
--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -79,7 +79,7 @@ describe("oidc authorization", () => {
                 await generateAuthorizationUrl(authorizationEndpoint, clientId, authorizationParams),
             );
 
-            expect(authUrl.searchParams.get("response_mode")).toEqual("fragment");
+            expect(authUrl.searchParams.get("response_mode")).toEqual("query");
             expect(authUrl.searchParams.get("response_type")).toEqual("code");
             expect(authUrl.searchParams.get("client_id")).toEqual(clientId);
             expect(authUrl.searchParams.get("code_challenge_method")).toEqual("S256");

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import fetchMockJest from "fetch-mock-jest";
+import fetchMock from "fetch-mock-jest";
 
 import { Method } from "../../../src";
 import * as crypto from "../../../src/crypto/crypto";
@@ -122,10 +122,10 @@ describe("oidc authorization", () => {
         };
 
         beforeEach(() => {
-            fetchMockJest.mockClear();
-            fetchMockJest.resetBehavior();
+            fetchMock.mockClear();
+            fetchMock.resetBehavior();
 
-            fetchMockJest.post(tokenEndpoint, {
+            fetchMock.post(tokenEndpoint, {
                 status: 200,
                 body: JSON.stringify(validBearerToken),
             });
@@ -134,7 +134,7 @@ describe("oidc authorization", () => {
         it("should make correct request to the token endpoint", async () => {
             await completeAuthorizationCodeGrant(code, { clientId, codeVerifier, redirectUri, delegatedAuthConfig });
 
-            expect(fetchMockJest).toHaveBeenCalledWith(tokenEndpoint, {
+            expect(fetchMock).toHaveBeenCalledWith(tokenEndpoint, {
                 method: Method.Post,
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: `grant_type=authorization_code&client_id=${clientId}&code_verifier=${codeVerifier}&redirect_uri=https%3A%2F%2Ftest.com&code=${code}`,
@@ -153,7 +153,7 @@ describe("oidc authorization", () => {
         });
 
         it("should throw with code exchange failed error when request fails", async () => {
-            fetchMockJest.post(
+            fetchMock.post(
                 tokenEndpoint,
                 {
                     status: 500,
@@ -170,7 +170,7 @@ describe("oidc authorization", () => {
                 ...validBearerToken,
                 access_token: null,
             };
-            fetchMockJest.post(
+            fetchMock.post(
                 tokenEndpoint,
                 { status: 200, body: JSON.stringify(invalidBearerToken) },
                 { overwriteRoutes: true },

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -67,8 +67,6 @@ describe("oidc authorization", () => {
             expect(authUrl.searchParams.get("response_type")).toEqual("code");
             expect(authUrl.searchParams.get("client_id")).toEqual(clientId);
             expect(authUrl.searchParams.get("code_challenge_method")).toEqual("S256");
-
-            // scope ends with a 10char randomstring deviceId
             expect(authUrl.searchParams.get("scope")).toEqual(authorizationParams.scope);
             expect(authUrl.searchParams.get("state")).toEqual(authorizationParams.state);
             expect(authUrl.searchParams.get("nonce")).toEqual(authorizationParams.nonce);

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -114,7 +114,7 @@ describe("oidc authorization", () => {
         const codeVerifier = "abc123";
         const redirectUri = baseUrl;
         const code = "auth_code_xyz";
-        const validBearerToken = {
+        const validBearerTokenResponse = {
             token_type: "Bearer",
             access_token: "test_access_token",
             refresh_token: "test_refresh_token",
@@ -127,7 +127,7 @@ describe("oidc authorization", () => {
 
             fetchMock.post(tokenEndpoint, {
                 status: 200,
-                body: JSON.stringify(validBearerToken),
+                body: JSON.stringify(validBearerTokenResponse),
             });
         });
 
@@ -149,7 +149,7 @@ describe("oidc authorization", () => {
                 delegatedAuthConfig,
             });
 
-            expect(result).toEqual(validBearerToken);
+            expect(result).toEqual(validBearerTokenResponse);
         });
 
         it("should throw with code exchange failed error when request fails", async () => {
@@ -166,18 +166,18 @@ describe("oidc authorization", () => {
         });
 
         it("should throw invalid token error when token is invalid", async () => {
-            const invalidBearerToken = {
-                ...validBearerToken,
+            const invalidBearerTokenResponse = {
+                ...validBearerTokenResponse,
                 access_token: null,
             };
             fetchMock.post(
                 tokenEndpoint,
-                { status: 200, body: JSON.stringify(invalidBearerToken) },
+                { status: 200, body: JSON.stringify(invalidBearerTokenResponse) },
                 { overwriteRoutes: true },
             );
             await expect(() =>
                 completeAuthorizationCodeGrant(code, { clientId, codeVerifier, redirectUri, delegatedAuthConfig }),
-            ).rejects.toThrow(new Error(OidcError.InvalidBearerToken));
+            ).rejects.toThrow(new Error(OidcError.InvalidBearerTokenResponse));
         });
     });
 });

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -152,6 +152,26 @@ describe("oidc authorization", () => {
             expect(result).toEqual(validBearerTokenResponse);
         });
 
+        it("should return with valid bearer token where token_type is lowercase", async () => {
+            const tokenResponse = {
+                ...validBearerTokenResponse,
+                token_type: "bearer",
+            };
+            fetchMock.post(tokenEndpoint, {
+                status: 200,
+                body: JSON.stringify(tokenResponse),
+            }, { overwriteRoutes: true });
+            
+            const result = await completeAuthorizationCodeGrant(code, {
+                clientId,
+                codeVerifier,
+                redirectUri,
+                delegatedAuthConfig,
+            });
+
+            expect(result).toEqual(validBearerTokenResponse);
+        });
+
         it("should throw with code exchange failed error when request fails", async () => {
             fetchMock.post(
                 tokenEndpoint,

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -157,11 +157,15 @@ describe("oidc authorization", () => {
                 ...validBearerTokenResponse,
                 token_type: "bearer",
             };
-            fetchMock.post(tokenEndpoint, {
-                status: 200,
-                body: JSON.stringify(tokenResponse),
-            }, { overwriteRoutes: true });
-            
+            fetchMock.post(
+                tokenEndpoint,
+                {
+                    status: 200,
+                    body: JSON.stringify(tokenResponse),
+                },
+                { overwriteRoutes: true },
+            );
+
             const result = await completeAuthorizationCodeGrant(code, {
                 clientId,
                 codeVerifier,
@@ -169,7 +173,9 @@ describe("oidc authorization", () => {
                 delegatedAuthConfig,
             });
 
+            // results in token that uses 'Bearer' token type
             expect(result).toEqual(validBearerTokenResponse);
+            expect(result.token_type).toEqual("Bearer");
         });
 
         it("should throw with code exchange failed error when request fails", async () => {

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as crypto from "../../../src/crypto/crypto";
+import { logger } from "../../../src/logger";
+import { generateAuthorizationParams, generateAuthorizationUrl } from "../../../src/oidc/authorize";
+
+// save for resetting mocks
+const realSubtleCrypto = crypto.subtleCrypto;
+
+describe("oidc authorization", () => {
+    const authorizationEndpoint = "https://auth.com/authorization";
+    const clientId = "xyz789";
+    const baseUrl = "https://test.com";
+
+    beforeAll(() => {
+        jest.spyOn(logger, "warn");
+    });
+
+    afterEach(() => {
+        // @ts-ignore reset any ugly mocking we did
+        crypto.subtleCrypto = realSubtleCrypto;
+    });
+
+    it("should generate authorization params", () => {
+        const result = generateAuthorizationParams({ redirectUri: baseUrl });
+
+        expect(result.redirectUri).toEqual(baseUrl);
+
+        // random strings
+        expect(result.state.length).toEqual(8);
+        expect(result.nonce.length).toEqual(8);
+        expect(result.codeVerifier.length).toEqual(64);
+
+        const expectedScope =
+            "openid urn:matrix:org.matrix.msc2967.client:api:* urn:matrix:org.matrix.msc2967.client:device:";
+        expect(result.scope.startsWith(expectedScope)).toBeTruthy();
+        // deviceId of 10 characters is appended to the device scope
+        expect(result.scope.length).toEqual(expectedScope.length + 10);
+    });
+
+    describe("generateAuthorizationUrl()", () => {
+        it("should generate url with correct parameters", async () => {
+            // test the no crypto case here
+            // @ts-ignore mocking
+            crypto.subtleCrypto = undefined;
+
+            const authorizationParams = generateAuthorizationParams({ redirectUri: baseUrl });
+            const authUrl = new URL(
+                await generateAuthorizationUrl(authorizationEndpoint, clientId, authorizationParams),
+            );
+
+            expect(authUrl.searchParams.get("response_mode")).toEqual("fragment");
+            expect(authUrl.searchParams.get("response_type")).toEqual("code");
+            expect(authUrl.searchParams.get("client_id")).toEqual(clientId);
+            expect(authUrl.searchParams.get("code_challenge_method")).toEqual("S256");
+
+            // scope ends with a 10char randomstring deviceId
+            expect(authUrl.searchParams.get("scope")).toEqual(authorizationParams.scope);
+            expect(authUrl.searchParams.get("state")).toEqual(authorizationParams.state);
+            expect(authUrl.searchParams.get("nonce")).toEqual(authorizationParams.nonce);
+
+            // crypto not available, plain text code_challenge is used
+            expect(authUrl.searchParams.get("code_challenge")).toEqual(authorizationParams.codeVerifier);
+            expect(logger.warn).toHaveBeenCalledWith(
+                "A secure context is required to generate code challenge. Using plain text code challenge",
+            );
+        });
+
+        it("uses a s256 code challenge when crypto is available", async () => {
+            jest.spyOn(crypto.subtleCrypto, "digest");
+            const authorizationParams = generateAuthorizationParams({ redirectUri: baseUrl });
+            const authUrl = new URL(
+                await generateAuthorizationUrl(authorizationEndpoint, clientId, authorizationParams),
+            );
+
+            const codeChallenge = authUrl.searchParams.get("code_challenge");
+            expect(crypto.subtleCrypto.digest).toHaveBeenCalledWith("SHA-256", expect.any(Object));
+
+            // didn't use plain text code challenge
+            expect(authorizationParams.codeVerifier).not.toEqual(codeChallenge);
+            expect(codeChallenge).toBeTruthy();
+        });
+    });
+});

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -376,7 +376,35 @@ describe("RustCrypto", () => {
             rustCrypto = await makeTestRustCrypto(undefined, testData.TEST_USER_ID);
         });
 
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it("returns false initially", async () => {
+            jest.useFakeTimers();
+            const prom = rustCrypto.userHasCrossSigningKeys();
+            // the getIdentity() request should wait for a /keys/query request to complete, but times out after 1500ms
+            await jest.advanceTimersByTimeAsync(2000);
+            await expect(prom).resolves.toBe(false);
+        });
+
         it("returns false if there is no cross-signing identity", async () => {
+            // @ts-ignore private field
+            const olmMachine = rustCrypto.olmMachine;
+
+            const outgoingRequests: OutgoingRequest[] = await olmMachine.outgoingRequests();
+            // pick out the KeysQueryRequest, and respond to it with the device keys but *no* cross-signing keys.
+            const req = outgoingRequests.find((r) => r instanceof KeysQueryRequest)!;
+            await olmMachine.markRequestAsSent(
+                req.id!,
+                req.type,
+                JSON.stringify({
+                    device_keys: {
+                        [testData.TEST_USER_ID]: { [testData.TEST_DEVICE_ID]: testData.SIGNED_TEST_DEVICE_DATA },
+                    },
+                }),
+            );
+
             await expect(rustCrypto.userHasCrossSigningKeys()).resolves.toBe(false);
         });
 
@@ -390,7 +418,12 @@ describe("RustCrypto", () => {
             await olmMachine.markRequestAsSent(
                 req.id!,
                 req.type,
-                JSON.stringify(testData.SIGNED_CROSS_SIGNING_KEYS_DATA),
+                JSON.stringify({
+                    device_keys: {
+                        [testData.TEST_USER_ID]: { [testData.TEST_DEVICE_ID]: testData.SIGNED_TEST_DEVICE_DATA },
+                    },
+                    ...testData.SIGNED_CROSS_SIGNING_KEYS_DATA,
+                }),
             );
 
             // ... and we should now have cross-signing keys.

--- a/src/client.ts
+++ b/src/client.ts
@@ -863,6 +863,7 @@ export interface TimestampToEventResponse {
 interface IWhoamiResponse {
     user_id: string;
     device_id?: string;
+    is_guest?: boolean;
 }
 /* eslint-enable camelcase */
 

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -81,7 +81,7 @@ export const generateAuthorizationUrl = async (
     { scope, redirectUri, state, nonce, codeVerifier }: AuthorizationParams,
 ): Promise<string> => {
     const url = new URL(authorizationUrl);
-    url.searchParams.append("response_mode", "fragment");
+    url.searchParams.append("response_mode", "query");
     url.searchParams.append("response_type", "code");
     url.searchParams.append("redirect_uri", redirectUri);
     url.searchParams.append("client_id", clientId);

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { IDelegatedAuthConfig } from "../client";
 import { Method } from "../http-api";
-import { subtleCrypto } from "../crypto/crypto";
+import { subtleCrypto, TextEncoder } from "../crypto/crypto";
 import { logger } from "../logger";
 import { randomString } from "../randomstring";
 import { OidcError } from "./error";

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -98,6 +98,7 @@ export const generateAuthorizationUrl = async (
 export type BearerToken = {
     token_type: "Bearer";
     access_token: string;
+    scope: string;
     refresh_token?: string;
     expires_in?: number;
     id_token?: string;

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -101,7 +101,13 @@ export const generateAuthorizationUrl = async (
     return url.toString();
 };
 
-export type BearerToken = {
+/**
+ * The expected response type from the token endpoint during authorization code flow
+ *
+ * See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4, 
+ * https://openid.net/specs/openid-connect-basic-1_0.html#TokenOK.
+ */
+export type BearerTokenResponse = {
     token_type: "Bearer";
     access_token: string;
     scope: string;
@@ -109,7 +115,7 @@ export type BearerToken = {
     expires_in?: number;
     id_token?: string;
 };
-const isValidBearerToken = (token: any): token is BearerToken =>
+const isValidBearerTokenResponse = (token: any): token is BearerTokenResponse =>
     typeof token == "object" &&
     token["token_type"] === "Bearer" &&
     typeof token["access_token"] === "string" &&
@@ -124,8 +130,8 @@ const isValidBearerToken = (token: any): token is BearerToken =>
  *
  * @param code - authorization code as returned by OP during authorization
  * @param storedAuthorizationParams - stored params from start of oidc login flow
- * @returns valid bearer token
- * @throws when request fails, or returned token is invalid
+ * @returns valid bearer token response
+ * @throws when request fails, or returned token response is invalid
  */
 export const completeAuthorizationCodeGrant = async (
     code: string,
@@ -140,7 +146,7 @@ export const completeAuthorizationCodeGrant = async (
         redirectUri: string;
         delegatedAuthConfig: IDelegatedAuthConfig & ValidatedIssuerConfig;
     },
-): Promise<BearerToken> => {
+): Promise<BearerTokenResponse> => {
     const params = new URLSearchParams();
     params.append("grant_type", "authorization_code");
     params.append("client_id", clientId);
@@ -163,9 +169,9 @@ export const completeAuthorizationCodeGrant = async (
 
     const token = await response.json();
 
-    if (isValidBearerToken(token)) {
+    if (isValidBearerTokenResponse(token)) {
         return token;
     }
 
-    throw new Error(OidcError.InvalidBearerToken);
+    throw new Error(OidcError.InvalidBearerTokenResponse);
 };

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -74,7 +74,7 @@ export const generateAuthorizationParams = ({ redirectUri }: { redirectUri: stri
 });
 
 /**
- * Generates a URL to attempt authorization with the OP
+ * Generate a URL to attempt authorization with the OP
  * See https://openid.net/specs/openid-connect-basic-1_0.html#CodeRequest
  * @param authorizationUrl - endpoint to attempt authorization with the OP
  * @param clientId - id of this client as registered with the OP

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { subtleCrypto } from "../crypto/crypto";
+import { logger } from "../logger";
+import { randomString } from "../randomstring";
+
+type AuthorizationParams = {
+    state: string;
+    scope: string;
+    redirectUri: string;
+    codeVerifier: string;
+    nonce: string;
+};
+
+const generateScope = (): string => {
+    const deviceId = randomString(10);
+    return `openid urn:matrix:org.matrix.msc2967.client:api:* urn:matrix:org.matrix.msc2967.client:device:${deviceId}`;
+};
+
+// https://www.rfc-editor.org/rfc/rfc7636
+const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
+    if (!subtleCrypto) {
+        // @TODO(kerrya) should this be allowed? configurable?
+        logger.warn("A secure context is required to generate code challenge. Using plain text code challenge");
+        return codeVerifier;
+    }
+    const utf8 = new TextEncoder().encode(codeVerifier);
+
+    const digest = await subtleCrypto.digest("SHA-256", utf8);
+
+    return btoa(String.fromCharCode(...new Uint8Array(digest)))
+        .replace(/=/g, "")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_");
+};
+
+/**
+ * Generate authorization params to pass to authorizationEndpoint
+ * As part of an authorization code OIDC flow
+ * @param redirectUri - absolute url for OP to redirect to after authorization
+ * @returns AuthorizationParams
+ */
+export const generateAuthorizationParams = ({ redirectUri }: { redirectUri: string }): AuthorizationParams => ({
+    scope: generateScope(),
+    redirectUri,
+    state: randomString(8),
+    nonce: randomString(8),
+    codeVerifier: randomString(64), // https://tools.ietf.org/html/rfc7636#section-4.1 length needs to be 43-128 characters
+});
+
+/**
+ * Generates a URL to attempt authorization with the OP
+ * See https://openid.net/specs/openid-connect-basic-1_0.html#CodeRequest
+ * @param authorizationUrl - endpoint to attempt authorization with the OP
+ * @param clientId - id of this client as registered with the OP
+ * @param authorizationParams - params to be used in the url
+ * @returns a Promise with the url as a string
+ */
+export const generateAuthorizationUrl = async (
+    authorizationUrl: string,
+    clientId: string,
+    { scope, redirectUri, state, nonce, codeVerifier }: AuthorizationParams,
+): Promise<string> => {
+    const url = new URL(authorizationUrl);
+    url.searchParams.append("response_mode", "fragment");
+    url.searchParams.append("response_type", "code");
+    url.searchParams.append("redirect_uri", redirectUri);
+    url.searchParams.append("client_id", clientId);
+    url.searchParams.append("state", state);
+    url.searchParams.append("scope", scope);
+    url.searchParams.append("nonce", nonce);
+
+    url.searchParams.append("code_challenge_method", "S256");
+    url.searchParams.append("code_challenge", await generateCodeChallenge(codeVerifier));
+
+    return url.toString();
+};

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -18,6 +18,7 @@ import { subtleCrypto } from "../crypto/crypto";
 import { logger } from "../logger";
 import { randomString } from "../randomstring";
 
+// See https://openid.net/specs/openid-connect-basic-1_0.html#CodeRequest
 type AuthorizationParams = {
     state: string;
     scope: string;

--- a/src/oidc/error.ts
+++ b/src/oidc/error.ts
@@ -23,5 +23,5 @@ export enum OidcError {
     DynamicRegistrationFailed = "Dynamic registration failed",
     DynamicRegistrationInvalid = "Dynamic registration invalid response",
     CodeExchangeFailed = "Failed to exchange code for token",
-    InvalidBearerToken = "Invalid bearer token",
+    InvalidBearerTokenResponse = "Invalid bearer token",
 }

--- a/src/oidc/error.ts
+++ b/src/oidc/error.ts
@@ -22,4 +22,6 @@ export enum OidcError {
     DynamicRegistrationNotSupported = "Dynamic registration not supported",
     DynamicRegistrationFailed = "Dynamic registration failed",
     DynamicRegistrationInvalid = "Dynamic registration invalid response",
+    CodeExchangeFailed = "Failed to exchange code for token",
+    InvalidBearerToken = "Invalid bearer token",
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/25574
Used https://github.com/matrix-org/matrix-react-sdk/pull/11096

[3.1.1.  Authorization Code Flow Steps
](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
)
**1. Client prepares an Authentication Request containing the desired request parameters.
2. Client sends the request to the Authorization Server.
3. Authorization Server Authenticates the End-User.
4. Authorization Server obtains End-User Consent/Authorization.
5. Authorization Server sends the End-User back to the Client with an Authorization Code.**
6. Client requests a response using the Authorization Code at the Token Endpoint.
7. Client receives a response that contains an ID Token and Access Token in the response body.
8. Client validates the ID token and retrieves the End-User's Subject Identifier.

This task addresses steps 1-5.

Splitting this flow into two parts to keep change set a reasonable size.

- generates authorization params and navigates to authorization endpoint

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * OIDC: navigate to authorization endpoint ([\#3499](https://github.com/matrix-org/matrix-js-sdk/pull/3499)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->