### PR TITLE
Cypress workflow: remove redundant `rust-crypto` param

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,7 +33,6 @@ jobs:
             TCMS_PASSWORD: ${{ secrets.TCMS_PASSWORD }}
         with:
             react-sdk-repository: matrix-org/matrix-react-sdk
-            rust-crypto: true
 
     # We want to make the cypress tests a required check for the merge queue.
     #


### PR DESCRIPTION
https://github.com/matrix-org/matrix-react-sdk/pull/11828 removes the `rust-crypto` input param from the reusable cypress workflow. This gets rid of it on the calling side.