### PR TITLE
Create a new event type for verification requests

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -510,7 +510,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
                     timestamp: Date.now() - 1000,
                 },
             });
-            const request: VerificationRequest = await emitPromise(aliceClient, CryptoEvent.VerificationRequest);
+            const request: VerificationRequest = await emitPromise(
+                aliceClient,
+                CryptoEvent.VerificationRequestReceived,
+            );
             expect(request.transactionId).toEqual(TRANSACTION_ID);
             expect(request.phase).toEqual(VerificationPhase.Requested);
             expect(request.roomId).toBeUndefined();

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -69,6 +69,12 @@ beforeAll(async () => {
     await global.Olm.init();
 });
 
+// load the rust library. This can take a few seconds on a slow GH worker.
+beforeAll(async () => {
+    const RustSdkCryptoJs = await require("@matrix-org/matrix-sdk-crypto-js");
+    await RustSdkCryptoJs.initAsync();
+}, 10000);
+
 afterEach(() => {
     // reset fake-indexeddb after each test, to make sure we don't leak connections
     // cf https://github.com/dumbmatter/fakeIndexedDB#wipingresetting-the-indexeddb-for-a-fresh-state

--- a/src/client.ts
+++ b/src/client.ts
@@ -923,6 +923,7 @@ type CryptoEvents =
     | CryptoEvent.RoomKeyRequest
     | CryptoEvent.RoomKeyRequestCancellation
     | CryptoEvent.VerificationRequest
+    | CryptoEvent.VerificationRequestReceived
     | CryptoEvent.DeviceVerificationChanged
     | CryptoEvent.UserTrustStatusChanged
     | CryptoEvent.KeysChanged

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -91,6 +91,7 @@ import {
     CrossSigningStatus,
     DeviceVerificationStatus,
     ImportRoomKeysOpts,
+    VerificationRequest as CryptoApiVerificationRequest,
 } from "../crypto-api";
 import { Device, DeviceMap } from "../models/device";
 import { deviceInfoToDevice } from "./device-converter";
@@ -218,7 +219,16 @@ export enum CryptoEvent {
     KeyBackupFailed = "crypto.keyBackupFailed",
     KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
     KeySignatureUploadFailure = "crypto.keySignatureUploadFailure",
+    /** @deprecated Use `VerificationRequestReceived`. */
     VerificationRequest = "crypto.verification.request",
+
+    /**
+     * Fires when a key verification request is received.
+     *
+     * The payload is a {@link Crypto.VerificationRequest}.
+     */
+    VerificationRequestReceived = "crypto.verificationRequestReceived",
+
     Warning = "crypto.warning",
     WillUpdateDevices = "crypto.willUpdateDevices",
     DevicesUpdated = "crypto.devicesUpdated",
@@ -280,8 +290,16 @@ export type CryptoEventHandlerMap = {
     ) => void;
     /**
      * Fires when a key verification is requested.
+     *
+     * Deprecated: use `CryptoEvent.VerificationRequestReceived`.
      */
     [CryptoEvent.VerificationRequest]: (request: VerificationRequest<any>) => void;
+
+    /**
+     * Fires when a key verification request is received.
+     */
+    [CryptoEvent.VerificationRequestReceived]: (request: CryptoApiVerificationRequest) => void;
+
     /**
      * Fires when the app may wish to warn the user about something related
      * the end-to-end crypto.
@@ -3541,6 +3559,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             !request.observeOnly;
         if (shouldEmit) {
             this.baseApis.emit(CryptoEvent.VerificationRequest, request);
+            this.baseApis.emit(CryptoEvent.VerificationRequestReceived, request);
         }
     }
 


### PR DESCRIPTION
Previous PRs (https://github.com/matrix-org/matrix-js-sdk/pull/3449, etc) have pulled out an interface from the `VerificationRequest` class, but applications registering for the `CryptoEvent.VerificationRequest` event could still be expecting a fully-fledged class rather than the interface.

To handle this without breaking backwards compat, add a new event type that carries the interface, not the class.

based on https://github.com/matrix-org/matrix-js-sdk/pull/3515

Notes: Deprecate `Crypto.VerificationRequest` application event, replacing it with `Crypto.VerificationRequestReceived`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate `Crypto.VerificationRequest` application event, replacing it with `Crypto.VerificationRequestReceived`. ([\#3514](https://github.com/matrix-org/matrix-js-sdk/pull/3514)).<!-- CHANGELOG_PREVIEW_END -->