### PR TITLE
Add membershipID to call memberships

### DIFF
--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -29,6 +29,7 @@ export interface CallMembershipData {
     created_ts?: number;
     expires: number;
     foci_active?: Focus[];
+    membershipID: string;
 }
 
 export class CallMembership {
@@ -62,6 +63,10 @@ export class CallMembership {
 
     public get scope(): CallScope {
         return this.data.scope;
+    }
+
+    public get membershipID(): string {
+        return this.data.membershipID;
     }
 
     public createdTs(): number {


### PR DESCRIPTION
This allows us to recognise easily when a membership is from some previous sessions rather than our own and therefore ignore it (see comment for more).

This was causing us to see existing, expired membership events and bump the expiry on them rather than send a new membership. This might have been okay if we bumped them enough to actually make them un-expired, but it's a fresh session so semanticly we want to post a fresh membership rather than resurrecting a previous, expired membership.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
