### PR TITLE
Dont access indexed db when undefined

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -87,4 +87,19 @@ describe("MatrixClient.clearStores", () => {
         await matrixClient.clearStores();
         expect(await indexedDB.databases()).toHaveLength(0);
     });
+
+    it("should not fail in environments without indexedDB", async () => {
+        // eslint-disable-next-line no-global-assign
+        indexedDB = undefined!;
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+        });
+
+        await matrixClient.stopClient();
+
+        await matrixClient.clearStores();
+        // No error thrown in clearStores
+    });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1748,8 +1748,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             let indexedDB: IDBFactory;
             try {
                 indexedDB = global.indexedDB;
+                if (!indexedDB) return; // No indexedDB support
             } catch (e) {
-                // No indexeddb support
+                // No indexedDB support
                 return;
             }
             for (const dbname of [


### PR DESCRIPTION
`T-Defect`

In some environments global.indexedDB is undefined. This is checked in other places of the code but was forgotten in client.clearStores(). This leads to an error being thrown: `TypeError: Cannot read property 'deleteDatabase' of undefined`

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Dont access indexed db when undefined ([\#3707](https://github.com/matrix-org/matrix-js-sdk/pull/3707)). Contributed by @finsterwalder.<!-- CHANGELOG_PREVIEW_END -->