### PR TITLE
Element-R: log when we send to-device messages

### DIFF
--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -121,7 +121,7 @@ describe("OutgoingRequestProcessor", () => {
 
     it("should handle ToDeviceRequests", async () => {
         // first, mock up the ToDeviceRequest as we might expect to receive it from the Rust layer ...
-        const testBody = '{ "foo": "bar" }';
+        const testBody = '{ "messages": { "user": {"device": "bar" }}}';
         const outgoingRequest = new ToDeviceRequest("1234", "test/type", "test/txnid", testBody);
 
         // ... then poke it into the OutgoingRequestProcessor under test.

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -31,6 +31,7 @@ import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
 import { QueryDict } from "../utils";
 import { IAuthDict, UIAuthCallback } from "../interactive-auth";
 import { UIAResponse } from "../@types/uia";
+import { ToDeviceMessageId } from "../@types/event";
 
 /**
  * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
@@ -82,10 +83,7 @@ export class OutgoingRequestProcessor {
                 msg.body,
             );
         } else if (msg instanceof ToDeviceRequest) {
-            const path =
-                `/_matrix/client/v3/sendToDevice/${encodeURIComponent(msg.event_type)}/` +
-                encodeURIComponent(msg.txn_id);
-            resp = await this.rawJsonRequest(Method.Put, path, {}, msg.body);
+            resp = await this.sendToDeviceRequest(msg);
         } else if (msg instanceof RoomMessageRequest) {
             const path =
                 `/_matrix/client/v3/rooms/${encodeURIComponent(msg.room_id)}/send/` +
@@ -120,6 +118,34 @@ export class OutgoingRequestProcessor {
                 }
             }
         }
+    }
+
+    /**
+     * Send the HTTP request for a `ToDeviceRequest`
+     *
+     * @param request request to send
+     * @returns JSON-serialized body of the response, if successful
+     */
+    private async sendToDeviceRequest(request: ToDeviceRequest): Promise<string> {
+        // a bit of extra logging, to help trace to-device messages through the system
+        const parsedBody: { messages: Record<string, Record<string, Record<string, any>>> } = JSON.parse(request.body);
+
+        const messageList = [];
+        for (const [userId, perUserMessages] of Object.entries(parsedBody.messages)) {
+            for (const [deviceId, message] of Object.entries(perUserMessages)) {
+                messageList.push(`${userId}/${deviceId} (msgid ${message[ToDeviceMessageId]})`);
+            }
+        }
+
+        logger.info(
+            `Sending batch of to-device messages. type=${request.event_type} txnid=${request.txn_id}`,
+            messageList,
+        );
+
+        const path =
+            `/_matrix/client/v3/sendToDevice/${encodeURIComponent(request.event_type)}/` +
+            encodeURIComponent(request.txn_id);
+        return await this.rawJsonRequest(Method.Put, path, {}, request.body);
     }
 
     private async makeRequestWithUIA<T>(

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -123,7 +123,7 @@ export class OutgoingRequestProcessor {
     /**
      * Send the HTTP request for a `ToDeviceRequest`
      *
-     * @param request request to send
+     * @param request - request to send
      * @returns JSON-serialized body of the response, if successful
      */
     private async sendToDeviceRequest(request: ToDeviceRequest): Promise<string> {


### PR DESCRIPTION
The logs will look something like this:

![image](https://github.com/matrix-org/matrix-js-sdk/assets/1389908/3e32f162-953b-435f-956b-28fefc83ef7d)

The first line comes from the rust-sdk; I think it's helpful to also log just before we actually send the batch.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Element-R: log when we send to-device messages ([\#3810](https://github.com/matrix-org/matrix-js-sdk/pull/3810)).<!-- CHANGELOG_PREVIEW_END -->