### PR TITLE
Add support for scanning QR codes during verification, with Rust crypto

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -85,6 +85,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
     // Rust backend. Once we have full support in the rust sdk, it will go away.
     const oldBackendOnly = backend === "rust-sdk" ? test.skip : test;
 
+    // newBackendOnly is the opposite to `oldBackendOnly`: it will skip the test if we are running against the legacy
+    // backend.
+    const newBackendOnly = backend === "rust-sdk" ? test : test.skip;
+
     /** the client under test */
     let aliceClient: MatrixClient;
 
@@ -469,6 +473,64 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             await verificationPromise;
             expect(request.phase).toEqual(VerificationPhase.Done);
         });
+
+        newBackendOnly("can verify another by scanning their QR code", async () => {
+            aliceClient = await startTestClient();
+            // we need cross-signing keys for a QR code verification
+            e2eKeyResponder.addCrossSigningData(SIGNED_CROSS_SIGNING_KEYS_DATA);
+            await waitForDeviceList();
+
+            // Alice sends a m.key.verification.request
+            const [, request] = await Promise.all([
+                expectSendToDeviceMessage("m.key.verification.request"),
+                aliceClient.getCrypto()!.requestDeviceVerification(TEST_USER_ID, TEST_DEVICE_ID),
+            ]);
+            const transactionId = request.transactionId!;
+
+            // The dummy device replies with an m.key.verification.ready, indicating it can show a QR code
+            returnToDeviceMessageFromSync(buildReadyMessage(transactionId, ["m.qr_code.show.v1", "m.reciprocate.v1"]));
+            await waitForVerificationRequestChanged(request);
+            expect(request.phase).toEqual(VerificationPhase.Ready);
+            expect(request.otherPartySupportsMethod("m.qr_code.show.v1")).toBe(true);
+
+            // the dummy device shows a QR code
+            const sharedSecret = "SUPERSEKRET";
+            const qrCodeBuffer = buildQRCode(
+                transactionId,
+                TEST_DEVICE_PUBLIC_ED25519_KEY_BASE64,
+                MASTER_CROSS_SIGNING_PUBLIC_KEY_BASE64,
+                sharedSecret,
+            );
+
+            // Alice scans the QR code
+            const sendToDevicePromise = expectSendToDeviceMessage("m.key.verification.start");
+            const verifier = await request.scanQRCode(qrCodeBuffer);
+
+            const requestBody = await sendToDevicePromise;
+            const toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
+            expect(toDeviceMessage).toEqual({
+                from_device: aliceClient.deviceId,
+                method: "m.reciprocate.v1",
+                transaction_id: transactionId,
+                secret: encodeUnpaddedBase64(Buffer.from(sharedSecret)),
+            });
+
+            expect(request.phase).toEqual(VerificationPhase.Started);
+            expect(request.chosenMethod).toEqual("m.reciprocate.v1");
+            expect(verifier.getReciprocateQrCodeCallbacks()).toBeNull();
+
+            const verificationPromise = verifier.verify();
+
+            // the dummy device confirms that Alice scanned the QR code, by replying with a done
+            returnToDeviceMessageFromSync(buildDoneMessage(transactionId));
+
+            // Alice also replies with a 'done'
+            await expectSendToDeviceMessage("m.key.verification.done");
+
+            // ... and the whole thing should be done!
+            await verificationPromise;
+            expect(request.phase).toEqual(VerificationPhase.Done);
+        });
     });
 
     describe("cancellation", () => {
@@ -793,4 +855,23 @@ function buildDoneMessage(transactionId: string) {
             transaction_id: transactionId,
         },
     };
+}
+
+function buildQRCode(transactionId: string, key1Base64: string, key2Base64: string, sharedSecret: string): Uint8Array {
+    // https://spec.matrix.org/v1.7/client-server-api/#qr-code-format
+
+    const qrCodeBuffer = Buffer.alloc(150); // oversize
+    let idx = 0;
+    idx += qrCodeBuffer.write("MATRIX", idx, "ascii");
+    idx = qrCodeBuffer.writeUInt8(0x02, idx); // version
+    idx = qrCodeBuffer.writeUInt8(0x02, idx); // mode
+    idx = qrCodeBuffer.writeInt16BE(transactionId.length, idx);
+    idx += qrCodeBuffer.write(transactionId, idx, "ascii");
+
+    idx += Buffer.from(key1Base64, "base64").copy(qrCodeBuffer, idx);
+    idx += Buffer.from(key2Base64, "base64").copy(qrCodeBuffer, idx);
+    idx += qrCodeBuffer.write(sharedSecret, idx);
+
+    // truncate to the right length
+    return qrCodeBuffer.subarray(0, idx);
 }

--- a/spec/unit/rust-crypto/verification.spec.ts
+++ b/spec/unit/rust-crypto/verification.spec.ts
@@ -87,7 +87,7 @@ function makeTestRequest(
 ): RustVerificationRequest {
     inner ??= makeMockedInner();
     outgoingRequestProcessor ??= {} as OutgoingRequestProcessor;
-    return new RustVerificationRequest(inner, outgoingRequestProcessor, undefined);
+    return new RustVerificationRequest(inner, outgoingRequestProcessor, []);
 }
 
 /** Mock up a rust-side VerificationRequest */

--- a/src/client.ts
+++ b/src/client.ts
@@ -2241,7 +2241,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             this.cryptoCallbacks,
             useIndexedDB ? RUST_SDK_STORE_PREFIX : null,
         );
-        rustCrypto.supportedVerificationMethods = this.verificationMethods;
+        rustCrypto.setSupportedVerificationMethods(this.verificationMethods);
 
         this.cryptoBackend = rustCrypto;
 

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -136,11 +136,26 @@ export interface VerificationRequest
     /**
      * Send an `m.key.verification.start` event to start verification via a particular method.
      *
+     * This is normally used when starting a verification via emojis (ie, `method` is set to `m.sas.v1`).
+     *
      * @param method - the name of the verification method to use.
      *
      * @returns The verifier which will do the actual verification.
      */
     startVerification(method: string): Promise<Verifier>;
+
+    /**
+     * Start a QR code verification by providing a scanned QR code for this verification flow.
+     *
+     * Validates the QR code, and if it is ok, sends an `m.key.verification.start` event with `method` set to
+     * `m.reciprocate.v1`, to tell the other side the scan was successful.
+     *
+     * See also {@link VerificationRequest#startVerification} which can be used to start other verification methods.
+     *
+     * @param qrCodeData - the decoded QR code.
+     * @returns A verifier; call `.verify()` on it to wait for the other side to complete the verification flow.
+     */
+    scanQRCode(qrCodeData: Uint8Array): Promise<Verifier>;
 
     /**
      * The verifier which is doing the actual verification, once the method has been established.

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -478,6 +478,10 @@ export class VerificationRequest<C extends IVerificationChannel = IVerificationC
         return verifier;
     }
 
+    public scanQRCode(qrCodeData: Uint8Array): Promise<Verifier> {
+        throw new Error("QR code scanning not supported by legacy crypto");
+    }
+
     /**
      * sends the initial .request event.
      * @returns resolves when the event has been sent.

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -56,7 +56,7 @@ export class RustVerificationRequest
     public constructor(
         private readonly inner: RustSdkCryptoJs.VerificationRequest,
         private readonly outgoingRequestProcessor: OutgoingRequestProcessor,
-        private readonly supportedVerificationMethods: string[] | undefined,
+        private readonly supportedVerificationMethods: string[],
     ) {
         super();
 
@@ -223,12 +223,9 @@ export class RustVerificationRequest
 
         this._accepting = true;
         try {
-            const req: undefined | OutgoingRequest =
-                this.supportedVerificationMethods === undefined
-                    ? this.inner.accept()
-                    : this.inner.acceptWithMethods(
-                          this.supportedVerificationMethods.map(verificationMethodIdentifierToMethod),
-                      );
+            const req: undefined | OutgoingRequest = this.inner.acceptWithMethods(
+                this.supportedVerificationMethods.map(verificationMethodIdentifierToMethod),
+            );
             if (req) {
                 await this.outgoingRequestProcessor.makeOutgoingRequest(req);
             }

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -391,7 +391,7 @@ export class RustVerificationRequest
  *
  * The generic parameter `InnerType` is the type of the rust Verification class which we wrap.
  */
-class BaseRustVerifer<InnerType extends RustSdkCryptoJs.Qr | RustSdkCryptoJs.Sas> extends TypedEventEmitter<
+abstract class BaseRustVerifer<InnerType extends RustSdkCryptoJs.Qr | RustSdkCryptoJs.Sas> extends TypedEventEmitter<
     VerifierEvent,
     VerifierEventHandlerMap
 > {


### PR DESCRIPTION
Before I change *displaying* QR codes, I need an end-to-end test for it. And before I can write an end-to-end test for it, I need to be able to *scan* QR codes. So here is support in the js-sdk for scanning QR codes. It will only work with Rust crypto, but that's enough for a Cypress test, and Rust is the future.

Suggest review commit-by-commit.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add support for scanning QR codes during verification, with Rust crypto ([\#3565](https://github.com/matrix-org/matrix-js-sdk/pull/3565)).<!-- CHANGELOG_PREVIEW_END -->