### PR TITLE
Fix fetchRoomThreadList emitting spurious Room.Timeline events

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2054,7 +2054,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         for (const rootEvent of matrixEvents) {
             timelineSet.addLiveEvent(rootEvent, {
                 duplicateStrategy: DuplicateStrategy.Replace,
-                fromCache: false,
+                // We say these events are from cache as we're abusing a single timeline to maintain events
+                // from multiple threads and as such do not want to emit Room.Timeline events for these events
+                fromCache: true,
                 roomState,
             });
         }


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix fetchRoomThreadList emitting spurious Room.Timeline events ([\#3507](https://github.com/matrix-org/matrix-js-sdk/pull/3507)).<!-- CHANGELOG_PREVIEW_END -->