### PR TITLE
Export typed event emitter key types

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -73,7 +73,6 @@ export {
 export type { GroupCall } from "./webrtc/groupCall";
 export { CryptoEvent } from "./crypto";
 export { SlidingSyncEvent } from "./sliding-sync";
-export { VerificationRequestEvent, VerifierEvent } from "./crypto-api/verification";
 export { MediaHandlerEvent } from "./webrtc/mediaHandler";
 export { CallEvent } from "./webrtc/call";
 export { CallFeedEvent } from "./webrtc/callFeed";

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -63,9 +63,23 @@ export * as SecretStorage from "./secret-storage";
 export type { ICryptoCallbacks } from "./crypto"; // used to be located here
 export { createNewMatrixCall } from "./webrtc/call";
 export type { MatrixCall } from "./webrtc/call";
-export { GroupCallEvent, GroupCallIntent, GroupCallState, GroupCallType } from "./webrtc/groupCall";
+export {
+    GroupCallEvent,
+    GroupCallIntent,
+    GroupCallState,
+    GroupCallType,
+    GroupCallStatsReportEvent,
+} from "./webrtc/groupCall";
 export type { GroupCall } from "./webrtc/groupCall";
 export { CryptoEvent } from "./crypto";
+export { SlidingSyncEvent } from "./sliding-sync";
+export { VerificationRequestEvent, VerifierEvent } from "./crypto-api/verification";
+export { MediaHandlerEvent } from "./webrtc/mediaHandler";
+export { CallEvent } from "./webrtc/call";
+export { CallFeedEvent } from "./webrtc/callFeed";
+export { StatsReport } from "./webrtc/stats/statsReport";
+export { RelationsEvent } from "./models/relations";
+export { LocalStorageErrors } from "./store/local-storage-events-emitter";
 
 /**
  * Types supporting cryptography.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/3506

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Export typed event emitter key types ([\#3597](https://github.com/matrix-org/matrix-js-sdk/pull/3597)). Fixes #3506.<!-- CHANGELOG_PREVIEW_END -->