### PR TITLE
Add events to the thread even if they appear to be out of order

### DIFF
--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -430,22 +430,19 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             // If initial events have not been fetched, we are OK to throw away
             // this event, because we are about to fetch all the events for this
             // thread from the server.
-            //
-            // If not, this looks like a bug - we should always add the event to
-            // the thread. See https://github.com/vector-im/element-web/issues/26254
-            logger.warn(
-                `Not adding event ${event.getId()} to thread timeline!
-                isNewestReply=${isNewestReply}
-                event.localTimestamp=${event.localTimestamp}
-                !!lastReply=${!!lastReply}
-                lastReply?.getId()=${lastReply?.getId()}
-                lastReply?.localTimestamp=${lastReply?.localTimestamp}
-                toStartOfTimeline=${toStartOfTimeline}
-                Thread.hasServerSideSupport=${Thread.hasServerSideSupport}
-                event.isRelation(RelationType.Annotation)=${event.isRelation(RelationType.Annotation)}
-                event.isRelation(RelationType.Replace)=${event.isRelation(RelationType.Replace)}
-                `,
-            );
+
+            // Otherwise, we should add it, but we suspect it is out of order.
+            if (toStartOfTimeline) {
+                // If we're adding at the start of the timeline, it doesn't
+                // matter that it's out of order.
+                this.addEventToTimeline(event, toStartOfTimeline);
+            } else {
+                // We think this event might be out of order, because isNewestReply
+                // is false (otherwise we would have gone into the earlier if
+                // clause), so try to insert it in the right place based on
+                // timestamp.
+                this.insertEventIntoTimeline(event);
+            }
         }
 
         if (


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26254
(hopefully)

Reduce the number of cases where we drop events that we are trying to add to a thread.

I have lots of refactorings I would like to do to addEvent but this change isolates the functional change that may address the referenced bug.

I will be holding off on merging this until after the release candidate on 17th October 2023, so that we can try it out for a couple of weeks and evaluate whether it causes more stuck notifications.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->