### PR TITLE
Reduce some log spam from `MatrixRTCSession.callMembershipsForRoom`

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -118,10 +118,12 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
 
         callMemberships.sort((a, b) => a.createdTs() - b.createdTs());
-        logger.debug(
-            "Call memberships, in order: ",
-            callMemberships.map((m) => [m.createdTs(), m.sender]),
-        );
+        if (callMemberships.length > 1) {
+            logger.debug(
+                `Call memberships in room ${room.roomId}, in order: `,
+                callMemberships.map((m) => [m.createdTs(), m.sender]),
+            );
+        }
 
         return callMemberships;
     }


### PR DESCRIPTION
This gets logged very frequently - including once for each room at startup - and it's filling the logs.

/cc @dbkr

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->