### PR TITLE
Element-R: Emit `CryptoEvent.UserTrustStatusChanged` when user identity is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^1.2.1",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^1.2.3-alpha.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
+++ b/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
@@ -52,7 +52,7 @@ describe("CrossSigningIdentity", () => {
                 get: jest.fn(),
             } as unknown as Mocked<ServerSideSecretStorage>;
 
-            crossSigning = new CrossSigningIdentity(olmMachine, outgoingRequestProcessor, secretStorage, jest.fn());
+            crossSigning = new CrossSigningIdentity(olmMachine, outgoingRequestProcessor, secretStorage);
         });
 
         it("should do nothing if keys are present on-device and in secret storage", async () => {

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -32,8 +32,6 @@ export class CrossSigningIdentity {
         private readonly olmMachine: OlmMachine,
         private readonly outgoingRequestProcessor: OutgoingRequestProcessor,
         private readonly secretStorage: ServerSideSecretStorage,
-        /** Called if the cross signing keys are imported from the secret storage */
-        private readonly onCrossSigningKeysImport: () => Promise<void>,
     ) {}
 
     /**
@@ -95,8 +93,6 @@ export class CrossSigningIdentity {
             // Sign the device with our cross-signing key and upload the signature
             const request: RustSdkCryptoJs.SignatureUploadRequest = await device.verify();
             await this.outgoingRequestProcessor.makeOutgoingRequest(request);
-
-            await this.onCrossSigningKeysImport();
         }
 
         // TODO: we might previously have bootstrapped cross-signing but not completed uploading the keys to the

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -65,6 +65,9 @@ export async function initRustCrypto(
     await olmMachine.registerRoomKeyUpdatedCallback((sessions: RustSdkCryptoJs.RoomKeyInfo[]) =>
         rustCrypto.onRoomKeysUpdated(sessions),
     );
+    await olmMachine.registerUserIdentityUpdatedCallback((userId: RustSdkCryptoJs.UserId) =>
+        rustCrypto.onUserIdentityUpdated(userId),
+    );
 
     // Tell the OlmMachine to think about its outgoing requests before we hand control back to the application.
     //

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1250,6 +1250,19 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     }
 
     /**
+     * Callback for `OlmMachine.registerUserIdentityUpdatedCallback`
+     *
+     * Called by the rust-sdk whenever there is an update to any user's cross-signing status. We re-check their trust
+     * status and emit a `UserTrustStatusChanged` event.
+     *
+     * @param userId - the user with the updated identity
+     */
+    public async onUserIdentityUpdated(userId: RustSdkCryptoJs.UserId): Promise<void> {
+        const newVerification = await this.getUserVerificationStatus(userId.toString());
+        this.emit(CryptoEvent.UserTrustStatusChanged, userId.toString(), newVerification);
+    }
+
+    /**
      * Handle a live event received via /sync.
      * See {@link ClientEventHandlerMap#event}
      *
@@ -1457,7 +1470,7 @@ type RustCryptoEventMap = {
     [CryptoEvent.VerificationRequestReceived]: (request: VerificationRequest) => void;
 
     /**
-     * Fires when the cross signing keys are imported during {@link CryptoApi#bootstrapCrossSigning}
+     * Fires when the trust status of a user changes.
      */
     [CryptoEvent.UserTrustStatusChanged]: (userId: string, userTrustLevel: UserVerificationStatus) => void;
 } & RustBackupCryptoEventMap;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -136,17 +136,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             CryptoEvent.KeyBackupFailed,
         ]);
 
-        // Fire if the cross signing keys are imported from the secret storage
-        const onCrossSigningKeysImport = async (): Promise<void> => {
-            const newVerification = await this.getUserVerificationStatus(this.userId);
-            this.emit(CryptoEvent.UserTrustStatusChanged, this.userId, newVerification);
-        };
-        this.crossSigningIdentity = new CrossSigningIdentity(
-            olmMachine,
-            this.outgoingRequestProcessor,
-            secretStorage,
-            onCrossSigningKeysImport,
-        );
+        this.crossSigningIdentity = new CrossSigningIdentity(olmMachine, this.outgoingRequestProcessor, secretStorage);
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,10 +1537,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-1.2.1.tgz#5b546c8a0e53b614f10b77b3b649818aed9d0db1"
-  integrity sha512-DCb7Q83PCQK0uav5vB3KNV/hJPlxAhT/ddar+VHz2kC39hMLKGzWYVhprpLYVcavaE/6OX+Q/xFkAoV/3QtUHQ==
+"@matrix-org/matrix-sdk-crypto-wasm@^1.2.3-alpha.0":
+  version "1.2.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-1.2.3-alpha.0.tgz#f6f93e3ee44c5f1e0e255badd26f4a7d3fb1dab8"
+  integrity sha512-BFLqfq/WbYZ+83r4UWLhwtBYvTp5DKTHNeWUSDBVvudFtqBvkntNAAUz+xmhmO1XkyNm+sBaElxF8IS9S8zdww==
 
 "@matrix-org/olm@https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz":
   version "3.2.14"


### PR DESCRIPTION
Fixes https://github.com/vector-im/crypto-internal/issues/148

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->