### PR TITLE
Don't allow Olm unwedging rate-limiting to race

### DIFF
--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -130,7 +130,12 @@ export function isCryptoAvailable(): boolean {
     return Boolean(global.Olm);
 }
 
+// minimum time between attempting to unwedge an Olm session, if we succeeded
+// in creating a new session
 const MIN_FORCE_SESSION_INTERVAL_MS = 60 * 60 * 1000;
+// minimum time between attempting to unwedge an Olm session, if we failed
+// to create a new session
+const FORCE_SESSION_RETRY_INTERVAL_MS = 5 * 60 * 1000;
 
 interface IInitOpts {
     exportedOlmDevice?: IExportedDevice;
@@ -390,7 +395,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     // to avoid loading room members as long as possible.
     private roomDeviceTrackingState: { [roomId: string]: Promise<void> } = {};
 
-    // The timestamp of the last time we forced establishment
+    // The timestamp of the minimum time at which we will retry forcing establishment
     // of a new session for each device, in milliseconds.
     // {
     //     userId: {
@@ -398,7 +403,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     //     },
     // }
     // Map: user Id → device Id → timestamp
-    private lastNewSessionForced: MapWithDefault<string, MapWithDefault<string, number>> = new MapWithDefault(
+    private forceNewSessionRetryTime: MapWithDefault<string, MapWithDefault<string, number>> = new MapWithDefault(
         () => new MapWithDefault(() => 0),
     );
 
@@ -3591,24 +3596,26 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
             return;
         }
 
-        // check when we last forced a new session with this device: if we've already done so
+        // check when we can force a new session with this device: if we've already done so
         // recently, don't do it again.
-        const lastNewSessionDevices = this.lastNewSessionForced.getOrCreate(sender);
-        const lastNewSessionForced = lastNewSessionDevices.getOrCreate(deviceKey);
-        if (lastNewSessionForced + MIN_FORCE_SESSION_INTERVAL_MS > Date.now()) {
+        const forceNewSessionRetryTimeDevices = this.forceNewSessionRetryTime.getOrCreate(sender);
+        const forceNewSessionRetryTime = forceNewSessionRetryTimeDevices.getOrCreate(deviceKey);
+        if (forceNewSessionRetryTime > Date.now()) {
             logger.debug(
                 "New session already forced with device " +
                     sender +
                     ":" +
                     deviceKey +
-                    " at " +
-                    lastNewSessionForced +
-                    ": not forcing another",
+                    ": not forcing another until at least ",
+                    forceNewSessionRetryTime
             );
             await this.olmDevice.recordSessionProblem(deviceKey, "wedged", true);
             retryDecryption();
             return;
         }
+
+        // make sure we don't retry to unwedge too soon even if we fail to create a new session
+        forceNewSessionRetryTimeDevices.set(deviceKey, Date.now() + FORCE_SESSION_RETRY_INTERVAL_MS);
 
         // establish a new olm session with this device since we're failing to decrypt messages
         // on a current session.
@@ -3630,7 +3637,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         const devicesByUser = new Map([[sender, [device]]]);
         await olmlib.ensureOlmSessionsForDevices(this.olmDevice, this.baseApis, devicesByUser, true);
 
-        lastNewSessionDevices.set(deviceKey, Date.now());
+        forceNewSessionRetryTimeDevices.set(deviceKey, Date.now() + MIN_FORCE_SESSION_INTERVAL_MS);
 
         // Now send a blank message on that session so the other side knows about it.
         // (The keyshare request is sent in the clear so that won't do)

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -132,10 +132,10 @@ export function isCryptoAvailable(): boolean {
 
 // minimum time between attempting to unwedge an Olm session, if we succeeded
 // in creating a new session
-const MIN_FORCE_SESSION_INTERVAL_MS = 60 * 60 * 1000;
+const MIN_FORCE_SESSION_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 // minimum time between attempting to unwedge an Olm session, if we failed
 // to create a new session
-const FORCE_SESSION_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+const FORCE_SESSION_RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 interface IInitOpts {
     exportedOlmDevice?: IExportedDevice;
@@ -3602,12 +3602,8 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         const forceNewSessionRetryTime = forceNewSessionRetryTimeDevices.getOrCreate(deviceKey);
         if (forceNewSessionRetryTime > Date.now()) {
             logger.debug(
-                "New session already forced with device " +
-                    sender +
-                    ":" +
-                    deviceKey +
-                    ": not forcing another until at least ",
-                    forceNewSessionRetryTime
+                `New session already forced with device ${sender}:${deviceKey}: ` +
+                    `not forcing another until at least ${new Date(forceNewSessionRetryTime).toUTCString()}`,
             );
             await this.olmDevice.recordSessionProblem(deviceKey, "wedged", true);
             retryDecryption();


### PR DESCRIPTION
Previously, we only marked the time that we re-created an Olm session after the session was created.  So if we try to unwedge while we're in the middle of unwedging, it won't be rate-limited, and we end up creating multiple new sessions.  This patch sets up rate limiting before any `await`s, with a delay of 5 minutes, so it doesn't race any more.

Fixes https://github.com/vector-im/element-web/issues/25716

No tests yet because I'm not sure how to test this.  Suggestions welcome.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't allow Olm unwedging rate-limiting to race ([\#3549](https://github.com/matrix-org/matrix-js-sdk/pull/3549)). Fixes vector-im/element-web#25716.<!-- CHANGELOG_PREVIEW_END -->