### PR TITLE
Ignore receipts pointing at missing or invalid events

### DIFF
--- a/spec/unit/read-receipt.spec.ts
+++ b/spec/unit/read-receipt.spec.ts
@@ -225,6 +225,7 @@ describe("Read receipt", () => {
         it("should not allow an older unthreaded receipt to clobber a `main` threaded one", () => {
             const userId = client.getSafeUserId();
             const room = new Room(ROOM_ID, client, userId);
+            room.findEventById = jest.fn().mockReturnValue({} as MatrixEvent);
 
             const unthreadedReceipt: WrappedReceipt = {
                 eventId: "$olderEvent",

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3255,7 +3255,7 @@ describe("Room", function () {
                     for (let i = 1; i <= 2; i++) {
                         room.getUnfilteredTimelineSet = () =>
                             ({
-                                compareEventOrdering: (event1: string) => {
+                                compareEventOrdering: (event1: string, _event2: string) => {
                                     return event1 === `eventId${i}` ? 1 : -1;
                                 },
                                 findEventById: jest.fn().mockReturnValue({} as MatrixEvent),

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1746,6 +1746,7 @@ describe("Room", function () {
             it("should acknowledge if an event has been read", function () {
                 const ts = 13787898424;
                 room.addReceipt(mkReceipt(roomId, [mkRecord(eventToAck.getId()!, "m.read", userB, ts)]));
+                room.findEventById = jest.fn().mockReturnValue({} as MatrixEvent);
                 expect(room.hasUserReadEvent(userB, eventToAck.getId()!)).toEqual(true);
             });
             it("return false for an unknown event", function () {
@@ -3151,7 +3152,7 @@ describe("Room", function () {
             room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
                 return receiptType === ReceiptType.ReadPrivate ? ({ eventId: "eventId" } as WrappedReceipt) : null;
             };
-
+            room.findEventById = jest.fn().mockReturnValue({} as MatrixEvent);
             expect(room.getEventReadUpTo(userA)).toEqual("eventId");
         });
 
@@ -3170,10 +3171,11 @@ describe("Room", function () {
                 for (let i = 1; i <= 2; i++) {
                     room.getUnfilteredTimelineSet = () =>
                         ({
-                            compareEventOrdering: (event1, event2) => {
+                            compareEventOrdering: (event1: string) => {
                                 return event1 === `eventId${i}` ? 1 : -1;
                             },
-                        } as EventTimelineSet);
+                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                        } as unknown as EventTimelineSet);
 
                     expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
                 }
@@ -3184,8 +3186,9 @@ describe("Room", function () {
                     for (let i = 1; i <= 2; i++) {
                         room.getUnfilteredTimelineSet = () =>
                             ({
-                                compareEventOrdering: (_1, _2) => null,
-                            } as EventTimelineSet);
+                                compareEventOrdering: () => null,
+                                findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                            } as unknown as EventTimelineSet);
                         room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
                             if (receiptType === ReceiptType.ReadPrivate) {
                                 return { eventId: "eventId1", data: { ts: i === 1 ? 2 : 1 } } as WrappedReceipt;
@@ -3203,8 +3206,9 @@ describe("Room", function () {
                 it("should correctly compare, if private read receipt is missing", () => {
                     room.getUnfilteredTimelineSet = () =>
                         ({
-                            compareEventOrdering: (_1, _2) => null,
-                        } as EventTimelineSet);
+                            compareEventOrdering: () => null,
+                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                        } as unknown as EventTimelineSet);
                     room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
                         if (receiptType === ReceiptType.Read) {
                             return { eventId: "eventId2", data: { ts: 1 } } as WrappedReceipt;
@@ -3220,8 +3224,9 @@ describe("Room", function () {
                 beforeAll(() => {
                     room.getUnfilteredTimelineSet = () =>
                         ({
-                            compareEventOrdering: (_1, _2) => null,
-                        } as EventTimelineSet);
+                            compareEventOrdering: () => null,
+                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                        } as unknown as EventTimelineSet);
                 });
 
                 it("should give precedence to m.read.private", () => {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3148,110 +3148,195 @@ describe("Room", function () {
         const client = new TestClient(userA).client;
         const room = new Room(roomId, client, userA);
 
-        it("handles missing receipt type", () => {
-            room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                return receiptType === ReceiptType.ReadPrivate ? ({ eventId: "eventId" } as WrappedReceipt) : null;
-            };
-            room.findEventById = jest.fn().mockReturnValue({} as MatrixEvent);
-            expect(room.getEventReadUpTo(userA)).toEqual("eventId");
-        });
-
-        describe("prefers newer receipt", () => {
-            it("should compare correctly using timelines", () => {
-                room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                    if (receiptType === ReceiptType.ReadPrivate) {
-                        return { eventId: "eventId1" } as WrappedReceipt;
-                    }
-                    if (receiptType === ReceiptType.Read) {
-                        return { eventId: "eventId2" } as WrappedReceipt;
-                    }
-                    return null;
-                };
-
-                for (let i = 1; i <= 2; i++) {
-                    room.getUnfilteredTimelineSet = () =>
-                        ({
-                            compareEventOrdering: (event1: string) => {
-                                return event1 === `eventId${i}` ? 1 : -1;
-                            },
-                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
-                        } as unknown as EventTimelineSet);
-
-                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
-                }
+        describe("invalid receipts", () => {
+            beforeEach(() => {
+                // Clear the spies on logger.warn
+                jest.clearAllMocks();
             });
 
-            describe("correctly compares by timestamp", () => {
-                it("should correctly compare, if we have all receipts", () => {
+            it("ignores receipts pointing at missing events", () => {
+                // Given a receipt exists
+                room.getReadReceiptForUserId = (): WrappedReceipt | null => {
+                    return { eventId: "missingEventId" } as WrappedReceipt;
+                };
+                // But the event ID it contains does not refer to an event we have
+                room.findEventById = jest.fn().mockReturnValue(null);
+
+                // When we ask what they have read
+                // Then we say "nothing"
+                expect(room.getEventReadUpTo(userA)).toBeNull();
+                expect(logger.warn).toHaveBeenCalledWith("Ignoring receipt for missing event with id missingEventId");
+            });
+
+            it("ignores receipts pointing at the wrong thread", () => {
+                // Given a threaded receipt exists
+                room.getReadReceiptForUserId = (): WrappedReceipt | null => {
+                    return { eventId: "wrongThreadEventId", data: { ts: 0, thread_id: "thread1" } } as WrappedReceipt;
+                };
+                // But the event it refers to is in a thread
+                room.findEventById = jest.fn().mockReturnValue({ threadRootId: "thread2" } as MatrixEvent);
+
+                // When we ask what they have read
+                // Then we say "nothing"
+                expect(room.getEventReadUpTo(userA)).toBeNull();
+                expect(logger.warn).toHaveBeenCalledWith(
+                    "Ignoring receipt because its thread_id (thread1) disagrees with the thread root (thread2) " +
+                        "of the referenced event (event ID = wrongThreadEventId)",
+                );
+            });
+
+            it("accepts unthreaded receipts pointing at an event in a thread", () => {
+                // Given an unthreaded receipt exists
+                room.getReadReceiptForUserId = (): WrappedReceipt | null => {
+                    return { eventId: "inThreadEventId" } as WrappedReceipt;
+                };
+                // And the event it refers to is in a thread
+                room.findEventById = jest.fn().mockReturnValue({ threadRootId: "thread2" } as MatrixEvent);
+
+                // When we ask what they have read
+                // Then we say the event
+                expect(room.getEventReadUpTo(userA)).toEqual("inThreadEventId");
+            });
+
+            it("accepts main thread receipts pointing at an event in main timeline", () => {
+                // Given a threaded receipt exists, in main thread
+                room.getReadReceiptForUserId = (): WrappedReceipt | null => {
+                    return { eventId: "mainThreadEventId", data: { ts: 12, thread_id: "main" } } as WrappedReceipt;
+                };
+                // And the event it refers to is in a thread
+                room.findEventById = jest.fn().mockReturnValue({ threadRootId: undefined } as MatrixEvent);
+
+                // When we ask what they have read
+                // Then we say the event
+                expect(room.getEventReadUpTo(userA)).toEqual("mainThreadEventId");
+            });
+
+            it("accepts main thread receipts pointing at a thread root", () => {
+                // Given a threaded receipt exists, in main thread
+                room.getReadReceiptForUserId = (): WrappedReceipt | null => {
+                    return { eventId: "rootId", data: { ts: 12, thread_id: "main" } } as WrappedReceipt;
+                };
+                // And the event it refers to is in a thread, because it is a thread root
+                room.findEventById = jest
+                    .fn()
+                    .mockReturnValue({ isThreadRoot: true, threadRootId: "thread1" } as MatrixEvent);
+
+                // When we ask what they have read
+                // Then we say the event
+                expect(room.getEventReadUpTo(userA)).toEqual("rootId");
+            });
+        });
+
+        describe("valid receipts", () => {
+            beforeEach(() => {
+                // When we look up the event referred to by the receipt, it exists
+                room.findEventById = jest.fn().mockReturnValue({} as MatrixEvent);
+            });
+
+            it("handles missing receipt type", () => {
+                room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
+                    return receiptType === ReceiptType.ReadPrivate ? ({ eventId: "eventId" } as WrappedReceipt) : null;
+                };
+                expect(room.getEventReadUpTo(userA)).toEqual("eventId");
+            });
+
+            describe("prefers newer receipt", () => {
+                it("should compare correctly using timelines", () => {
+                    room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
+                        if (receiptType === ReceiptType.ReadPrivate) {
+                            return { eventId: "eventId1" } as WrappedReceipt;
+                        }
+                        if (receiptType === ReceiptType.Read) {
+                            return { eventId: "eventId2" } as WrappedReceipt;
+                        }
+                        return null;
+                    };
+
                     for (let i = 1; i <= 2; i++) {
+                        room.getUnfilteredTimelineSet = () =>
+                            ({
+                                compareEventOrdering: (event1: string) => {
+                                    return event1 === `eventId${i}` ? 1 : -1;
+                                },
+                                findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                            } as unknown as EventTimelineSet);
+
+                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
+                    }
+                });
+
+                describe("correctly compares by timestamp", () => {
+                    it("should correctly compare, if we have all receipts", () => {
+                        for (let i = 1; i <= 2; i++) {
+                            room.getUnfilteredTimelineSet = () =>
+                                ({
+                                    compareEventOrdering: () => null,
+                                    findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                                } as unknown as EventTimelineSet);
+                            room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
+                                if (receiptType === ReceiptType.ReadPrivate) {
+                                    return { eventId: "eventId1", data: { ts: i === 1 ? 2 : 1 } } as WrappedReceipt;
+                                }
+                                if (receiptType === ReceiptType.Read) {
+                                    return { eventId: "eventId2", data: { ts: i === 2 ? 2 : 1 } } as WrappedReceipt;
+                                }
+                                return null;
+                            };
+
+                            expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
+                        }
+                    });
+
+                    it("should correctly compare, if private read receipt is missing", () => {
                         room.getUnfilteredTimelineSet = () =>
                             ({
                                 compareEventOrdering: () => null,
                                 findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
                             } as unknown as EventTimelineSet);
                         room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                            if (receiptType === ReceiptType.ReadPrivate) {
-                                return { eventId: "eventId1", data: { ts: i === 1 ? 2 : 1 } } as WrappedReceipt;
-                            }
                             if (receiptType === ReceiptType.Read) {
-                                return { eventId: "eventId2", data: { ts: i === 2 ? 2 : 1 } } as WrappedReceipt;
+                                return { eventId: "eventId2", data: { ts: 1 } } as WrappedReceipt;
                             }
                             return null;
                         };
 
-                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId${i}`);
-                    }
+                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId2`);
+                    });
                 });
 
-                it("should correctly compare, if private read receipt is missing", () => {
-                    room.getUnfilteredTimelineSet = () =>
-                        ({
-                            compareEventOrdering: () => null,
-                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
-                        } as unknown as EventTimelineSet);
-                    room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                        if (receiptType === ReceiptType.Read) {
-                            return { eventId: "eventId2", data: { ts: 1 } } as WrappedReceipt;
-                        }
-                        return null;
-                    };
+                describe("fallback precedence", () => {
+                    beforeAll(() => {
+                        room.getUnfilteredTimelineSet = () =>
+                            ({
+                                compareEventOrdering: () => null,
+                                findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
+                            } as unknown as EventTimelineSet);
+                    });
 
-                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId2`);
-                });
-            });
+                    it("should give precedence to m.read.private", () => {
+                        room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
+                            if (receiptType === ReceiptType.ReadPrivate) {
+                                return { eventId: "eventId1", data: { ts: 123 } };
+                            }
+                            if (receiptType === ReceiptType.Read) {
+                                return { eventId: "eventId2", data: { ts: 123 } };
+                            }
+                            return null;
+                        };
 
-            describe("fallback precedence", () => {
-                beforeAll(() => {
-                    room.getUnfilteredTimelineSet = () =>
-                        ({
-                            compareEventOrdering: () => null,
-                            findEventById: jest.fn().mockReturnValue({} as MatrixEvent),
-                        } as unknown as EventTimelineSet);
-                });
+                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId1`);
+                    });
 
-                it("should give precedence to m.read.private", () => {
-                    room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                        if (receiptType === ReceiptType.ReadPrivate) {
-                            return { eventId: "eventId1", data: { ts: 123 } };
-                        }
-                        if (receiptType === ReceiptType.Read) {
-                            return { eventId: "eventId2", data: { ts: 123 } };
-                        }
-                        return null;
-                    };
+                    it("should give precedence to m.read", () => {
+                        room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
+                            if (receiptType === ReceiptType.Read) {
+                                return { eventId: "eventId3" } as WrappedReceipt;
+                            }
+                            return null;
+                        };
 
-                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId1`);
-                });
-
-                it("should give precedence to m.read", () => {
-                    room.getReadReceiptForUserId = (userId, ignore, receiptType): WrappedReceipt | null => {
-                        if (receiptType === ReceiptType.Read) {
-                            return { eventId: "eventId3" } as WrappedReceipt;
-                        }
-                        return null;
-                    };
-
-                    expect(room.getEventReadUpTo(userA)).toEqual(`eventId3`);
+                        expect(room.getEventReadUpTo(userA)).toEqual(`eventId3`);
+                    });
                 });
             });
         });

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -156,9 +156,9 @@ export abstract class ReadReceipt<
 
         // The thread ID doesn't match up
         logger.warn(
-            `Ignoring receipt because its thread_id (${receipt.data.thread_id}) disagrees \
-                with the thread root (${event.threadRootId}) of the referenced event \
-                (event ID = ${receipt.eventId})`,
+            `Ignoring receipt because its thread_id (${receipt.data.thread_id}) disagrees ` +
+                `with the thread root (${event.threadRootId}) of the referenced event ` +
+                `(event ID = ${receipt.eventId})`,
         );
         return false;
     }


### PR DESCRIPTION
Helps with some of the flaking redaction tests, and some of the just-plain-failing editing tests.

We were seeing bugs where the latest receipt was not pointing at an event in this thread (or an event we had at all), so the room was considered unread, but we were unable to send a correct receipt because we already had one. This change means we effectively ignore the existing receipt because we can't use it, allowing us to send a correct one.

Part of https://github.com/vector-im/element-web/issues/24392

When I enable lots of disabled tests (in https://github.com/matrix-org/matrix-react-sdk/pull/11781 ) with this change, they pass consistently on my machine.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ignore receipts pointing at missing or invalid events ([\#3817](https://github.com/matrix-org/matrix-js-sdk/pull/3817)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->