### PR TITLE
Ensure `setUserCreator` is called when a store is assigned

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1497,7 +1497,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     public set store(newStore: Store) {
-        if (!newStore) throw new Error("store passed to MatrixClient.store setter is undefined!");
         this._store = newStore;
         this._store.setUserCreator((userId) => User.createUser(userId, this));
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1217,7 +1217,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public reEmitter = new TypedReEmitter<EmittedEvents, ClientEventHandlerMap>(this);
     public olmVersion: [number, number, number] | null = null; // populated after initCrypto
     public usingExternalCrypto = false;
-    public store: Store;
+    public store!: Store;
     public deviceId: string | null;
     public credentials: { userId: string | null };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1217,7 +1217,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public reEmitter = new TypedReEmitter<EmittedEvents, ClientEventHandlerMap>(this);
     public olmVersion: [number, number, number] | null = null; // populated after initCrypto
     public usingExternalCrypto = false;
-    public store!: Store;
+    private _store!: Store;
     public deviceId: string | null;
     public credentials: { userId: string | null };
 
@@ -1331,7 +1331,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.identityServer = opts.identityServer;
 
         this.usingExternalCrypto = opts.usingExternalCrypto ?? false;
-        this.setStore(opts.store || new StubStore());
+        this.store = opts.store || new StubStore();
         this.deviceId = opts.deviceId || null;
         this.sessionId = randomString(10);
 
@@ -1496,14 +1496,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this._secretStorage = new ServerSideSecretStorageImpl(this, opts.cryptoCallbacks ?? {});
     }
 
-    /**
-     * Use this method to set/change the store used by the client
-     * @param newStore - The new store object
-     */
-    public setStore(newStore: Store): void {
-        if (!newStore) throw new Error("store passed to MatrixClient.setStore() is undefined!");
-        this.store = newStore;
-        this.store.setUserCreator((userId) => User.createUser(userId, this));
+    public set store(newStore: Store) {
+        if (!newStore) throw new Error("store passed to MatrixClient.store setter is undefined!");
+        this._store = newStore;
+        this._store.setUserCreator((userId) => User.createUser(userId, this));
+    }
+
+    public get store(): Store {
+        return this._store;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1331,8 +1331,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.identityServer = opts.identityServer;
 
         this.usingExternalCrypto = opts.usingExternalCrypto ?? false;
-        this.store = opts.store || new StubStore();
-        this.store.setUserCreator((userId) => User.createUser(userId, this));
+        this.setStore(opts.store || new StubStore());
         this.deviceId = opts.deviceId || null;
         this.sessionId = randomString(10);
 
@@ -1495,6 +1494,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.ignoredInvites = new IgnoredInvites(this);
         this._secretStorage = new ServerSideSecretStorageImpl(this, opts.cryptoCallbacks ?? {});
+    }
+
+    /**
+     * Use this method to set/change the store used by the client
+     * @param newStore - The new store object
+     */
+    public setStore(newStore: Store): void {
+        if (!newStore) throw new Error("store passed to MatrixClient.setStore() is undefined!");
+        this.store = newStore;
+        this.store.setUserCreator((userId) => User.createUser(userId, this));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/26520

If you're interested in know why we need a `userCreator` in the first place, see https://github.com/matrix-org/matrix-js-sdk/pull/3796#discussion_r1362060951

This PR merely adds a method that sets the store property while making sure that userCreator is also wired correctly.


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Ensure `setUserCreator` is called when a store is assigned ([\#3867](https://github.com/matrix-org/matrix-js-sdk/pull/3867)). Fixes vector-im/element-web#26520. Contributed by @MidhunSureshR.<!-- CHANGELOG_PREVIEW_END -->