### PR TITLE
Make some types packages regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",
+        "@types/content-type": "^1.1.5",
         "jwt-decode": "^3.1.2",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
@@ -67,7 +68,8 @@
         "p-retry": "4",
         "sdp-transform": "^2.14.1",
         "unhomoglyph": "^1.0.6",
-        "uuid": "9"
+        "uuid": "9",
+        "@types/uuid": "9"
     },
     "devDependencies": {
         "@babel/cli": "^7.12.10",
@@ -85,13 +87,11 @@
         "@casualbot/jest-sonar-reporter": "^2.2.5",
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz",
         "@types/bs58": "^4.0.1",
-        "@types/content-type": "^1.1.5",
         "@types/debug": "^4.1.7",
         "@types/domexception": "^4.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "18",
         "@types/sdp-transform": "^2.4.5",
-        "@types/uuid": "9",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "allchange": "^1.0.6",


### PR DESCRIPTION
Due to the fact that we import packages like 'uuid' in files that users of the library import, these types essentially end up being part of our public library interface (to TypeScript consumers). However, some of these libraries don't come with their own types and we import the definitelytyped module, but this is a dev dependency for us so the types are not available when js-sdk is installed as a regular dependency. This means type checks on that application will fail.

I think the correct solution here (other than those libraries having their own types) is to just make the types packages regular dependencies.

This PR does that for the two types packages that element call was failing because of. I haven't added the rest as they might not all be part of external facing bits of the library (whatever that is now with js-sdk).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->