### PR TITLE
Bump pagination limit to account for threaded events

### DIFF
--- a/src/timeline-window.ts
+++ b/src/timeline-window.ts
@@ -35,10 +35,13 @@ const debuglog = DEBUG ? logger.log.bind(logger) : function (): void {};
 
 /**
  * the number of times we ask the server for more events before giving up
+ * this is currently higher than it needs to be to workaround lack of a filter
+ * for excluding thread responses from main timeline pagination which can cause
+ * giving up incorrectly - https://github.com/matrix-org/matrix-spec-proposals/pull/3874
  *
  * @internal
  */
-const DEFAULT_PAGINATE_LOOP_LIMIT = 5;
+const DEFAULT_PAGINATE_LOOP_LIMIT = 10;
 
 interface IOpts {
     /**


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25873

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Bump pagination limit to account for threaded events ([\#3638](https://github.com/matrix-org/matrix-js-sdk/pull/3638)).<!-- CHANGELOG_PREVIEW_END -->