### PR TITLE
Prevent optional arguments in existing re-emitted event handlers

### DIFF
--- a/spec/unit/ToDeviceMessageQueue.spec.ts
+++ b/spec/unit/ToDeviceMessageQueue.spec.ts
@@ -31,7 +31,7 @@ describe("onResumedSync", () => {
         onSendToDeviceSuccess = () => {};
         resumeSync = (newState, oldState) => {
             shouldFailSendToDevice = false;
-            mockClient.emit(ClientEvent.Sync, newState, oldState);
+            mockClient.emit(ClientEvent.Sync, newState, oldState, undefined);
         };
 
         store = new StubStore();

--- a/spec/unit/event-timeline-set.spec.ts
+++ b/spec/unit/event-timeline-set.spec.ts
@@ -303,8 +303,8 @@ describe("EventTimelineSet", () => {
                     messageEventIsDecryptionFailureSpy.mockReturnValue(true);
                     replyEventIsDecryptionFailureSpy.mockReturnValue(true);
 
-                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent);
-                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent);
+                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent, undefined);
+                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent, undefined);
 
                     // simulate decryption
                     messageEventIsDecryptionFailureSpy.mockReturnValue(false);
@@ -313,8 +313,8 @@ describe("EventTimelineSet", () => {
                     messageEventShouldAttemptDecryptionSpy.mockReturnValue(false);
                     replyEventShouldAttemptDecryptionSpy.mockReturnValue(false);
 
-                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent);
-                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent);
+                    messageEvent.emit(MatrixEventEvent.Decrypted, messageEvent, undefined);
+                    replyEvent.emit(MatrixEventEvent.Decrypted, replyEvent, undefined);
                 });
 
                 itShouldReturnTheRelatedEvents();

--- a/spec/unit/room-state.spec.ts
+++ b/spec/unit/room-state.spec.ts
@@ -1035,7 +1035,7 @@ describe("RoomState", function () {
 
                 // this event is a message after decryption
                 decryptingRelatedEvent.event.type = EventType.RoomMessage;
-                decryptingRelatedEvent.emit(MatrixEventEvent.Decrypted, decryptingRelatedEvent);
+                decryptingRelatedEvent.emit(MatrixEventEvent.Decrypted, decryptingRelatedEvent, undefined);
 
                 expect(addLocationsSpy).not.toHaveBeenCalled();
             });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3542,13 +3542,13 @@ describe("Room", function () {
             expect(room.polls.get(pollStartEventId)).toBeUndefined();
 
             // now emit a Decrypted event but keep the decryption failure
-            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent);
+            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent, undefined);
             // still do not expect a poll to show up for the room
             expect(room.polls.get(pollStartEventId)).toBeUndefined();
 
             // clear decryption failure and emit a Decrypted event again
             isDecryptionFailureSpy.mockRestore();
-            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent);
+            pollStartEvent.emit(MatrixEventEvent.Decrypted, pollStartEvent, undefined);
 
             // the poll should now show up in the room's polls
             const poll = room.polls.get(pollStartEventId);

--- a/spec/unit/webrtc/callEventHandler.spec.ts
+++ b/spec/unit/webrtc/callEventHandler.spec.ts
@@ -56,7 +56,7 @@ describe("CallEventHandler", () => {
 
     const sync = async () => {
         client.getSyncState = jest.fn().mockReturnValue(SyncState.Syncing);
-        client.emit(ClientEvent.Sync, SyncState.Syncing, SyncState.Prepared);
+        client.emit(ClientEvent.Sync, SyncState.Syncing, SyncState.Prepared, undefined);
 
         // We can't await the event processing
         await sleep(10);
@@ -153,7 +153,7 @@ describe("CallEventHandler", () => {
         client.on(CallEventHandlerEvent.Incoming, incomingCallEmitted);
 
         client.getSyncState = jest.fn().mockReturnValue(SyncState.Syncing);
-        client.emit(ClientEvent.Sync, SyncState.Syncing, null);
+        client.emit(ClientEvent.Sync, SyncState.Syncing, null, undefined);
 
         expect(incomingCallEmitted).not.toHaveBeenCalled();
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1086,7 +1086,7 @@ export type ClientEventHandlerMap = {
      * });
      * ```
      */
-    [ClientEvent.Sync]: (state: SyncState, lastState: SyncState | null, data?: ISyncStateData) => void;
+    [ClientEvent.Sync]: (state: SyncState, lastState: SyncState | null, data: ISyncStateData | undefined) => void;
     /**
      * Fires whenever the SDK receives a new event.
      * <p>

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -305,7 +305,7 @@ export class RoomWidgetClient extends MatrixClient {
     private setSyncState(state: SyncState): void {
         const oldState = this.syncState;
         this.syncState = state;
-        this.emit(ClientEvent.Sync, state, oldState);
+        this.emit(ClientEvent.Sync, state, oldState, undefined);
     }
 
     private async ack(ev: CustomEvent<IWidgetApiRequest>): Promise<void> {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -226,7 +226,7 @@ export type MatrixEventHandlerMap = {
      * @param event - The matrix event which has been decrypted
      * @param err - The error that occurred during decryption, or `undefined` if no error occurred.
      */
-    [MatrixEventEvent.Decrypted]: (event: MatrixEvent, err?: Error) => void;
+    [MatrixEventEvent.Decrypted]: (event: MatrixEvent, err: Error | undefined) => void;
     [MatrixEventEvent.BeforeRedaction]: (event: MatrixEvent, redactionEvent: MatrixEvent) => void;
     [MatrixEventEvent.VisibilityChange]: (event: MatrixEvent, visible: boolean) => void;
     [MatrixEventEvent.LocalEventIdReplaced]: (event: MatrixEvent) => void;

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -43,7 +43,7 @@ export type RoomMemberEventHandlerMap = {
      * });
      * ```
      */
-    [RoomMemberEvent.Membership]: (event: MatrixEvent, member: RoomMember, oldMembership?: string) => void;
+    [RoomMemberEvent.Membership]: (event: MatrixEvent, member: RoomMember, oldMembership: string | undefined) => void;
     /**
      * Fires whenever any room member's name changes.
      * @param event - The matrix event which caused this event to fire.

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -122,7 +122,7 @@ export type RoomStateEventHandlerMap = {
     [RoomStateEvent.NewMember]: (event: MatrixEvent, state: RoomState, member: RoomMember) => void;
     [RoomStateEvent.Update]: (state: RoomState) => void;
     [RoomStateEvent.BeaconLiveness]: (state: RoomState, hasLiveBeacons: boolean) => void;
-    [RoomStateEvent.Marker]: (event: MatrixEvent, setStateOptions?: IMarkerFoundOptions) => void;
+    [RoomStateEvent.Marker]: (event: MatrixEvent, setStateOptions: IMarkerFoundOptions | undefined) => void;
     [BeaconEvent.New]: (event: MatrixEvent, beacon: Beacon) => void;
 };
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -175,7 +175,7 @@ export type RoomEventHandlerMap = {
      * @param membership - The new membership value
      * @param prevMembership - The previous membership value
      */
-    [RoomEvent.MyMembership]: (room: Room, membership: string, prevMembership?: string) => void;
+    [RoomEvent.MyMembership]: (room: Room, membership: string, prevMembership: string | undefined) => void;
     /**
      * Fires whenever a room's tags are updated.
      * @param event - The tags event
@@ -204,7 +204,7 @@ export type RoomEventHandlerMap = {
      * });
      * ```
      */
-    [RoomEvent.AccountData]: (event: MatrixEvent, room: Room, lastEvent?: MatrixEvent) => void;
+    [RoomEvent.AccountData]: (event: MatrixEvent, room: Room, lastEvent: MatrixEvent | undefined) => void;
     /**
      * Fires whenever a receipt is received for a room
      * @param event - The receipt event
@@ -283,13 +283,16 @@ export type RoomEventHandlerMap = {
     [RoomEvent.LocalEchoUpdated]: (
         event: MatrixEvent,
         room: Room,
-        oldEventId?: string,
-        oldStatus?: EventStatus | null,
+        oldEventId: string | undefined,
+        oldStatus: EventStatus | null | undefined,
     ) => void;
     [RoomEvent.OldStateUpdated]: (room: Room, previousRoomState: RoomState, roomState: RoomState) => void;
     [RoomEvent.CurrentStateUpdated]: (room: Room, previousRoomState: RoomState, roomState: RoomState) => void;
     [RoomEvent.HistoryImportedWithinTimeline]: (markerEvent: MatrixEvent, room: Room) => void;
-    [RoomEvent.UnreadNotifications]: (unreadNotifications?: NotificationCount, threadId?: string) => void;
+    [RoomEvent.UnreadNotifications]: (
+        unreadNotifications: NotificationCount | undefined,
+        threadId: string | undefined,
+    ) => void;
     [RoomEvent.TimelineRefresh]: (room: Room, eventTimelineSet: EventTimelineSet) => void;
     /**
      * Fires when a new room summary is returned by `/sync`.

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1476,7 +1476,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.threadNotifications.clear();
         }
-        this.emit(RoomEvent.UnreadNotifications);
+        this.emit(RoomEvent.UnreadNotifications, undefined, undefined);
     }
 
     /**
@@ -1486,7 +1486,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public setUnreadNotificationCount(type: NotificationCountType, count: number): void {
         this.notificationCounts[type] = count;
-        this.emit(RoomEvent.UnreadNotifications, this.notificationCounts);
+        this.emit(RoomEvent.UnreadNotifications, this.notificationCounts, undefined);
     }
 
     public setUnread(type: NotificationCountType, count: number): void {
@@ -2517,7 +2517,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             }
         }
 
-        this.emit(RoomEvent.LocalEchoUpdated, event, this);
+        this.emit(RoomEvent.LocalEchoUpdated, event, this, undefined, undefined);
     }
 
     /**

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -77,8 +77,8 @@ export type GroupCallEventHandlerMap = {
     [GroupCallEvent.ScreenshareFeedsChanged]: (feeds: CallFeed[]) => void;
     [GroupCallEvent.LocalScreenshareStateChanged]: (
         isScreensharing: boolean,
-        feed?: CallFeed,
-        sourceId?: string,
+        feed: CallFeed | undefined,
+        sourceId: string | undefined,
     ) => void;
     [GroupCallEvent.LocalMuteStateChanged]: (audioMuted: boolean, videoMuted: boolean) => void;
     [GroupCallEvent.ParticipantsChanged]: (participants: Map<RoomMember, Map<string, ParticipantState>>) => void;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

This is a redo of https://github.com/matrix-org/matrix-js-sdk/pull/3748

## Motivation

Re-emitting events inserts the source as an extra argument after other arguments
https://github.com/matrix-org/matrix-js-sdk/blob/9b2f22692ec35a804c6214f6f6691f04868163e6/src/ReEmitter.ts#L40-L42
Some handlers have optional arguments at the end of their signature
https://github.com/matrix-org/matrix-js-sdk/blob/6385c9c0dab8fe67bd3a8992a4777f243fdd1b68/src/models/room.ts#L283-L288
and are called with those optional arguments omitted
https://github.com/matrix-org/matrix-js-sdk/blob/6385c9c0dab8fe67bd3a8992a4777f243fdd1b68/src/models/room.ts#L2517
When a handler receives this re-emitted event, the expected `oldEventId` will instead be the source `Room`.
```ts
client.addListener(
  RoomEvent.LocalEchoUpdated, 
  (event: MatrixEvent, room: Room, oldEventId?: string) => {
    // will be true during the `emit` linked above, making types a lie
    assert(oldEventId instanceof Room); 
  })
```

## Changes
- [6f3c577](https://github.com/matrix-org/matrix-js-sdk/pull/3751/commits/6f3c577e1c900215540d41f8c997cebdf519def5) Removed optional arguments from all type signatures of event handlers for re-emitted events. (I did this by searching the codebase for `ReEmitter` and `TypedReEmitter`, and then looking through all of the event handler maps referenced in the type param.)
- [59ea6e7](https://github.com/matrix-org/matrix-js-sdk/pull/3751/commits/59ea6e7feef6e14002cfb0ed97bba53fc4602328) Updated call sites of all event handlers to match new types. (I did this by running `yarn lint:types` then fixing all the type errors caused by the previous commit.)

I think this is more comprehensive and _more_ robust than https://github.com/matrix-org/matrix-js-sdk/pull/3748, but this can easily regress if someone adds or modifies a re-emitted event handler signature to have an optional argument. I can't think of a solution for this (only thought is some lint rule, but I'm not sure if eslint would be able to know "this is an event handler signature").

Signed-off-by: David Lee <david.isaac.lee@gmail.com>


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Prevent optional arguments in existing re-emitted event handlers ([\#3751](https://github.com/matrix-org/matrix-js-sdk/pull/3751)). Contributed by @davidisaaclee.<!-- CHANGELOG_PREVIEW_END -->