### PR TITLE
remove unhelpful logging about events without age params.

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -668,11 +668,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * It is supposed to only be used like this: `ev.getAge() ?? ev.fallbackAge()`
      */
     private fallbackAge(): number {
-        if (!this.getAge()) {
-            logger.warn(
-                "Age for event was not available, using `now - origin_server_ts` as a fallback. If the device clock is not correct issues might occur.",
-            );
-        }
         return Math.max(Date.now() - this.getTs(), 0);
     }
 


### PR DESCRIPTION
the conditional was unnecessary, the logline wasn't wrapped, and it creates literally tens of thousands of warn-level logspam on my account


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->