### PR TITLE
Element-R: check that UIA callbacks return sensible data

### DIFF
--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -29,7 +29,7 @@ import {
 import { logger } from "../logger";
 import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
 import { QueryDict } from "../utils";
-import { IAuthDict, UIAuthCallback } from "../interactive-auth";
+import { AuthDict, UIAuthCallback } from "../interactive-auth";
 import { UIAResponse } from "../@types/uia";
 
 /**
@@ -116,7 +116,11 @@ export class OutgoingRequestProcessor {
         }
 
         const parsedBody = JSON.parse(body);
-        const makeRequest = async (auth: IAuthDict): Promise<UIAResponse<T>> => {
+        const makeRequest = async (auth: AuthDict): Promise<UIAResponse<T>> => {
+            // Auth dicts must have a 'type', contrary to what the type of 'AuthDict' would have you believe
+            if (!auth || !(auth as any).type) {
+                throw new Error("UIA callback returned invalid data");
+            }
             const newBody = {
                 ...parsedBody,
                 auth,


### PR DESCRIPTION
There seems to be a bug somewhere where one of our UIA callbacks returns `auth: null` and hence triggers https://github.com/matrix-org/synapse/issues/15871.

I hope this will help track it down.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->