### PR TITLE
Element-R: support for starting a SAS verification

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -16,9 +16,11 @@ limitations under the License.
 
 import "fake-indexeddb/auto";
 
+import anotherjson from "another-json";
 import { MockResponse } from "fetch-mock";
 import fetchMock from "fetch-mock-jest";
 import { IDBFactory } from "fake-indexeddb";
+import { createHash } from "crypto";
 
 import { createClient, CryptoEvent, ICreateClientOpts, MatrixClient } from "../../../src";
 import {
@@ -275,6 +277,102 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
 
             // at this point, cancelling should do nothing.
             await request.cancel();
+            expect(request.phase).toEqual(VerificationPhase.Done);
+
+            // we're done with the temporary keypair
+            olmSAS.free();
+        });
+
+        it("can initiate SAS verification ourselves", async () => {
+            aliceClient = await startTestClient();
+            await waitForDeviceList();
+
+            // Alice sends a m.key.verification.request
+            const [, request] = await Promise.all([
+                expectSendToDeviceMessage("m.key.verification.request"),
+                aliceClient.getCrypto()!.requestDeviceVerification(TEST_USER_ID, TEST_DEVICE_ID),
+            ]);
+            const transactionId = request.transactionId!;
+
+            // The dummy device replies with an m.key.verification.ready
+            returnToDeviceMessageFromSync(buildReadyMessage(transactionId, ["m.sas.v1"]));
+            await waitForVerificationRequestChanged(request);
+            expect(request.phase).toEqual(VerificationPhase.Ready);
+            expect(request.otherPartySupportsMethod("m.sas.v1")).toBe(true);
+
+            // advance the clock, because the devicelist likes to sleep for 5ms during key downloads
+            await jest.advanceTimersByTimeAsync(10);
+
+            // And now Alice starts a SAS verification
+            let sendToDevicePromise = expectSendToDeviceMessage("m.key.verification.start");
+            await request.startVerification("m.sas.v1");
+            let requestBody = await sendToDevicePromise;
+
+            let toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
+            expect(toDeviceMessage).toEqual({
+                from_device: aliceClient.deviceId,
+                method: "m.sas.v1",
+                transaction_id: transactionId,
+                hashes: ["sha256"],
+                key_agreement_protocols: expect.arrayContaining(["curve25519-hkdf-sha256"]),
+                message_authentication_codes: expect.arrayContaining(["hkdf-hmac-sha256.v2"]),
+                short_authentication_string: ["decimal", "emoji"],
+            });
+
+            expect(request.chosenMethod).toEqual("m.sas.v1");
+
+            // There should now be a `verifier`
+            const verifier: Verifier = request.verifier!;
+            expect(verifier).toBeDefined();
+            expect(verifier.getShowSasCallbacks()).toBeNull();
+            const verificationPromise = verifier.verify();
+
+            // The dummy device makes up a curve25519 keypair and uses the hash in an 'm.key.verification.accept'
+            // We use the Curve25519, HMAC and HKDF implementations in libolm, for now
+            const olmSAS = new global.Olm.SAS();
+            const commitmentStr = olmSAS.get_pubkey() + anotherjson.stringify(toDeviceMessage);
+
+            sendToDevicePromise = expectSendToDeviceMessage("m.key.verification.key");
+            returnToDeviceMessageFromSync(buildSasAcceptMessage(transactionId, commitmentStr));
+
+            // alice responds with a 'key' ...
+            requestBody = await sendToDevicePromise;
+
+            toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
+            expect(toDeviceMessage.transaction_id).toEqual(transactionId);
+            const aliceDevicePubKeyBase64 = toDeviceMessage.key;
+            olmSAS.set_their_key(aliceDevicePubKeyBase64);
+
+            // ... and the dummy device also sends a 'key'
+            returnToDeviceMessageFromSync(buildSasKeyMessage(transactionId, olmSAS.get_pubkey()));
+
+            // ... and the client is notified to show the emoji
+            const showSas = await new Promise<ShowSasCallbacks>((resolve) => {
+                verifier.once(VerifierEvent.ShowSas, resolve);
+            });
+
+            // `getShowSasCallbacks` is an alternative way to get the callbacks
+            expect(verifier.getShowSasCallbacks()).toBe(showSas);
+            expect(verifier.getReciprocateQrCodeCallbacks()).toBeNull();
+
+            // user confirms that the emoji match, and alice sends a 'mac'
+            [requestBody] = await Promise.all([expectSendToDeviceMessage("m.key.verification.mac"), showSas.confirm()]);
+            toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
+            expect(toDeviceMessage.transaction_id).toEqual(transactionId);
+
+            // the dummy device also confirms that the emoji match, and sends a mac
+            returnToDeviceMessageFromSync(
+                buildSasMacMessage(transactionId, olmSAS, TEST_USER_ID, aliceClient.deviceId!),
+            );
+
+            // that should satisfy Alice, who should reply with a 'done'
+            await expectSendToDeviceMessage("m.key.verification.done");
+
+            // the dummy device also confirms done-ness
+            returnToDeviceMessageFromSync(buildDoneMessage(transactionId));
+
+            // ... and the whole thing should be done!
+            await verificationPromise;
             expect(request.phase).toEqual(VerificationPhase.Done);
 
             // we're done with the temporary keypair
@@ -587,6 +685,11 @@ function calculateMAC(olmSAS: Olm.SAS, input: string, info: string): string {
     return mac;
 }
 
+/** Calculate the sha256 hash of a string, encoding as unpadded base64 */
+function sha256(commitmentStr: string): string {
+    return encodeUnpaddedBase64(createHash("sha256").update(commitmentStr, "utf8").digest());
+}
+
 function encodeUnpaddedBase64(uint8Array: ArrayBuffer | Uint8Array): string {
     return Buffer.from(uint8Array).toString("base64").replace(/=+$/g, "");
 }
@@ -616,6 +719,21 @@ function buildSasStartMessage(transactionId: string): { type: string; content: o
             message_authentication_codes: ["hkdf-hmac-sha256.v2"],
             // we have to include "decimal" per the spec.
             short_authentication_string: ["decimal", "emoji"],
+        },
+    };
+}
+
+/** build an m.key.verification.accept to-device message suitable for the SAS flow */
+function buildSasAcceptMessage(transactionId: string, commitmentStr: string) {
+    return {
+        type: "m.key.verification.accept",
+        content: {
+            transaction_id: transactionId,
+            commitment: sha256(commitmentStr),
+            hash: "sha256",
+            key_agreement_protocol: "curve25519-hkdf-sha256",
+            short_authentication_string: ["decimal", "emoji"],
+            message_authentication_code: "hkdf-hmac-sha256.v2",
         },
     };
 }

--- a/spec/unit/rust-crypto/verification.spec.ts
+++ b/spec/unit/rust-crypto/verification.spec.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import { Mocked } from "jest-mock";
+
+import { RustVerificationRequest } from "../../../src/rust-crypto/verification";
+import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+
+describe("VerificationRequest", () => {
+    describe("startVerification", () => {
+        let mockedInner: Mocked<RustSdkCryptoJs.VerificationRequest>;
+        let mockedOutgoingRequestProcessor: Mocked<OutgoingRequestProcessor>;
+        let request: RustVerificationRequest;
+
+        beforeEach(() => {
+            mockedInner = {
+                registerChangesCallback: jest.fn(),
+                startSas: jest.fn(),
+            } as unknown as Mocked<RustSdkCryptoJs.VerificationRequest>;
+            mockedOutgoingRequestProcessor = {} as Mocked<OutgoingRequestProcessor>;
+            request = new RustVerificationRequest(mockedInner, mockedOutgoingRequestProcessor);
+        });
+
+        it("does not permit methods other than SAS", async () => {
+            await expect(request.startVerification("m.reciprocate.v1")).rejects.toThrow(
+                "Unsupported verification method",
+            );
+        });
+
+        it("raises an error if starting verification does not produce a verifier", async () => {
+            await expect(request.startVerification("m.sas.v1")).rejects.toThrow(
+                "Still no verifier after startSas() call",
+            );
+        });
+    });
+});

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -128,8 +128,19 @@ export interface VerificationRequest
      * @param targetDevice - details of where to send the request to.
      *
      * @returns The verifier which will do the actual verification.
+     *
+     * @deprecated Use {@link VerificationRequest#startVerification} instead.
      */
     beginKeyVerification(method: string, targetDevice?: { userId?: string; deviceId?: string }): Verifier;
+
+    /**
+     * Send an `m.key.verification.start` event to start verification via a particular method.
+     *
+     * @param method - the name of the verification method to use.
+     *
+     * @returns The verifier which will do the actual verification.
+     */
+    startVerification(method: string): Promise<Verifier>;
 
     /**
      * The verifier which is doing the actual verification, once the method has been established.

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -30,6 +30,7 @@ import {
     VerificationRequest as IVerificationRequest,
     VerificationRequestEvent,
     VerificationRequestEventHandlerMap,
+    Verifier,
 } from "../../../crypto-api/verification";
 
 // backwards-compatibility exports
@@ -456,6 +457,13 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
             }
         }
         return this._verifier!;
+    }
+
+    public async startVerification(method: string): Promise<Verifier> {
+        const verifier = this.beginKeyVerification(method);
+        // kick off the verification in the background, but *don't* wait for to complete: we need to return the `Verifier`.
+        verifier.verify();
+        return verifier;
     }
 
     /**


### PR DESCRIPTION
Once we have a verification request in flight, we can start a SAS flow by sending an `m.key.verification.start`. This is slightly fiddly because at the moment the js-sdk breaks this into two steps: first do a `.beginKeyVerification` on the `VerificationRequest` to immediately get a `Verifier`, and then call `.verify` on the `Verifier` to send the `start` message.

However, in the Rust world, creating the equivalent to a verifier is asynchronous and sends the `start` message.

So, we create a new method which does both, and implement it in legacy crypto for forward compatibility.

Notes: Deprecate `VerificationRequest.beginKeyVerification()` in favour of `VerificationRequest.startVerification()`.

Part of https://github.com/vector-im/element-web/issues/25320.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate `VerificationRequest.beginKeyVerification()` in favour of `VerificationRequest.startVerification()`. ([\#3528](https://github.com/matrix-org/matrix-js-sdk/pull/3528)).<!-- CHANGELOG_PREVIEW_END -->