### PR TITLE
Don't rotate keys if not managing media keys

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -563,7 +563,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         const isMyMembership = (m: CallMembership): boolean =>
             m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
 
-        if (this.isJoined() && this.makeNewKeyTimeout === undefined) {
+        if (this.manageMediaKeys && this.isJoined() && this.makeNewKeyTimeout === undefined) {
             const oldMebershipIds = new Set(
                 oldMemberships.filter((m) => !isMyMembership(m)).map(getParticipantIdFromMembership),
             );
@@ -767,6 +767,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     }
 
     private onRotateKeyTimeout = (): void => {
+        if (!this.manageMediaKeys) return;
+
         this.makeNewKeyTimeout = undefined;
         logger.info("Making new sender key for key rotation");
         this.makeNewSenderKey(true);


### PR DESCRIPTION
This could have caused weirdness in non per-user key calling mode.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Don't rotate keys if not managing media keys ([\#3877](https://github.com/matrix-org/matrix-js-sdk/pull/3877)).<!-- CHANGELOG_PREVIEW_END -->