### PR TITLE
Drop support for Node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 specs: [browserify, integ, unit]
-                node: [16, 18, latest]
+                node: [18, latest]
         steps:
             - name: Checkout code
               uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "26.1.0",
     "description": "Matrix Client-Server SDK for Javascript",
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "scripts": {
         "prepublishOnly": "yarn build",


### PR DESCRIPTION
Node 16 is quite old, and is somewhat slow. We don't appear to have any need to support it.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Drop support for Node 16 ([\#3533](https://github.com/matrix-org/matrix-js-sdk/pull/3533)).<!-- CHANGELOG_PREVIEW_END -->