### PR TITLE
Use the right anchor emoji for SAS verification

### DIFF
--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -52,17 +52,22 @@ const newMismatchedSASError = errorFactory("m.mismatched_sas", "Mismatched short
 
 const newMismatchedCommitmentError = errorFactory("m.mismatched_commitment", "Mismatched commitment");
 
+// This list was generated from the data in the Matrix specification [1] with the following command:
+//
+//    jq  -r '.[] |  "    [\"" + .emoji + "\", \"" + (.description|ascii_downcase) + "\"], // " + (.number|tostring)' sas-emoji.json
+//
+// [1]: https://github.com/matrix-org/matrix-spec/blob/main/data-definitions/sas-emoji.json
 const emojiMapping: EmojiMapping[] = [
-    ["🐶", "dog"], //  0
-    ["🐱", "cat"], //  1
-    ["🦁", "lion"], //  2
-    ["🐎", "horse"], //  3
-    ["🦄", "unicorn"], //  4
-    ["🐷", "pig"], //  5
-    ["🐘", "elephant"], //  6
-    ["🐰", "rabbit"], //  7
-    ["🐼", "panda"], //  8
-    ["🐓", "rooster"], //  9
+    ["🐶", "dog"], // 0
+    ["🐱", "cat"], // 1
+    ["🦁", "lion"], // 2
+    ["🐎", "horse"], // 3
+    ["🦄", "unicorn"], // 4
+    ["🐷", "pig"], // 5
+    ["🐘", "elephant"], // 6
+    ["🐰", "rabbit"], // 7
+    ["🐼", "panda"], // 8
+    ["🐓", "rooster"], // 9
     ["🐧", "penguin"], // 10
     ["🐢", "turtle"], // 11
     ["🐟", "fish"], // 12
@@ -113,7 +118,7 @@ const emojiMapping: EmojiMapping[] = [
     ["🎸", "guitar"], // 57
     ["🎺", "trumpet"], // 58
     ["🔔", "bell"], // 59
-    ["⚓️", "anchor"], // 60
+    ["⚓", "anchor"], // 60
     ["🎧", "headphones"], // 61
     ["📁", "folder"], // 62
     ["📌", "pin"], // 63


### PR DESCRIPTION
Currently, the anchor emoji has a ["Variation Selector-16"](https://codepoints.net/U+FE0F) (U+FE0F) character after it.

The unicode specs do define U+2694 U+FE0F as a valid sequence (with suggested rendering ![image](https://github.com/matrix-org/matrix-js-sdk/assets/1389908/c9a328f8-6d49-4d45-9b7a-af42627d3122)), but our spec doesn't include the variation selector, and the difference means that my cypress tests (which attempt a verification between Element-R and unrusty Element Web) fail intermittently. As far as I can tell, it doesn't make any difference to our actual displayed output in Element.

Something of a follow-up to https://github.com/matrix-org/matrix-js-sdk/pull/3523, but hopefully this will be the last, because I have regenerated the whole list from the spec data.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Use the right anchor emoji for SAS verification ([\#3534](https://github.com/matrix-org/matrix-js-sdk/pull/3534)).<!-- CHANGELOG_PREVIEW_END -->