### PR TITLE
Mark all the rust crypto stuff internal

### DIFF
--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -24,6 +24,8 @@ import { IEventDecryptionResult } from "../@types/crypto";
 
 /**
  * Common interface for the crypto implementations
+ *
+ * @internal
  */
 export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
     /**
@@ -90,7 +92,10 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
     getStoredCrossSigningForUser(userId: string): CrossSigningInfo | null;
 }
 
-/** The methods which crypto implementations should expose to the Sync api */
+/** The methods which crypto implementations should expose to the Sync api
+ *
+ * @internal
+ */
 export interface SyncCryptoCallbacks {
     /**
      * Called by the /sync loop whenever there are incoming to-device messages.
@@ -146,6 +151,9 @@ export interface SyncCryptoCallbacks {
     onSyncCompleted(syncState: OnSyncCompletedData): void;
 }
 
+/**
+ * @internal
+ */
 export interface OnSyncCompletedData {
     /**
      * The 'next_batch' result from /sync, which will become the 'since' token for the next call to /sync.

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -22,6 +22,8 @@ import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProc
 import { UIAuthCallback } from "../interactive-auth";
 
 /** Manages the cross-signing keys for our own user.
+ *
+ * @internal
  */
 export class CrossSigningIdentity {
     public constructor(

--- a/src/rust-crypto/KeyClaimManager.ts
+++ b/src/rust-crypto/KeyClaimManager.ts
@@ -22,6 +22,8 @@ import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
  * KeyClaimManager: linearises calls to OlmMachine.getMissingSessions to avoid races
  *
  * We have one of these per `RustCrypto` (and hence per `MatrixClient`).
+ *
+ * @internal
  */
 export class KeyClaimManager {
     private currentClaimPromise: Promise<void>;

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -34,6 +34,8 @@ import { UIAResponse } from "../@types/uia";
 
 /**
  * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
+ *
+ * @internal
  */
 export interface OutgoingRequest {
     readonly id: string | undefined;
@@ -49,6 +51,8 @@ export interface OutgoingRequest {
  *   * holding the reference to the `MatrixHttpApi`
  *   * turning `OutgoingRequest`s from the rust backend into HTTP requests, and sending them
  *   * sending the results of such requests back to the rust backend.
+ *
+ * @internal
  */
 export class OutgoingRequestProcessor {
     public constructor(

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -26,6 +26,8 @@ import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
 
 /**
  * RoomEncryptor: responsible for encrypting messages to a given room
+ *
+ * @internal
  */
 export class RoomEncryptor {
     private readonly prefixedLogger: PrefixedLogger;

--- a/src/rust-crypto/device-converter.ts
+++ b/src/rust-crypto/device-converter.ts
@@ -23,6 +23,8 @@ import { DeviceKeys } from "../client";
  * Convert a {@link RustSdkCryptoJs.Device} to a {@link Device}
  * @param device - Rust Sdk device
  * @param userId - owner of the device
+ *
+ * @internal
  */
 export function rustDeviceToJsDevice(device: RustSdkCryptoJs.Device, userId: RustSdkCryptoJs.UserId): Device {
     // Copy rust device keys to Device.keys
@@ -84,6 +86,8 @@ export function rustDeviceToJsDevice(device: RustSdkCryptoJs.Device, userId: Rus
 /**
  * Convert {@link DeviceKeys}  from `/keys/query` request to a `Map<string, Device>`
  * @param deviceKeys - Device keys object to convert
+ *
+ * @internal
  */
 export function deviceKeysToDeviceMap(deviceKeys: DeviceKeys): Map<string, Device> {
     return new Map(
@@ -97,6 +101,8 @@ type QueryDevice = DeviceKeys[keyof DeviceKeys];
 /**
  * Convert `/keys/query` {@link QueryDevice} device to {@link Device}
  * @param device - Device from `/keys/query` request
+ *
+ * @internal
  */
 export function downloadDeviceToJsDevice(device: QueryDevice): Device {
     const keys = new Map(Object.entries(device.keys));

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -33,6 +33,8 @@ import { ICryptoCallbacks } from "../crypto";
  * @param cryptoCallbacks - Crypto callbacks provided by the application
  * @param storePrefix - the prefix to use on the indexeddbs created by rust-crypto.
  *     If unset, a memory store will be used.
+ *
+ * @internal
  */
 export async function initRustCrypto(
     http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -58,6 +58,8 @@ import { TypedEventEmitter } from "../models/typed-event-emitter";
 
 /**
  * An implementation of {@link CryptoBackend} using the Rust matrix-sdk-crypto.
+ *
+ * @internal
  */
 export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEventMap> implements CryptoBackend {
     public globalErrorOnUnknownDevices = false;

--- a/src/rust-crypto/secret-storage.ts
+++ b/src/rust-crypto/secret-storage.ts
@@ -21,6 +21,8 @@ import { ServerSideSecretStorage } from "../secret-storage";
  *
  * @param secretStorage - The secret store using account data
  * @returns True if the cross-signing keys are all stored and encrypted with the same secret storage key.
+ *
+ * @internal
  */
 export async function secretStorageContainsCrossSigningKeys(secretStorage: ServerSideSecretStorage): Promise<boolean> {
     // Check if the master cross-signing key is stored in secret storage

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -33,6 +33,8 @@ import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProc
 
 /**
  * An incoming, or outgoing, request to verify a user or a device via cross-signing.
+ *
+ * @internal
  */
 export class RustVerificationRequest
     extends TypedEventEmitter<VerificationRequestEvent, VerificationRequestEventHandlerMap>
@@ -357,6 +359,7 @@ export class RustVerificationRequest
     }
 }
 
+/** @internal */
 export class RustSASVerifier extends TypedEventEmitter<VerifierEvent, VerifierEventHandlerMap> implements Verifier {
     /** A promise which completes when the verification completes (or rejects when it is cancelled/fails) */
     private readonly completionPromise: Promise<void>;
@@ -507,6 +510,8 @@ const verificationMethodsByIdentifier: Record<string, RustSdkCryptoJs.Verificati
  * @param method - specced method identifier, for example `m.sas.v1`.
  * @returns Rust-side `VerificationMethod` corresponding to `method`.
  * @throws An error if the method is unknown.
+ *
+ * @internal
  */
 export function verificationMethodIdentifierToMethod(method: string): RustSdkCryptoJs.VerificationMethod {
     const meth = verificationMethodsByIdentifier[method];


### PR DESCRIPTION
... for the avoidance of doubt such as that discussed at https://github.com/matrix-org/matrix-js-sdk/pull/3565#pullrequestreview-1522185838

Personally I think this is totally unnecessary but if everybody else thinks this is the only way for things to not be considered part of the public API, I guess I have to live with it.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->