### PR TITLE
Simplify `MatrixClient::setPowerLevel` API

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1386,14 +1386,11 @@ describe("MatrixClient", function () {
                 expectation: {},
             },
         ])("should modify power levels of $userId correctly", async ({ userId, powerLevel, expectation }) => {
-            const event = {
-                getType: () => "m.room.power_levels",
-                getContent: () => ({
-                    users: {
-                        "alice@localhost": 50,
-                    },
-                }),
-            } as MatrixEvent;
+            httpBackend!.when("GET", "/state/m.room.power_levels/").respond(200, {
+                users: {
+                    "alice@localhost": 50,
+                },
+            });
 
             httpBackend!
                 .when("PUT", "/state/m.room.power_levels")
@@ -1402,7 +1399,7 @@ describe("MatrixClient", function () {
                 })
                 .respond(200, {});
 
-            const prom = client!.setPowerLevel("!room_id:server", userId, powerLevel, event);
+            const prom = client!.setPowerLevel("!room_id:server", userId, powerLevel);
             await httpBackend!.flushAllExpected();
             await prom;
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -111,7 +111,7 @@ import * as ContentHelpers from "./content-helpers";
 import { CrossSigningInfo, DeviceTrustLevel, ICacheCallbacks, UserTrustLevel } from "./crypto/CrossSigning";
 import { Room, NotificationCountType, RoomEvent, RoomEventHandlerMap, RoomNameState } from "./models/room";
 import { RoomMemberEvent, RoomMemberEventHandlerMap } from "./models/room-member";
-import { RoomStateEvent, RoomStateEventHandlerMap } from "./models/room-state";
+import { IPowerLevelsContent, RoomStateEvent, RoomStateEventHandlerMap } from "./models/room-state";
 import {
     IAddThreePidOnlyBody,
     IBindThreePidBody,
@@ -4256,24 +4256,38 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * Set a power level to one or multiple users.
+     * Will apply changes atop of current power level event from local state if running & synced, falling back
+     * to fetching latest from the `/state/` API.
+     * @param roomId - the room to update power levels in
+     * @param userId - the ID of the user or users to update power levels of
+     * @param powerLevel - the numeric power level to update given users to
+     * @param event - deprecated and no longer used.
      * @returns Promise which resolves: to an ISendEventResponse object
      * @returns Rejects: with an error response.
      */
-    public setPowerLevel(
+    public async setPowerLevel(
         roomId: string,
         userId: string | string[],
         powerLevel: number | undefined,
+        /**
+         * @deprecated no longer needed, unused.
+         */
         event: MatrixEvent | null,
     ): Promise<ISendEventResponse> {
-        let content = {
-            users: {} as Record<string, number>,
-        };
-        if (event?.getType() === EventType.RoomPowerLevels) {
-            // take a copy of the content to ensure we don't corrupt
-            // existing client state with a failed power level change
-            content = utils.deepCopy(event.getContent());
+        let content: IPowerLevelsContent | undefined;
+        if (this.clientRunning && this.isInitialSyncComplete()) {
+            content = this.getRoom(roomId)?.currentState?.getStateEvents(EventType.RoomPowerLevels, "")?.getContent();
         }
+        if (!content) {
+            content = await this.getStateEvent(roomId, EventType.RoomPowerLevels, "");
+        }
+        // take a copy of the content to ensure we don't corrupt
+        // existing client state with a failed power level change
+        content = utils.deepCopy(content);
 
+        if (!content?.users) {
+            content.users = {};
+        }
         const users = Array.isArray(userId) ? userId : [userId];
         for (const user of users) {
             if (powerLevel == null) {
@@ -4283,10 +4297,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
         }
 
-        const path = utils.encodeUri("/rooms/$roomId/state/m.room.power_levels", {
-            $roomId: roomId,
-        });
-        return this.http.authedRequest(Method.Put, path, undefined, content);
+        return this.sendStateEvent(roomId, EventType.RoomPowerLevels, content, "");
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -4272,7 +4272,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         /**
          * @deprecated no longer needed, unused.
          */
-        event: MatrixEvent | null,
+        event?: MatrixEvent | null,
     ): Promise<ISendEventResponse> {
         let content: IPowerLevelsContent | undefined;
         if (this.clientRunning && this.isInitialSyncComplete()) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4279,8 +4279,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             content = this.getRoom(roomId)?.currentState?.getStateEvents(EventType.RoomPowerLevels, "")?.getContent();
         }
         if (!content) {
-            content = await this.getStateEvent(roomId, EventType.RoomPowerLevels, "");
+            try {
+                content = await this.getStateEvent(roomId, EventType.RoomPowerLevels, "");
+            } catch (e) {
+                // It is possible for a Matrix room to not have a power levels event
+                if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
+                    content = {};
+                } else {
+                    throw e;
+                }
+            }
         }
+
         // take a copy of the content to ensure we don't corrupt
         // existing client state with a failed power level change
         content = utils.deepCopy(content);


### PR DESCRIPTION
While making it more resilient to causing issues like nuking room state
Removes the need to pass the current power level `event` param

Fixes https://github.com/vector-im/element-web/issues/13900
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/1844

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Simplify `MatrixClient::setPowerLevel` API ([\#3570](https://github.com/matrix-org/matrix-js-sdk/pull/3570)). Fixes vector-im/element-web#13900 and #1844.<!-- CHANGELOG_PREVIEW_END -->