### PR TITLE
OIDC: use `oidc-client-ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
         "matrix-widget-api": "^1.3.1",
+        "oidc-client-ts": "^2.2.4",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",
         "unhomoglyph": "^1.0.6",

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -46,7 +46,8 @@ export const mockOpenIdConfiguration = (issuer = "https://auth.org/"): Validated
     token_endpoint: issuer + "token",
     authorization_endpoint: issuer + "auth",
     registration_endpoint: issuer + "registration",
-    response_types_supported: ["query"],
-    grant_types_supported: ["code", "refreshToken"],
+    jwks_uri: issuer + "jwks",
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
 });

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OidcAuthorityConfig } from "../../src";
+import { OidcClientConfig } from "../../src";
 import { ValidatedIssuerMetadata } from "../../src/oidc/validate";
 
 /**
- * Makes a valid OidcAuthorityConfig with minimum valid values
+ * Makes a valid OidcClientConfig with minimum valid values
  * @param issuer used as the base for all other urls
- * @returns OidcAuthorityConfig
+ * @returns OidcClientConfig
  */
-export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcAuthorityConfig => {
+export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcClientConfig => {
     const metadata = mockOpenIdConfiguration(issuer);
 
     return {

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { OidcAuthorityConfig } from "../../src";
+import { ValidatedIssuerMetadata } from "../../src/oidc/validate";
+
+/**
+ * Makes a valid OidcAuthorityConfig with minimum valid values
+ * @param issuer used as the base for all other urls
+ * @returns OidcAuthorityConfig
+ */
+export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcAuthorityConfig => {
+    const metadata = mockOpenIdConfiguration(issuer);
+
+    return {
+        issuer,
+        account: issuer + "account",
+        registrationEndpoint: metadata.registration_endpoint,
+        authorizationEndpoint: metadata.authorization_endpoint,
+        tokenEndpoint: metadata.token_endpoint,
+        metadata,
+    };
+};
+
+/**
+ * Useful for mocking <issuer>/.well-known/openid-configuration
+ * @param issuer used as the base for all other urls
+ * @returns ValidatedIssuerMetadata
+ */
+export const mockOpenIdConfiguration = (issuer = "https://auth.org/"): ValidatedIssuerMetadata => ({
+    issuer,
+    revocation_endpoint: issuer + "revoke",
+    token_endpoint: issuer + "token",
+    authorization_endpoint: issuer + "auth",
+    registration_endpoint: issuer + "registration",
+    response_types_supported: ["query"],
+    grant_types_supported: ["code", "refreshToken"],
+    code_challenge_methods_supported: ["S256"],
+});

--- a/spec/unit/autodiscovery.spec.ts
+++ b/spec/unit/autodiscovery.spec.ts
@@ -15,10 +15,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import fetchMock from "fetch-mock-jest";
 import MockHttpBackend from "matrix-mock-request";
 
+import { M_AUTHENTICATION } from "../../src";
 import { AutoDiscovery } from "../../src/autodiscovery";
 import { OidcError } from "../../src/oidc/error";
+import { makeDelegatedAuthConfig } from "../test-utils/oidc";
+
+// keep to reset the fetch function after using MockHttpBackend
+// @ts-ignore private property
+const realAutoDiscoveryFetch: typeof global.fetch = AutoDiscovery.fetchFn;
 
 describe("AutoDiscovery", function () {
     const getHttpBackend = (): MockHttpBackend => {
@@ -26,6 +33,10 @@ describe("AutoDiscovery", function () {
         AutoDiscovery.setFetchFn(httpBackend.fetchFn as typeof global.fetch);
         return httpBackend;
     };
+
+    afterAll(() => {
+        AutoDiscovery.setFetchFn(realAutoDiscoveryFetch);
+    });
 
     it("should throw an error when no domain is specified", function () {
         getHttpBackend();
@@ -854,5 +865,76 @@ describe("AutoDiscovery", function () {
                 expect(conf).toEqual(expected);
             }),
         ]);
+    });
+
+    describe("m.authentication", () => {
+        const homeserverName = "example.org";
+        const homeserverUrl = "https://chat.example.org/";
+        const issuer = "https://auth.org/";
+
+        beforeAll(() => {
+            // make these tests independent from fetch mocking above
+            AutoDiscovery.setFetchFn(realAutoDiscoveryFetch);
+        });
+
+        beforeEach(() => {
+            fetchMock.resetBehavior();
+            fetchMock.get(`${homeserverUrl}_matrix/client/versions`, { versions: ["r0.0.1"] });
+
+            fetchMock.get("https://example.org/.well-known/matrix/client", {
+                "m.homeserver": {
+                    // Note: we also expect this test to trim the trailing slash
+                    base_url: "https://chat.example.org/",
+                },
+                "m.authentication": {
+                    issuer,
+                },
+            });
+        });
+
+        it("should return valid authentication configuration", async () => {
+            const config = makeDelegatedAuthConfig(issuer);
+
+            fetchMock.get(`${config.metadata.issuer}.well-known/openid-configuration`, config.metadata);
+            fetchMock.get(`${config.metadata.issuer}jwks`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                keys: [],
+            });
+
+            const result = await AutoDiscovery.findClientConfig(homeserverName);
+
+            expect(result[M_AUTHENTICATION.stable!]).toEqual({
+                state: AutoDiscovery.SUCCESS,
+                ...config,
+                signingKeys: [],
+                account: undefined,
+                error: null,
+            });
+        });
+
+        it("should set state to error for invalid authentication configuration", async () => {
+            const config = makeDelegatedAuthConfig(issuer);
+            // authorization_code is required
+            config.metadata.grant_types_supported = ["openid"];
+
+            fetchMock.get(`${config.metadata.issuer}.well-known/openid-configuration`, config.metadata);
+            fetchMock.get(`${config.metadata.issuer}jwks`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                keys: [],
+            });
+
+            const result = await AutoDiscovery.findClientConfig(homeserverName);
+
+            expect(result[M_AUTHENTICATION.stable!]).toEqual({
+                state: AutoDiscovery.FAIL_ERROR,
+                error: OidcError.OpSupport,
+            });
+        });
     });
 });

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -129,6 +129,7 @@ describe("validateOIDCIssuerWellKnown", () => {
         authorization_endpoint: "https://test.org/authorize",
         token_endpoint: "https://authorize.org/token",
         registration_endpoint: "https://authorize.org/regsiter",
+        revocation_endpoint: "https://authorize.org/regsiter",
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code"],
         code_challenge_methods_supported: ["S256"],

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -35,7 +35,7 @@ describe("validateWellKnownAuthentication()", () => {
         },
     };
     it("should throw not supported error when wellKnown has no m.authentication section", () => {
-        expect(() => validateWellKnownAuthentication(baseWk)).toThrow(OidcError.NotSupported);
+        expect(() => validateWellKnownAuthentication(undefined)).toThrow(OidcError.NotSupported);
     });
 
     it("should throw misconfigured error when authentication issuer is not a string", () => {
@@ -45,7 +45,9 @@ describe("validateWellKnownAuthentication()", () => {
                 issuer: { url: "test.com" },
             },
         };
-        expect(() => validateWellKnownAuthentication(wk)).toThrow(OidcError.Misconfigured);
+        expect(() => validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!] as any)).toThrow(
+            OidcError.Misconfigured,
+        );
     });
 
     it("should throw misconfigured error when authentication account is not a string", () => {
@@ -56,7 +58,9 @@ describe("validateWellKnownAuthentication()", () => {
                 account: { url: "test" },
             },
         };
-        expect(() => validateWellKnownAuthentication(wk)).toThrow(OidcError.Misconfigured);
+        expect(() => validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!] as any)).toThrow(
+            OidcError.Misconfigured,
+        );
     });
 
     it("should throw misconfigured error when authentication account is false", () => {
@@ -67,7 +71,9 @@ describe("validateWellKnownAuthentication()", () => {
                 account: false,
             },
         };
-        expect(() => validateWellKnownAuthentication(wk)).toThrow(OidcError.Misconfigured);
+        expect(() => validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!] as any)).toThrow(
+            OidcError.Misconfigured,
+        );
     });
 
     it("should return valid config when wk uses stable m.authentication", () => {
@@ -78,7 +84,7 @@ describe("validateWellKnownAuthentication()", () => {
                 account: "account.com",
             },
         };
-        expect(validateWellKnownAuthentication(wk)).toEqual({
+        expect(validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!])).toEqual({
             issuer: "test.com",
             account: "account.com",
         });
@@ -91,7 +97,7 @@ describe("validateWellKnownAuthentication()", () => {
                 issuer: "test.com",
             },
         };
-        expect(validateWellKnownAuthentication(wk)).toEqual({
+        expect(validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!])).toEqual({
             issuer: "test.com",
         });
     });
@@ -104,22 +110,8 @@ describe("validateWellKnownAuthentication()", () => {
                 somethingElse: "test",
             },
         };
-        expect(validateWellKnownAuthentication(wk)).toEqual({
+        expect(validateWellKnownAuthentication(wk[M_AUTHENTICATION.stable!])).toEqual({
             issuer: "test.com",
-        });
-    });
-
-    it("should return valid config when wk uses unstable prefix for m.authentication", () => {
-        const wk = {
-            ...baseWk,
-            [M_AUTHENTICATION.unstable!]: {
-                issuer: "test.com",
-                account: "account.com",
-            },
-        };
-        expect(validateWellKnownAuthentication(wk)).toEqual({
-            issuer: "test.com",
-            account: "account.com",
         });
     });
 });

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -59,15 +59,15 @@ interface AutoDiscoveryState {
 interface WellKnownConfig extends Omit<IWellKnownConfig, "error">, AutoDiscoveryState {}
 
 /**
- * @deprecated in favour of OidcAuthorityConfig
+ * @deprecated in favour of OidcClientConfig
  */
 interface DelegatedAuthConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig, AutoDiscoveryState {}
 
 /**
  * @experimental
  */
-export interface OidcAuthorityConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig {
-    metadata?: ValidatedIssuerMetadata;
+export interface OidcClientConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig {
+    metadata: ValidatedIssuerMetadata;
     signingKeys?: SigningKey[];
 }
 
@@ -77,7 +77,7 @@ export interface ClientConfig extends Omit<IClientWellKnown, "m.homeserver" | "m
     /**
      * @experimental
      */
-    "m.authentication"?: (OidcAuthorityConfig & AutoDiscoveryState) | AutoDiscoveryState;
+    "m.authentication"?: (OidcClientConfig & AutoDiscoveryState) | AutoDiscoveryState;
 }
 
 /**
@@ -355,7 +355,7 @@ export class AutoDiscovery {
      */
     public static async discoverAndValidateAuthenticationConfig(
         wellKnown: IClientWellKnown,
-    ): Promise<(OidcAuthorityConfig & AutoDiscoveryState) | AutoDiscoveryState> {
+    ): Promise<(OidcClientConfig & AutoDiscoveryState) | AutoDiscoveryState> {
         try {
             const result = await discoverAndValidateAuthenticationConfig(wellKnown);
 

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -66,7 +66,7 @@ interface DelegatedAuthConfig extends IDelegatedAuthConfig, ValidatedIssuerConfi
 /**
  * @experimental
  */
-export interface OidcAuthorityConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig, AutoDiscoveryState {
+export interface OidcAuthorityConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig {
     metadata?: ValidatedIssuerMetadata;
     signingKeys?: SigningKey[];
 }
@@ -77,7 +77,7 @@ export interface ClientConfig extends Omit<IClientWellKnown, "m.homeserver" | "m
     /**
      * @experimental
      */
-    "m.authentication"?: OidcAuthorityConfig | AutoDiscoveryState;
+    "m.authentication"?: (OidcAuthorityConfig & AutoDiscoveryState) | AutoDiscoveryState;
 }
 
 /**
@@ -355,7 +355,7 @@ export class AutoDiscovery {
      */
     public static async discoverAndValidateAuthenticationConfig(
         wellKnown: IClientWellKnown,
-    ): Promise<OidcAuthorityConfig | AutoDiscoveryState> {
+    ): Promise<(OidcAuthorityConfig & AutoDiscoveryState) | AutoDiscoveryState> {
         try {
             const result = await discoverAndValidateAuthenticationConfig(wellKnown);
 

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -15,10 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { SigningKey } from "oidc-client-ts";
+
 import { IClientWellKnown, IWellKnownConfig, IDelegatedAuthConfig, IServerVersions, M_AUTHENTICATION } from "./client";
 import { logger } from "./logger";
 import { MatrixError, Method, timeoutSignal } from "./http-api";
-import { ValidatedIssuerConfig, validateOIDCIssuerWellKnown, validateWellKnownAuthentication } from "./oidc/validate";
+import { discoverAndValidateAuthenticationConfig } from "./oidc/discovery";
+import {
+    ValidatedIssuerConfig,
+    ValidatedIssuerMetadata,
+    validateOIDCIssuerWellKnown,
+    validateWellKnownAuthentication,
+} from "./oidc/validate";
 import { OidcError } from "./oidc/error";
 
 // Dev note: Auto discovery is part of the spec.
@@ -50,12 +58,26 @@ interface AutoDiscoveryState {
 }
 interface WellKnownConfig extends Omit<IWellKnownConfig, "error">, AutoDiscoveryState {}
 
+/**
+ * @deprecated in favour of OidcAuthorityConfig
+ */
 interface DelegatedAuthConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig, AutoDiscoveryState {}
+
+/**
+ * @experimental
+ */
+export interface OidcAuthorityConfig extends IDelegatedAuthConfig, ValidatedIssuerConfig, AutoDiscoveryState {
+    metadata?: ValidatedIssuerMetadata;
+    signingKeys?: SigningKey[];
+}
 
 export interface ClientConfig extends Omit<IClientWellKnown, "m.homeserver" | "m.identity_server"> {
     "m.homeserver": WellKnownConfig;
     "m.identity_server": WellKnownConfig;
-    "m.authentication"?: DelegatedAuthConfig | AutoDiscoveryState;
+    /**
+     * @experimental
+     */
+    "m.authentication"?: OidcAuthorityConfig | AutoDiscoveryState;
 }
 
 /**
@@ -262,7 +284,7 @@ export class AutoDiscovery {
             }
         });
 
-        const authConfig = await this.validateDiscoveryAuthenticationConfig(wellknown);
+        const authConfig = await this.discoverAndValidateAuthenticationConfig(wellknown);
         clientConfig[M_AUTHENTICATION.stable!] = authConfig;
 
         // Step 8: Give the config to the caller (finally)
@@ -271,6 +293,7 @@ export class AutoDiscovery {
 
     /**
      * Validate delegated auth configuration
+     * @deprecated use discoverAndValidateAuthenticationConfig
      * - m.authentication config is present and valid
      * - delegated auth issuer openid-configuration is reachable
      * - delegated auth issuer openid-configuration is configured correctly for us
@@ -305,6 +328,47 @@ export class AutoDiscovery {
                 ...validatedIssuerConfig,
             };
             return delegatedAuthConfig;
+        } catch (error) {
+            const errorMessage = (error as Error).message as unknown as OidcError;
+            const errorType = Object.values(OidcError).includes(errorMessage) ? errorMessage : OidcError.General;
+
+            const state =
+                errorType === OidcError.NotSupported ? AutoDiscoveryAction.IGNORE : AutoDiscoveryAction.FAIL_ERROR;
+
+            return {
+                state,
+                error: errorType,
+            };
+        }
+    }
+
+    /**
+     * Validate delegated auth configuration
+     * - m.authentication config is present and valid
+     * - delegated auth issuer openid-configuration is reachable
+     * - delegated auth issuer openid-configuration is configured correctly for us
+     * When successful, validated authentication metadata and optionally signing keys will be returned
+     * Any errors are caught, and AutoDiscoveryState returned with error
+     * @param wellKnown - configuration object as returned
+     * by the .well-known auto-discovery endpoint
+     * @returns Config or failure result
+     */
+    public static async discoverAndValidateAuthenticationConfig(
+        wellKnown: IClientWellKnown,
+    ): Promise<OidcAuthorityConfig | AutoDiscoveryState> {
+        try {
+            const result = await discoverAndValidateAuthenticationConfig(wellKnown);
+
+            // include this for backwards compatibility
+            const validatedIssuerConfig = validateOIDCIssuerWellKnown(result.metadata);
+
+            const response = {
+                state: AutoDiscoveryAction.SUCCESS,
+                error: null,
+                ...validatedIssuerConfig,
+                ...result,
+            };
+            return response;
         } catch (error) {
             const errorMessage = (error as Error).message as unknown as OidcError;
             const errorType = Object.values(OidcError).includes(errorMessage) ? errorMessage : OidcError.General;

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -307,7 +307,8 @@ export class AutoDiscovery {
         wellKnown: IClientWellKnown,
     ): Promise<DelegatedAuthConfig | AutoDiscoveryState> {
         try {
-            const homeserverAuthenticationConfig = validateWellKnownAuthentication(wellKnown);
+            const authentication = M_AUTHENTICATION.findIn<IDelegatedAuthConfig>(wellKnown) || undefined;
+            const homeserverAuthenticationConfig = validateWellKnownAuthentication(authentication);
 
             const issuerOpenIdConfigUrl = `${this.sanitizeWellKnownUrl(
                 homeserverAuthenticationConfig.issuer,
@@ -357,7 +358,8 @@ export class AutoDiscovery {
         wellKnown: IClientWellKnown,
     ): Promise<(OidcClientConfig & AutoDiscoveryState) | AutoDiscoveryState> {
         try {
-            const result = await discoverAndValidateAuthenticationConfig(wellKnown);
+            const authentication = M_AUTHENTICATION.findIn<IDelegatedAuthConfig>(wellKnown) || undefined;
+            const result = await discoverAndValidateAuthenticationConfig(authentication);
 
             // include this for backwards compatibility
             const validatedIssuerConfig = validateOIDCIssuerWellKnown(result.metadata);

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -22,7 +22,7 @@ import { subtleCrypto, TextEncoder } from "../crypto/crypto";
 import { logger } from "../logger";
 import { randomString } from "../randomstring";
 import { OidcError } from "./error";
-import { validateIdToken, ValidatedIssuerConfig, ValidatedIssuerMetadata } from "./validate";
+import { validateIdToken, ValidatedIssuerConfig, ValidatedIssuerMetadata, UserState } from "./validate";
 
 /**
  * Authorization parameters which are used in the authentication request of an OIDC auth code flow.
@@ -122,15 +122,15 @@ export const generateOidcAuthorizationUrl = async ({
     redirectUri,
     clientId,
     homeserverUrl,
+    identityServerUrl,
     nonce,
-    state,
 }: {
     clientId: string;
     metadata: ValidatedIssuerMetadata;
     homeserverUrl: string;
+    identityServerUrl?: string;
     redirectUri: string;
     nonce: string;
-    state: string;
 }): Promise<string> => {
     const scope = await generateScope();
     const oidcClient = new OidcClient({
@@ -143,8 +143,9 @@ export const generateOidcAuthorizationUrl = async ({
         scope,
         stateStore: new WebStorageStateStore({ prefix: "mx_oidc_", store: window.sessionStorage }),
     });
+    const userState: UserState = { homeserverUrl, nonce, identityServerUrl };
     const request = await oidcClient.createSigninRequest({
-        state,
+        state: userState,
         nonce,
     });
 

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { OidcClient, OidcClientSettings, WebStorageStateStore } from "oidc-client-ts";
+
 import { IDelegatedAuthConfig } from "../client";
 import { Method } from "../http-api";
 import { subtleCrypto, TextEncoder } from "../crypto/crypto";
@@ -74,6 +76,7 @@ export const generateAuthorizationParams = ({ redirectUri }: { redirectUri: stri
 });
 
 /**
+ * @deprecated use generateOidcAuthorizationUrl
  * Generate a URL to attempt authorization with the OP
  * See https://openid.net/specs/openid-connect-basic-1_0.html#CodeRequest
  * @param authorizationUrl - endpoint to attempt authorization with the OP
@@ -99,6 +102,29 @@ export const generateAuthorizationUrl = async (
     url.searchParams.append("code_challenge", await generateCodeChallenge(codeVerifier));
 
     return url.toString();
+};
+
+/**
+ * @experimental
+ * Generate a URL to attempt authorization with the OP
+ * See https://openid.net/specs/openid-connect-basic-1_0.html#CodeRequest
+ * @param oidcClientSettings - oidc configuration
+ * @param homeserverName - used as state
+ * @returns a Promise with the url as a string
+ */
+export const generateOidcAuthorizationUrl = async (
+    oidcClientSettings: OidcClientSettings,
+    homeserverName: string,
+): Promise<string> => {
+    const oidcClient = new OidcClient({
+        ...oidcClientSettings,
+        stateStore: new WebStorageStateStore({ store: window.sessionStorage }),
+    });
+    const request = await oidcClient.createSigninRequest({
+        state: { host: homeserverName },
+    });
+
+    return request.url;
 };
 
 /**

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -123,12 +123,14 @@ export const generateOidcAuthorizationUrl = async ({
     clientId,
     homeserverUrl,
     nonce,
+    state,
 }: {
     clientId: string;
     metadata: ValidatedIssuerMetadata;
     homeserverUrl: string;
     redirectUri: string;
     nonce: string;
+    state: string;
 }): Promise<string> => {
     const scope = await generateScope();
     const oidcClient = new OidcClient({
@@ -138,14 +140,12 @@ export const generateOidcAuthorizationUrl = async ({
         authority: metadata.issuer,
         response_mode: "query",
         response_type: "code",
-        extraQueryParams: {
-            nonce,
-        },
         scope,
-        stateStore: new WebStorageStateStore({ prefix: "mx_", store: window.sessionStorage }),
+        stateStore: new WebStorageStateStore({ prefix: "mx_oidc_", store: window.sessionStorage }),
     });
     const request = await oidcClient.createSigninRequest({
-        state: { host: homeserverUrl },
+        state,
+        nonce,
     });
 
     return request.url;

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { MetadataService, OidcClientSettingsStore, SigningKey } from "oidc-client-ts";
 
-import { IClientWellKnown, IDelegatedAuthConfig } from "../client";
+import { IDelegatedAuthConfig } from "../client";
 import { isValidatedIssuerMetadata, ValidatedIssuerMetadata, validateWellKnownAuthentication } from "./validate";
 
 /**
@@ -32,14 +32,14 @@ import { isValidatedIssuerMetadata, ValidatedIssuerMetadata, validateWellKnownAu
  * @throws when delegated auth config is invalid or unreachable
  */
 export const discoverAndValidateAuthenticationConfig = async (
-    wellKnown: IClientWellKnown,
+    authenticationConfig?: IDelegatedAuthConfig,
 ): Promise<
     IDelegatedAuthConfig & {
         metadata: ValidatedIssuerMetadata;
         signingKeys?: SigningKey[];
     }
 > => {
-    const homeserverAuthenticationConfig = validateWellKnownAuthentication(wellKnown);
+    const homeserverAuthenticationConfig = validateWellKnownAuthentication(authenticationConfig);
 
     // create a temporary settings store so we can use metadata service for discovery
     const settings = new OidcClientSettingsStore({

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { MetadataService, OidcClientSettingsStore, SigningKey } from "oidc-client-ts";
+
+import { IClientWellKnown } from "../client";
+import { isValidatedIssuerMetadata, ValidatedIssuerMetadata, validateWellKnownAuthentication } from "./validate";
+
+/**
+ * @experimental
+ * Discover and validate delegated auth configuration
+ * - m.authentication config is present and valid
+ * - delegated auth issuer openid-configuration is reachable
+ * - delegated auth issuer openid-configuration is configured correctly for us
+ * When successful, validated metadata is returned
+ * @param wellKnown - configuration object as returned
+ * by the .well-known auto-discovery endpoint
+ * @returns validated authentication metadata and optionally signing keys
+ * @throws when delegated auth config is invalid or unreachable
+ */
+export const discoverAndValidateAuthenticationConfig = async (
+    wellKnown: IClientWellKnown,
+): Promise<{
+    metadata: ValidatedIssuerMetadata;
+    signingKeys?: SigningKey[];
+}> => {
+    const homeserverAuthenticationConfig = validateWellKnownAuthentication(wellKnown);
+
+    // create a temporary settings store so we can use metadata service for discovery
+    const settings = new OidcClientSettingsStore({
+        authority: homeserverAuthenticationConfig.issuer,
+        redirect_uri: "", // Not known yet, this is here to make the type checker happy
+        client_id: "", // Not known yet, this is here to make the type checker happy
+    });
+    const metadataService = new MetadataService(settings);
+    const metadata = await metadataService.getMetadata();
+    const signingKeys = (await metadataService.getSigningKeys()) ?? undefined;
+
+    isValidatedIssuerMetadata(metadata);
+
+    return {
+        metadata,
+        signingKeys,
+    };
+};

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { MetadataService, OidcClientSettingsStore, SigningKey } from "oidc-client-ts";
 
-import { IClientWellKnown } from "../client";
+import { IClientWellKnown, IDelegatedAuthConfig } from "../client";
 import { isValidatedIssuerMetadata, ValidatedIssuerMetadata, validateWellKnownAuthentication } from "./validate";
 
 /**
@@ -33,10 +33,12 @@ import { isValidatedIssuerMetadata, ValidatedIssuerMetadata, validateWellKnownAu
  */
 export const discoverAndValidateAuthenticationConfig = async (
     wellKnown: IClientWellKnown,
-): Promise<{
-    metadata: ValidatedIssuerMetadata;
-    signingKeys?: SigningKey[];
-}> => {
+): Promise<
+    IDelegatedAuthConfig & {
+        metadata: ValidatedIssuerMetadata;
+        signingKeys?: SigningKey[];
+    }
+> => {
     const homeserverAuthenticationConfig = validateWellKnownAuthentication(wellKnown);
 
     // create a temporary settings store so we can use metadata service for discovery
@@ -52,6 +54,7 @@ export const discoverAndValidateAuthenticationConfig = async (
     isValidatedIssuerMetadata(metadata);
 
     return {
+        ...homeserverAuthenticationConfig,
         metadata,
         signingKeys,
     };

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -229,3 +229,19 @@ export const validateIdToken = (idToken: string | undefined, issuer: string, cli
         throw new Error(OidcError.InvalidIdToken);
     }
 };
+
+/**
+ * State we ask OidcClient to store when starting oidc authorization flow (in `generateOidcAuthorizationUrl`)
+ * so that we can access it on return from the OP and complete login
+ */
+export type UserState = {
+    /**
+     * Remember which server we were trying to login to
+     */
+    homeserverUrl: string;
+    identityServerUrl?: string;
+    /**
+     * Used to validate id token
+     */
+    nonce: string;
+};

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import jwtDecode from "jwt-decode";
 import { OidcMetadata } from "oidc-client-ts";
 
-import { IClientWellKnown, IDelegatedAuthConfig, M_AUTHENTICATION } from "../client";
+import { IDelegatedAuthConfig } from "../client";
 import { logger } from "../logger";
 import { OidcError } from "./error";
 
@@ -40,9 +40,7 @@ export type ValidatedIssuerConfig = {
  * @returns config - when present and valid
  * @throws when config is not found or invalid
  */
-export const validateWellKnownAuthentication = (wellKnown: IClientWellKnown): IDelegatedAuthConfig => {
-    const authentication = M_AUTHENTICATION.findIn<IDelegatedAuthConfig>(wellKnown);
-
+export const validateWellKnownAuthentication = (authentication?: IDelegatedAuthConfig): IDelegatedAuthConfig => {
     if (!authentication) {
         throw new Error(OidcError.NotSupported);
     }

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -128,9 +128,11 @@ export const validateOIDCIssuerWellKnown = (wellKnown: unknown): ValidatedIssuer
 export type ValidatedIssuerMetadata = Partial<OidcMetadata> &
     Pick<
         OidcMetadata,
+        | "issuer"
         | "authorization_endpoint"
         | "token_endpoint"
         | "registration_endpoint"
+        | "revocation_endpoint"
         | "response_types_supported"
         | "grant_types_supported"
         | "code_challenge_methods_supported"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,6 +3115,11 @@ crypto-browserify@^3.0.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 cssom@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
@@ -5919,6 +5924,14 @@ object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oidc-client-ts@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-2.2.4.tgz#7d86b5efe2248f3637a6f3a0ee1af86764aea125"
+  integrity sha512-nOZwIomju+AmXObl5Oq5PjrES/qTt8bLsENJCIydVgi9TEWk7SCkOU6X3RNkY7yfySRM1OJJvDKdREZdmnDT2g==
+  dependencies:
+    crypto-js "^4.1.1"
+    jwt-decode "^3.1.2"
 
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/25392

- adds `oidc-client-ts` library
- use `oidc-client-ts` for discovery and authorization url creation
- deprecate `autodiscovery.validateDiscoveryAuthenticationConfig` and `generateAuthorizationUrl`

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->