### PR TITLE
Element-R: don't log every HTTP request

### DIFF
--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -164,13 +164,6 @@ export class OutgoingRequestProcessor {
             prefix: "",
         };
 
-        try {
-            const response = await this.http.authedRequest<string>(method, path, queryParams, body, opts);
-            logger.info(`rust-crypto: successfully made HTTP request: ${method} ${path}`);
-            return response;
-        } catch (e) {
-            logger.warn(`rust-crypto: error making HTTP request: ${method} ${path}: ${e}`);
-            throw e;
-        }
+        return await this.http.authedRequest<string>(method, path, queryParams, body, opts);
     }
 }


### PR DESCRIPTION
Since #3485, we log every request anyway, so there's no need to log twice.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->