### PR TITLE
Remove the dist script since we no longer have a browserify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "scripts": {
         "prepublishOnly": "yarn build",
         "start": "echo THIS IS FOR LEGACY PURPOSES ONLY. && babel src -w -s -d lib --verbose --extensions \".ts,.js\"",
-        "dist": "echo 'This is for the release script so it can make assets (browser bundle).' && yarn build",
-        "clean": "rimraf lib dist",
+        "clean": "rimraf lib",
         "build": "yarn build:dev",
         "build:dev": "yarn clean && git rev-parse HEAD > git-revision.txt && yarn build:compile && yarn build:types",
         "build:types": "tsc -p tsconfig-build.json --emitDeclarationOnly",
@@ -40,7 +39,6 @@
     "author": "matrix.org",
     "license": "Apache-2.0",
     "files": [
-        "dist",
         "lib",
         "src",
         "git-revision.txt",


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-js-sdk/pull/3759 we removed the browserify builds.

This removes the `dist` script (and handling of the `dist/` directory) from package.json.

This should persuade our `release.sh` script to make a release without failing because there are no artifacts created in the `dist/` directory.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->