### PR TITLE
Increase another crypto test timeout

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -54,9 +54,13 @@ describe("RustCrypto", () => {
     describe(".importRoomKeys and .exportRoomKeys", () => {
         let rustCrypto: RustCrypto;
 
-        beforeEach(async () => {
-            rustCrypto = await makeTestRustCrypto();
-        });
+        beforeEach(
+            async () => {
+                rustCrypto = await makeTestRustCrypto();
+            },
+            /* it can take a while to initialise the crypto library on the first pass, so bump up the timeout. */
+            10000,
+        );
 
         it("should import and export keys", async () => {
             const someRoomKeys = [


### PR DESCRIPTION
Followup to https://github.com/matrix-org/matrix-js-sdk/pull/3500: increase the timeout for another test which is also timing out.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->