### PR TITLE
Fix up comments on `globalErrorOnUnknownDevices`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2679,12 +2679,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * This API is currently UNSTABLE and may change or be removed without notice.
      *
+     * It has no effect with the Rust crypto implementation.
+     *
      * @param value - whether error on unknown devices
      *
-     * @deprecated Prefer direct access to {@link CryptoApi.globalBlacklistUnverifiedDevices}:
-     *
      * ```ts
-     * client.getCrypto().globalBlacklistUnverifiedDevices = value;
+     * client.getCrypto().globalErrorOnUnknownDevices = value;
      * ```
      */
     public setGlobalErrorOnUnknownDevices(value: boolean): void {

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -35,8 +35,8 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * symmetry with setGlobalBlacklistUnverifiedDevices but there is currently
      * no room-level equivalent for this setting.
      *
-     * @remarks this is here, rather than in `CryptoApi`, because I don't think we're
-     * going to support it in the rust crypto implementation.
+     * @remarks This has no effect in Rust Crypto; it exists only for the sake of
+     * the accessors in MatrixClient.
      */
     globalErrorOnUnknownDevices: boolean;
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -88,7 +88,6 @@ const KEY_BACKUP_CHECK_RATE_LIMIT = 5000; // ms
  * @internal
  */
 export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEventMap> implements CryptoBackend {
-    public globalErrorOnUnknownDevices = false;
     private _trustCrossSignedDevices = true;
 
     /** whether {@link stop} has been called */
@@ -219,6 +218,15 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     // CryptoBackend implementation
     //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public set globalErrorOnUnknownDevices(_v: boolean) {
+        // Not implemented for rust crypto.
+    }
+
+    public get globalErrorOnUnknownDevices(): boolean {
+        // Not implemented for rust crypto.
+        return false;
+    }
 
     public stop(): void {
         // stop() may be called multiple times, but attempting to close() the OlmMachine twice


### PR DESCRIPTION
The current deprecation notice advises you to use a method which does something completely different.

Fixing this "properly" is slightly challenging because we don't want to support setting it to `true` in Rust Crypto; yet I don't really want to change the default for legacy crypto.

Let's just document the behaviour for now.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->