### PR TITLE
Emit summary update event

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1202,6 +1202,21 @@ describe("Room", function () {
                 room.recalculate();
                 expect(room.name).toEqual("Empty room");
             });
+
+            it("emits an update event", function () {
+                const spy = jest.fn();
+                const summary = {
+                    "m.heroes": [],
+                    "m.invited_member_count": 1,
+                };
+
+                room.once(RoomEvent.Summary, spy);
+
+                room.setSummary(summary);
+                room.recalculate();
+
+                expect(spy).toHaveBeenCalledWith(summary);
+            });
         });
 
         describe("Room.recalculate => Room Name", function () {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -291,6 +291,12 @@ export type RoomEventHandlerMap = {
     [RoomEvent.HistoryImportedWithinTimeline]: (markerEvent: MatrixEvent, room: Room) => void;
     [RoomEvent.UnreadNotifications]: (unreadNotifications?: NotificationCount, threadId?: string) => void;
     [RoomEvent.TimelineRefresh]: (room: Room, eventTimelineSet: EventTimelineSet) => void;
+    /**
+     * Fires when the room summary is updated.
+     * See `RoomSummary` on https://spec.matrix.org/latest/client-server-api/
+     * for full details
+     * @param summary - the room summary object
+     */
     [RoomEvent.Summary]: (summary: IRoomSummary) => void;
     [ThreadEvent.New]: (thread: Thread, toStartOfTimeline: boolean) => void;
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -146,6 +146,7 @@ export enum RoomEvent {
     CurrentStateUpdated = "Room.CurrentStateUpdated",
     HistoryImportedWithinTimeline = "Room.historyImportedWithinTimeline",
     UnreadNotifications = "Room.UnreadNotifications",
+    Summary = "Room.Summary",
 }
 
 export type RoomEmittedEvents =
@@ -290,6 +291,7 @@ export type RoomEventHandlerMap = {
     [RoomEvent.HistoryImportedWithinTimeline]: (markerEvent: MatrixEvent, room: Room) => void;
     [RoomEvent.UnreadNotifications]: (unreadNotifications?: NotificationCount, threadId?: string) => void;
     [RoomEvent.TimelineRefresh]: (room: Room, eventTimelineSet: EventTimelineSet) => void;
+    [RoomEvent.Summary]: (summary: IRoomSummary) => void;
     [ThreadEvent.New]: (thread: Thread, toStartOfTimeline: boolean) => void;
     /**
      * Fires when a new poll instance is added to the room state
@@ -1499,6 +1501,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                 return userId !== this.myUserId;
             });
         }
+
+        this.emit(RoomEvent.Summary, summary);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -292,8 +292,9 @@ export type RoomEventHandlerMap = {
     [RoomEvent.UnreadNotifications]: (unreadNotifications?: NotificationCount, threadId?: string) => void;
     [RoomEvent.TimelineRefresh]: (room: Room, eventTimelineSet: EventTimelineSet) => void;
     /**
-     * Fires when the room summary is updated.
-     * See `RoomSummary` on https://spec.matrix.org/latest/client-server-api/
+     * Fires when a new room summary is returned by `/sync`.
+     *
+     * See https://spec.matrix.org/v1.8/client-server-api/#_matrixclientv3sync_roomsummary
      * for full details
      * @param summary - the room summary object
      */


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26033

We can not move the `setSummary` before adding the events to the timeline. Therefore we need a way for applications to know when the summary has been updated so they can update their logic

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Emit summary update event ([\#3687](https://github.com/matrix-org/matrix-js-sdk/pull/3687)). Fixes vector-im/element-web#26033.<!-- CHANGELOG_PREVIEW_END -->