### PR TITLE
Warn when we drop an event trying to add it to a thread

### DIFF
--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -367,6 +367,26 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             this.timelineSet.relations?.aggregateParentEvent(event);
             this.timelineSet.relations?.aggregateChildEvent(event, this.timelineSet);
             return;
+        } else if (this.initialEventsFetched) {
+            // If initial events have not been fetched, we are OK to throw away
+            // this event, because we are about to fetch all the events for this
+            // thread from the server.
+            //
+            // If not, this looks like a bug - we should always add the event to
+            // the thread. See https://github.com/vector-im/element-web/issues/26254
+            logger.warn(
+                `Not adding event ${event.getId()} to thread timeline!
+                isNewestReply=${isNewestReply}
+                event.localTimestamp=${event.localTimestamp}
+                !!lastReply=${!!lastReply}
+                lastReply?.getId()=${lastReply?.getId()}
+                lastReply?.localTimestamp=${lastReply?.localTimestamp}
+                toStartOfTimeline=${toStartOfTimeline}
+                Thread.hasServerSideSupport=${Thread.hasServerSideSupport}
+                event.isRelation(RelationType.Annotation)=${event.isRelation(RelationType.Annotation)}
+                event.isRelation(RelationType.Replace)=${event.isRelation(RelationType.Replace)}
+                `,
+            );
         }
 
         if (


### PR DESCRIPTION
Added to try and help debug https://github.com/vector-im/element-web/issues/26254


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->