### PR TITLE
New release automations

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
+change-template: "* $TITLE ([#$NUMBER]($URL)). Contributed by @$AUTHOR."
 categories:
     - title: "🚨 BREAKING CHANGES"
       label: "X-Breaking-Change"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,24 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+    - title: "🚨 BREAKING CHANGES"
+      label: "X-Breaking-Change"
+    - title: "🦖 Deprecations"
+      label: "T-Deprecation"
+    - title: "✨ Features"
+      label: "T-Enhancement"
+    - title: "🐛 Bug Fixes"
+      label: "T-Defect"
+    - title: "🧰 Maintenance"
+      label: "Dependencies"
+      collapse-after: 5
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+    major:
+        labels:
+            - "X-Breaking-Change"
+    default: minor
+template: |
+    $CHANGES
+prerelease: true
+prerelease-identifier: rc

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,3 +23,4 @@ template: |
     $CHANGES
 prerelease: true
 prerelease-identifier: rc
+include-pre-releases: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,3 +12,4 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   disable-autolabeler: true
+                  include-pre-releases: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
     draft:
         runs-on: ubuntu-latest
         steps:
-            - uses: release-drafter/release-drafter@22a02a47912cdc2d3b8c022762cfd4e59ceb9b0c # v5
+            - uses: release-drafter/release-drafter@dabcf3767562210392d862070ed2ef6434b9bc6f # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ jobs:
     draft:
         runs-on: ubuntu-latest
         steps:
-            - uses: release/drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
+            - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,7 @@ name: Release Drafter
 on:
     push:
         branches: [staging]
+concurrency: ${{ github.workflow }}
 jobs:
     draft:
         runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,13 @@
+name: Prepare Draft release
+on:
+    push:
+        branches: [staging]
+jobs:
+    draft:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: release/drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  disable-autolabeler: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
     draft:
         runs-on: ubuntu-latest
         steps:
-            - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
+            - uses: release-drafter/release-drafter@58e93a19a10b09b3e1763b8aed11bd04275c0cfc # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Prepare Draft release
+name: Release Drafter
 on:
     push:
         branches: [staging]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,4 +12,3 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   disable-autolabeler: true
-                  include-pre-releases: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
     draft:
         runs-on: ubuntu-latest
         steps:
-            - uses: release-drafter/release-drafter@58e93a19a10b09b3e1763b8aed11bd04275c0cfc # v5
+            - uses: release-drafter/release-drafter@22a02a47912cdc2d3b8c022762cfd4e59ceb9b0c # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -1,0 +1,45 @@
+# Gitflow merge-back master->develop
+name: Merge master -> develop
+on:
+    push:
+        branches: [master]
+concurrency: ${{ github.workflow }}
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+            - name: Merge to develop
+              run: |
+                  git checkout develop
+                  git merge -X theirs master
+
+            - name: Update package.json fields
+              run: |
+                  # When merging to develop, we need revert the `main` and `typings` fields if we adjusted them previously.
+                  for i in main typings browser
+                  do
+                      # If a `lib` prefixed value is present, it means we adjusted the field
+                      # earlier at publish time, so we should revert it now.
+                      if [ "$(jq -r ".matrix_lib_$i" package.json)" != "null" ]; then
+                          # If there's a `src` prefixed value, use that, otherwise delete.
+                          # This is used to delete the `typings` field and reset `main` back to the TypeScript source.
+                          src_value=$(jq -r ".matrix_src_$i" package.json)
+                          if [ "$src_value" != "null" ]; then
+                              jq ".$i = .matrix_src_$i" package.json > package.json.new && mv package.json.new package.json && yarn prettier --write package.json
+                          else
+                              jq "del(.$i)" package.json > package.json.new && mv package.json.new package.json && yarn prettier --write package.json
+                          fi
+                      fi
+                  done
+
+            - name: Commit and push changes
+              run: |
+                  git config --global user.email "releases@riot.im"
+                  git config --global user.name "RiotRobot"
+                  git add package.json
+                  git commit -m "Resetting package fields for development"
+                  git push origin develop

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Merge to develop
               run: |
                   git checkout develop
-                  git merge -X theirs master
+                  git merge -X ours master
 
             - name: Update package.json fields
               run: |

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -5,12 +5,13 @@ on:
         branches: [master]
 concurrency: ${{ github.workflow }}
 jobs:
-    release:
+    merge:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+                  fetch-depth: 0
 
             - name: Merge to develop
               run: |

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -13,6 +13,11 @@ jobs:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
                   fetch-depth: 0
 
+            - name: Set up git
+              run: |
+                  git config --global user.email "releases@riot.im"
+                  git config --global user.name "RiotRobot"
+
             - name: Merge to develop
               run: |
                   git checkout develop
@@ -39,8 +44,6 @@ jobs:
 
             - name: Commit and push changes
               run: |
-                  git config --global user.email "releases@riot.im"
-                  git config --global user.name "RiotRobot"
                   git add package.json
                   git commit -m "Resetting package fields for development"
                   git push origin develop

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -13,6 +13,13 @@ jobs:
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
                   fetch-depth: 0
 
+            - uses: actions/setup-node@v3
+              with:
+                  cache: "yarn"
+
+            - name: Install Deps
+              run: "yarn install --frozen-lockfile"
+
             - name: Set up git
               run: |
                   git config --global user.email "releases@riot.im"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,4 +1,3 @@
-# Must only be called from `release#published` triggers
 name: Publish to npm
 on:
     workflow_call:
@@ -32,7 +31,7 @@ jobs:
                   ignore-scripts: false
 
             - name: 🎖️ Add `latest` dist-tag to final releases
-              if: github.event.release.prerelease == false && steps.npm-publish.outputs.id
+              if: steps.npm-publish.outputs.id && !contains(steps.npm-publish.outputs.id, '-rc.')
               run: npm dist-tag add "$release" latest
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
                   latest: true
 
             - uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
             - uses: actions/setup-node@v3
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,95 @@
 name: Release Process
 on:
-    release:
-        types: [published]
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+    workflow_dispatch:
+        inputs:
+            mode:
+                description: What type of release
+                required: true
+                default: rc
+                type: choice
+                options:
+                    - rc
+                    - final
+            docs:
+                description: Publish docs
+                required: true
+                type: boolean
+                default: true
+            npm:
+                description: Publish to npm
+                required: true
+                type: boolean
+                default: true
+concurrency: ${{ github.workflow }}
 jobs:
-    jsdoc:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Assert on staging branch
+              if: github.ref_name != 'staging'
+              run: |
+                  echo "Action must run on staging branch"
+                  exit 1
+
+            - name: Get draft release
+              id: release
+              uses: cardinalby/git-get-release-action@cedef2faf69cb7c55b285bad07688d04430b7ada # v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  draft: true
+                  commitSha: ${{ github.sha }}
+
+            - uses: actions/checkout@v4
+
+            - name: Bump package.json version
+              run: yarn version --no-git-tag-version --new-version "$VERSION"
+              env:
+                  VERSION: ${{ steps.release.outputs.tag_name }}
+
+            - name: Add to CHANGELOG.md
+              run: |
+                  mv CHANGELOG.md CHANGELOG.md.old
+                  HEADER="Changes in [${VERSION#v}](https://github.com/${{ github.repository }}/releases/tag/$VERSION) ($(date '+%Y-%m-%d'))"
+
+                  echo "$HEADER" >> CHANGELOG.md
+                  printf '=%.0s' $(seq ${#HEADER}) >> CHANGELOG.md
+                  echo "\n$BODY\n" >> CHANGELOG.md
+
+                  cat CHANGELOG.md.old >> CHANGELOG.md
+                  rm CHANGELOG.md.old
+              env:
+                  VERSION: ${{ steps.release.outputs.tag_name }}
+                  BODY: ${{ steps.release.outputs.body }}
+
+            # For the published and dist versions of the package,
+            # we copy the `matrix_lib_main` and `matrix_lib_typings` fields to `main` and `typings` (if they exist).
+            # This small bit of gymnastics allows us to use the TypeScript source directly for development without
+            # needing to build before linting or testing.
+            - name: Update package.json fields
+              run: |
+                  for i in main typings browser
+                  do
+                      lib_value=$(jq -r ".matrix_lib_$i" package.json)
+                      if [ "$lib_value" != "null" ]; then
+                          jq ".$i = .matrix_lib_$i" package.json > package.json.new && mv package.json.new package.json && yarn prettier --write package.json
+                      fi
+                  done
+
+            - name: Commit and push changes
+              run: |
+                  git config --global user.email "releases@riot.im"
+                  git config --global user.name "RiotRobot"
+                  git add package.json CHANGELOG.md
+                  git commit -m "$VERSION"
+                  git push
+              env:
+                  VERSION: ${{ steps.release.outputs.tag_name }}
+
+    docs:
         name: Publish Documentation
+        needs: release
+        if: inputs.docs
         runs-on: ubuntu-latest
         steps:
             - name: 🧮 Checkout code
@@ -47,6 +131,8 @@ jobs:
 
     npm:
         name: Publish
+        needs: release
+        if: inputs.npm
         uses: matrix-org/matrix-js-sdk/.github/workflows/release-npm.yml@develop
         secrets:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,18 @@ jobs:
               run: yarn version --no-git-tag-version --new-version "$VERSION"
 
             - name: Add to CHANGELOG.md
+              if: inputs.final
               run: |
                   mv CHANGELOG.md CHANGELOG.md.old
                   HEADER="Changes in [${VERSION#v}](https://github.com/${{ github.repository }}/releases/tag/$VERSION) ($(date '+%Y-%m-%d'))"
 
-                  echo "$HEADER" >> CHANGELOG.md
-                  printf '=%.0s' $(seq ${#HEADER}) >> CHANGELOG.md
-                  echo "" >> CHANGELOG.md
-                  echo "$BODY" >> CHANGELOG.md
-                  echo "" >> CHANGELOG.md
+                  {
+                      echo "$HEADER"
+                      printf '=%.0s' $(seq ${#HEADER})
+                      echo ""
+                      echo "$BODY"
+                      echo ""
+                  } > CHANGELOG.md
 
                   cat CHANGELOG.md.old >> CHANGELOG.md
                   rm CHANGELOG.md.old

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,13 @@ jobs:
                       fi
                   done
 
-            - name: Commit and push changes
+            - name: Set up git
               run: |
                   git config --global user.email "releases@riot.im"
                   git config --global user.name "RiotRobot"
+
+            - name: Commit and push changes
+              run: |
                   git add package.json CHANGELOG.md
                   git commit -m "$VERSION"
                   git push origin staging
@@ -170,10 +173,13 @@ jobs:
                   yarn gendoc
                   symlinks -rc _docs
 
-            - name: 🚀 Deploy
+            - name: 🔨 Set up git
               run: |
                   git config --global user.email "releases@riot.im"
                   git config --global user.name "RiotRobot"
+
+            - name: 🚀 Deploy
+              run: |
                   git add . --all
                   git commit -m "Update docs"
                   git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,14 @@ jobs:
                   VERSION: ${{ steps.release.outputs.tag_name }}
 
             - name: Finalise version
-              if: inputs.final
+              if: inputs.mode == 'final'
               run: echo "VERSION=$(echo $VERSION | cut -d- -f1)" >> $GITHUB_ENV
 
             - name: Bump package.json version
               run: yarn version --no-git-tag-version --new-version "$VERSION"
 
             - name: Add to CHANGELOG.md
-              if: inputs.final
+              if: inputs.mode == 'final'
               run: |
                   mv CHANGELOG.md CHANGELOG.md.old
                   HEADER="Changes in [${VERSION#v}](https://github.com/${{ github.repository }}/releases/tag/$VERSION) ($(date '+%Y-%m-%d'))"
@@ -100,7 +100,7 @@ jobs:
                   git push origin staging
 
             - name: Merge to master
-              if: inputs.final
+              if: inputs.mode == 'final'
               run: |
                   git checkout master
                   git merge -X theirs staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,36 @@ jobs:
               env:
                   VERSION: ${{ steps.release.outputs.tag_name }}
 
+            - name: Publish release
+              uses: actions/github-script@v6
+              id: my-script
+              env:
+                  RELEASE_ID: ${{ steps.release.outputs.id }}
+                  TAG_NAME: ${{ steps.release.outputs.tag_name }}
+                  MODE: ${{ inputs.mode }}
+              with:
+                  result-encoding: string
+                  retries: 3
+                  script: |
+                      let { RELEASE_ID, TAG_NAME, MODE } = process.env;
+                      const { owner, repo } = context.repo;
+
+                      const opts = {
+                          owner,
+                          repo,
+                          release_id,
+                          tag_name: TAG_NAME,
+                          name: TAG_NAME,
+                          draft: false,
+                      };
+
+                      if (MODE === "final") {
+                          opts.tag_name = opts.name = TAG_NAME.split("-")[0];
+                          opts.prerelease = false;
+                      }
+
+                      github.rest.repos.updateRelease(opts);
+
     docs:
         name: Publish Documentation
         needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
 
                   echo "$HEADER" >> CHANGELOG.md
                   printf '=%.0s' $(seq ${#HEADER}) >> CHANGELOG.md
-                  echo "\n$BODY\n" >> CHANGELOG.md
+                  echo "" >> CHANGELOG.md
+                  echo "$BODY" >> CHANGELOG.md
+                  echo "" >> CHANGELOG.md
 
                   cat CHANGELOG.md.old >> CHANGELOG.md
                   rm CHANGELOG.md.old

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,17 @@ jobs:
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
 
-            - name: Bump package.json version
-              run: yarn version --no-git-tag-version --new-version "$VERSION"
+            - name: Load version
+              run: echo "VERSION=$VERSION" >> $GITHUB_ENV
               env:
                   VERSION: ${{ steps.release.outputs.tag_name }}
+
+            - name: Finalise version
+              if: inputs.final
+              run: echo "VERSION=$(echo $VERSION | cut -d- -f1)" >> $GITHUB_ENV
+
+            - name: Bump package.json version
+              run: yarn version --no-git-tag-version --new-version "$VERSION"
 
             - name: Add to CHANGELOG.md
               run: |
@@ -70,7 +77,6 @@ jobs:
                   cat CHANGELOG.md.old >> CHANGELOG.md
                   rm CHANGELOG.md.old
               env:
-                  VERSION: ${{ steps.release.outputs.tag_name }}
                   BODY: ${{ steps.release.outputs.body }}
 
             # For the published and dist versions of the package,
@@ -94,34 +100,30 @@ jobs:
                   git add package.json CHANGELOG.md
                   git commit -m "$VERSION"
                   git push
-              env:
-                  VERSION: ${{ steps.release.outputs.tag_name }}
 
             - name: Publish release
               uses: actions/github-script@v6
               id: my-script
               env:
                   RELEASE_ID: ${{ steps.release.outputs.id }}
-                  TAG_NAME: ${{ steps.release.outputs.tag_name }}
                   MODE: ${{ inputs.mode }}
               with:
                   result-encoding: string
                   retries: 3
                   script: |
-                      let { RELEASE_ID: release_id, TAG_NAME, MODE } = process.env;
+                      let { RELEASE_ID: release_id, VERSION, MODE } = process.env;
                       const { owner, repo } = context.repo;
 
                       const opts = {
                           owner,
                           repo,
                           release_id,
-                          tag_name: TAG_NAME,
-                          name: TAG_NAME,
+                          tag_name: VERSION,
+                          name: VERSION,
                           draft: false,
                       };
 
                       if (MODE === "final") {
-                          opts.tag_name = opts.name = TAG_NAME.split("-")[0];
                           opts.prerelease = false;
                           opts.make_latest = true;
                       }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,14 @@ jobs:
                   git config --global user.name "RiotRobot"
                   git add package.json CHANGELOG.md
                   git commit -m "$VERSION"
-                  git push
+                  git push origin staging
+
+            - name: Merge to master
+              if: input.final
+              run: |
+                  git checkout master
+                  git merge -X theirs staging
+                  git push origin master
 
             - name: Publish release
               uses: actions/github-script@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
                       if (MODE === "final") {
                           opts.tag_name = opts.name = TAG_NAME.split("-")[0];
                           opts.prerelease = false;
+                          opts.make_latest = true;
                       }
 
                       github.rest.repos.updateRelease(opts);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
               with:
                   ref: staging
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+                  fetch-depth: 0
 
             - uses: actions/setup-node@v3
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,6 @@ jobs:
     release:
         runs-on: ubuntu-latest
         steps:
-            - name: Assert on staging branch
-              if: github.ref_name != 'staging'
-              run: |
-                  echo "Action must run on staging branch"
-                  exit 1
-
             - name: Get draft release
               id: release
               uses: cardinalby/git-get-release-action@cedef2faf69cb7c55b285bad07688d04430b7ada # v1
@@ -42,6 +36,7 @@ jobs:
 
             - uses: actions/checkout@v4
               with:
+                  ref: staging
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
             - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
                   result-encoding: string
                   retries: 3
                   script: |
-                      let { RELEASE_ID, TAG_NAME, MODE } = process.env;
+                      let { RELEASE_ID: release_id, TAG_NAME, MODE } = process.env;
                       const { owner, repo } = context.repo;
 
                       const opts = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
                   git push origin staging
 
             - name: Merge to master
-              if: input.final
+              if: inputs.final
               run: |
                   git checkout master
                   git merge -X theirs staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,16 @@ jobs:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
                   draft: true
-                  commitSha: ${{ github.sha }}
+                  latest: true
 
             - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v3
+              with:
+                  cache: "yarn"
+
+            - name: Install Deps
+              run: "yarn install --frozen-lockfile"
 
             - name: Bump package.json version
               run: yarn version --no-git-tag-version --new-version "$VERSION"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,5 +4,6 @@
 
 # Deep dive
 
+-   [Release Process](release.md)
 -   [Storage notes](storage-notes.md)
 -   [Unverified devices](warning-on-unverified-devices.md)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,24 @@
+# Release Process
+
+## Hotfix and off-cycle releases
+
+1. Prepare the `staging` branch by using the backport automation and manually merging
+2. Go to [Releasing](#Releasing)
+
+## Release candidates
+
+1. Prepare the `staging` branch by running the [branch cut automation](https://github.com/vector-im/element-web/actions/workflows/release_prepare.yml)
+2. Go to [Releasing](#Releasing)
+
+## Releasing
+
+1. Open the [Releases page](https://github.com/matrix-org/matrix-js-sdk/releases) and inspect the draft release there
+2. Make any modifications to the release notes and tag/version as required
+3. Run [workflow](https://github.com/matrix-org/matrix-js-sdk/actions/workflows/release.yml) with the type set appropriately
+
+## Artifacts
+
+Releasing the Matrix JS SDK has just two artifacts:
+
+-   Package published to [npm](https://github.com/matrix-org/matrix-js-sdk)
+-   Docs published to [Github Pages](https://matrix-org.github.io/matrix-js-sdk/)


### PR DESCRIPTION
Fixes https://github.com/vector-im/wat-internal/issues/21

Notes:
+ Changes our first RC from `rc.1` to `rc.0`
+ Switches from allchange to release-drafter set up with similar rules

Example:

https://github.com/t3chguy/matrix-js-sdk/pull/21 before RC:
![image](https://github.com/matrix-org/matrix-js-sdk/assets/2403652/8e22fc67-d2c8-4082-8cab-7a80d72aac02)

Finalise RC0:
![image](https://github.com/matrix-org/matrix-js-sdk/assets/2403652/3249ebff-6fd6-47c0-aac6-6acf208d384f)

https://github.com/t3chguy/matrix-js-sdk/pull/22 after RC:
![image](https://github.com/matrix-org/matrix-js-sdk/assets/2403652/636f3209-3d88-4e1c-8346-3d92e9e69c50)

Finalise as final:
![image](https://github.com/matrix-org/matrix-js-sdk/assets/2403652/a81250f4-4307-488e-89b8-d61c52fd3aaf)

Workflow:
+ Release captain uses automation to cut branches
+ Release captain waits for draft release to be made and reads the release notes for sanity and makes any changes necessary, including changing version number
+ Release captain uses automation to promote the draft release into an RC 0-N times as appropriate
+ Release captain uses automation to promote the draft release into a final one


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->