### PR TITLE
Use the right smiley in emoji verification

### DIFF
--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -83,7 +83,7 @@ const emojiMapping: EmojiMapping[] = [
     ["🍕", "pizza"], // 27
     ["🎂", "cake"], // 28
     ["❤️", "heart"], // 29
-    ["🙂", "smiley"], // 30
+    ["😀", "smiley"], // 30
     ["🤖", "robot"], // 31
     ["🎩", "hat"], // 32
     ["👓", "glasses"], // 33


### PR DESCRIPTION
Notes: fix a bug which caused the wrong emoji to be shown during SAS device verification.

The [spec](https://spec.matrix.org/v1.7/client-server-api/#sas-method-emoji) mandates U+1F600 ("Grinning Face"), not U+1F642 "Slightly Smiling Face".

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * fix a bug which caused the wrong emoji to be shown during SAS device verification. ([\#3523](https://github.com/matrix-org/matrix-js-sdk/pull/3523)).<!-- CHANGELOG_PREVIEW_END -->