### PR TITLE
Add github action to mark cypress tests skipped

### DIFF
--- a/.github/workflows/cypress-skipped.yml
+++ b/.github/workflows/cypress-skipped.yml
@@ -1,0 +1,29 @@
+# We only want to run the cypress tests in the merge queue (to save CI time),
+# but we do want to make it a required check for the merge queue.
+#
+# Unfortunately, github doesn't distinguish between "checks needed for branch
+# protection" (ie, the things that must pass before the PR will even be added
+# to the merge queue) and "checks needed in the merge queue". We just have to add
+# the check to the branch protection list.
+#
+# Ergo, if we know we're not going to run the cypress tests, we need to add a
+# passing status check manually.
+
+name: Mark cypress skipped
+on:
+    pull_request: {}
+permissions:
+    statuses: write
+jobs:
+    mark_skipped:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+              with:
+                  authToken: "${{ secrets.GITHUB_TOKEN }}"
+                  state: success
+                  description: Cypress skipped
+                  context: "matrix-react-sdk Cypress End to End Tests / cypress"
+                  sha: "${{ github.event.pull_request.head.sha }}"
+                  # link to this file
+                  target_url: "${{ github.event.pull_request.head.repo.html_url }}/blob/${{ github.event.pull_request.head.ref }}/.github/workflows/cypress-skipped.yml"


### PR DESCRIPTION
Hopefully the comments explain this.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->