### PR TITLE
stop keepAlive when the connection was aborted, as done by calling stopSync(), to prevent endless looping

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1604,7 +1604,13 @@ export class SyncApi {
                     success();
                 },
                 (err) => {
-                    if (err.httpStatus == 400 || err.httpStatus == 404) {
+                    if (err.name === "AbortError") {
+                        clearTimeout(this.keepAliveTimer);
+                        if (this.connectionReturnedDefer) {
+                            this.connectionReturnedDefer.reject();
+                            this.connectionReturnedDefer = undefined;
+                        }
+                    } else if (err.httpStatus == 400 || err.httpStatus == 404) {
                         // treat this as a success because the server probably just doesn't
                         // support /versions: point is, we're getting a response.
                         // We wait a short time though, just in case somehow the server


### PR DESCRIPTION
This PR solves issue: https://github.com/matrix-org/matrix-js-sdk/issues/3678

When you start a client, which has connection problems, a keepAlive is started.
But when the connection is actively stopped e.g. via calling stopSync(), the connection is aborted.
When the connection is aborted, it does not make sense to continue to try to connect, because it will never succeed.

This is solved by this PR.

I could not find any tests for the sync, so I didn't find a place to extend tests to check this special case.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
