### PR TITLE
Prevent threads code from making identical simultaneous API hits

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -603,12 +603,6 @@ describe("MatrixClient event timelines", function () {
                 .respond(200, function () {
                     return THREAD_ROOT;
                 });
-
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
             httpBackend
                 .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
                 .respond(200, function () {
@@ -634,12 +628,6 @@ describe("MatrixClient event timelines", function () {
             const thread = room.createThread(THREAD_ROOT.event_id!, undefined, [], false);
             await httpBackend.flushAllExpected();
             const timelineSet = thread.timelineSet;
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            await flushHttp(emitPromise(thread, ThreadEvent.Update));
 
             const timeline = await client.getEventTimeline(timelineSet, THREAD_REPLY.event_id!);
 
@@ -1510,7 +1498,8 @@ describe("MatrixClient event timelines", function () {
                     },
                     event: true,
                 });
-                THREAD_REPLY2.localTimestamp += 1000;
+                // this has to come after THREAD_REPLY which hasn't been instantiated by us
+                THREAD_REPLY2.localTimestamp += 10000000;
 
                 // Test data for the first thread, with the second reply
                 const THREAD_ROOT_UPDATED = {
@@ -1570,14 +1559,11 @@ describe("MatrixClient event timelines", function () {
                 thread.initialEventsFetched = true;
                 const prom = emitPromise(room, ThreadEvent.NewReply);
                 respondToEvent(THREAD_ROOT_UPDATED);
-                respondToEvent(THREAD_ROOT_UPDATED);
-                respondToEvent(THREAD_ROOT_UPDATED);
-                respondToEvent(THREAD_ROOT_UPDATED);
                 respondToEvent(THREAD2_ROOT);
                 await room.addLiveEvents([THREAD_REPLY2]);
                 await httpBackend.flushAllExpected();
                 await prom;
-                expect(thread.length).toBe(2);
+                expect(thread.length).toBe(1);
                 // Test threads are in chronological order
                 expect(timeline!.getEvents().map((it) => it.event.event_id)).toEqual([
                     THREAD2_ROOT.event_id,
@@ -1699,13 +1685,11 @@ describe("MatrixClient event timelines", function () {
                 thread.initialEventsFetched = true;
                 const prom = emitPromise(room, ThreadEvent.Update);
                 respondToEvent(THREAD_ROOT_UPDATED);
-                respondToEvent(THREAD_ROOT_UPDATED);
-                respondToEvent(THREAD_ROOT_UPDATED);
                 respondToEvent(THREAD2_ROOT);
                 await room.addLiveEvents([THREAD_REPLY_REACTION]);
                 await httpBackend.flushAllExpected();
                 await prom;
-                expect(thread.length).toBe(2);
+                expect(thread.length).toBe(1); // reactions don't count towards the length of a thread
                 // Test thread order is unchanged
                 expect(timeline!.getEvents().map((it) => it.event.event_id)).toEqual([
                     THREAD_ROOT.event_id,
@@ -2021,25 +2005,6 @@ describe("MatrixClient event timelines", function () {
                 .respond(200, function () {
                     return THREAD_ROOT;
                 });
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            httpBackend
-                .when(
-                    "GET",
-                    "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                        encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        buildRelationPaginationQuery({ dir: Direction.Backward, limit: 1 }),
-                )
-                .respond(200, function () {
-                    return {
-                        chunk: [THREAD_REPLY],
-                    };
-                });
             await Promise.all([httpBackend.flushAllExpected(), utils.syncPromise(client)]);
 
             const room = client.getRoom(roomId)!;
@@ -2047,71 +2012,7 @@ describe("MatrixClient event timelines", function () {
             expect(thread.initialEventsFetched).toBeTruthy();
             const timelineSet = thread.timelineSet;
 
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/event/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return THREAD_ROOT;
-                });
-            httpBackend
-                .when("GET", "/rooms/!foo%3Abar/context/" + encodeURIComponent(THREAD_ROOT.event_id!))
-                .respond(200, function () {
-                    return {
-                        start: "start_token",
-                        events_before: [],
-                        event: THREAD_ROOT,
-                        events_after: [],
-                        end: "end_token",
-                        state: [],
-                    };
-                });
-            httpBackend
-                .when(
-                    "GET",
-                    "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                        encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        buildRelationPaginationQuery({
-                            dir: Direction.Backward,
-                            from: "start_token",
-                        }),
-                )
-                .respond(200, function () {
-                    return {
-                        chunk: [],
-                    };
-                });
-            httpBackend
-                .when(
-                    "GET",
-                    "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                        encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        buildRelationPaginationQuery({ dir: Direction.Forward, from: "end_token" }),
-                )
-                .respond(200, function () {
-                    return {
-                        chunk: [THREAD_REPLY],
-                    };
-                });
-
-            const timeline = await flushHttp(client.getEventTimeline(timelineSet, THREAD_ROOT.event_id!));
+            const timeline = await client.getEventTimeline(timelineSet, THREAD_ROOT.event_id!);
 
             httpBackend.when("GET", "/sync").respond(200, {
                 next_batch: "s_5_5",

--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -1563,7 +1563,7 @@ describe("MatrixClient event timelines", function () {
                 await room.addLiveEvents([THREAD_REPLY2]);
                 await httpBackend.flushAllExpected();
                 await prom;
-                expect(thread.length).toBe(1);
+                expect(thread.length).toBe(2);
                 // Test threads are in chronological order
                 expect(timeline!.getEvents().map((it) => it.event.event_id)).toEqual([
                     THREAD2_ROOT.event_id,

--- a/spec/test-utils/thread.ts
+++ b/spec/test-utils/thread.ts
@@ -157,7 +157,7 @@ export const mkThread = ({
         room?.reEmitter.reEmit(evt, [MatrixEventEvent.BeforeRedaction]);
     }
 
-    const thread = room.createThread(rootEvent.getId() ?? "", rootEvent, events, true);
+    const thread = room.createThread(rootEvent.getId() ?? "", rootEvent, [rootEvent, ...events], true);
 
     return { thread, rootEvent, events };
 };

--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -699,11 +699,7 @@ async function createThread(client: MatrixClient, user: string, roomId: string):
     root.setThreadId(root.getId());
     await room.addLiveEvents([root]);
 
-    // Create the thread and wait for it to be initialised
-    const thread = room.createThread(root.getId()!, root, [], false);
-    await new Promise<void>((res) => thread.once(RoomEvent.TimelineReset, () => res()));
-
-    return thread;
+    return room.createThread(root.getId()!, root, [], false);
 }
 
 /**

--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -18,7 +18,7 @@ import { mocked } from "jest-mock";
 
 import { MatrixClient, PendingEventOrdering } from "../../../src/client";
 import { Room, RoomEvent } from "../../../src/models/room";
-import { Thread, THREAD_RELATION_TYPE, ThreadEvent, FeatureSupport } from "../../../src/models/thread";
+import { FeatureSupport, Thread, THREAD_RELATION_TYPE, ThreadEvent } from "../../../src/models/thread";
 import { makeThreadEvent, mkThread } from "../../test-utils/thread";
 import { TestClient } from "../../TestClient";
 import { emitPromise, mkEdit, mkMessage, mkReaction, mock } from "../../test-utils/test-utils";
@@ -43,6 +43,7 @@ describe("Thread", () => {
         const myUserId = "@bob:example.org";
         const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, { timelineSupport: false });
         const client = testClient.client;
+        client.supportsThreads = jest.fn().mockReturnValue(true);
         const room = new Room("123", client, myUserId, {
             pendingEventOrdering: PendingEventOrdering.Detached,
         });
@@ -300,6 +301,7 @@ describe("Thread", () => {
                 timelineSupport: false,
             });
             const client = testClient.client;
+            client.supportsThreads = jest.fn().mockReturnValue(true);
             const room = new Room("123", client, myUserId, {
                 pendingEventOrdering: PendingEventOrdering.Detached,
             });
@@ -354,6 +356,7 @@ describe("Thread", () => {
                 timelineSupport: false,
             });
             const client = testClient.client;
+            client.supportsThreads = jest.fn().mockReturnValue(true);
             const room = new Room("123", client, myUserId, {
                 pendingEventOrdering: PendingEventOrdering.Detached,
             });
@@ -405,6 +408,7 @@ describe("Thread", () => {
                 timelineSupport: false,
             });
             const client = testClient.client;
+            client.supportsThreads = jest.fn().mockReturnValue(true);
             const room = new Room("123", client, myUserId, {
                 pendingEventOrdering: PendingEventOrdering.Detached,
             });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -2787,10 +2787,10 @@ describe("Room", function () {
             let prom = emitPromise(room, ThreadEvent.New);
             await room.addLiveEvents([threadRoot, threadResponse1]);
             const thread: Thread = await prom;
-            await emitPromise(room, ThreadEvent.Update);
 
             expect(thread.initialEventsFetched).toBeTruthy();
             await room.addLiveEvents([threadResponse2]);
+            await emitPromise(room, ThreadEvent.Update);
             expect(thread).toHaveLength(2);
             expect(thread.replyToEvent!.getId()).toBe(threadResponse2.getId());
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -362,7 +362,7 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             return;
         }
 
-        if (event.isRelation(THREAD_RELATION_TYPE.name)) {
+        if (event.getId() !== this.id && event.isRelation(THREAD_RELATION_TYPE.name)) {
             this.replyCount++;
         }
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -362,9 +362,7 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             return;
         }
 
-        // If no thread support exists we want to count all thread relation
-        // added as a reply. We can't rely on the bundled relationships count
-        if ((!Thread.hasServerSideSupport || !this.rootEvent) && event.isRelation(THREAD_RELATION_TYPE.name)) {
+        if (event.isRelation(THREAD_RELATION_TYPE.name)) {
             this.replyCount++;
         }
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -308,6 +308,11 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
     public async addEvent(event: MatrixEvent, toStartOfTimeline: boolean, emit = true): Promise<void> {
         this.setEventMetadata(event);
 
+        if (!this.initialEventsFetched && !toStartOfTimeline && event.getId() === this.id) {
+            // We're loading the thread organically
+            this.initialEventsFetched = true;
+        }
+
         const lastReply = this.lastReply();
         const isNewestReply = !lastReply || event.localTimestamp >= lastReply!.localTimestamp;
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -200,6 +200,7 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
         } else {
             if (this.lastEvent?.getId() === event.getAssociatedId()) {
                 // XXX: If our last event got redacted we query the server for the last event once again
+                await this.processRootEventPromise;
                 this.processRootEventPromise = undefined;
             }
             await this.updateThreadMetadata();


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/25395

Currently the `fetchRootEvent` method would get called for each emit of `Room.Timeline` which meant if a thread was found with 10 events, we'd call `/event/` 10 times. A lot of our tests seem to expect the `/event/` API being hammered which should have been a red flag much much earlier. This change doesn't fix all the issues with the Thread model (https://github.com/matrix-org/matrix-js-sdk/pull/3542 aims to do that) but helps avoid calling the init code paths multiple times (especially at the same time). The only time the init code path will be re-called is if the last event was redacted just to simplify the change. Perfect is the enemy of freaking hugely better.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Prevent threads code from making identical simultaneous API hits ([\#3541](https://github.com/matrix-org/matrix-js-sdk/pull/3541)). Fixes vector-im/element-web#25395.<!-- CHANGELOG_PREVIEW_END -->