### PR TITLE
Bump version of the react-sdk cypress workflow file

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
     cypress:
         name: Cypress
-        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@v3.73.1
+        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@v3.74.0
         permissions:
             actions: read
             issues: read


### PR DESCRIPTION
`cypress.yaml` is currently pinned to an old version of the react-sdk, meaning that each attempt to run it is currently failing with an error.

(See https://github.com/matrix-org/matrix-js-sdk/actions/runs/5355422916:

> `The workflow is not valid. .github/workflows/cypress.yml (Line: 27, Col: 28): Invalid secret, TCMS_USERNAME is not defined in the referenced workflow. .github/workflows/cypress.yml (Line: 28, Col: 28): Invalid secret, TCMS_PASSWORD is not defined in the referenced workflow.`

)

(Introduced by https://github.com/matrix-org/matrix-js-sdk/pull/3480)

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->