### PR TITLE
Remove the dist script since we no longer have a browserify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "scripts": {
         "prepublishOnly": "yarn build",
         "start": "echo THIS IS FOR LEGACY PURPOSES ONLY. && babel src -w -s -d lib --verbose --extensions \".ts,.js\"",
-        "dist": "echo 'This is for the release script so it can make assets (browser bundle).' && yarn build",
-        "clean": "rimraf lib dist",
+        "clean": "rimraf lib",
         "build": "yarn build:dev",
         "build:dev": "yarn clean && git rev-parse HEAD > git-revision.txt && yarn build:compile && yarn build:types",
         "build:types": "tsc -p tsconfig-build.json --emitDeclarationOnly",
@@ -40,7 +39,6 @@
     "author": "matrix.org",
     "license": "Apache-2.0",
     "files": [
-        "dist",
         "lib",
         "src",
         "git-revision.txt",


### PR DESCRIPTION
Manual backport of https://github.com/matrix-org/matrix-js-sdk/pull/3771 to fix the release process.