### PR TITLE
Log query parameters on HTTP requests

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -300,7 +300,7 @@ describe("FetchHttpApi", () => {
         const fetchFn = jest.fn().mockReturnValue(deferred.promise);
         jest.spyOn(logger, "debug").mockImplementation(() => {});
         const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
-        const prom = api.requestOtherUrl(Method.Get, "https://server:8448/some/path#fragment?query=param");
+        const prom = api.requestOtherUrl(Method.Get, "https://server:8448/some/path?query=param#fragment");
         jest.advanceTimersByTime(1234);
         deferred.resolve({ ok: true, status: 200, text: () => Promise.resolve("RESPONSE") } as Response);
         await prom;
@@ -310,12 +310,12 @@ describe("FetchHttpApi", () => {
         expect(logger.debug).toHaveBeenCalledTimes(2);
         expect(mocked(logger.debug).mock.calls[0]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: --> GET https://server:8448/some/path",
+              "FetchHttpApi: --> GET https://server:8448/some/path?query=xxx",
             ]
         `);
         expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
             [
-              "FetchHttpApi: <-- GET https://server:8448/some/path [1234ms 200]",
+              "FetchHttpApi: <-- GET https://server:8448/some/path?query=xxx [1234ms 200]",
             ]
         `);
     });

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -314,7 +314,8 @@ export class FetchHttpApi<O extends IHttpOpts> {
             for (const key of asUrl.searchParams.keys()) {
                 sanitizedQs.append(key, "xxx");
             }
-            const sanitizedQsUrlPiece = sanitizedQs.toString() ? `?${sanitizedQs.toString()}` : "";
+            const sanitizedQsString = sanitizedQs.toString();
+            const sanitizedQsUrlPiece = sanitizedQsString ? `?${sanitizedQsString}` : "";
 
             return asUrl.origin + asUrl.pathname + sanitizedQsUrlPiece;
         } catch (error) {


### PR DESCRIPTION
Log query parameters on HTTP requests

Follow-up to https://github.com/matrix-org/matrix-js-sdk/pull/3485

**Before:**

```
FetchHttpApi: --> GET https://server:8448/some/path
FetchHttpApi: <-- GET https://server:8448/some/path [1234ms 200]
```

**After:**

```
FetchHttpApi: --> GET https://server:8448/some/path?query=xxx
FetchHttpApi: <-- GET https://server:8448/some/path?query=xxx [1234ms 200]
```

All query parameters values are sanitized to `xxx` but the existence of the query parameter is helpful to distinguish between requests and a peace of mind sanity check to see that they are on the request. Like initial vs incremental `/sync` with `?since=xxx`. In the future, it would be nice to log more values.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->


### Dev notes

```
yarn jest spec/unit/http-api/fetch.spec.ts
```


## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] ~~Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))~~

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->