### PR TITLE
QRCode: fix breakage on node 16

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -50,21 +50,7 @@ import { E2EKeyReceiver } from "../../test-utils/E2EKeyReceiver";
 // to ensure that we don't end up with dangling timeouts.
 jest.useFakeTimers();
 
-let previousCrypto: Crypto | undefined;
-
 beforeAll(async () => {
-    // Stub out global.crypto
-    previousCrypto = global["crypto"];
-
-    Object.defineProperty(global, "crypto", {
-        value: {
-            getRandomValues: function <T extends Uint8Array>(array: T): T {
-                array.fill(0x12);
-                return array;
-            },
-        },
-    });
-
     // we use the libolm primitives in the test, so init the Olm library
     await global.Olm.init();
 });
@@ -80,18 +66,6 @@ afterEach(() => {
     // cf https://github.com/dumbmatter/fakeIndexedDB#wipingresetting-the-indexeddb-for-a-fresh-state
     // eslint-disable-next-line no-global-assign
     indexedDB = new IDBFactory();
-});
-
-// restore the original global.crypto
-afterAll(() => {
-    if (previousCrypto === undefined) {
-        // @ts-ignore deleting a non-optional property. It *is* optional really.
-        delete global.crypto;
-    } else {
-        Object.defineProperty(global, "crypto", {
-            value: previousCrypto,
-        });
-    }
 });
 
 /** The homeserver url that we give to the test client, and where we intercept /sync, /keys, etc requests. */

--- a/src/crypto/verification/QRCode.ts
+++ b/src/crypto/verification/QRCode.ts
@@ -18,6 +18,7 @@ limitations under the License.
  * QR code key verification.
  */
 
+import { crypto } from "../crypto";
 import { VerificationBase as Base } from "./Base";
 import { newKeyMismatchError, newUserCancelledError } from "./Error";
 import { decodeBase64, encodeUnpaddedBase64 } from "../olmlib";
@@ -200,7 +201,7 @@ export class QRCodeData {
 
     private static generateSharedSecret(): string {
         const secretBytes = new Uint8Array(11);
-        global.crypto.getRandomValues(secretBytes);
+        crypto.getRandomValues(secretBytes);
         return encodeUnpaddedBase64(secretBytes);
     }
 


### PR DESCRIPTION
[`crypto.getRandomValues`](https://nodejs.org/docs/latest-v18.x/api/crypto.html#cryptogetrandomvaluestypedarray) was added to the nodejs library in node 17. However, it was actually available in node 16, hiding under [`crypto.webcrypto`](https://nodejs.org/docs/latest-v16.x/api/webcrypto.html#cryptogetrandomvaluestypedarray). We have some shims that sort this out in `src/crypto/crypto.ts`, so let's use them.

All of this means that we don't need to monkey-patch `crypto` to run the tests on node 16.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->