### PR TITLE
Implement `getEncryptionInfoForEvent` and deprecate `getEventEncryptionInfo`

### DIFF
--- a/spec/unit/crypto.spec.ts
+++ b/spec/unit/crypto.spec.ts
@@ -181,7 +181,7 @@ describe("Crypto", function () {
 
             expect(await client.getCrypto()!.getEncryptionInfoForEvent(event)).toEqual({
                 shieldColour: EventShieldColour.RED,
-                shieldReason: EventShieldReason.UNVERIFIED_IDENTITY,
+                shieldReason: EventShieldReason.MISMATCHED_SENDER_KEY,
             });
 
             client.stopClient();

--- a/src/client.ts
+++ b/src/client.ts
@@ -2846,6 +2846,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param event - event to be checked
      * @returns The event information.
+     * @deprecated Prefer {@link CryptoApi.getEncryptionInfoForEvent | `CryptoApi.getEncryptionInfoForEvent`}.
      */
     public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
         if (!this.cryptoBackend) {

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -203,6 +203,10 @@ export interface EventDecryptionResult {
      * ed25519 key claimed by the sender of this event. See {@link MatrixEvent#getClaimedEd25519Key}.
      */
     claimedEd25519Key?: string;
+    /**
+     * Whether the keys for this event have been received via an unauthenticated source (eg via key forwards, or
+     * restored from backup)
+     */
     untrusted?: boolean;
     /**
      * The sender doesn't authorize the unverified devices to decrypt his messages

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -629,7 +629,7 @@ export interface GeneratedSecretStorageKey {
 }
 
 /**
- *  Result type of {@link CryptoApi#getEventEncryptionInfo}.
+ *  Result type of {@link CryptoApi#getEncryptionInfoForEvent}.
  */
 export interface EventEncryptionInfo {
     /** "Shield" to be shown next to this event representing its verification status */

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -91,6 +91,9 @@ import {
     BootstrapCrossSigningOpts,
     CrossSigningStatus,
     DeviceVerificationStatus,
+    EventEncryptionInfo,
+    EventShieldColour,
+    EventShieldReason,
     ImportRoomKeysOpts,
     KeyBackupCheck,
     KeyBackupInfo,
@@ -2692,6 +2695,68 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         }
 
         return ret as IEncryptedEventInfo;
+    }
+
+    /**
+     * Implementation of {@link CryptoApi.getEncryptionInfoForEvent}.
+     */
+    public async getEncryptionInfoForEvent(event: MatrixEvent): Promise<EventEncryptionInfo | null> {
+        const encryptionInfo = this.getEventEncryptionInfo(event);
+        if (!encryptionInfo.encrypted) {
+            return null;
+        }
+
+        const senderId = event.getSender();
+        if (!senderId || encryptionInfo.mismatchedSender) {
+            // something definitely wrong is going on here
+            return {
+                shieldColour: EventShieldColour.RED,
+                shieldReason: EventShieldReason.MISMATCHED_SENDER_KEY,
+            };
+        }
+
+        const userTrust = this.checkUserTrust(senderId);
+        if (!userTrust.isCrossSigningVerified()) {
+            // If the message is unauthenticated, then display a grey
+            // shield, otherwise if the user isn't cross-signed then
+            // nothing's needed
+            if (!encryptionInfo.authenticated) {
+                return {
+                    shieldColour: EventShieldColour.GREY,
+                    shieldReason: EventShieldReason.AUTHENTICITY_NOT_GUARANTEED,
+                };
+            } else {
+                return { shieldColour: EventShieldColour.NONE, shieldReason: null };
+            }
+        }
+
+        const eventSenderTrust =
+            senderId &&
+            encryptionInfo.sender &&
+            (await this.getDeviceVerificationStatus(senderId, encryptionInfo.sender.deviceId));
+
+        if (!eventSenderTrust) {
+            return {
+                shieldColour: EventShieldColour.GREY,
+                shieldReason: EventShieldReason.UNKNOWN_DEVICE,
+            };
+        }
+
+        if (!eventSenderTrust.isVerified()) {
+            return {
+                shieldColour: EventShieldColour.RED,
+                shieldReason: EventShieldReason.UNVERIFIED_IDENTITY,
+            };
+        }
+
+        if (!encryptionInfo.authenticated) {
+            return {
+                shieldColour: EventShieldColour.GREY,
+                shieldReason: EventShieldReason.AUTHENTICITY_NOT_GUARANTEED,
+            };
+        }
+
+        return { shieldColour: EventShieldColour.NONE, shieldReason: null };
     }
 
     /**

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1026,7 +1026,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * signing the public curve25519 key with the ed25519 key.
      *
      * In general, applications should not use this method directly, but should
-     * instead use MatrixClient.getEventSenderDeviceInfo.
+     * instead use {@link CryptoApi#getEncryptionInfoForEvent}.
      */
     public getClaimedEd25519Key(): string | null {
         return this.claimedEd25519Key;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -39,6 +39,8 @@ import {
     CrossSigningStatus,
     CryptoCallbacks,
     DeviceVerificationStatus,
+    EventEncryptionInfo,
+    EventShieldColour,
     GeneratedSecretStorageKey,
     ImportRoomKeyProgressData,
     ImportRoomKeysOpts,
@@ -200,6 +202,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         return await this.eventDecryptor.attemptEventDecryption(event);
     }
 
+    /**
+     * Implementation of (deprecated) {@link MatrixClient#getEventEncryptionInfo}.
+     *
+     * @param event - event to inspect
+     */
     public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
         // TODO: make this work properly. Or better, replace it.
 
@@ -700,6 +707,16 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             keyInfo,
             encodedPrivateKey,
             privateKey: key,
+        };
+    }
+
+    /**
+     * Implementation of {@link CryptoApi.getEncryptionInfoForEvent}.
+     */
+    public async getEncryptionInfoForEvent(event: MatrixEvent): Promise<EventEncryptionInfo | null> {
+        return {
+            shieldColour: EventShieldColour.NONE,
+            shieldReason: null,
         };
     }
 


### PR DESCRIPTION
Part of https://github.com/vector-im/element-web/issues/25321. This implements a new API which tells the application what sort of "shield" it should display for a given encrypted event.

We have to do it this way because the Rust crypto SDK wants to expose the information in that way (see https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_common/deserialized_responses/struct.EncryptionInfo.html, and [`VerificationState::to_shield_state_lax`](https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_common/deserialized_responses/enum.VerificationState.html#method.to_shield_state_lax).

The logic here is lifted from the current code in react-sdk, https://github.com/matrix-org/matrix-react-sdk/blob/v3.79.0/src/components/views/rooms/EventTile.tsx#L589-L637.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🦖 Deprecations
 * Implement `getEncryptionInfoForEvent` and deprecate `getEventEncryptionInfo` ([\#3693](https://github.com/matrix-org/matrix-js-sdk/pull/3693)).<!-- CHANGELOG_PREVIEW_END -->