### PR TITLE
Legacy crypto: re-check key backup after `bootstrapSecretStorage`

### DIFF
--- a/spec/unit/crypto/secrets.spec.ts
+++ b/spec/unit/crypto/secrets.spec.ts
@@ -312,6 +312,7 @@ describe("Secrets", function () {
                 this.emit(ClientEvent.AccountData, event);
                 return {};
             };
+            bob.getKeyBackupVersion = jest.fn().mockResolvedValue(null);
 
             await bob.bootstrapCrossSigning({
                 authUploadDeviceSigningKeys: async (func) => {

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -228,6 +228,8 @@ export class EncryptionSetupOperation {
                     prefix: ClientPrefix.V3,
                 });
             }
+            // tell the backup manager to re-check the keys now that they have been (maybe) updated
+            await crypto.backupManager.checkKeyBackup();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26115.

Ideally we'd have better tests for this, but since:
 1. it's a bug in legacy crypto which we hope to kill off soon
 2. the only reason I'm fixing it now is because it broke a cypress test I'm trying to write

... I'm afraid I'm not inclined to spend a lot of time on it.

element-web notes: Fix bug which caused "Set up secure backup" flow not to actually enable  backups.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Legacy crypto: re-check key backup after `bootstrapSecretStorage` ([\#3692](https://github.com/matrix-org/matrix-js-sdk/pull/3692)). Fixes vector-im/element-web#26115.<!-- CHANGELOG_PREVIEW_END -->