### PR TITLE
Deprecate `MatrixClient.checkUserTrust`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2643,6 +2643,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * The cross-signing API is currently UNSTABLE and may change without notice.
      *
      * @param userId - The ID of the user to check.
+     *
+     * @deprecated Use {@link Crypto.CryptoApi.getUserVerificationStatus | `CryptoApi.getUserVerificationStatus`}
      */
     public checkUserTrust(userId: string): UserTrustLevel {
         if (!this.cryptoBackend) {

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -46,9 +46,9 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
     /**
      * Get the verification level for a given user
      *
-     * TODO: define this better
-     *
      * @param userId - user to be checked
+     *
+     * @deprecated Superceded by {@link CryptoApi#getUserVerificationStatus}.
      */
     checkUserTrust(userId: string): UserTrustLevel;
 

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -133,6 +133,14 @@ export interface CryptoApi {
     getTrustCrossSignedDevices(): boolean;
 
     /**
+     * Get the verification status of a given user.
+     *
+     * @param userId - The ID of the user to check.
+     *
+     */
+    getUserVerificationStatus(userId: string): Promise<UserVerificationStatus>;
+
+    /**
      * Get the verification status of a given device.
      *
      * @param userId - The ID of the user whose device is to be checked.
@@ -396,6 +404,46 @@ export interface BootstrapCrossSigningOpts {
      * will not be uploaded to the server (which seems like a bad thing?).
      */
     authUploadDeviceSigningKeys?: UIAuthCallback<void>;
+}
+
+/**
+ * Represents the ways in which we trust a user
+ */
+export class UserVerificationStatus {
+    public constructor(
+        private readonly crossSigningVerified: boolean,
+        private readonly crossSigningVerifiedBefore: boolean,
+        private readonly tofu: boolean,
+    ) {}
+
+    /**
+     * @returns true if this user is verified via any means
+     */
+    public isVerified(): boolean {
+        return this.isCrossSigningVerified();
+    }
+
+    /**
+     * @returns true if this user is verified via cross signing
+     */
+    public isCrossSigningVerified(): boolean {
+        return this.crossSigningVerified;
+    }
+
+    /**
+     * @returns true if we ever verified this user before (at least for
+     * the history of verifications observed by this device).
+     */
+    public wasCrossSigningVerified(): boolean {
+        return this.crossSigningVerifiedBefore;
+    }
+
+    /**
+     * @returns true if this user's key is trusted on first use
+     */
+    public isTofu(): boolean {
+        return this.tofu;
+    }
 }
 
 export class DeviceVerificationStatus {

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -30,7 +30,10 @@ import { ICryptoCallbacks } from ".";
 import { ISignatures } from "../@types/signed";
 import { CryptoStore, SecretStorePrivateKeys } from "./store/base";
 import { ServerSideSecretStorage, SecretStorageKeyDescription } from "../secret-storage";
-import { DeviceVerificationStatus } from "../crypto-api";
+import { DeviceVerificationStatus, UserVerificationStatus as UserTrustLevel } from "../crypto-api";
+
+// backwards-compatibility re-exports
+export { UserTrustLevel };
 
 const KEY_REQUEST_TIMEOUT_MS = 1000 * 60;
 
@@ -585,46 +588,6 @@ export enum CrossSigningLevel {
     MASTER = 4,
     USER_SIGNING = 2,
     SELF_SIGNING = 1,
-}
-
-/**
- * Represents the ways in which we trust a user
- */
-export class UserTrustLevel {
-    public constructor(
-        private readonly crossSigningVerified: boolean,
-        private readonly crossSigningVerifiedBefore: boolean,
-        private readonly tofu: boolean,
-    ) {}
-
-    /**
-     * @returns true if this user is verified via any means
-     */
-    public isVerified(): boolean {
-        return this.isCrossSigningVerified();
-    }
-
-    /**
-     * @returns true if this user is verified via cross signing
-     */
-    public isCrossSigningVerified(): boolean {
-        return this.crossSigningVerified;
-    }
-
-    /**
-     * @returns true if we ever verified this user before (at least for
-     * the history of verifications observed by this device).
-     */
-    public wasCrossSigningVerified(): boolean {
-        return this.crossSigningVerifiedBefore;
-    }
-
-    /**
-     * @returns true if this user's key is trusted on first use
-     */
-    public isTofu(): boolean {
-        return this.tofu;
-    }
 }
 
 /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1525,6 +1525,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
+     * Implementation of {@link CryptoApi.getUserVerificationStatus}.
+     */
+    public async getUserVerificationStatus(userId: string): Promise<UserTrustLevel> {
+        return this.checkUserTrust(userId);
+    }
+
+    /**
      * Check whether a given device is trusted.
      *
      * @param userId - The ID of the user whose device is to be checked.

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -33,7 +33,7 @@ export class CrossSigningIdentity {
         private readonly outgoingRequestProcessor: OutgoingRequestProcessor,
         private readonly secretStorage: ServerSideSecretStorage,
         /** Called if the cross signing keys are imported from the secret storage */
-        private readonly onCrossSigningKeysImport: () => void,
+        private readonly onCrossSigningKeysImport: () => Promise<void>,
     ) {}
 
     /**
@@ -96,7 +96,7 @@ export class CrossSigningIdentity {
             const request: RustSdkCryptoJs.SignatureUploadRequest = await device.verify();
             await this.outgoingRequestProcessor.makeOutgoingRequest(request);
 
-            this.onCrossSigningKeysImport();
+            await this.onCrossSigningKeysImport();
         }
 
         // TODO: we might previously have bootstrapped cross-signing but not completed uploading the keys to the


### PR DESCRIPTION
... in favour of a new `CryptoApi.getUserVerificationStatus` API

They are the same, but the new one is async.

Part of https://github.com/vector-im/element-web/issues/25752

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Deprecate `MatrixClient.checkUserTrust` ([\#3691](https://github.com/matrix-org/matrix-js-sdk/pull/3691)).<!-- CHANGELOG_PREVIEW_END -->