### PR TITLE
ElementR: Track untracked users in `CryptoApi.getUserDeviceInfo`

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -585,6 +585,27 @@ describe("RustCrypto", () => {
             );
         });
     });
+
+    describe("getUserDeviceInfo", () => {
+        it("Add unknown users to tracked users", async () => {
+            const mockHttpApi = new MatrixHttpApi(new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>(), {
+                baseUrl: "http://server/",
+                prefix: "",
+                onlyData: true,
+            });
+            const keysQueryMock = fetchMock.post("path:/_matrix/client/v3/keys/query", {});
+
+            const rustCrypto = await makeTestRustCrypto(mockHttpApi);
+
+            // Bob is not tracked, we expect bob to be added to tracked users and to download manually his keys
+            await rustCrypto.getUserDeviceInfo(["@box:xyz"], true);
+            expect(keysQueryMock.calls().length).toBe(1);
+
+            await rustCrypto.getUserDeviceInfo(["@box:xyz"], true);
+            // We expect bob to be tracked, we don't manually download bob keys
+            expect(keysQueryMock.calls().length).toBe(1);
+        });
+    });
 });
 
 /** build a basic RustCrypto instance for testing

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -296,12 +296,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
         const untrackedUsers = userIds.filter((userId) => !trackedUsers.has(userId));
 
-        // Track and download device list of untracked users
+        // Track and download the keys of the untracked users
         if (downloadUncached && untrackedUsers.length > 0) {
             const rustUntrackedUsers = untrackedUsers.map((user) => new RustSdkCryptoJs.UserId(user));
-            // Add the untracked users to the olm machine to track them
+            // Add the untracked users to the olm machine
             await this.olmMachine.updateTrackedUsers(rustUntrackedUsers);
-            // Get the keys of the previous untracked users
+            // Get the keys of the untracked users
             const keyQueryRequest = this.olmMachine.queryKeysForUsers(rustUntrackedUsers);
             await this.outgoingRequestProcessor.makeOutgoingRequest(keyQueryRequest);
         }

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -95,7 +95,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
          *
          * We expect it to set the access token, etc.
          */
-        readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+        http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
 
         /** The local user's User ID. */
         private readonly userId: string,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

`getUserDeviceInfo` was downloading the device list of the untrack users but didn't add them to the `olmMachine`.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * ElementR: Track untracked users in `CryptoApi.getUserDeviceInfo` ([\#3649](https://github.com/matrix-org/matrix-js-sdk/pull/3649)). Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->