### PR TITLE
Improve types to match reality around old identity servers

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -176,7 +176,8 @@ export interface IAddThreePidOnlyBody {
 export interface IBindThreePidBody {
     client_secret: string;
     id_server: string;
-    id_access_token: string;
+    // Some older identity servers have no auth enabled
+    id_access_token: string | null;
     sid: string;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -9095,6 +9095,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param msisdnToken - The MSISDN token, as enetered by the user.
      * @param identityAccessToken - The `access_token` field of the Identity
      * Server `/account/register` response (see {@link registerWithIdentityServer}).
+     * Some legacy identity servers had no authentication here.
      *
      * @returns Promise which resolves: Object, containing success boolean.
      * @returns Rejects: with an error response.
@@ -9104,7 +9105,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         sid: string,
         clientSecret: string,
         msisdnToken: string,
-        identityAccessToken: string,
+        identityAccessToken: string | null,
     ): Promise<{ success: boolean }> {
         const params = {
             sid: sid,
@@ -9117,7 +9118,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             "/validate/msisdn/submitToken",
             params,
             IdentityPrefix.V2,
-            identityAccessToken,
+            identityAccessToken ?? undefined,
         );
     }
 


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->