### PR TITLE
matrix-sdk-crypto-js -> matrix-sdk-crypto-wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-js": "^0.1.3",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^1.0.1",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -59,7 +59,7 @@ beforeAll(async () => {
 
 // load the rust library. This can take a few seconds on a slow GH worker.
 beforeAll(async () => {
-    const RustSdkCryptoJs = await require("@matrix-org/matrix-sdk-crypto-js");
+    const RustSdkCryptoJs = await require("@matrix-org/matrix-sdk-crypto-wasm");
     await RustSdkCryptoJs.initAsync();
 }, 10000);
 

--- a/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
+++ b/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Mocked } from "jest-mock";
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { CrossSigningIdentity } from "../../../src/rust-crypto/CrossSigningIdentity";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";

--- a/spec/unit/rust-crypto/KeyClaimManager.spec.ts
+++ b/spec/unit/rust-crypto/KeyClaimManager.spec.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import fetchMock from "fetch-mock-jest";
 import { Mocked } from "jest-mock";
-import { KeysClaimRequest, UserId } from "@matrix-org/matrix-sdk-crypto-js";
+import { KeysClaimRequest, UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { KeyClaimManager } from "../../../src/rust-crypto/KeyClaimManager";

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import MockHttpBackend from "matrix-mock-request";
 import { Mocked } from "jest-mock";
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import {
     KeysBackupRequest,
     KeysClaimRequest,
@@ -26,7 +26,7 @@ import {
     SignatureUploadRequest,
     SigningKeysUploadRequest,
     ToDeviceRequest,
-} from "@matrix-org/matrix-sdk-crypto-js";
+} from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
 import { HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, UIAuthCallback } from "../../../src";

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
-import { KeysQueryRequest, OlmMachine } from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import { KeysQueryRequest, OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 import { Mocked } from "jest-mock";
 import fetchMock from "fetch-mock-jest";
 

--- a/spec/unit/rust-crypto/verification.spec.ts
+++ b/spec/unit/rust-crypto/verification.spec.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { Mocked } from "jest-mock";
 
 import { RustVerificationRequest } from "../../../src/rust-crypto/verification";

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine, CrossSigningStatus } from "@matrix-org/matrix-sdk-crypto-js";
+import { OlmMachine, CrossSigningStatus } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { BootstrapCrossSigningOpts } from "../crypto-api";
 import { logger } from "../logger";

--- a/src/rust-crypto/KeyClaimManager.ts
+++ b/src/rust-crypto/KeyClaimManager.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine, UserId } from "@matrix-org/matrix-sdk-crypto-js";
+import { OlmMachine, UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
 

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -24,7 +24,7 @@ import {
     SignatureUploadRequest,
     ToDeviceRequest,
     SigningKeysUploadRequest,
-} from "@matrix-org/matrix-sdk-crypto-js";
+} from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { logger } from "../logger";
 import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EncryptionSettings, OlmMachine, RoomId, UserId } from "@matrix-org/matrix-sdk-crypto-js";
+import { EncryptionSettings, OlmMachine, RoomId, UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { EventType } from "../@types/event";
 import { IContent, MatrixEvent } from "../models/event";

--- a/src/rust-crypto/device-converter.ts
+++ b/src/rust-crypto/device-converter.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { Device, DeviceVerification } from "../models/device";
 import { DeviceKeys } from "../client";

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { RustCrypto } from "./rust-crypto";
 import { logger } from "../logger";
@@ -44,7 +44,7 @@ export async function initRustCrypto(
     cryptoCallbacks: ICryptoCallbacks,
     storePrefix: string | null,
 ): Promise<RustCrypto> {
-    // initialise the rust matrix-sdk-crypto-js, if it hasn't already been done
+    // initialise the rust matrix-sdk-crypto-wasm, if it hasn't already been done
     await RustSdkCryptoJs.initAsync();
 
     // enable tracing in the rust-sdk

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-js";
-import { Emoji } from "@matrix-org/matrix-sdk-crypto-js";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import { Emoji } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
     ShowQrCodeCallbacks,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@
   dependencies:
     lodash "^4.17.21"
 
-"@matrix-org/matrix-sdk-crypto-js@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-js/-/matrix-sdk-crypto-js-0.1.3.tgz#19981e7613d3673d07c885a98d39276b5fe74ef0"
-  integrity sha512-RcRlE3wcMnE5ijACHIHmhXFogEEJdIcb/CbJ4rK1PCMduQ4yvxycVpMxwh7aKxFNitZbHZLCK7TfRzUpzjU2tw==
+"@matrix-org/matrix-sdk-crypto-wasm@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-1.0.1.tgz#21a0557a7bb3f60b37c6d412be8906c056fe79b8"
+  integrity sha512-VTwV5IowvhhLXwAsDDAv02bC5/qBQbG2YtpYAije11253sQ3MePIoSR+dS40Ih3lAlEzqQ00GU3O+i45jMzIRQ==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
We've renamed matrix-sdk-crypto-js and released a v1.0.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->