### PR TITLE
Explain why synthetic receipts don't mark the room as read

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2948,7 +2948,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                         // If the read receipt sent for the logged in user matches
                         // the last event of the live timeline, then we know for a fact
                         // that the user has read that message, so we can mark the room
-                        // as read and not wait for the local echo from synapse.
+                        // as read and not wait for the remote echo from synapse.
                         //
                         // This needs to be done after the initial sync as we do not want this
                         // logic to run whilst the room is being initialised

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2947,11 +2947,17 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
 
                         // If the read receipt sent for the logged in user matches
                         // the last event of the live timeline, then we know for a fact
-                        // that the user has read that message.
-                        // We can mark the room as read and not wait for the local echo
-                        // from synapse
+                        // that the user has read that message, so we can mark the room
+                        // as read and not wait for the local echo from synapse.
+                        //
                         // This needs to be done after the initial sync as we do not want this
                         // logic to run whilst the room is being initialised
+                        //
+                        // We only do this for non-synthetic receipts, because
+                        // our intention is to do this when the user really did
+                        // just read a message, not when we are e.g. receiving
+                        // an event during the sync. More explanation at:
+                        // https://github.com/matrix-org/matrix-js-sdk/issues/3684
                         if (!synthetic && this.client.isInitialSyncComplete() && userId === this.client.getUserId()) {
                             const lastEvent = receiptDestination.timeline[receiptDestination.timeline.length - 1];
                             if (lastEvent && eventId === lastEvent.getId() && userId === lastEvent.getSender()) {


### PR DESCRIPTION


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->