### PR TITLE
Skip processing thread roots and fetching threads list when support is disabled

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -207,7 +207,7 @@ function startClient(httpBackend: HttpBackend, client: MatrixClient) {
     httpBackend.when("POST", "/filter").respond(200, { filter_id: "fid" });
     httpBackend.when("GET", "/sync").respond(200, INITIAL_SYNC_DATA);
 
-    client.startClient();
+    client.startClient({ threadSupport: true });
 
     // set up a promise which will resolve once the client is initialised
     const prom = new Promise<void>((resolve) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9768,6 +9768,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param toStartOfTimeline - the direction
      */
     public processThreadRoots(room: Room, threadedEvents: MatrixEvent[], toStartOfTimeline: boolean): void {
+        if (!this.supportsThreads()) return;
         room.processThreadRoots(threadedEvents, toStartOfTimeline);
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1877,6 +1877,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * Takes the given thread root events and creates threads for them.
      */
     public processThreadRoots(events: MatrixEvent[], toStartOfTimeline: boolean): void {
+        if (!this.client.supportsThreads()) return;
         for (const rootEvent of events) {
             EventTimeline.setEventMetadata(rootEvent, this.currentState, toStartOfTimeline);
             if (!this.getThread(rootEvent.getId()!)) {
@@ -2031,6 +2032,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @internal
      */
     private async fetchRoomThreadList(filter?: ThreadFilterType): Promise<void> {
+        if (!this.client.supportsThreads()) return;
         if (this.threadsTimelineSets.length === 0) return;
 
         const timelineSet = filter === ThreadFilterType.My ? this.threadsTimelineSets[1] : this.threadsTimelineSets[0];


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/25676#issue-1778333111

> Some rooms don't clear the unread count / dot when entering them

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Skip processing thread roots and fetching threads list when support is disabled ([\#3642](https://github.com/matrix-org/matrix-js-sdk/pull/3642)).<!-- CHANGELOG_PREVIEW_END -->