### PR TITLE
Don't update calls with no livekit URL

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1270,7 +1270,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     private useE2eForGroupCall = true;
     private toDeviceMessageQueue: ToDeviceMessageQueue;
-    private livekitServiceURL?: string;
+    public livekitServiceURL?: string;
 
     private _secretStorage: ServerSideSecretStorageImpl;
 
@@ -1961,6 +1961,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     public getLivekitServiceURL(): string | undefined {
         return this.livekitServiceURL;
+    }
+
+    // This shouldn't need to exist, but the widget API has startup ordering problems that
+    // mean it doesn't know the livekit URL fast enough: remove this once this is fixed.
+    public setLivekitServiceURL(newURL: string): void {
+        this.livekitServiceURL = newURL;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -216,7 +216,6 @@ import {
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
 } from "./secret-storage";
-import { FocusInfo } from "./webrtc/callEventTypes";
 import { RegisterRequest, RegisterResponse } from "./@types/registration";
 
 export type Store = IStore;
@@ -381,7 +380,7 @@ export interface ICreateClientOpts {
      */
     useE2eForGroupCall?: boolean;
 
-    foci?: FocusInfo[];
+    livekitServiceURL?: string;
 
     /**
      * Crypto callbacks provided by the application
@@ -1271,7 +1270,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     private useE2eForGroupCall = true;
     private toDeviceMessageQueue: ToDeviceMessageQueue;
-    private foci: FocusInfo[] = [];
+    private livekitServiceURL?: string;
 
     private _secretStorage: ServerSideSecretStorageImpl;
 
@@ -1376,7 +1375,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         if (opts.useE2eForGroupCall !== undefined) this.useE2eForGroupCall = opts.useE2eForGroupCall;
 
-        this.foci = opts.foci ?? [];
+        this.livekitServiceURL = opts.livekitServiceURL;
 
         // List of which rooms have encryption enabled: separate from crypto because
         // we still want to know which rooms are encrypted even if crypto is disabled:
@@ -1956,12 +1955,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             dataChannelOptions,
             this.isVoipWithNoMediaAllowed,
             this.useLivekitForGroupCalls,
-            this.foci,
+            this.livekitServiceURL,
         ).create();
     }
 
-    public getFoci(): FocusInfo[] {
-        return this.foci;
+    public getLivekitServiceURL(): string | undefined {
+        return this.livekitServiceURL;
     }
 
     /**

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -89,8 +89,4 @@ export interface MCallHangupReject extends MCallBase {
     reason?: CallErrorCode;
 }
 
-export interface FocusInfo {
-    livekitServiceUrl: string;
-}
-
 /* eslint-enable camelcase */

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -23,7 +23,6 @@ import { RoomMember } from "../models/room-member";
 import { logger } from "../logger";
 import { EventType } from "../@types/event";
 import { SyncState } from "../sync";
-import { FocusInfo } from "./callEventTypes";
 
 export enum GroupCallEventHandlerEvent {
     Incoming = "GroupCall.incoming",
@@ -178,22 +177,6 @@ export class GroupCallEventHandler {
             dataChannelOptions = { ordered, maxPacketLifeTime, maxRetransmits, protocol };
         }
 
-        const livekitServiceUrl = content["io.element.livekit_service_url"];
-
-        let focus: FocusInfo | undefined;
-        if (livekitServiceUrl) {
-            focus = {
-                livekitServiceUrl: livekitServiceUrl,
-            };
-        } else {
-            focus = this.client.getFoci()[0]!;
-            content["io.element.livekit_service_url"] = focus.livekitServiceUrl;
-            // try to update the state event to add our livekit service url. We may not be able to
-            // as we don't currently have permission to send this event in embedded mode
-            // (although it doesn't actually appear to reject when it fails).
-            this.client.sendStateEvent(room.roomId, EventType.GroupCallPrefix, content, groupCallId);
-        }
-
         const groupCall = new GroupCall(
             this.client,
             room,
@@ -207,7 +190,7 @@ export class GroupCallEventHandler {
             dataChannelOptions,
             this.client.isVoipWithNoMediaAllowed,
             this.client.useLivekitForGroupCalls,
-            focus ? [focus] : [],
+            content["io.element.livekit_service_url"],
         );
 
         this.groupCalls.set(room.roomId, groupCall);


### PR DESCRIPTION
Expose method to update it instead and generally simplify a bit: change it to a single string rather than an array of structs.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't update calls with no livekit URL ([\#3598](https://github.com/matrix-org/matrix-js-sdk/pull/3598)).<!-- CHANGELOG_PREVIEW_END -->