### PR TITLE
Fix read receipt sending behaviour around thread roots

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5004,6 +5004,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             const isThread = !!event.threadRootId && !event.isThreadRoot;
             body = {
                 ...body,
+                // Only thread replies should define a specific thread. Thread roots can only be read in the main timeline.
                 thread_id: isThread ? event.threadRootId : MAIN_ROOM_TIMELINE,
             };
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -5000,7 +5000,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         });
 
         if (!unthreaded) {
-            const isThread = !!event.threadRootId;
+            // A thread cannot be just a thread root and a thread root can only be read in the main timeline
+            const isThread = !!event.threadRootId && !event.isThreadRoot;
             body = {
                 ...body,
                 thread_id: isThread ? event.threadRootId : MAIN_ROOM_TIMELINE,


### PR DESCRIPTION
Should fix issues like

> ```
> POST /_matrix/client/r0/rooms/{room_id}/receipt/m.read/{event_id} 400
>
> M_INVALID_PARAM: MatrixError: [400] event_id $foo is not related to thread $bar
> ```

![image](https://github.com/matrix-org/matrix-js-sdk/assets/2403652/f98c67e1-f820-49aa-bd07-18ca6fbde745)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix read receipt sending behaviour around thread roots ([\#3600](https://github.com/matrix-org/matrix-js-sdk/pull/3600)).<!-- CHANGELOG_PREVIEW_END -->