### PR TITLE
Use sender instead of content.creator field on m.room.create events

### DIFF
--- a/spec/integ/matrix-client-event-emitter.spec.ts
+++ b/spec/integ/matrix-client-event-emitter.spec.ts
@@ -92,9 +92,7 @@ describe("MatrixClient events", function () {
                                     type: "m.room.create",
                                     room: "!erufh:bar",
                                     user: "@foo:bar",
-                                    content: {
-                                        creator: "@foo:bar",
-                                    },
+                                    content: {},
                                 }),
                             ],
                         },

--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -107,9 +107,7 @@ const INITIAL_SYNC_DATA = {
                         utils.mkEvent({
                             type: "m.room.create",
                             user: userId,
-                            content: {
-                                creator: userId,
-                            },
+                            content: {},
                             event: false,
                         }),
                     ],

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1988,10 +1988,7 @@ const buildEventMember = () =>
 const buildEventCreate = () =>
     new MatrixEvent({
         age: 80126105,
-        content: {
-            creator: "@andybalaam-test1:matrix.org",
-            room_version: "6",
-        },
+        content: {},
         event_id: "$e7j2Gt37k5NPwB6lz2N3V9lO5pUdNK8Ai7i2FPEK-oI",
         origin_server_ts: 1643815438782,
         room_id: "!STrMRsukXHtqQdSeHa:matrix.org",

--- a/spec/integ/matrix-client-opts.spec.ts
+++ b/spec/integ/matrix-client-opts.spec.ts
@@ -57,9 +57,7 @@ describe("MatrixClient opts", function () {
                                 type: "m.room.create",
                                 room: roomId,
                                 user: userId,
-                                content: {
-                                    creator: userId,
-                                },
+                                content: {},
                             }),
                         ],
                     },

--- a/spec/integ/matrix-client-room-timeline.spec.ts
+++ b/spec/integ/matrix-client-room-timeline.spec.ts
@@ -85,9 +85,7 @@ describe("MatrixClient room timelines", function () {
                                 type: "m.room.create",
                                 room: roomId,
                                 user: userId,
-                                content: {
-                                    creator: userId,
-                                },
+                                content: {},
                             }),
                         ],
                     },

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -389,9 +389,7 @@ describe("MatrixClient syncing", () => {
                             type: "m.room.create",
                             room: roomOne,
                             user: selfUserId,
-                            content: {
-                                creator: selfUserId,
-                            },
+                            content: {},
                         }),
                     ],
                 },
@@ -577,9 +575,7 @@ describe("MatrixClient syncing", () => {
                                     type: "m.room.create",
                                     room: roomOne,
                                     user: selfUserId,
-                                    content: {
-                                        creator: selfUserId,
-                                    },
+                                    content: {},
                                 }),
                             ],
                         },
@@ -611,9 +607,7 @@ describe("MatrixClient syncing", () => {
                                     type: "m.room.create",
                                     room: roomTwo,
                                     user: selfUserId,
-                                    content: {
-                                        creator: selfUserId,
-                                    },
+                                    content: {},
                                 }),
                             ],
                         },
@@ -757,10 +751,7 @@ describe("MatrixClient syncing", () => {
                         type: "m.room.create",
                         room: roomOne,
                         user: otherUserId,
-                        content: {
-                            creator: otherUserId,
-                            room_version: "9",
-                        },
+                        content: {},
                     });
                     const normalFirstSync = {
                         next_batch: "batch_token",
@@ -843,10 +834,7 @@ describe("MatrixClient syncing", () => {
                         type: "m.room.create",
                         room: roomOne,
                         user: otherUserId,
-                        content: {
-                            creator: otherUserId,
-                            room_version: testMeta.roomVersion,
-                        },
+                        content: {},
                     });
 
                     const markerEventFromRoomCreator = utils.mkEvent({
@@ -1372,9 +1360,7 @@ describe("MatrixClient syncing", () => {
                                     type: "m.room.create",
                                     room: roomOne,
                                     user: selfUserId,
-                                    content: {
-                                        creator: selfUserId,
-                                    },
+                                    content: {},
                                 }),
                             ],
                         } as Partial<IJoinedRoom>,
@@ -1471,9 +1457,7 @@ describe("MatrixClient syncing", () => {
                                     type: "m.room.create",
                                     room: roomOne,
                                     user: selfUserId,
-                                    content: {
-                                        creator: selfUserId,
-                                    },
+                                    content: {},
                                 }),
                             ],
                         },
@@ -1629,9 +1613,7 @@ describe("MatrixClient syncing", () => {
                                         type: "m.room.create",
                                         room: roomId,
                                         user: selfUserId,
-                                        content: {
-                                            creator: selfUserId,
-                                        },
+                                        content: {},
                                     }),
                                 ],
                             },

--- a/spec/integ/matrix-client-unread-notifications.spec.ts
+++ b/spec/integ/matrix-client-unread-notifications.spec.ts
@@ -178,10 +178,7 @@ describe("MatrixClient syncing", () => {
                         timeline: {
                             events: [
                                 {
-                                    content: {
-                                        creator: userB,
-                                        room_version: "9",
-                                    },
+                                    content: {},
                                     origin_server_ts: 1,
                                     sender: userB,
                                     state_key: "",

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -188,7 +188,7 @@ describe("SlidingSyncSdk", () => {
                 [roomA]: {
                     name: "A",
                     required_state: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnStateEvent(EventType.RoomName, { name: "A" }, ""),
@@ -203,7 +203,7 @@ describe("SlidingSyncSdk", () => {
                     name: "B",
                     required_state: [],
                     timeline: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnEvent(EventType.RoomMessage, { body: "hello B" }),
@@ -215,7 +215,7 @@ describe("SlidingSyncSdk", () => {
                     name: "C",
                     required_state: [],
                     timeline: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnEvent(EventType.RoomMessage, { body: "hello C" }),
@@ -228,7 +228,7 @@ describe("SlidingSyncSdk", () => {
                     name: "D",
                     required_state: [],
                     timeline: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnEvent(EventType.RoomMessage, { body: "hello D" }),
@@ -264,7 +264,7 @@ describe("SlidingSyncSdk", () => {
                 [roomF]: {
                     name: "#foo:localhost",
                     required_state: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnStateEvent(EventType.RoomCanonicalAlias, { alias: "#foo:localhost" }, ""),
@@ -280,7 +280,7 @@ describe("SlidingSyncSdk", () => {
                     name: "G",
                     required_state: [],
                     timeline: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     ],
@@ -292,7 +292,7 @@ describe("SlidingSyncSdk", () => {
                     name: "H",
                     required_state: [],
                     timeline: [
-                        mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                        mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                         mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                         mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                         mkOwnEvent(EventType.RoomMessage, { body: "live event" }),
@@ -602,7 +602,7 @@ describe("SlidingSyncSdk", () => {
                 name: "Room with Invite",
                 required_state: [],
                 timeline: [
-                    mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                    mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                     mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "invite" }, invitee),
@@ -718,7 +718,7 @@ describe("SlidingSyncSdk", () => {
                 name: "Room with account data",
                 required_state: [],
                 timeline: [
-                    mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                    mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                     mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     mkOwnEvent(EventType.RoomMessage, { body: "hello" }),
@@ -922,7 +922,7 @@ describe("SlidingSyncSdk", () => {
                 name: "Room with typing",
                 required_state: [],
                 timeline: [
-                    mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                    mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                     mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     mkOwnEvent(EventType.RoomMessage, { body: "hello" }),
@@ -963,7 +963,7 @@ describe("SlidingSyncSdk", () => {
                 name: "Room with typing",
                 required_state: [],
                 timeline: [
-                    mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                    mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                     mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     mkOwnEvent(EventType.RoomMessage, { body: "hello" }),
@@ -1049,7 +1049,7 @@ describe("SlidingSyncSdk", () => {
                 name: "Room with receipts",
                 required_state: [],
                 timeline: [
-                    mkOwnStateEvent(EventType.RoomCreate, { creator: selfUserId }, ""),
+                    mkOwnStateEvent(EventType.RoomCreate, {}, ""),
                     mkOwnStateEvent(EventType.RoomMember, { membership: "join" }, selfUserId),
                     mkOwnStateEvent(EventType.RoomPowerLevels, { users: { [selfUserId]: 100 } }, ""),
                     {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -2266,13 +2266,11 @@ describe("MatrixClient", function () {
         function roomCreateEvent(newRoomId: string, predecessorRoomId: string): MatrixEvent {
             return new MatrixEvent({
                 content: {
-                    "creator": "@daryl:alexandria.example.com",
                     "m.federate": true,
                     "predecessor": {
                         event_id: "id_of_last_event",
                         room_id: predecessorRoomId,
                     },
-                    "room_version": "9",
                 },
                 event_id: `create_event_id_pred_${predecessorRoomId}`,
                 origin_server_ts: 1432735824653,

--- a/spec/unit/room-state.spec.ts
+++ b/spec/unit/room-state.spec.ts
@@ -70,9 +70,7 @@ describe("RoomState", function () {
                 user: userA,
                 room: roomId,
                 event: true,
-                content: {
-                    creator: userA,
-                },
+                content: {},
             }),
         ]);
     });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -228,7 +228,7 @@ describe("Room", function () {
     });
 
     describe("getCreator", () => {
-        it("should return the creator from m.room.create", function () {
+        it("should return the sender from m.room.create", function () {
             // @ts-ignore - mocked doesn't handle overloads sanely
             mocked(room.currentState.getStateEvents).mockImplementation(function (type, key) {
                 if (type === EventType.RoomCreate && key === "") {
@@ -239,7 +239,7 @@ describe("Room", function () {
                         room: roomId,
                         user: userA,
                         content: {
-                            creator: userA,
+                            creator: userB, // The creator field was dropped in room version 11 but a malicious client might still send it
                         },
                     });
                 }
@@ -3471,12 +3471,10 @@ describe("Room", function () {
 
         function roomCreateEvent(newRoomId: string, predecessorRoomId: string | null): MatrixEvent {
             const content: {
-                creator: string;
                 ["m.federate"]: boolean;
                 room_version: string;
                 predecessor: { event_id: string; room_id: string } | undefined;
             } = {
-                "creator": "@daryl:alexandria.example.com",
                 "predecessor": undefined,
                 "m.federate": true,
                 "room_version": "9",

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1684,7 +1684,6 @@ const REDACT_KEEP_KEYS = new Set([
 // a map from state event type to the .content keys we keep when an event is redacted
 const REDACT_KEEP_CONTENT_MAP: Record<string, Record<string, 1>> = {
     [EventType.RoomMember]: { membership: 1 },
-    [EventType.RoomCreate]: { creator: 1 },
     [EventType.RoomJoinRules]: { join_rule: 1 },
     [EventType.RoomPowerLevels]: {
         ban: 1,

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -569,7 +569,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public getCreator(): string | null {
         const createEvent = this.currentState.getStateEvents(EventType.RoomCreate, "");
-        return createEvent?.getContent()["creator"] ?? null;
+        return createEvent?.getSender() ?? null;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

https://github.com/matrix-org/matrix-spec-proposals/pull/2175 removed the `content.creator` field from `m.room.create` fields in favor of the `sender` field. This was released with [room version 11](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3820-rooms-v11.md).

This PR amends the JS SDK to use the `sender` field instead of the `content.creator` field _regardless of room version_. In line with https://github.com/matrix-org/matrix-spec-proposals/pull/2175#issuecomment-1669891053, the `content.creator` field is not used at all anymore.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
