### PR TITLE
Add async method for generating a QR code

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -414,7 +414,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(request.phase).toEqual(VerificationPhase.Ready);
 
             // we should now have QR data we can display
-            const qrCodeBuffer = request.getQRCodeBytes()!;
+            const qrCodeBuffer = (await request.generateQRCode())!;
             expect(qrCodeBuffer).toBeTruthy();
 
             // https://spec.matrix.org/v1.7/client-server-api/#qr-code-format

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -152,8 +152,18 @@ export interface VerificationRequest
      * Get the data for a QR code allowing the other device to verify this one, if it supports it.
      *
      * Only set after a .ready if the other party can scan a QR code, otherwise undefined.
+     *
+     * @deprecated Not supported in Rust Crypto. Use {@link VerificationRequest#generateQRCode} instead.
      */
     getQRCodeBytes(): Buffer | undefined;
+
+    /**
+     * Generate the data for a QR code allowing the other device to verify this one, if it supports it.
+     *
+     * Only returns data once `phase` is {@link VerificationPhase.Ready} and the other party can scan a QR code;
+     * otherwise returns `undefined`.
+     */
+    generateQRCode(): Promise<Buffer | undefined>;
 
     /**
      * If this request has been cancelled, the cancellation code (e.g `m.user`) which is responsible for cancelling

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -268,7 +268,7 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
 
     /** Only set after a .ready if the other party can scan a QR code
      *
-     * @deprecated Prefer `getQRCodeBytes`.
+     * @deprecated Prefer `generateQRCode`.
      */
     public get qrCodeData(): QRCodeData | null {
         return this._qrCodeData;
@@ -278,9 +278,21 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
      * Get the data for a QR code allowing the other device to verify this one, if it supports it.
      *
      * Only set after a .ready if the other party can scan a QR code, otherwise undefined.
+     *
+     * @deprecated Prefer `generateQRCode`.
      */
     public getQRCodeBytes(): Buffer | undefined {
         return this._qrCodeData?.getBuffer();
+    }
+
+    /**
+     * Generate the data for a QR code allowing the other device to verify this one, if it supports it.
+     *
+     * Only returns data once `phase` is `Ready` and the other party can scan a QR code;
+     * otherwise returns `undefined`.
+     */
+    public async generateQRCode(): Promise<Buffer | undefined> {
+        return this.getQRCodeBytes();
     }
 
     /** Checks whether the other party supports a given verification method.

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -322,11 +322,19 @@ export class RustVerificationRequest
     }
 
     /**
-     * Get the data for a QR code allowing the other device to verify this one, if it supports it.
-     *
-     * Only set after a .ready if the other party can scan a QR code, otherwise undefined.
+     * Stub implementation of {@link Crypto.VerificationRequest#getQRCodeBytes}.
      */
     public getQRCodeBytes(): Buffer | undefined {
+        // TODO
+        return undefined;
+    }
+
+    /**
+     * Generate the data for a QR code allowing the other device to verify this one, if it supports it.
+     *
+     * Implementation of {@link Crypto.VerificationRequest#generateQRCode}.
+     */
+    public async generateQRCode(): Promise<Buffer | undefined> {
         // TODO
         return undefined;
     }


### PR DESCRIPTION
The api to generate a QR code is async in rust, and the easiest way to deal with it is to make a new method.

Notes: Deprecate `VerificationRequest.getQRCodeBytes` and replace it with the asynchronous `generateQRCode`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate `VerificationRequest.getQRCodeBytes` and replace it with the asynchronous `generateQRCode`. ([\#3562](https://github.com/matrix-org/matrix-js-sdk/pull/3562)).<!-- CHANGELOG_PREVIEW_END -->