### PR TITLE
Update workfile to pull in changes from react-sdk

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
         # from creeping in. They take a long time to run and consume 4 concurrent runners.
         if: github.event.workflow_run.event == 'merge_group'
 
-        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@v3.83.0-rc.1
+        uses: matrix-org/matrix-react-sdk/.github/workflows/cypress.yaml@03b01b4a50d0f3fbbfa6c1a9314ef2d346d089d4
         permissions:
             actions: read
             issues: read


### PR DESCRIPTION
For fixing broken cypress tests. 

The current workfile is pinned to an earlier tag that does not contain the changes to disable sorry-cypress

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->