### PR TITLE
Element-R: use the pickleKey to encrypt the crypto store

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -41,7 +41,7 @@ describe("MatrixClient.initRustCrypto", () => {
         await expect(() => unknownDeviceClient.initRustCrypto()).rejects.toThrow("unknown deviceId");
     });
 
-    it("should create the indexed dbs", async () => {
+    it("should create the indexed db", async () => {
         const matrixClient = createClient({
             baseUrl: "http://test.server",
             userId: "@alice:localhost",
@@ -53,7 +53,25 @@ describe("MatrixClient.initRustCrypto", () => {
 
         await matrixClient.initRustCrypto();
 
-        // should have two dbs now
+        // should have an indexed db now
+        const databaseNames = (await indexedDB.databases()).map((db) => db.name);
+        expect(databaseNames).toEqual(expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto"]));
+    });
+
+    it("should create the meta db if given a pickleKey", async () => {
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+            pickleKey: "testKey",
+        });
+
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
+        await matrixClient.initRustCrypto();
+
+        // should have two indexed dbs now
         const databaseNames = (await indexedDB.databases()).map((db) => db.name);
         expect(databaseNames).toEqual(
             expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto", "matrix-js-sdk::matrix-sdk-crypto-meta"]),
@@ -78,6 +96,7 @@ describe("MatrixClient.clearStores", () => {
             baseUrl: "http://test.server",
             userId: "@alice:localhost",
             deviceId: "aliceDevice",
+            pickleKey: "testKey",
         });
 
         await matrixClient.initRustCrypto();

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -54,6 +54,7 @@ const TEST_DEVICE_ID = "TEST_DEVICE";
 
 afterEach(() => {
     fetchMock.reset();
+    jest.restoreAllMocks();
 });
 
 describe("initRustCrypto", () => {
@@ -445,10 +446,6 @@ describe("RustCrypto", () => {
                 {} as ServerSideSecretStorage,
                 {} as CryptoCallbacks,
             );
-        });
-
-        afterEach(() => {
-            jest.restoreAllMocks();
         });
 
         async function makeEncryptedEvent(): Promise<MatrixEvent> {

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -32,7 +32,10 @@ import { ICryptoCallbacks } from "../crypto";
  * @param secretStorage - Interface to server-side secret storage.
  * @param cryptoCallbacks - Crypto callbacks provided by the application
  * @param storePrefix - the prefix to use on the indexeddbs created by rust-crypto.
- *     If unset, a memory store will be used.
+ *     If `null`, a memory store will be used.
+ * @param storePassphrase - a passphrase to use to encrypt the indexeddbs created by rust-crypto.
+ *     Ignored if `storePrefix` is null. If this is `undefined` (and `storePrefix` is not null), the indexeddbs
+ *     will be unencrypted.
  *
  * @internal
  */
@@ -43,6 +46,7 @@ export async function initRustCrypto(
     secretStorage: ServerSideSecretStorage,
     cryptoCallbacks: ICryptoCallbacks,
     storePrefix: string | null,
+    storePassphrase: string | undefined,
 ): Promise<RustCrypto> {
     // initialise the rust matrix-sdk-crypto-wasm, if it hasn't already been done
     await RustSdkCryptoJs.initAsync();
@@ -59,7 +63,7 @@ export async function initRustCrypto(
         u,
         d,
         storePrefix ?? undefined,
-        (storePrefix && "test pass") ?? undefined,
+        (storePrefix && storePassphrase) ?? undefined,
     );
     const rustCrypto = new RustCrypto(olmMachine, http, userId, deviceId, secretStorage, cryptoCallbacks);
     await olmMachine.registerRoomKeyUpdatedCallback((sessions: RustSdkCryptoJs.RoomKeyInfo[]) =>


### PR DESCRIPTION
`pickleKey` is a passphrase set by the application for this express purpose.

Fixes https://github.com/vector-im/element-web/issues/24967

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->