### PR TITLE
add stop() api to BackupManager for clean shutdown

### DIFF
--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -118,10 +118,19 @@ export class BackupManager {
     public checkedForBackup: boolean; // Have we checked the server for a backup we can use?
     private sendingBackups: boolean; // Are we currently sending backups?
     private sessionLastCheckAttemptedTime: Record<string, number> = {}; // When did we last try to check the server for a given session id?
+    // The backup manager will schedule backup of keys when active (`scheduleKeyBackupSend`), this allows cancel when client is stopped
+    private clientRunning = true;
 
     public constructor(private readonly baseApis: MatrixClient, public readonly getKey: GetKey) {
         this.checkedForBackup = false;
         this.sendingBackups = false;
+    }
+
+    /**
+     * Stop the backup manager from backing up keys and allow a clean shutdown.
+     */
+    public stop(): void {
+        this.clientRunning = false;
     }
 
     public get version(): string | undefined {
@@ -439,6 +448,10 @@ export class BackupManager {
             // the same time when a new key is sent
             const delay = Math.random() * maxDelay;
             await sleep(delay);
+            if (!this.clientRunning) {
+                logger.debug("Key backup send aborted, client stopped");
+                return;
+            }
             let numFailures = 0; // number of consecutive failures
             for (;;) {
                 if (!this.algorithm) {
@@ -472,6 +485,11 @@ export class BackupManager {
                 if (numFailures) {
                     // exponential backoff if we have failures
                     await sleep(1000 * Math.pow(2, Math.min(numFailures - 1, 4)));
+                }
+
+                if (!this.clientRunning) {
+                    logger.debug("Key backup send loop aborted, client stopped");
+                    return;
                 }
             }
         } finally {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1832,6 +1832,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         this.outgoingRoomKeyRequestManager.stop();
         this.deviceList.stop();
         this.dehydrationManager.stop();
+        this.backupManager.stop();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

When the client is stopped the background upload of keys to backup is not shutdown.
Added a new stop() api that is called by crypto (similar to outgoingRoomKeyRequestManager , deviceList ..)

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * add stop() api to BackupManager for clean shutdown ([\#3553](https://github.com/matrix-org/matrix-js-sdk/pull/3553)).<!-- CHANGELOG_PREVIEW_END -->