### PR TITLE
Add explicit arguments to LocalEchoUpdated to prevent re-emit inserting source as argument in ambiguous position

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1473,7 +1473,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.threadNotifications.clear();
         }
-        this.emit(RoomEvent.UnreadNotifications);
+        this.emit(RoomEvent.UnreadNotifications, undefined);
     }
 
     /**
@@ -2514,7 +2514,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             }
         }
 
-        this.emit(RoomEvent.LocalEchoUpdated, event, this);
+        this.emit(RoomEvent.LocalEchoUpdated, event, this, undefined, undefined);
     }
 
     /**


### PR DESCRIPTION
## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Re-emitting events inserts the source as an extra argument after other arguments
https://github.com/matrix-org/matrix-js-sdk/blob/9b2f22692ec35a804c6214f6f6691f04868163e6/src/ReEmitter.ts#L40-L42
Some handlers have optional arguments at the end of their signature
https://github.com/matrix-org/matrix-js-sdk/blob/6385c9c0dab8fe67bd3a8992a4777f243fdd1b68/src/models/room.ts#L283-L288
and are called with those optional arguments omitted
https://github.com/matrix-org/matrix-js-sdk/blob/6385c9c0dab8fe67bd3a8992a4777f243fdd1b68/src/models/room.ts#L2517
When a handler receives this re-emitted event, the expected `oldEventId` will instead be the source `Room`.
```ts
client.addListener(
  RoomEvent.LocalEchoUpdated, 
  (event: MatrixEvent, room: Room, oldEventId?: string) => {
    // will be true during the `emit` linked above, making types a lie
    assert(oldEventId instanceof Room); 
  })
```
---

I don't think this PR is a robust solution – new code that omits args from a re-emitted `emit` will cause a regression. I also doubt the changes in this PR contain all the problem areas – these are just the ones I was personally hitting.

I don't see how to robustly fix this without changing re-emit to no longer provide the source as an extra argument. 🤷 

I thought about changing all of the event handlers to pass `null` instead of `undefined` in their args, which would force callers to provide all args and thus avoid regression; but this would not work for handlers where `null` has meaning for the optional argument (*edit*: I thought I saw a concrete example of this in the codebase, but I was wrong – maybe this would not break anything?). This change would look like:
```diff
--- a/src/client.ts
+++ b/src/client.ts
@@ -1076,7 +1076,7 @@ export type ClientEventHandlerMap = {
      * });
      * ```
      */
-    [ClientEvent.Sync]: (state: SyncState, lastState: SyncState | null, data?: ISyncStateData) => void;
+    [ClientEvent.Sync]: (state: SyncState, lastState: SyncState | null, data: ISyncStateData | null) => void;
     /**
      * Fires whenever the SDK receives a new event.
      * <p>
```

Signed-off-by: David Lee <david.isaac.lee@gmail.com>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->