### PR TITLE
Element-R: Stub interface for secure key backup

### DIFF
--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -158,6 +158,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
 
         // tell Alice to trust the dummy device that signed the backup
         await aliceCrypto.setDeviceVerified(testData.TEST_USER_ID, testData.TEST_DEVICE_ID);
+        // @ts-ignore backupManager is an internal property
         await aliceCrypto.backupManager.checkAndStart();
 
         // Now, send Alice a message that she won't be able to decrypt, and check that she fetches the key from the backup.

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -16,16 +16,14 @@ limitations under the License.
 
 import fetchMock from "fetch-mock-jest";
 
-import { logger } from "../../../src/logger";
-import { decodeRecoveryKey } from "../../../src/crypto/recoverykey";
-import { IKeyBackupInfo, IKeyBackupSession } from "../../../src/crypto/keybackup";
+import { IKeyBackupSession } from "../../../src/crypto/keybackup";
 import { createClient, ICreateClientOpts, IEvent, MatrixClient } from "../../../src";
-import { MatrixEventEvent } from "../../../src/models/event";
 import { SyncResponder } from "../../test-utils/SyncResponder";
 import { E2EKeyReceiver } from "../../test-utils/E2EKeyReceiver";
 import { E2EKeyResponder } from "../../test-utils/E2EKeyResponder";
 import { mockInitialApiRequests } from "../../test-utils/mockEndpoints";
-import { syncPromise } from "../../test-utils/test-utils";
+import { awaitDecryption, syncPromise } from "../../test-utils/test-utils";
+import * as testData from "../../test-utils/test-data";
 
 const ROOM_ID = "!ROOM:ID";
 
@@ -72,18 +70,6 @@ const CURVE25519_KEY_BACKUP_DATA: IKeyBackupSession = {
     },
 };
 
-const CURVE25519_BACKUP_INFO: IKeyBackupInfo = {
-    algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-    version: "1",
-    auth_data: {
-        public_key: "hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo",
-        // Will be updated with correct value on the fly
-        signatures: {},
-    },
-};
-
-const RECOVERY_KEY = "EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d";
-
 const TEST_USER_ID = "@alice:localhost";
 const TEST_DEVICE_ID = "xzcvb";
 
@@ -108,6 +94,7 @@ describe("megolm key backups", function () {
         syncResponder = new SyncResponder(TEST_HOMESERVER_URL);
         e2eKeyReceiver = new E2EKeyReceiver(TEST_HOMESERVER_URL);
         e2eKeyResponder = new E2EKeyResponder(TEST_HOMESERVER_URL);
+        e2eKeyResponder.addDeviceKeys(testData.SIGNED_TEST_DEVICE_DATA);
         e2eKeyResponder.addKeyReceiver(TEST_USER_ID, e2eKeyReceiver);
     });
 
@@ -150,35 +137,31 @@ describe("megolm key backups", function () {
         };
 
         fetchMock.get("express:/_matrix/client/v3/room_keys/keys/:room_id/:session_id", CURVE25519_KEY_BACKUP_DATA);
-
-        // mock for the outgoing key requests that will be sent
-        fetchMock.put("express:/_matrix/client/r0/sendToDevice/m.room_key_request/:txid", {});
-
-        // We'll need to add a signature to the backup data, so take a copy to avoid mutating global state.
-        const backupData = JSON.parse(JSON.stringify(CURVE25519_BACKUP_INFO));
-        fetchMock.get("path:/_matrix/client/v3/room_keys/version", backupData);
+        fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
 
         aliceClient = await initTestClient();
-        await aliceClient.crypto!.signObject(backupData.auth_data);
-        await aliceClient.crypto!.storeSessionBackupPrivateKey(decodeRecoveryKey(RECOVERY_KEY));
-        await aliceClient.crypto!.backupManager!.checkAndStart();
+        const aliceCrypto = aliceClient.getCrypto()!;
+        await aliceCrypto.storeSessionBackupPrivateKey(Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"));
 
         // start after saving the private key
         await aliceClient.startClient();
 
+        // Persuade alice to fetch the device list. Completing the initial sync will make the device list download
+        // outdated device lists (of which our own user will be one).
+        syncResponder.sendOrQueueSyncResponse({});
+        await jest.advanceTimersByTimeAsync(10); // DeviceList has a sleep(5) which we need to make happen
+
+        // tell Alice to trust the dummy device that signed the backup
+        await aliceCrypto.setDeviceVerified(testData.TEST_USER_ID, testData.TEST_DEVICE_ID);
+        await aliceCrypto.backupManager.checkAndStart();
+
+        // Now, send Alice a message that she won't be able to decrypt, and check that she fetches the key from the backup.
         syncResponder.sendOrQueueSyncResponse(syncResponse);
         await syncPromise(aliceClient);
 
         const room = aliceClient.getRoom(ROOM_ID)!;
-
         const event = room.getLiveTimeline().getEvents()[0];
-        await new Promise((resolve, reject) => {
-            event.once(MatrixEventEvent.Decrypted, (ev) => {
-                logger.log(`${Date.now()} event ${event.getId()} now decrypted`);
-                resolve(ev);
-            });
-        });
-
+        await awaitDecryption(event, { waitOnDecryptionFailure: true });
         expect(event.getContent()).toEqual("testytest");
     });
 });

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -124,7 +124,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
     describe("Outgoing verification requests for another device", () => {
         beforeEach(async () => {
             // pretend that we have another device, which we will verify
-            e2eKeyResponder.addDeviceKeys(TEST_USER_ID, TEST_DEVICE_ID, SIGNED_TEST_DEVICE_DATA);
+            e2eKeyResponder.addDeviceKeys(SIGNED_TEST_DEVICE_DATA);
         });
 
         // test with (1) the default verification method list, (2) a custom verification method list.
@@ -626,7 +626,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
     describe("cancellation", () => {
         beforeEach(async () => {
             // pretend that we have another device, which we will start verifying
-            e2eKeyResponder.addDeviceKeys(TEST_USER_ID, TEST_DEVICE_ID, SIGNED_TEST_DEVICE_DATA);
+            e2eKeyResponder.addDeviceKeys(SIGNED_TEST_DEVICE_DATA);
             e2eKeyResponder.addCrossSigningData(SIGNED_CROSS_SIGNING_KEYS_DATA);
 
             aliceClient = await startTestClient();
@@ -743,7 +743,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
 
     describe("Incoming verification from another device", () => {
         beforeEach(async () => {
-            e2eKeyResponder.addDeviceKeys(TEST_USER_ID, TEST_DEVICE_ID, SIGNED_TEST_DEVICE_DATA);
+            e2eKeyResponder.addDeviceKeys(SIGNED_TEST_DEVICE_DATA);
 
             aliceClient = await startTestClient();
             await waitForDeviceList();

--- a/spec/test-utils/E2EKeyResponder.ts
+++ b/spec/test-utils/E2EKeyResponder.ts
@@ -89,12 +89,10 @@ export class E2EKeyResponder {
     /**
      * Add a set of device keys for return by a future `/keys/query`, as if they had been `/upload`ed
      *
-     * @param userId - user the keys belong to
-     * @param deviceId - device the keys belong to
      * @param keys - device keys for this device.
      */
-    public addDeviceKeys(userId: string, deviceId: string, keys: IDeviceKeys) {
-        this.deviceKeysByUserByDevice.getOrCreate(userId).set(deviceId, keys);
+    public addDeviceKeys(keys: IDeviceKeys) {
+        this.deviceKeysByUserByDevice.getOrCreate(keys.user_id).set(keys.device_id, keys);
     }
 
     /** Add a set of cross-signing keys for return by a future `/keys/query`, as if they had been `/keys/device_signing/upload`ed

--- a/spec/test-utils/test-data/generate-test-data.py
+++ b/spec/test-utils/test-data/generate-test-data.py
@@ -28,7 +28,7 @@ import base64
 import json
 
 from canonicaljson import encode_canonical_json
-from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 # input data
@@ -41,6 +41,8 @@ MASTER_CROSS_SIGNING_PRIVATE_KEY_BYTES = b"doyouspeakwhaaaaaaaaaaaaaaaaaale"
 USER_CROSS_SIGNING_PRIVATE_KEY_BYTES = b"useruseruseruseruseruseruseruser"
 SELF_CROSS_SIGNING_PRIVATE_KEY_BYTES = b"selfselfselfselfselfselfselfself"
 
+# Private key for secure key backup. There are some sessions encrypted with this key in megolm-backup.spec.ts
+B64_BACKUP_DECRYPTION_KEY = "dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo="
 
 def main() -> None:
     private_key = ed25519.Ed25519PrivateKey.from_private_bytes(
@@ -71,29 +73,47 @@ def main() -> None:
     b64_master_public_key = encode_base64(
         master_private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
     )
-    b64_master_private_key = encode_base64(
-        MASTER_CROSS_SIGNING_PRIVATE_KEY_BYTES
-    )
+    b64_master_private_key = encode_base64(MASTER_CROSS_SIGNING_PRIVATE_KEY_BYTES)
 
     self_signing_private_key = ed25519.Ed25519PrivateKey.from_private_bytes(
         SELF_CROSS_SIGNING_PRIVATE_KEY_BYTES
     )
     b64_self_signing_public_key = encode_base64(
-        self_signing_private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+        self_signing_private_key.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
     )
-    b64_self_signing_private_key = encode_base64(
-        SELF_CROSS_SIGNING_PRIVATE_KEY_BYTES
-    )
+    b64_self_signing_private_key = encode_base64(SELF_CROSS_SIGNING_PRIVATE_KEY_BYTES)
 
     user_signing_private_key = ed25519.Ed25519PrivateKey.from_private_bytes(
         USER_CROSS_SIGNING_PRIVATE_KEY_BYTES
     )
     b64_user_signing_public_key = encode_base64(
-        user_signing_private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+        user_signing_private_key.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
     )
-    b64_user_signing_private_key = encode_base64(
-        USER_CROSS_SIGNING_PRIVATE_KEY_BYTES
+    b64_user_signing_private_key = encode_base64(USER_CROSS_SIGNING_PRIVATE_KEY_BYTES)
+
+    backup_decryption_key = x25519.X25519PrivateKey.from_private_bytes(
+        base64.b64decode(B64_BACKUP_DECRYPTION_KEY)
     )
+    b64_backup_public_key = encode_base64(
+        backup_decryption_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+
+    backup_data = {
+        "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+        "version": "1",
+        "auth_data": {
+            "public_key": b64_backup_public_key,
+        },
+    }
+    # sign with our device key
+    sig = sign_json(backup_data["auth_data"], private_key)
+    backup_data["auth_data"]["signatures"] = {
+        TEST_USER_ID: {f"ed25519:{TEST_DEVICE_ID}": sig}
+    }
 
     print(
         f"""\
@@ -104,6 +124,7 @@ def main() -> None:
 
 import {{ IDeviceKeys }} from "../../../src/@types/crypto";
 import {{ IDownloadKeyResult }} from "../../../src";
+import {{ KeyBackupInfo }} from "../../../src/crypto-api";
 
 /* eslint-disable comma-dangle */
 
@@ -138,6 +159,12 @@ export const USER_CROSS_SIGNING_PRIVATE_KEY_BASE64 = "{b64_user_signing_private_
 export const SIGNED_CROSS_SIGNING_KEYS_DATA: Partial<IDownloadKeyResult> = {
         json.dumps(build_cross_signing_keys_data(), indent=4)
 };
+
+/** base64-encoded backup decryption (private) key */
+export const BACKUP_DECRYPTION_KEY_BASE64 = "{ B64_BACKUP_DECRYPTION_KEY }";
+
+/** Signed backup data, suitable for return from `GET /_matrix/client/v3/room_keys/keys/{{roomId}}/{{sessionId}}` */
+export const SIGNED_BACKUP_DATA: KeyBackupInfo = { json.dumps(backup_data, indent=4) };
 """,
         end="",
     )

--- a/spec/test-utils/test-data/index.ts
+++ b/spec/test-utils/test-data/index.ts
@@ -5,6 +5,7 @@
 
 import { IDeviceKeys } from "../../../src/@types/crypto";
 import { IDownloadKeyResult } from "../../../src";
+import { KeyBackupInfo } from "../../../src/crypto-api";
 
 /* eslint-disable comma-dangle */
 
@@ -93,6 +94,23 @@ export const SIGNED_CROSS_SIGNING_KEYS_DATA: Partial<IDownloadKeyResult> = {
                 "@alice:localhost": {
                     "ed25519:J+5An10v1vzZpAXTYFokD1/PEVccFnLC61EfRXit0UY": "6AkD1XM2H0/ebgP9oBdMKNeft7uxsrb0XN1CsjjHgeZCvCTMmv3BHlLiT/Hzy4fe8H+S1tr484dcXN/PIdnfDA"
                 }
+            }
+        }
+    }
+};
+
+/** base64-encoded backup decryption (private) key */
+export const BACKUP_DECRYPTION_KEY_BASE64 = "dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=";
+
+/** Signed backup data, suitable for return from `GET /_matrix/client/v3/room_keys/keys/{roomId}/{sessionId}` */
+export const SIGNED_BACKUP_DATA: KeyBackupInfo = {
+    "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+    "version": "1",
+    "auth_data": {
+        "public_key": "hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo",
+        "signatures": {
+            "@alice:localhost": {
+                "ed25519:test_device": "KDSNeumirTsd8piI0oVfv/wzg4J4HlEc7rs5XhODFcJ/YAcUdg65ajsZG+rLI0TQOSSGjorJqcrSiSB1HRSCAA"
             }
         }
     }

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
 import { MatrixEvent } from "../models/event";
 import { Room } from "../models/room";
-import { CryptoApi } from "../crypto-api";
+import { CryptoApi, SecureKeyBackup } from "../crypto-api";
 import { CrossSigningInfo, UserTrustLevel } from "../crypto/CrossSigning";
 import { IEncryptedEventInfo } from "../crypto/api";
 import { IEventDecryptionResult } from "../@types/crypto";
@@ -99,6 +99,13 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * @deprecated Unneeded for the new crypto
      */
     checkOwnCrossSigningTrust(opts?: CheckOwnCrossSigningTrustOpts): Promise<void>;
+
+    /**
+     * Access the backup manager
+     *
+     * @see SecureKeyBackup
+     */
+    readonly backupManager: SecureKeyBackup;
 }
 
 /** The methods which crypto implementations should expose to the Sync api

--- a/src/common-crypto/SecureKeyBackup.ts
+++ b/src/common-crypto/SecureKeyBackup.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { KeyBackupInfo } from "../crypto-api/keybackup";
+
+/**
+ * Interface to server-side key backup
+ *
+ * Server-side key backup, aka "secure (key) backup" or "session backup", is a feature in which devices save copies of
+ * the megolm session keys that they receive on the server. The keys are encrypted with the public part of an asymmetric
+ * key, which makes it easy for devices to add newly-received session keys. In future, if the user logs in on another
+ * device which lacks history, the backup can be restored by providing the private part of the key (the "backup
+ * decryption key"), thus providing access to historical messages.
+ *
+ * (The backup decryption key is normally retrieved from server-side-secret-storage (4S) or gossipped between devices
+ * using secret sharing, rather than being entered directly).
+ *
+ * @see https://spec.matrix.org/v1.7/client-server-api/#server-side-key-backups
+ * @internal
+ */
+export interface SecureKeyBackup {
+    /**
+     * Check the server for an active key backup.
+     *
+     * If a key backup is present, and has a valid signature from one of the user's verified devices, start backing up
+     * to it.
+     *
+     * @returns `null` if there was an error checking for an active backup; otherwise, information about the active backup
+     *    (or lack thereof).
+     */
+    checkAndStart(): Promise<KeyBackupCheck | null>;
+}
+
+/**
+ * The result of {@link SecureKeyBackup.checkAndStart}.
+ *
+ * @internal
+ */
+export interface KeyBackupCheck {
+    /** Information from the server about the backup. `undefined` if there is no active backup. */
+    backupInfo?: KeyBackupInfo;
+
+    /** Information on whether we trust this backup. */
+    trustInfo: BackupTrustInfo;
+}
+
+/**
+ * Information on whether a given server-side backup is trusted.
+ *
+ * @internal
+ */
+export interface BackupTrustInfo {
+    /**
+     * Is this backup trusted?
+     *
+     * True if, and only if, there is a valid signature on the backup from a trusted device
+     */
+    readonly usable: boolean;
+}

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -137,6 +137,22 @@ export interface CryptoApi {
     getDeviceVerificationStatus(userId: string, deviceId: string): Promise<DeviceVerificationStatus | null>;
 
     /**
+     * Mark the given device as locally verified.
+     *
+     * Marking a devices as locally verified has much the same effect as completing the verification dance, or receiving
+     * a cross-signing signature for it.
+     *
+     * @param userId - owner of the device
+     * @param deviceId - unique identifier for the device.
+     * @param verified - whether to mark the device as verified. Defaults to 'true'.
+     *
+     * @throws an error if the device is unknown, or has not published any encryption keys.
+     *
+     * @remarks Fires {@link CryptoEvent#DeviceVerificationChanged}
+     */
+    setDeviceVerified(userId: string, deviceId: string, verified?: boolean): Promise<void>;
+
+    /**
      * Checks whether cross signing:
      * - is enabled on this account and trusted by this device
      * - has private keys either cached locally or stored in secret storage

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -20,7 +20,7 @@ import { DeviceMap } from "./models/device";
 import { UIAuthCallback } from "./interactive-auth";
 import { AddSecretStorageKeyOpts, SecretStorageCallbacks, SecretStorageKeyDescription } from "./secret-storage";
 import { VerificationRequest } from "./crypto-api/verification";
-import { KeyBackupInfo, SecureKeyBackup } from "./crypto-api/keybackup";
+import { KeyBackupInfo } from "./crypto-api/keybackup";
 
 /**
  * Public interface to the cryptography parts of the js-sdk
@@ -308,13 +308,6 @@ export interface CryptoApi {
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Access the backup manager
-     *
-     * @see Crypto.SecureKeyBackup
-     */
-    readonly backupManager: SecureKeyBackup;
-
-    /**
      * Fetch the backup decryption key we have saved in our store.
      *
      * This can be used for gossiping the key to other devices.
@@ -539,3 +532,4 @@ export interface GeneratedSecretStorageKey {
 
 export * from "./crypto-api/verification";
 export * from "./crypto-api/keybackup";
+export type { SecureKeyBackup } from "./common-crypto/SecureKeyBackup";

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -20,7 +20,7 @@ import { DeviceMap } from "./models/device";
 import { UIAuthCallback } from "./interactive-auth";
 import { AddSecretStorageKeyOpts, SecretStorageCallbacks, SecretStorageKeyDescription } from "./secret-storage";
 import { VerificationRequest } from "./crypto-api/verification";
-import { KeyBackupInfo } from "./crypto-api/keybackup";
+import { KeyBackupInfo, SecureKeyBackup } from "./crypto-api/keybackup";
 
 /**
  * Public interface to the cryptography parts of the js-sdk
@@ -306,6 +306,13 @@ export interface CryptoApi {
     // Secure key backup
     //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Access the backup manager
+     *
+     * @see Crypto.SecureKeyBackup
+     */
+    readonly backupManager: SecureKeyBackup;
 
     /**
      * Fetch the backup decryption key we have saved in our store.

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -532,4 +532,3 @@ export interface GeneratedSecretStorageKey {
 
 export * from "./crypto-api/verification";
 export * from "./crypto-api/keybackup";
-export type { SecureKeyBackup } from "./common-crypto/SecureKeyBackup";

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -16,44 +16,6 @@ limitations under the License.
 
 import { ISigned } from "../@types/signed";
 
-/**
- * Interface to server-side key backup
- *
- * Server-side key backup, aka "secure (key) backup" or "session backup", is a feature in which devices save copies of
- * the megolm session keys that they receive on the server. The keys are encrypted with the public part of an asymmetric
- * key, which makes it easy for devices to add newly-received session keys. In future, if the user logs in on another
- * device which lacks history, the backup can be restored by providing the private part of the key (the "backup
- * decryption key"), thus providing access to historical messages.
- *
- * (The backup decryption key is normally retrieved from server-side-secret-storage (4S) or gossipped between devices
- * using secret sharing, rather than being entered directly).
- *
- * @see https://spec.matrix.org/v1.7/client-server-api/#server-side-key-backups
- */
-export interface SecureKeyBackup {
-    /**
-     * Check the server for an active key backup.
-     *
-     * If a key backup is present, and has a valid signature from one of the user's verified devices, start backing up
-     * to it.
-     *
-     * @returns `null` if there was an error checking for an active backup; otherwise, information about the active backup
-     *    (or lack thereof).
-     */
-    checkAndStart(): Promise<KeyBackupCheck | null>;
-}
-
-/**
- * The result of {@link SecureKeyBackup.checkAndStart}.
- */
-export interface KeyBackupCheck {
-    /** Information from the server about the backup. `undefined` if there is no active backup. */
-    backupInfo?: KeyBackupInfo;
-
-    /** Information on whether we trust this backup. */
-    trustInfo: BackupTrustInfo;
-}
-
 export interface Curve25519AuthData {
     public_key: string;
     private_key_salt?: string;
@@ -80,16 +42,4 @@ export interface KeyBackupInfo {
     count?: number;
     etag?: string;
     version?: string; // number contained within
-}
-
-/**
- * Information on whether a given server-side backup is trusted.
- */
-export interface BackupTrustInfo {
-    /**
-     * Is this backup trusted?
-     *
-     * True if, and only if, there is a valid signature on the backup from a trusted device
-     */
-    readonly usable: boolean;
 }

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -31,7 +31,27 @@ import { ISigned } from "../@types/signed";
  * @see https://spec.matrix.org/v1.7/client-server-api/#server-side-key-backups
  */
 export interface SecureKeyBackup {
-    // TODO: add some stuff here
+    /**
+     * Check the server for an active key backup.
+     *
+     * If a key backup is present, and has a valid signature from one of the user's verified devices, start backing up
+     * to it.
+     *
+     * @returns `null` if there was an error checking for an active backup; otherwise, information about the active backup
+     *    (or lack thereof).
+     */
+    checkAndStart(): Promise<KeyBackupCheck | null>;
+}
+
+/**
+ * The result of {@link SecureKeyBackup.checkAndStart}.
+ */
+export interface KeyBackupCheck {
+    /** Information from the server about the backup. `undefined` if there is no active backup. */
+    backupInfo?: KeyBackupInfo;
+
+    /** Information on whether we trust this backup. */
+    trustInfo: BackupTrustInfo;
 }
 
 export interface Curve25519AuthData {
@@ -49,7 +69,10 @@ export interface Aes256AuthData {
 }
 
 /**
- * Extra info of a recovery key
+ * Information about a server-side key backup.
+ *
+ * Returned by `GET /_matrix/client/v3/room_keys/version`
+ * (see https://spec.matrix.org/v1.7/client-server-api/#get_matrixclientv3room_keysversion).
  */
 export interface KeyBackupInfo {
     algorithm: string;
@@ -57,4 +80,16 @@ export interface KeyBackupInfo {
     count?: number;
     etag?: string;
     version?: string; // number contained within
+}
+
+/**
+ * Information on whether a given server-side backup is trusted.
+ */
+export interface BackupTrustInfo {
+    /**
+     * Is this backup trusted?
+     *
+     * True if, and only if, there is a valid signature on the backup from a trusted device
+     */
+    readonly usable: boolean;
 }

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -16,6 +16,24 @@ limitations under the License.
 
 import { ISigned } from "../@types/signed";
 
+/**
+ * Interface to server-side key backup
+ *
+ * Server-side key backup, aka "secure (key) backup" or "session backup", is a feature in which devices save copies of
+ * the megolm session keys that they receive on the server. The keys are encrypted with the public part of an asymmetric
+ * key, which makes it easy for devices to add newly-received session keys. In future, if the user logs in on another
+ * device which lacks history, the backup can be restored by providing the private part of the key (the "backup
+ * decryption key"), thus providing access to historical messages.
+ *
+ * (The backup decryption key is normally retrieved from server-side-secret-storage (4S) or gossipped between devices
+ * using secret sharing, rather than being entered directly).
+ *
+ * @see https://spec.matrix.org/v1.7/client-server-api/#server-side-key-backups
+ */
+export interface SecureKeyBackup {
+    // TODO: add some stuff here
+}
+
 export interface Curve25519AuthData {
     public_key: string;
     private_key_salt?: string;

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -55,7 +55,7 @@ type SigInfo = {
     deviceTrust?: DeviceTrustLevel;
 };
 
-/** @deprecated Prefer {@link Crypto.BackupTrustInfo} */
+/** @deprecated Prefer {@link BackupTrustInfo} */
 export type TrustInfo = {
     usable: boolean; // is the backup trusted, true iff there is a sig that is valid & from a trusted device
     sigs: SigInfo[];
@@ -63,7 +63,7 @@ export type TrustInfo = {
     trusted_locally?: boolean;
 };
 
-/** @deprecated Prefer {@link Crypto.KeyBackupCheck} */
+/** @deprecated Prefer {@link KeyBackupCheck} */
 export interface IKeyBackupCheck {
     backupInfo?: IKeyBackupInfo;
     trustInfo: TrustInfo;

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -55,6 +55,7 @@ type SigInfo = {
     deviceTrust?: DeviceTrustLevel;
 };
 
+/** @deprecated Prefer {@link Crypto.BackupTrustInfo} */
 export type TrustInfo = {
     usable: boolean; // is the backup trusted, true iff there is a sig that is valid & from a trusted device
     sigs: SigInfo[];
@@ -62,6 +63,7 @@ export type TrustInfo = {
     trusted_locally?: boolean;
 };
 
+/** @deprecated Prefer {@link Crypto.KeyBackupCheck} */
 export interface IKeyBackupCheck {
     backupInfo?: IKeyBackupInfo;
     trustInfo: TrustInfo;

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -40,7 +40,7 @@ import { UnstableValue } from "../NamespacedValue";
 import { CryptoEvent } from "./index";
 import { crypto } from "./crypto";
 import { HTTPError, MatrixError } from "../http-api";
-import { SecureKeyBackup } from "../crypto-api/keybackup";
+import { SecureKeyBackup } from "../common-crypto/SecureKeyBackup";
 
 const KEY_BACKUP_KEYS_PER_REQUEST = 200;
 const KEY_BACKUP_CHECK_RATE_LIMIT = 5000; // ms

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -40,6 +40,7 @@ import { UnstableValue } from "../NamespacedValue";
 import { CryptoEvent } from "./index";
 import { crypto } from "./crypto";
 import { HTTPError, MatrixError } from "../http-api";
+import { SecureKeyBackup } from "../crypto-api/keybackup";
 
 const KEY_BACKUP_KEYS_PER_REQUEST = 200;
 const KEY_BACKUP_CHECK_RATE_LIMIT = 5000; // ms
@@ -112,7 +113,7 @@ export interface IKeyBackup {
 /**
  * Manages the key backup.
  */
-export class BackupManager {
+export class BackupManager implements SecureKeyBackup {
     private algorithm: BackupAlgorithm | undefined;
     public backupInfo: IKeyBackupInfo | undefined; // The info dict from /room_keys/version
     public checkedForBackup: boolean; // Have we checked the server for a backup we can use?

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -2175,6 +2175,15 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
+     * Mark the given device as locally verified.
+     *
+     * Implementation of {@link CryptoApi#setDeviceVerified}.
+     */
+    public async setDeviceVerified(userId: string, deviceId: string, verified = true): Promise<void> {
+        await this.setDeviceVerification(userId, deviceId, verified);
+    }
+
+    /**
      * Update the blocked/verified state of the given device
      *
      * @param userId - owner of the device

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { SecureKeyBackup } from "../crypto-api/keybackup";
+import { KeyBackupCheck, SecureKeyBackup } from "../crypto-api/keybackup";
 
-export class RustBackupManager implements SecureKeyBackup {}
+export class RustBackupManager implements SecureKeyBackup {
+    public async checkAndStart(): Promise<KeyBackupCheck | null> {
+        return null;
+    }
+}

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { SecureKeyBackup } from "../crypto-api/keybackup";
+
+export class RustBackupManager implements SecureKeyBackup {}

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { KeyBackupCheck, SecureKeyBackup } from "../crypto-api/keybackup";
+import { KeyBackupCheck, SecureKeyBackup } from "../common-crypto/SecureKeyBackup";
 
 export class RustBackupManager implements SecureKeyBackup {
     public async checkAndStart(): Promise<KeyBackupCheck | null> {

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -55,6 +55,7 @@ import { RustVerificationRequest, verificationMethodIdentifierToMethod } from ".
 import { EventType } from "../@types/event";
 import { CryptoEvent } from "../crypto";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
+import { RustBackupManager } from "./backup";
 
 const ALL_VERIFICATION_METHODS = ["m.sas.v1", "m.qr_code.scan.v1", "m.qr_code.show.v1", "m.reciprocate.v1"];
 
@@ -80,6 +81,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     private keyClaimManager: KeyClaimManager;
     private outgoingRequestProcessor: OutgoingRequestProcessor;
     private crossSigningIdentity: CrossSigningIdentity;
+
+    public readonly backupManager: RustBackupManager;
 
     public constructor(
         /** The `OlmMachine` from the underlying rust crypto sdk. */
@@ -108,6 +111,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
         this.keyClaimManager = new KeyClaimManager(olmMachine, this.outgoingRequestProcessor);
         this.eventDecryptor = new EventDecryptor(olmMachine);
+        this.backupManager = new RustBackupManager();
 
         // Fire if the cross signing keys are imported from the secret storage
         const onCrossSigningKeysImport = (): void => {

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -377,6 +377,23 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     }
 
     /**
+     * Mark the given device as locally verified.
+     *
+     * Implementation of {@link CryptoApi#setDeviceVerified}.
+     */
+    public async setDeviceVerified(userId: string, deviceId: string, verified = true): Promise<void> {
+        const device: RustSdkCryptoJs.Device | undefined = await this.olmMachine.getDevice(
+            new RustSdkCryptoJs.UserId(userId),
+            new RustSdkCryptoJs.DeviceId(deviceId),
+        );
+
+        if (!device) {
+            throw new Error(`Unknown device ${userId}|${deviceId}`);
+        }
+        await device.setLocalTrust(verified ? RustSdkCryptoJs.LocalTrust.Verified : RustSdkCryptoJs.LocalTrust.Unset);
+    }
+
+    /**
      * Implementation of {@link CryptoApi#getDeviceVerificationStatus}.
      */
     public async getDeviceVerificationStatus(


### PR DESCRIPTION
Based on #3624 

I realised that the BackupManager interface is only used within the js-sdk, so I have made it properly internal.

Closes https://github.com/vector-im/crypto-internal/issues/105

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->