### PR TITLE
ElementR: Fix `userId` parameter usage in `CryptoApi#getVerificationRequestsToDeviceInProgress`

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -164,6 +164,14 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
                 expect(requests[0].transactionId).toEqual(transactionId);
             }
 
+            // check that the returned request depends on the given userID
+            {
+                const requests = aliceClient
+                    .getCrypto()!
+                    .getVerificationRequestsToDeviceInProgress("@unknown:localhost");
+                expect(requests.length).toEqual(0);
+            }
+
             let toDeviceMessage = requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
             expect(toDeviceMessage.from_device).toEqual(aliceClient.deviceId);
             expect(toDeviceMessage.transaction_id).toEqual(transactionId);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -575,7 +575,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
      */
     public getVerificationRequestsToDeviceInProgress(userId: string): VerificationRequest[] {
         const requests: RustSdkCryptoJs.VerificationRequest[] = this.olmMachine.getVerificationRequests(
-            new RustSdkCryptoJs.UserId(this.userId),
+            new RustSdkCryptoJs.UserId(userId),
         );
         return requests
             .filter((request) => request.roomId === undefined)


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

We were using the local `userId` instead of using the one in the function parameter.

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * ElementR: Fix `userId` parameter usage in `CryptoApi#getVerificationRequestsToDeviceInProgress` ([\#3611](https://github.com/matrix-org/matrix-js-sdk/pull/3611)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->