### PR TITLE
Ensure we don't overinflate the total notification count

### DIFF
--- a/spec/unit/event-timeline-set.spec.ts
+++ b/spec/unit/event-timeline-set.spec.ts
@@ -303,8 +303,13 @@ describe("EventTimelineSet", () => {
                     messageEventIsDecryptionFailureSpy.mockReturnValue(true);
                     replyEventIsDecryptionFailureSpy.mockReturnValue(true);
 
-                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent);
-                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent);
+                    messageEvent.emit(
+                        MatrixEventEvent.Decrypted,
+                        messageEvent,
+                        undefined,
+                        messageEvent.getPushDetails(),
+                    );
+                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent, undefined, replyEvent.getPushDetails());
 
                     // simulate decryption
                     messageEventIsDecryptionFailureSpy.mockReturnValue(false);
@@ -313,8 +318,13 @@ describe("EventTimelineSet", () => {
                     messageEventShouldAttemptDecryptionSpy.mockReturnValue(false);
                     replyEventShouldAttemptDecryptionSpy.mockReturnValue(false);
 
-                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent);
-                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent);
+                    messageEvent.emit(
+                        MatrixEventEvent.Decrypted,
+                        messageEvent,
+                        undefined,
+                        messageEvent.getPushDetails(),
+                    );
+                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent, undefined, replyEvent.getPushDetails());
                 });
 
                 itShouldReturnTheRelatedEvents();

--- a/spec/unit/room-state.spec.ts
+++ b/spec/unit/room-state.spec.ts
@@ -1037,7 +1037,12 @@ describe("RoomState", function () {
 
                 // this event is a message after decryption
                 decryptingRelatedEvent.event.type = EventType.RoomMessage;
-                decryptingRelatedEvent.emit(MatrixEventEvent.Decrypted, decryptingRelatedEvent);
+                decryptingRelatedEvent.emit(
+                    MatrixEventEvent.Decrypted,
+                    decryptingRelatedEvent,
+                    undefined,
+                    decryptingRelatedEvent.getPushDetails(),
+                );
 
                 expect(addLocationsSpy).not.toHaveBeenCalled();
             });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3428,13 +3428,13 @@ describe("Room", function () {
             expect(room.polls.get(pollStartEventId)).toBeUndefined();
 
             // now emit a Decrypted event but keep the decryption failure
-            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent);
+            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent, undefined, pollStartEvent.getPushDetails());
             // still do not expect a poll to show up for the room
             expect(room.polls.get(pollStartEventId)).toBeUndefined();
 
             // clear decryption failure and emit a Decrypted event again
             isDecryptionFailureSpy.mockRestore();
-            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent);
+            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent, undefined, pollStartEvent.getPushDetails());
 
             // the poll should now show up in the room's polls
             const poll = room.polls.get(pollStartEventId);

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -226,7 +226,7 @@ export type MatrixEventHandlerMap = {
      * @param event - The matrix event which has been decrypted
      * @param err - The error that occurred during decryption, or `undefined` if no error occurred.
      */
-    [MatrixEventEvent.Decrypted]: (event: MatrixEvent, err?: Error) => void;
+    [MatrixEventEvent.Decrypted]: (event: MatrixEvent, err: Error | undefined, pushDetails: PushDetails) => void;
     [MatrixEventEvent.BeforeRedaction]: (event: MatrixEvent, redactionEvent: MatrixEvent) => void;
     [MatrixEventEvent.VisibilityChange]: (event: MatrixEvent, visible: boolean) => void;
     [MatrixEventEvent.LocalEventIdReplaced]: (event: MatrixEvent) => void;
@@ -916,6 +916,8 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
             this.retryDecryption = false;
             this.setClearData(res);
 
+            const pushDetails = this.getPushDetails();
+
             // Before we emit the event, clear the push actions so that they can be recalculated
             // by relevant code. We do this because the clear event has now changed, making it
             // so that existing rules can be re-run over the applicable properties. Stuff like
@@ -925,7 +927,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
             this.setPushDetails();
 
             if (options.emit !== false) {
-                this.emit(MatrixEventEvent.Decrypted, this, err);
+                this.emit(MatrixEventEvent.Decrypted, this, err, pushDetails);
             }
 
             return;


### PR DESCRIPTION
By correctly comparing push rules before & after decryption
I suggest reviewing commit-by-commit

Fixes https://github.com/vector-im/element-web/issues/25803

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ensure we don't overinflate the total notification count ([\#3634](https://github.com/matrix-org/matrix-js-sdk/pull/3634)). Fixes vector-im/element-web#25803.<!-- CHANGELOG_PREVIEW_END -->