### PR TITLE
Add CallNotifyEvent to support matrixRTC ringing

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -60,6 +60,7 @@ describe("MatrixRTCSession", () => {
         expect(sess?.memberships[0].deviceId).toEqual("AAAAAAA");
         expect(sess?.memberships[0].membershipID).toEqual("bloop");
         expect(sess?.memberships[0].isExpired()).toEqual(false);
+        expect(sess?.sessionId).toEqual("");
     });
 
     it("ignores expired memberships events", () => {

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -60,7 +60,7 @@ describe("MatrixRTCSession", () => {
         expect(sess?.memberships[0].deviceId).toEqual("AAAAAAA");
         expect(sess?.memberships[0].membershipID).toEqual("bloop");
         expect(sess?.memberships[0].isExpired()).toEqual(false);
-        expect(sess?.sessionId).toEqual("");
+        expect(sess?.callId).toEqual("");
     });
 
     it("ignores expired memberships events", () => {

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -94,6 +94,9 @@ export enum EventType {
     // Group call events
     GroupCallPrefix = "org.matrix.msc3401.call",
     GroupCallMemberPrefix = "org.matrix.msc3401.call.member",
+
+    // MatrixRTC events
+    CallNotify = "org.matrix.msc4075.call.notify",
 }
 
 export enum RelationType {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -79,7 +79,7 @@ export type MatrixRTCSessionEventHandlerMap = {
  */
 export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, MatrixRTCSessionEventHandlerMap> {
     // The session Id of the call, this is the call_id of the call Member event.
-    private _sessionId: string | undefined;
+    private _callId: string | undefined;
 
     // How many ms after we joined the call, that our membership should expire, or undefined
     // if we're not yet joined
@@ -108,8 +108,15 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     // userId:deviceId => array of keys
     private encryptionKeys = new Map<string, Array<Uint8Array>>();
     private lastEncryptionKeyUpdateRequest?: number;
-    public get sessionId(): string | undefined {
-        return this._sessionId;
+
+    /**
+     * The callId (sessionId) of the call.
+     *
+     * It can be undefined since the callId is only known once the first membership joins.
+     * The callId is the property that, per definition, groups memberships into one call.
+     */
+    public get callId(): string | undefined {
+        return this._callId;
     }
     /**
      * Returns all the call memberships for a room, oldest first
@@ -183,7 +190,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         public memberships: CallMembership[],
     ) {
         super();
-        this._sessionId = memberships[0]?.callId;
+        this._callId = memberships[0]?.callId;
         this.setExpiryTimer();
     }
 
@@ -557,7 +564,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         const oldMemberships = this.memberships;
         this.memberships = MatrixRTCSession.callMembershipsForRoom(this.room);
 
-        this._sessionId = this._sessionId ?? this.memberships[0]?.callId;
+        this._callId = this._callId ?? this.memberships[0]?.callId;
 
         const changed =
             oldMemberships.length != this.memberships.length ||

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+import { IMentions } from "../matrix";
 export interface EncryptionKeyEntry {
     index: number;
     key: string;
@@ -23,4 +23,13 @@ export interface EncryptionKeysEventContent {
     keys: EncryptionKeyEntry[];
     device_id: string;
     call_id: string;
+}
+
+export type CallNotifyType = "ring" | "notify";
+
+export interface ICallNotifyContent {
+    "application": string;
+    "m.mentions": IMentions;
+    "notify_type": CallNotifyType;
+    "call_id": string;
 }


### PR DESCRIPTION
This adds the `CallNotify` event type and the corresponding `ICallNotifyContent`

Also this adds a sessionId to matrixRTCSessions. The sessionId is the value of call_id of the first membership. The memberships for a session are filtered by that id. So we can take either membership to calculate the sessionId

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add CallNotifyEvent to support matrixRTC ringing ([\#3878](https://github.com/matrix-org/matrix-js-sdk/pull/3878)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->