### PR TITLE
Fix broken unit tests for `FetchHttpApi.getUrl`

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -277,11 +277,13 @@ describe("FetchHttpApi", () => {
         ];
         const runTests = (fetchBaseUrl: string) => {
             it.each<TestCase>(testCases)(
-                "creates url with params %s",
-                ({ path, queryParams, prefix, baseUrl }, result) => {
+                "creates url with params %s => %s",
+                ({ path, queryParams, prefix, baseUrl }, expected) => {
                     const api = makeApi(fetchBaseUrl);
 
-                    expect(api.getUrl(path, queryParams, prefix, baseUrl)).toEqual(new URL(result));
+                    const result = api.getUrl(path, queryParams, prefix, baseUrl);
+                    // we only check the stringified URL, to avoid having the test depend on the internals of URL.
+                    expect(result.toString()).toEqual(expected);
                 },
             );
         };


### PR DESCRIPTION
These tests have broken on Node.js 18.17.0.

This is due to Node.js adopting an updated version of the URL parser, in which the internal `Symbol(query)` property is populated lazily.

We shouldn't be relying on the internal state of the URL object anyway. Let's just compare the stringified copy.