### PR TITLE
Use globalThis instead of global

### DIFF
--- a/spec/olm-loader.ts
+++ b/spec/olm-loader.ts
@@ -20,7 +20,7 @@ import { logger } from "../src/logger";
 // try to load the olm library.
 try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    global.Olm = require("@matrix-org/olm");
+    globalThis.Olm = require("@matrix-org/olm");
     logger.log("loaded libolm");
 } catch (e) {
     logger.warn("unable to run crypto tests: libolm not available", e);

--- a/src/browser-index.ts
+++ b/src/browser-index.ts
@@ -24,15 +24,15 @@ declare global {
     /* eslint-enable no-var */
 }
 
-if (global.__js_sdk_entrypoint) {
+if (globalThis.__js_sdk_entrypoint) {
     throw new Error("Multiple matrix-js-sdk entrypoints detected!");
 }
-global.__js_sdk_entrypoint = true;
+globalThis.__js_sdk_entrypoint = true;
 
 // just *accessing* indexedDB throws an exception in firefox with indexeddb disabled.
 let indexedDB: IDBFactory | undefined;
 try {
-    indexedDB = global.indexedDB;
+    indexedDB = globalThis.indexedDB;
 } catch (e) {}
 
 // if our browser (appears to) support indexeddb, use an indexeddb crypto store.
@@ -44,4 +44,4 @@ if (indexedDB) {
 // It's awkward, but required.
 export * from "./matrix";
 export default matrixcs; // keep export for browserify package deps
-global.matrixcs = matrixcs;
+globalThis.matrixcs = matrixcs;

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 import { logger } from "../logger";
 
-export let crypto = global.window?.crypto;
-export let subtleCrypto = global.window?.crypto?.subtle ?? global.window?.crypto?.webkitSubtle;
-export let TextEncoder = global.window?.TextEncoder;
+export let crypto = globalThis.window?.crypto;
+export let subtleCrypto = globalThis.window?.crypto?.subtle ?? global.window?.crypto?.webkitSubtle;
+export let TextEncoder = globalThis.window?.TextEncoder;
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 if (!crypto) {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -134,7 +134,7 @@ export const verificationMethods = {
 export type VerificationMethod = keyof typeof verificationMethods | string;
 
 export function isCryptoAvailable(): boolean {
-    return Boolean(global.Olm);
+    return Boolean(globalThis.Olm);
 }
 
 // minimum time between attempting to unwedge an Olm session, if we succeeded


### PR DESCRIPTION
Switches use of `global` to `globalThis`, which is better supported when building with modern build tools like Vite.

Refs #2903

Exiting tests pass, but to actually test this one needs to include the SDK in an app built with Vite. I've tested against our own, private repo and it works, but if we really need a sample repo for an integration test I could do that.

Signed-off-by: Damon Vestervand <damon@beyondwork.ai>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [X] Tests written for new code (and old code if feasible)
-   [X] Linter and other CI checks pass
-   [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))



<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->