### PR TITLE
Sync knock rooms

### DIFF
--- a/spec/integ/matrix-client-unread-notifications.spec.ts
+++ b/spec/integ/matrix-client-unread-notifications.spec.ts
@@ -376,6 +376,7 @@ describe("MatrixClient syncing", () => {
                 },
                 [Category.Leave]: {},
                 [Category.Invite]: {},
+                [Category.Knock]: {},
             },
         };
     }

--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -99,6 +99,7 @@ export function getSyncResponse(roomMembers: string[], roomId = TEST_ROOM_ID): I
             join: { [roomId]: roomResponse },
             invite: {},
             leave: {},
+            knock: {},
         },
         account_data: { events: [] },
     };

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -840,7 +840,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
-     * @returns the membership type (join | leave | invite) for the logged in user
+     * @returns the membership type (join | leave | invite | knock) for the logged in user
      */
     public getMyMembership(): string {
         return this.selfMembership ?? "leave";

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -99,6 +99,10 @@ export interface IInviteState {
     events: IStrippedState[];
 }
 
+export interface IKnockState {
+    events: IStrippedState[];
+}
+
 export interface IInvitedRoom {
     invite_state: IInviteState;
 }
@@ -109,10 +113,15 @@ export interface ILeftRoom {
     account_data: IAccountData;
 }
 
+export interface IKnockedRoom {
+    knock_state: IKnockState;
+}
+
 export interface IRooms {
     [Category.Join]: Record<string, IJoinedRoom>;
     [Category.Invite]: Record<string, IInvitedRoom>;
     [Category.Leave]: Record<string, ILeftRoom>;
+    [Category.Knock]: Record<string, IKnockedRoom>;
 }
 
 interface IPresence {
@@ -156,6 +165,7 @@ export enum Category {
     Invite = "invite",
     Leave = "leave",
     Join = "join",
+    Knock = "knock",
 }
 
 interface IRoom {
@@ -196,6 +206,7 @@ function isTaggedEvent(event: IRoomEvent): event is TaggedEvent {
 export class SyncAccumulator {
     private accountData: Record<string, IMinimalEvent> = {}; // $event_type: Object
     private inviteRooms: Record<string, IInvitedRoom> = {}; // $roomId: { ... sync 'invite' json data ... }
+    private knockRooms: Record<string, IKnockedRoom> = {}; // $roomId: { ... sync 'knock' json data ... }
     private joinRooms: { [roomId: string]: IRoom } = {};
     // the /sync token which corresponds to the last time rooms were
     // accumulated. We remember this so that any caller can obtain a
@@ -247,11 +258,17 @@ export class SyncAccumulator {
                 this.accumulateRoom(roomId, Category.Leave, syncResponse.rooms.leave[roomId], fromDatabase);
             });
         }
+        if (syncResponse.rooms.knock) {
+            Object.keys(syncResponse.rooms.knock).forEach((roomId) => {
+                this.accumulateRoom(roomId, Category.Knock, syncResponse.rooms.knock[roomId], fromDatabase);
+            });
+        }
     }
 
     private accumulateRoom(roomId: string, category: Category.Invite, data: IInvitedRoom, fromDatabase: boolean): void;
     private accumulateRoom(roomId: string, category: Category.Join, data: IJoinedRoom, fromDatabase: boolean): void;
     private accumulateRoom(roomId: string, category: Category.Leave, data: ILeftRoom, fromDatabase: boolean): void;
+    private accumulateRoom(roomId: string, category: Category.Knock, data: IKnockedRoom, fromDatabase: boolean): void;
     private accumulateRoom(roomId: string, category: Category, data: any, fromDatabase = false): void {
         // Valid /sync state transitions
         //       +--------+ <======+            1: Accept an invite
@@ -267,6 +284,10 @@ export class SyncAccumulator {
         switch (category) {
             case Category.Invite: // (5)
                 this.accumulateInviteState(roomId, data as IInvitedRoom);
+                break;
+
+            case Category.Knock:
+                this.accumulateKnockState(roomId, data as IKnockedRoom);
                 break;
 
             case Category.Join:
@@ -322,6 +343,36 @@ export class SyncAccumulator {
             }
             if (!hasAdded) {
                 currentData.invite_state.events.push(e);
+            }
+        });
+    }
+
+    private accumulateKnockState(roomId: string, data: IKnockedRoom): void {
+        if (!data.knock_state || !data.knock_state.events) {
+            // no new data
+            return;
+        }
+        if (!this.knockRooms[roomId]) {
+            this.knockRooms[roomId] = {
+                knock_state: data.knock_state,
+            };
+            return;
+        }
+        // accumulate extra keys
+        // clobber based on event type / state key
+        // We expect knock_state to be small, so just loop over the events
+        const currentData = this.knockRooms[roomId];
+        data.knock_state.events.forEach((e) => {
+            let hasAdded = false;
+            for (let i = 0; i < currentData.knock_state.events.length; i++) {
+                const current = currentData.knock_state.events[i];
+                if (current.type === e.type && current.state_key == e.state_key) {
+                    currentData.knock_state.events[i] = e; // update
+                    hasAdded = true;
+                }
+            }
+            if (!hasAdded) {
+                currentData.knock_state.events.push(e);
             }
         });
     }
@@ -485,6 +536,7 @@ export class SyncAccumulator {
         const data: IRooms = {
             join: {},
             invite: {},
+            knock: {},
             // always empty. This is set by /sync when a room was previously
             // in 'invite' or 'join'. On fresh startup, the client won't know
             // about any previous room being in 'invite' or 'join' so we can
@@ -500,6 +552,9 @@ export class SyncAccumulator {
         };
         Object.keys(this.inviteRooms).forEach((roomId) => {
             data.invite[roomId] = this.inviteRooms[roomId];
+        });
+        Object.keys(this.knockRooms).forEach((roomId) => {
+            data.knock[roomId] = this.knockRooms[roomId];
         });
         Object.keys(this.joinRooms).forEach((roomId) => {
             const roomData = this.joinRooms[roomId];


### PR DESCRIPTION
We [@nordeck](https://github.com/nordeck) are currently implementing the knock rooms behind the feature flag `feature_ask_to_join` (introduced in https://github.com/matrix-org/matrix-react-sdk/pull/11182).

This PR reads `knock` information from the `/sync` endpoint.

Epic: [https://github.com/vector-im/element-web/issues/18655](https://github.com/vector-im/element-web/issues/18655)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

Type: enhancement

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Sync knock rooms ([\#3703](https://github.com/matrix-org/matrix-js-sdk/pull/3703)). Contributed by @maheichyk.<!-- CHANGELOG_PREVIEW_END -->