### PR TITLE
Only send threaded read receipts if threads support is enabled

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4999,7 +4999,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             $eventId: event.getId()!,
         });
 
-        if (!unthreaded) {
+        if (!unthreaded && this.supportsThreads()) {
             // A thread cannot be just a thread root and a thread root can only be read in the main timeline
             const isThread = !!event.threadRootId && !event.isThreadRoot;
             body = {


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Only send threaded read receipts if threads support is enabled ([\#3612](https://github.com/matrix-org/matrix-js-sdk/pull/3612)).<!-- CHANGELOG_PREVIEW_END -->