### PR TITLE
Revert "Better fallback for unavailable event age"

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -85,9 +85,7 @@ describe("CallMembership", () => {
 
     it("considers memberships expired when local age large", () => {
         const fakeEvent = makeMockEvent(1000);
-        const evAge = 6000;
-        fakeEvent.getLocalAge = jest.fn().mockReturnValue(evAge);
-        fakeEvent.localTimestamp = Date.now() - evAge;
+        fakeEvent.getLocalAge = jest.fn().mockReturnValue(6000);
         const membership = new CallMembership(fakeEvent, membershipTemplate);
         expect(membership.isExpired()).toEqual(true);
     });

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -61,7 +61,7 @@ export function mockRTCEvent(
         getSender: jest.fn().mockReturnValue("@mock:user.example"),
         getTs: jest.fn().mockReturnValue(1000),
         getLocalAge: getLocalAgeFn,
-        localTimestamp: Date.now() - getLocalAgeFn(),
+        localTimestamp: Date.now(),
         getRoomId: jest.fn().mockReturnValue(roomId),
         sender: {
             userId: "@mock:user.example",

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -91,7 +91,7 @@ export class CallMembership {
     }
 
     public isExpired(): boolean {
-        return this.getMsUntilExpiry() <= 0;
+        return this.getAbsoluteExpiry() < this.parentEvent.getTs() + this.parentEvent.getLocalAge();
     }
 
     public getActiveFoci(): Focus[] {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -390,7 +390,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         });
 
         this.txnId = event.txn_id;
-        this.localTimestamp = Date.now() - (this.getAge() ?? this.fallbackAge());
+        this.localTimestamp = Date.now() - (this.getAge() ?? 0);
         this.reEmitter = new TypedReEmitter(this);
     }
 
@@ -659,21 +659,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     public getAge(): number | undefined {
         return this.getUnsigned().age || this.event.age; // v2 / v1
-    }
-
-    /**
-     * The fallbackAge is computed by using the origin_server_ts. So it is not adjusted
-     * to the local device clock. It should never be used.
-     * If there is no unsigned field in the event this is a better fallback then 0.
-     * It is supposed to only be used like this: `ev.getAge() ?? ev.fallbackAge()`
-     */
-    private fallbackAge(): number {
-        if (!this.getAge()) {
-            logger.warn(
-                "Age for event was not available, using `now - origin_server_ts` as a fallback. If the device clock is not correct issues might occur.",
-            );
-        }
-        return Math.max(Date.now() - this.getTs(), 0);
     }
 
     /**
@@ -1357,7 +1342,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
             this.emit(MatrixEventEvent.LocalEventIdReplaced, this);
         }
 
-        this.localTimestamp = Date.now() - (this.getAge() ?? this.fallbackAge());
+        this.localTimestamp = Date.now() - this.getAge()!;
     }
 
     /**


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#3854.

This causes significant logspam, and seems like it needs more thought for various other reasons which I've tried to set out at https://github.com/matrix-org/matrix-js-sdk/pull/3861#issuecomment-1803863086.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->