### PR TITLE
Element-R: silence log errors when viewing a decryption failure

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1650,7 +1650,7 @@ class EventDecryptor {
     }
 
     public async getEncryptionInfoForEvent(event: MatrixEvent): Promise<EventEncryptionInfo | null> {
-        if (!event.getClearContent()) {
+        if (!event.getClearContent() || event.isDecryptionFailure()) {
             // not successfully decrypted
             return null;
         }


### PR DESCRIPTION
Fixes part of https://github.com/vector-im/element-web/issues/26272

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Element-R: silence log errors when viewing a decryption failure ([\#3821](https://github.com/matrix-org/matrix-js-sdk/pull/3821)).<!-- CHANGELOG_PREVIEW_END -->