### PR TITLE
Reduce log spam from rust crypto

### DIFF
--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -54,7 +54,7 @@ export async function initRustCrypto(
     await RustSdkCryptoJs.initAsync();
 
     // enable tracing in the rust-sdk
-    new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Trace).turnOn();
+    new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
 
     const u = new RustSdkCryptoJs.UserId(userId);
     const d = new RustSdkCryptoJs.DeviceId(deviceId);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1537,7 +1537,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 // if `this.outgoingRequestLoop()` was called while `OlmMachine.outgoingRequests()` was running.
                 this.outgoingRequestLoopOneMoreLoop = false;
 
-                this.logger.debug("Calling OlmMachine.outgoingRequests()");
                 const outgoingRequests: Object[] = await this.olmMachine.outgoingRequests();
 
                 if (this.stopped) {


### PR DESCRIPTION
* turn the log level down to DEBUG
* don't pointlessly log every call to `outgoingRequests`

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->