### PR TITLE
Automate checking there is no published release using the version already

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -60,6 +60,21 @@ jobs:
               if: inputs.mode == 'final'
               run: echo "VERSION=$(echo $VERSION | cut -d- -f1)" >> $GITHUB_ENV
 
+            - name: Check version number not in use
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const { VERSION } = process.env;
+                      github.rest.repos.getReleaseByTag({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          tag: VERSION,
+                      }).then(() => {
+                          core.setFailed(`Version ${VERSION} already exists`);
+                      }).catch(() => {
+                        // This is fine, we expect there to not be any release with this version yet
+                      });
+
             - name: Set up git
               run: |
                   git config --global user.email "releases@riot.im"


### PR DESCRIPTION
Fixes https://github.com/vector-im/wat-internal/issues/15

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->