### PR TITLE
Allow applications to specify their own logger instance

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { mocked } from "jest-mock";
+import { Mocked } from "jest-mock";
 
 import { FetchHttpApi } from "../../../src/http-api/fetch";
 import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
 import { ClientPrefix, HttpApiEvent, HttpApiEventHandlerMap, IdentityPrefix, IHttpOpts, Method } from "../../../src";
 import { emitPromise } from "../../test-utils/test-utils";
 import { defer, QueryDict } from "../../../src/utils";
-import { logger } from "../../../src/logger";
+import { Logger } from "../../../src/logger";
 
 describe("FetchHttpApi", () => {
     const baseUrl = "http://baseUrl";
@@ -300,22 +300,29 @@ describe("FetchHttpApi", () => {
         jest.useFakeTimers();
         const deferred = defer<Response>();
         const fetchFn = jest.fn().mockReturnValue(deferred.promise);
-        jest.spyOn(logger, "debug").mockImplementation(() => {});
-        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
+        const mockLogger = {
+            debug: jest.fn(),
+        } as unknown as Mocked<Logger>;
+        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {
+            baseUrl,
+            prefix,
+            fetchFn,
+            logger: mockLogger,
+        });
         const prom = api.requestOtherUrl(Method.Get, "https://server:8448/some/path?query=param#fragment");
         jest.advanceTimersByTime(1234);
         deferred.resolve({ ok: true, status: 200, text: () => Promise.resolve("RESPONSE") } as Response);
         await prom;
-        expect(logger.debug).not.toHaveBeenCalledWith("fragment");
-        expect(logger.debug).not.toHaveBeenCalledWith("query");
-        expect(logger.debug).not.toHaveBeenCalledWith("param");
-        expect(logger.debug).toHaveBeenCalledTimes(2);
-        expect(mocked(logger.debug).mock.calls[0]).toMatchInlineSnapshot(`
+        expect(mockLogger.debug).not.toHaveBeenCalledWith("fragment");
+        expect(mockLogger.debug).not.toHaveBeenCalledWith("query");
+        expect(mockLogger.debug).not.toHaveBeenCalledWith("param");
+        expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+        expect(mockLogger.debug.mock.calls[0]).toMatchInlineSnapshot(`
             [
               "FetchHttpApi: --> GET https://server:8448/some/path?query=xxx",
             ]
         `);
-        expect(mocked(logger.debug).mock.calls[1]).toMatchInlineSnapshot(`
+        expect(mockLogger.debug.mock.calls[1]).toMatchInlineSnapshot(`
             [
               "FetchHttpApi: <-- GET https://server:8448/some/path?query=xxx [1234ms 200]",
             ]

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -48,6 +48,7 @@ import {
 } from "../../../src/crypto-api";
 import * as testData from "../../test-utils/test-data";
 import { defer } from "../../../src/utils";
+import { logger } from "../../../src/logger";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";
@@ -71,6 +72,7 @@ describe("initRustCrypto", () => {
         jest.spyOn(OlmMachine, "initialize").mockResolvedValue(testOlmMachine);
 
         await initRustCrypto(
+            logger,
             {} as MatrixClient["http"],
             TEST_USER,
             TEST_DEVICE_ID,
@@ -93,6 +95,7 @@ describe("initRustCrypto", () => {
         jest.spyOn(OlmMachine, "initialize").mockResolvedValue(testOlmMachine);
 
         await initRustCrypto(
+            logger,
             {} as MatrixClient["http"],
             TEST_USER,
             TEST_DEVICE_ID,
@@ -315,6 +318,7 @@ describe("RustCrypto", () => {
             } as unknown as Mocked<OutgoingRequestProcessor>;
 
             rustCrypto = new RustCrypto(
+                logger,
                 olmMachine,
                 {} as MatrixHttpApi<any>,
                 TEST_USER,
@@ -444,6 +448,7 @@ describe("RustCrypto", () => {
                 getRoomEventEncryptionInfo: jest.fn(),
             } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
             rustCrypto = new RustCrypto(
+                logger,
                 olmMachine,
                 {} as MatrixClient["http"],
                 TEST_USER,
@@ -618,6 +623,7 @@ describe("RustCrypto", () => {
                 getDevice: jest.fn(),
             } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
             rustCrypto = new RustCrypto(
+                logger,
                 olmMachine,
                 {} as MatrixClient["http"],
                 TEST_USER,
@@ -836,6 +842,7 @@ describe("RustCrypto", () => {
                 getIdentity: jest.fn(),
             } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
             rustCrypto = new RustCrypto(
+                logger,
                 olmMachine,
                 {} as MatrixClient["http"],
                 TEST_USER,
@@ -882,6 +889,7 @@ describe("RustCrypto", () => {
             } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
             const rustCrypto = new RustCrypto(
+                logger,
                 olmMachine,
                 mockHttpApi,
                 testData.TEST_USER_ID,
@@ -914,5 +922,5 @@ async function makeTestRustCrypto(
     secretStorage: ServerSideSecretStorage = {} as ServerSideSecretStorage,
     cryptoCallbacks: CryptoCallbacks = {} as CryptoCallbacks,
 ): Promise<RustCrypto> {
-    return await initRustCrypto(http, userId, deviceId, secretStorage, cryptoCallbacks, null, undefined);
+    return await initRustCrypto(logger, http, userId, deviceId, secretStorage, cryptoCallbacks, null, undefined);
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1349,6 +1349,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             extraParams: opts.queryParams,
             localTimeoutMs: opts.localTimeoutMs,
             useAuthorizationHeader: opts.useAuthorizationHeader,
+            logger: this.logger,
         });
 
         if (opts.deviceToImport) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -52,7 +52,7 @@ import { IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice";
 import { IOlmDevice } from "./crypto/algorithms/megolm";
 import { TypedReEmitter } from "./ReEmitter";
 import { IRoomEncryption, RoomList } from "./crypto/RoomList";
-import { logger } from "./logger";
+import { logger, Logger } from "./logger";
 import { SERVICE_TYPES } from "./service-types";
 import {
     Body,
@@ -415,6 +415,12 @@ export interface ICreateClientOpts {
      * so that livekit media can be used in the application layert (js-sdk contains no livekit code).
      */
     useLivekitForGroupCalls?: boolean;
+
+    /**
+     * A logger to associate with this MatrixClient.
+     * Defaults to the built-in global logger.
+     */
+    logger?: Logger;
 }
 
 export interface IMatrixClientCreateOpts extends ICreateClientOpts {
@@ -1207,6 +1213,8 @@ const SSO_ACTION_PARAM = new UnstableValue("action", "org.matrix.msc3824.action"
 export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHandlerMap> {
     public static readonly RESTORE_BACKUP_ERROR_BAD_KEY = "RESTORE_BACKUP_ERROR_BAD_KEY";
 
+    private readonly logger: Logger;
+
     public reEmitter = new TypedReEmitter<EmittedEvents, ClientEventHandlerMap>(this);
     public olmVersion: [number, number, number] | null = null; // populated after initCrypto
     public usingExternalCrypto = false;
@@ -1311,6 +1319,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     public constructor(opts: IMatrixClientCreateOpts) {
         super();
+
+        // If a custom logger is provided, use it. Otherwise, default to the global
+        // one in logger.ts.
+        this.logger = opts.logger ?? logger;
 
         opts.baseUrl = utils.ensureNoTrailingSlash(opts.baseUrl);
         opts.idBaseUrl = utils.ensureNoTrailingSlash(opts.idBaseUrl);

--- a/src/client.ts
+++ b/src/client.ts
@@ -2320,6 +2320,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // needed.
         const RustCrypto = await import("./rust-crypto");
         const rustCrypto = await RustCrypto.initRustCrypto(
+            this.logger,
             this.http,
             userId,
             deviceId,

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -25,7 +25,6 @@ import { ConnectionError, MatrixError } from "./errors";
 import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, IRequestOpts, Body } from "./interface";
 import { anySignal, parseErrorResponse, timeoutSignal } from "./utils";
 import { QueryDict } from "../utils";
-import { logger } from "../logger";
 
 interface TypedResponse<T> extends Response {
     json(): Promise<T>;
@@ -225,7 +224,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         opts: Pick<IRequestOpts, "headers" | "json" | "localTimeoutMs" | "keepAlive" | "abortSignal" | "priority"> = {},
     ): Promise<ResponseType<T, O>> {
         const urlForLogs = this.sanitizeUrlForLogs(url);
-        logger.debug(`FetchHttpApi: --> ${method} ${urlForLogs}`);
+        this.opts.logger?.debug(`FetchHttpApi: --> ${method} ${urlForLogs}`);
 
         const headers = Object.assign({}, opts.headers || {});
         const json = opts.json ?? true;
@@ -279,9 +278,11 @@ export class FetchHttpApi<O extends IHttpOpts> {
                 priority: opts.priority,
             });
 
-            logger.debug(`FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${res.status}]`);
+            this.opts.logger?.debug(
+                `FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${res.status}]`,
+            );
         } catch (e) {
-            logger.debug(`FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${e}]`);
+            this.opts.logger?.debug(`FetchHttpApi: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${e}]`);
             if ((<Error>e).name === "AbortError") {
                 throw e;
             }

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { MatrixError } from "./errors";
+import { Logger } from "../logger";
 
 export type Body = Record<string, any> | BodyInit;
 
@@ -31,6 +32,9 @@ export interface IHttpOpts {
 
     onlyData?: boolean;
     localTimeoutMs?: number;
+
+    /** Optional logger instance. If provided, requests and responses will be logged. */
+    logger?: Logger;
 }
 
 export interface IRequestOpts extends Pick<RequestInit, "priority"> {

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -17,14 +17,15 @@ limitations under the License.
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { RustCrypto } from "./rust-crypto";
-import { logger } from "../logger";
 import { IHttpOpts, MatrixHttpApi } from "../http-api";
 import { ServerSideSecretStorage } from "../secret-storage";
 import { ICryptoCallbacks } from "../crypto";
+import { Logger } from "../logger";
 
 /**
  * Create a new `RustCrypto` implementation
  *
+ * @param logger - A `Logger` instance that will be used for debug output.
  * @param http - Low-level HTTP interface: used to make outgoing requests required by the rust SDK.
  *     We expect it to set the access token, etc.
  * @param userId - The local user's User ID.
@@ -40,6 +41,7 @@ import { ICryptoCallbacks } from "../crypto";
  * @internal
  */
 export async function initRustCrypto(
+    logger: Logger,
     http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
     userId: string,
     deviceId: string,
@@ -65,7 +67,7 @@ export async function initRustCrypto(
         storePrefix ?? undefined,
         (storePrefix && storePassphrase) ?? undefined,
     );
-    const rustCrypto = new RustCrypto(olmMachine, http, userId, deviceId, secretStorage, cryptoCallbacks);
+    const rustCrypto = new RustCrypto(logger, olmMachine, http, userId, deviceId, secretStorage, cryptoCallbacks);
     await olmMachine.registerRoomKeyUpdatedCallback((sessions: RustSdkCryptoJs.RoomKeyInfo[]) =>
         rustCrypto.onRoomKeysUpdated(sessions),
     );

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -24,7 +24,7 @@ import { IContent, MatrixEvent, MatrixEventEvent } from "../models/event";
 import { Room } from "../models/room";
 import { RoomMember } from "../models/room-member";
 import { BackupDecryptor, CryptoBackend, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
-import { logger } from "../logger";
+import { Logger } from "../logger";
 import { ClientPrefix, IHttpOpts, MatrixHttpApi, Method } from "../http-api";
 import { RoomEncryptor } from "./RoomEncryptor";
 import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
@@ -118,6 +118,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     private readonly reemitter = new TypedReEmitter<RustCryptoEvents, RustCryptoEventMap>(this);
 
     public constructor(
+        private readonly logger: Logger,
+
         /** The `OlmMachine` from the underlying rust crypto sdk. */
         private readonly olmMachine: RustSdkCryptoJs.OlmMachine,
 
@@ -143,7 +145,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         super();
         this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
         this.keyClaimManager = new KeyClaimManager(olmMachine, this.outgoingRequestProcessor);
-        this.eventDecryptor = new EventDecryptor(olmMachine, this);
+        this.eventDecryptor = new EventDecryptor(this.logger, olmMachine, this);
 
         this.backupManager = new RustBackupManager(olmMachine, http, this.outgoingRequestProcessor);
         this.reemitter.reEmit(this.backupManager, [
@@ -1309,11 +1311,13 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
     private onRoomKeyUpdated(key: RustSdkCryptoJs.RoomKeyInfo): void {
         if (this.stopped) return;
-        logger.debug(`Got update for session ${key.senderKey.toBase64()}|${key.sessionId} in ${key.roomId.toString()}`);
+        this.logger.debug(
+            `Got update for session ${key.senderKey.toBase64()}|${key.sessionId} in ${key.roomId.toString()}`,
+        );
         const pendingList = this.eventDecryptor.getEventsPendingRoomKey(key);
         if (pendingList.length === 0) return;
 
-        logger.debug(
+        this.logger.debug(
             "Retrying decryption on events:",
             pendingList.map((e) => `${e.getId()}`),
         );
@@ -1326,7 +1330,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         // and deduplicates repeated attempts for the same event.
         for (const ev of pendingList) {
             ev.attemptDecryption(this, { isRetry: true }).catch((_e) => {
-                logger.info(`Still unable to decrypt event ${ev.getId()} after receiving key`);
+                this.logger.info(`Still unable to decrypt event ${ev.getId()} after receiving key`);
             });
         }
     }
@@ -1402,7 +1406,9 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             throw new Error("missing roomId in the event");
         }
 
-        logger.debug(`Incoming verification event ${event.getId()} type ${event.getType()} from ${event.getSender()}`);
+        this.logger.debug(
+            `Incoming verification event ${event.getId()} type ${event.getType()} from ${event.getSender()}`,
+        );
 
         await this.olmMachine.receiveVerificationEvent(
             JSON.stringify({
@@ -1427,7 +1433,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
             if (!request) {
                 // There are multiple reasons this can happen; probably the most likely is that the event is too old.
-                logger.info(
+                this.logger.info(
                     `Ignoring just-received verification request ${event.getId()} which did not start a rust-side verification`,
                 );
             } else {
@@ -1467,7 +1473,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         }
         // fire off the loop in the background
         this.outgoingRequestLoopInner().catch((e) => {
-            logger.error("Error processing outgoing-message requests from rust crypto-sdk", e);
+            this.logger.error("Error processing outgoing-message requests from rust crypto-sdk", e);
         });
     }
 
@@ -1483,7 +1489,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 // if `this.outgoingRequestLoop()` was called while `OlmMachine.outgoingRequests()` was running.
                 this.outgoingRequestLoopOneMoreLoop = false;
 
-                logger.debug("Calling OlmMachine.outgoingRequests()");
+                this.logger.debug("Calling OlmMachine.outgoingRequests()");
                 const outgoingRequests: Object[] = await this.olmMachine.outgoingRequests();
 
                 if (this.stopped) {
@@ -1518,10 +1524,14 @@ class EventDecryptor {
         () => new MapWithDefault<string, Set<MatrixEvent>>(() => new Set()),
     );
 
-    public constructor(private readonly olmMachine: RustSdkCryptoJs.OlmMachine, private readonly crypto: RustCrypto) {}
+    public constructor(
+        private readonly logger: Logger,
+        private readonly olmMachine: RustSdkCryptoJs.OlmMachine,
+        private readonly crypto: RustCrypto,
+    ) {}
 
     public async attemptEventDecryption(event: MatrixEvent): Promise<IEventDecryptionResult> {
-        logger.info(
+        this.logger.info(
             `Attempting decryption of event ${event.getId()} in ${event.getRoomId()} from ${event.getSender()}`,
         );
 
@@ -1602,7 +1612,7 @@ class EventDecryptor {
             new RustSdkCryptoJs.RoomId(event.getRoomId()!),
         );
 
-        return rustEncryptionInfoToJsEncryptionInfo(encryptionInfo);
+        return rustEncryptionInfoToJsEncryptionInfo(this.logger, encryptionInfo);
     }
 
     /**
@@ -1674,6 +1684,7 @@ function stringifyEvent(event: MatrixEvent): string {
 }
 
 function rustEncryptionInfoToJsEncryptionInfo(
+    logger: Logger,
     encryptionInfo: RustSdkCryptoJs.EncryptionInfo | undefined,
 ): EventEncryptionInfo | null {
     if (encryptionInfo === undefined) {


### PR DESCRIPTION
Allow clients to specify a logger instance when instantiating a matrix client via the `ClientOpts`.

This is is particularly useful for clients that want to support multiple matrix accounts, but I also want to use it in the cypress tests.

It builds on the work done by @clokep in #3484, and replaces that PR.

It's not yet complete - there are still *lots* of places that use the global `logger` - but it puts the framework in place and catches quite a lot of the main culprits.

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/1899.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Allow applications to specify their own logger instance ([\#3792](https://github.com/matrix-org/matrix-js-sdk/pull/3792)). Fixes #1899.<!-- CHANGELOG_PREVIEW_END -->