### PR TITLE
Explicitly forward ELEMENT_BOT_TOKEN

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -7,4 +7,5 @@ on:
 jobs:
     call-triage-labelled:
         uses: vector-im/element-web/.github/workflows/triage-labelled.yml@develop
-        secrets: inherit
+        secrets:
+            ELEMENT_BOT_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}


### PR DESCRIPTION
`inherit` doesn't work across orgs, sadly.


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->