### PR TITLE
Fix how `Room::eventShouldLiveIn` handles replies to unknown parents

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3018,6 +3018,14 @@ describe("Room", function () {
             expect(responseRelations![0][1].size).toEqual(1);
             expect(responseRelations![0][1].has(threadReaction)).toBeTruthy();
         });
+
+        it("a non-thread reply to an unknown parent event should live in the main timeline only", async () => {
+            const message = mkMessage(); // we do not add this message to any timelines
+            const reply = mkReply(message);
+
+            expect(room.eventShouldLiveIn(reply).shouldLiveInRoom).toBeTruthy();
+            expect(room.eventShouldLiveIn(reply).shouldLiveInThread).toBeFalsy();
+        });
     });
 
     describe("getEventReadUpTo()", () => {

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -984,11 +984,20 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
             );
         }
 
-        const { threadId, shouldLiveInRoom } = this.room.eventShouldLiveIn(event);
+        const { threadId, shouldLiveInRoom, shouldLiveInThread } = this.room.eventShouldLiveIn(event);
 
         if (this.thread) {
             return this.thread.id === threadId;
         }
+
+        if (!shouldLiveInRoom && !shouldLiveInThread) {
+            logger.warn(
+                `EventTimelineSet:canContain event encountered which cannot be added to any timeline roomId=${
+                    this.room?.roomId
+                } eventId=${event.getId()} threadId=${event.threadRootId}`,
+            );
+        }
+
         return shouldLiveInRoom;
     }
 }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2157,7 +2157,10 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             };
         }
 
-        if (!parentEventId) {
+        // Due to replies not being typical relations and being used as fallbacks for threads relations
+        // If we bypass the if case above then we know we are not a thread, so if we are still a reply
+        // then we know that we must be in the main timeline. Same goes if we have no associated parent event.
+        if (!parentEventId || !!event.replyEventId) {
             return {
                 shouldLiveInRoom: true,
                 shouldLiveInThread: false,


### PR DESCRIPTION
This caused missing messages especially when building permalink timelines (/context API)

Fixes https://github.com/vector-im/element-web/issues/22603

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix how `Room::eventShouldLiveIn` handles replies to unknown parents ([\#3615](https://github.com/matrix-org/matrix-js-sdk/pull/3615)). Fixes vector-im/element-web#22603.<!-- CHANGELOG_PREVIEW_END -->