### PR TITLE
Remove IsUserMention and IsRoomMention from DEFAULT_OVERRIDE_RULES

### DIFF
--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -72,36 +72,6 @@ const DEFAULT_OVERRIDE_RULES: IPushRule[] = [
         actions: [PushRuleActionName.DontNotify],
     },
     {
-        rule_id: RuleId.IsUserMention,
-        default: true,
-        enabled: true,
-        conditions: [
-            {
-                kind: ConditionKind.EventPropertyContains,
-                key: "content.m\\.mentions.user_ids",
-                value: "", // The user ID is dynamically added in rewriteDefaultRules.
-            },
-        ],
-        actions: [PushRuleActionName.Notify, { set_tweak: TweakName.Highlight }],
-    },
-    {
-        rule_id: RuleId.IsRoomMention,
-        default: true,
-        enabled: true,
-        conditions: [
-            {
-                kind: ConditionKind.EventPropertyIs,
-                key: "content.m\\.mentions.room",
-                value: true,
-            },
-            {
-                kind: ConditionKind.SenderNotificationPermission,
-                key: "room",
-            },
-        ],
-        actions: [PushRuleActionName.Notify, { set_tweak: TweakName.Highlight }],
-    },
-    {
         // For homeservers which don't support MSC3786 yet
         rule_id: ".org.matrix.msc3786.rule.room.server_acl",
         default: true,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

For https://github.com/vector-im/element-web/issues/26227

Stop overriding intentional mentions rules, so that users can set their preferences

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Remove IsUserMention and IsRoomMention from DEFAULT_OVERRIDE_RULES ([\#3752](https://github.com/matrix-org/matrix-js-sdk/pull/3752)). Contributed by @kerryarchibald.<!-- CHANGELOG_PREVIEW_END -->