### PR TITLE
Move the redaction event to main at the same time we move redacted

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1197,6 +1197,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         // to the main timeline. This will change if MSC3389 is merged.
         if (room && !this.isThreadRoot && this.threadRootId && this.threadRootId !== this.getId()) {
             this.moveAllRelatedToMainTimeline(room);
+            redactionEvent.moveToMainTimeline(room);
         }
 
         this.invalidateExtensibleEvent();

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -236,8 +236,9 @@ export type RoomEventHandlerMap = {
      *
      * @param event - The matrix redaction event
      * @param room - The room containing the redacted event
+     * @param threadId - The thread containing the redacted event (before it was redacted)
      */
-    [RoomEvent.Redaction]: (event: MatrixEvent, room: Room) => void;
+    [RoomEvent.Redaction]: (event: MatrixEvent, room: Room, threadId?: string) => void;
     /**
      * Fires when an event that was previously redacted isn't anymore.
      * This happens when the redaction couldn't be sent and
@@ -2113,6 +2114,12 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * Relations (other than m.thread), redactions, replies to a thread root live only in the main timeline
      * Relations, redactions, replies where the parent cannot be found live in no timelines but should be aggregated regardless.
      * Otherwise, the event lives in the main timeline only.
+     *
+     * Note: when a redaction is applied, the redacted event, events relating
+     * to it, and the redaction event itself, will all move to the main thread.
+     * This method classifies them as inside the thread of the redacted event.
+     * They are moved later as part of makeRedacted.
+     * This will change if MSC3389 is merged.
      */
     public eventShouldLiveIn(
         event: MatrixEvent,
@@ -2329,6 +2336,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             // if we know about this event, redact its contents now.
             const redactedEvent = redactId ? this.findEventById(redactId) : undefined;
             if (redactedEvent) {
+                const threadRootId = redactedEvent.threadRootId;
                 redactedEvent.makeRedacted(event, this);
 
                 // If this is in the current state, replace it with the redacted version
@@ -2342,7 +2350,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                     }
                 }
 
-                this.emit(RoomEvent.Redaction, event, this);
+                this.emit(RoomEvent.Redaction, event, this, threadRootId);
 
                 // TODO: we stash user displaynames (among other things) in
                 // RoomMember objects which are then attached to other events
@@ -2495,7 +2503,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                 }
                 if (redactedEvent) {
                     redactedEvent.markLocallyRedacted(event);
-                    this.emit(RoomEvent.Redaction, event, this);
+                    this.emit(RoomEvent.Redaction, event, this, redactedEvent.threadRootId);
                 }
             }
         } else {

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -228,8 +228,8 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
         }
     };
 
-    private onRedaction = async (event: MatrixEvent): Promise<void> => {
-        if (event.threadRootId !== this.id) return; // ignore redactions for other timelines
+    private onRedaction = async (event: MatrixEvent, room: Room, threadRootId?: string): Promise<void> => {
+        if (threadRootId !== this.id) return; // ignore redactions for other timelines
         if (this.replyCount <= 0) {
             for (const threadEvent of this.timeline) {
                 this.clearEventMetadata(threadEvent);


### PR DESCRIPTION
Since the redacted event is moving to the main timeline, the redaction belongs there too, since its relationship to the redacted event is the only thing making it part of the thread.

It's possible this will fix some flakiness in our read receipt tests. I found it while investigating them...

Part of https://github.com/vector-im/element-web/issues/24392

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Move the redaction event to main at the same time we move redacted ([\#3815](https://github.com/matrix-org/matrix-js-sdk/pull/3815)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->