### PR TITLE
Element-R: Avoid errors in `VerificationRequest.generateQRCode` when QR code is unavailable

### DIFF
--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -392,7 +392,10 @@ export class RustVerificationRequest
      * Implementation of {@link Crypto.VerificationRequest#generateQRCode}.
      */
     public async generateQRCode(): Promise<Buffer | undefined> {
-        const innerVerifier: RustSdkCryptoJs.Qr = await this.inner.generateQrCode();
+        const innerVerifier: RustSdkCryptoJs.Qr | undefined = await this.inner.generateQrCode();
+        // If we are unable to generate a QRCode, we return undefined
+        if (!innerVerifier) return;
+
         return Buffer.from(innerVerifier.toBytes());
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Fixes https://github.com/vector-im/element-web/issues/26300
Update doc https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/35

Crash when https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/components/views/right_panel/VerificationPanel.tsx#L432 is executed when a device doesn't support QR Code.

SDK Bindings https://matrix-org.github.io/matrix-rust-sdk-crypto-wasm/classes/VerificationRequest.html#generateQrCode documentation misses that https://github.com/matrix-org/matrix-rust-sdk/blob/main/crates/matrix-sdk-crypto/src/verification/requests.rs#L395 can return `None` 


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Element-R: Avoid errors in `VerificationRequest.generateQRCode` when QR code is unavailable ([\#3779](https://github.com/matrix-org/matrix-js-sdk/pull/3779)). Fixes vector-im/element-web#26300. Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->