### PR TITLE
Don't use event.sender in CallMembership

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -29,9 +29,7 @@ const membershipTemplate: CallMembershipData = {
 function makeMockEvent(originTs = 0): MatrixEvent {
     return {
         getTs: jest.fn().mockReturnValue(originTs),
-        sender: {
-            userId: "@alice:example.org",
-        },
+        getSender: jest.fn().mockReturnValue("@alice:example.org"),
     } as unknown as MatrixEvent;
 }
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent, RoomMember } from "../matrix";
+import { MatrixEvent } from "../matrix";
 import { deepCompare } from "../utils";
 import { Focus } from "./focus";
 
@@ -42,11 +42,11 @@ export class CallMembership {
         if (typeof data.device_id !== "string") throw new Error("Malformed membership event: device_id must be string");
         if (typeof data.call_id !== "string") throw new Error("Malformed membership event: call_id must be string");
         if (typeof data.scope !== "string") throw new Error("Malformed membership event: scope must be string");
-        if (!parentEvent.sender) throw new Error("Invalid parent event: sender is null");
+        if (!parentEvent.getSender()) throw new Error("Invalid parent event: sender is null");
     }
 
-    public get member(): RoomMember {
-        return this.parentEvent.sender!;
+    public get sender(): string | undefined {
+        return this.parentEvent.getSender();
     }
 
     public get callId(): string {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -120,7 +120,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         callMemberships.sort((a, b) => a.createdTs() - b.createdTs());
         logger.debug(
             "Call memberships, in order: ",
-            callMemberships.map((m) => [m.createdTs(), m.member.userId]),
+            callMemberships.map((m) => [m.createdTs(), m.sender]),
         );
 
         return callMemberships;


### PR DESCRIPTION
I fell into another js-sdk trap: this is "only guaranteed to be set for events that appear in a timeline" and not state events. It does not say why. We only ever used it to get the sender user ID anyway, so just use getSender().

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't use event.sender in CallMembership ([\#3793](https://github.com/matrix-org/matrix-js-sdk/pull/3793)).<!-- CHANGELOG_PREVIEW_END -->