### PR TITLE
Fix sending call member events on leave

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -427,7 +427,6 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             memberships: this.makeNewMemberships(memberships, myCallMemberEvent, myPrevMembership),
         };
 
-        let resendDelay = 0;
         try {
             await this.client.sendStateEvent(
                 this.room.roomId,
@@ -438,13 +437,12 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             logger.info(`Sent updated call member event.`);
 
             // check periodically to see if we need to refresh our member event
-            if (this.isJoined()) resendDelay = MEMBER_EVENT_CHECK_PERIOD;
+            if (this.isJoined()) {
+                this.memberEventTimeout = setTimeout(this.triggerCallMembershipEventUpdate, MEMBER_EVENT_CHECK_PERIOD);
+            }
         } catch (e) {
-            resendDelay = CALL_MEMBER_EVENT_RETRY_DELAY_MIN + Math.random() * 2000;
+            const resendDelay = CALL_MEMBER_EVENT_RETRY_DELAY_MIN + Math.random() * 2000;
             logger.warn(`Failed to send call member event: retrying in ${resendDelay}`);
-        }
-
-        if (resendDelay) {
             await new Promise((resolve) => setTimeout(resolve, resendDelay));
             await this.triggerCallMembershipEventUpdate();
         }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-js-sdk/pull/3756 changed the membership update function to await on the next call, but this meant it never returned and therefore never cleared `updateCallMembershipRunning`. We therefore didn't send the updated call member event when leaving, instead sending it whenever the next poll interval arrived.

This changes it to only await if we are retrying, not if we're just scheduling the next poll.

@toger5 review appreciated on this one - does this line up with what you expected your fix to do?

Fixes https://github.com/vector-im/element-call/issues/1763

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix sending call member events on leave ([\#3799](https://github.com/matrix-org/matrix-js-sdk/pull/3799)). Fixes vector-im/element-call#1763.<!-- CHANGELOG_PREVIEW_END -->