### PR TITLE
Put LiveKit info into the `m.call` state event

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -209,6 +209,7 @@ import {
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
 } from "./secret-storage";
+import { FocusInfo } from "./webrtc/callEventTypes";
 
 export type Store = IStore;
 
@@ -366,6 +367,8 @@ export interface ICreateClientOpts {
      * with Olm. Default: true.
      */
     useE2eForGroupCall?: boolean;
+
+    foci?: FocusInfo[];
 
     cryptoCallbacks?: ICryptoCallbacks;
 
@@ -1260,6 +1263,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     private useE2eForGroupCall = true;
     private toDeviceMessageQueue: ToDeviceMessageQueue;
+    private foci: FocusInfo[] = [];
 
     private _secretStorage: ServerSideSecretStorageImpl;
 
@@ -1363,6 +1367,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.isVoipWithNoMediaAllowed = opts.isVoipWithNoMediaAllowed || false;
 
         if (opts.useE2eForGroupCall !== undefined) this.useE2eForGroupCall = opts.useE2eForGroupCall;
+
+        this.foci = opts.foci ?? [];
 
         // List of which rooms have encryption enabled: separate from crypto because
         // we still want to know which rooms are encrypted even if crypto is disabled:
@@ -1942,7 +1948,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             dataChannelOptions,
             this.isVoipWithNoMediaAllowed,
             this.useLivekitForGroupCalls,
+            this.foci,
         ).create();
+    }
+
+    public getFoci(): FocusInfo[] {
+        return this.foci;
     }
 
     /**

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -90,8 +90,7 @@ export interface MCallHangupReject extends MCallBase {
 }
 
 export interface FocusInfo {
-    url: string;
-    jwtServiceUrl: string;
+    livekitServiceUrl: string;
 }
 
 /* eslint-enable camelcase */

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -89,4 +89,9 @@ export interface MCallHangupReject extends MCallBase {
     reason?: CallErrorCode;
 }
 
+export interface FocusInfo {
+    url: string;
+    jwtServiceUrl: string;
+}
+
 /* eslint-enable camelcase */

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -17,7 +17,7 @@ import { Room } from "../models/room";
 import { RoomStateEvent } from "../models/room-state";
 import { logger } from "../logger";
 import { ReEmitter } from "../ReEmitter";
-import { SDPStreamMetadataPurpose } from "./callEventTypes";
+import { FocusInfo, SDPStreamMetadataPurpose } from "./callEventTypes";
 import { MatrixEvent } from "../models/event";
 import { EventType } from "../@types/event";
 import { CallEventHandlerEvent } from "./callEventHandler";
@@ -170,6 +170,9 @@ export interface IGroupCallRoomState {
     // TODO: Specify data-channels
     "dataChannelsEnabled"?: boolean;
     "dataChannelOptions"?: IGroupCallDataChannelOptions;
+
+    "io.element.livekit_server_url"?: string;
+    "io.element.livekit_jwt_service_url"?: string;
 }
 
 export interface IGroupCallRoomMemberFeed {
@@ -272,10 +275,12 @@ export class GroupCall extends TypedEventEmitter<
         // create the group call signaling events, with the intention that the actual media will be
         // handled using livekit. The js-sdk doesn't contain any code to do the actual livekit call though.
         private useLivekit = false,
+        foci?: FocusInfo[],
     ) {
         super();
         this.reEmitter = new ReEmitter(this);
         this.groupCallId = groupCallId ?? genCallID();
+        this._foci = foci ?? [];
         this.creationTs =
             room.currentState.getStateEvents(EventType.GroupCallPrefix, this.groupCallId)?.getTs() ?? null;
         this.updateParticipants();
@@ -324,6 +329,8 @@ export class GroupCall extends TypedEventEmitter<
         this.client.groupCallEventHandler!.groupCalls.set(this.room.roomId, this);
         this.client.emit(GroupCallEventHandlerEvent.Outgoing, this);
 
+        const focus = this._foci[0];
+
         const groupCallState: IGroupCallRoomState = {
             "m.intent": this.intent,
             "m.type": this.type,
@@ -332,10 +339,20 @@ export class GroupCall extends TypedEventEmitter<
             "dataChannelsEnabled": this.dataChannelsEnabled,
             "dataChannelOptions": this.dataChannelsEnabled ? this.dataChannelOptions : undefined,
         };
+        if (focus) {
+            groupCallState["io.element.livekit_server_url"] = focus.url;
+            groupCallState["io.element.livekit_jwt_service_url"] = focus.jwtServiceUrl;
+        }
 
         await this.client.sendStateEvent(this.room.roomId, EventType.GroupCallPrefix, groupCallState, this.groupCallId);
 
         return this;
+    }
+
+    private _foci: FocusInfo[] = [];
+
+    public get foci(): FocusInfo[] {
+        return this._foci;
     }
 
     private _state = GroupCallState.LocalCallFeedUninitialized;

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -171,8 +171,7 @@ export interface IGroupCallRoomState {
     "dataChannelsEnabled"?: boolean;
     "dataChannelOptions"?: IGroupCallDataChannelOptions;
 
-    "io.element.livekit_server_url"?: string;
-    "io.element.livekit_jwt_service_url"?: string;
+    "io.element.livekit_service_url"?: string;
 }
 
 export interface IGroupCallRoomMemberFeed {
@@ -340,8 +339,7 @@ export class GroupCall extends TypedEventEmitter<
             "dataChannelOptions": this.dataChannelsEnabled ? this.dataChannelOptions : undefined,
         };
         if (focus) {
-            groupCallState["io.element.livekit_server_url"] = focus.url;
-            groupCallState["io.element.livekit_jwt_service_url"] = focus.jwtServiceUrl;
+            groupCallState["io.element.livekit_service_url"] = focus.livekitServiceUrl;
         }
 
         await this.client.sendStateEvent(this.room.roomId, EventType.GroupCallPrefix, groupCallState, this.groupCallId);

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -178,19 +178,16 @@ export class GroupCallEventHandler {
             dataChannelOptions = { ordered, maxPacketLifeTime, maxRetransmits, protocol };
         }
 
-        const livekitServerUrl = content["io.element.livekit_server_url"];
-        const livekitJwtServiceUrl = content["io.element.livekit_jwt_service_url"];
+        const livekitServiceUrl = content["io.element.livekit_service_url"];
 
         let focus: FocusInfo | undefined;
-        if (livekitServerUrl && livekitJwtServiceUrl) {
+        if (livekitServiceUrl) {
             focus = {
-                url: livekitServerUrl,
-                jwtServiceUrl: livekitJwtServiceUrl,
+                livekitServiceUrl: livekitServiceUrl,
             };
         } else {
             focus = this.client.getFoci()[0]!;
-            content["io.element.livekit_server_url"] = focus.url;
-            content["io.element.livekit_jwt_service_url"] = focus.jwtServiceUrl;
+            content["io.element.livekit_service_url"] = focus.livekitServiceUrl;
             this.client.sendStateEvent(room.roomId, EventType.GroupCallPrefix, content, groupCallId);
         }
 


### PR DESCRIPTION
Fixes https://github.com/vector-im/voip-internal/issues/168
Requires https://github.com/vector-im/element-call/pull/1159

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->