### PR TITLE
Reduce console log spam

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1494,6 +1494,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.ignoredInvites = new IgnoredInvites(this);
         this._secretStorage = new ServerSideSecretStorageImpl(this, opts.cryptoCallbacks ?? {});
+
+        // having lots of event listeners is not unusual. 0 means "unlimited".
+        this.setMaxListeners(0);
     }
 
     public set store(newStore: Store) {

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -142,7 +142,8 @@ export abstract class ReadReceipt<
             //    was deleted.)
             //
             // 4. The receipt had the incorrect thread ID (due to a bug in a
-            //    client, or malicious behaviour).
+            // client, or malicious behaviour).
+            logger.warn(`Ignoring receipt for missing event with id ${receipt.eventId}`);
 
             // This receipt is not "valid" because it doesn't point at an event
             // we have. We want to pretend it doesn't exist.

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -142,8 +142,7 @@ export abstract class ReadReceipt<
             //    was deleted.)
             //
             // 4. The receipt had the incorrect thread ID (due to a bug in a
-            // client, or malicious behaviour).
-            logger.warn(`Ignoring receipt for missing event with id ${receipt.eventId}`);
+            //    client, or malicious behaviour).
 
             // This receipt is not "valid" because it doesn't point at an event
             // we have. We want to pretend it doesn't exist.

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -143,6 +143,9 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
     public constructor(public readonly id: string, public rootEvent: MatrixEvent | undefined, opts: IThreadOpts) {
         super();
 
+        // each Event in the thread adds a reemitter, so we could hit the listener limit.
+        this.setMaxListeners(1000);
+
         if (!opts?.room) {
             // Logging/debugging for https://github.com/vector-im/element-web/issues/22141
             // Hope is that we end up with a more obvious stack trace.

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -64,12 +64,13 @@ export class RoomEncryptor {
         // start tracking devices for any users already known to be in this room.
         // Do not load members here, would defeat lazy loading.
         const members = room.getJoinedMembers();
+
         // At this point just mark the known members as tracked, it might not be the full list of members
         // because of lazy loading. This is fine, because we will get a member list update when sending a message for
         // the first time, see `RoomEncryptor#ensureEncryptionSession`
-        this.olmMachine.updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId))).then(() => {
-            this.prefixedLogger.debug(`Updated tracked users for room ${room.roomId}`);
-        });
+        this.olmMachine
+            .updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId)))
+            .catch((e) => this.prefixedLogger.error("Error initializing tracked users", e));
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1560,10 +1560,6 @@ class EventDecryptor {
     ) {}
 
     public async attemptEventDecryption(event: MatrixEvent): Promise<IEventDecryptionResult> {
-        this.logger.info(
-            `Attempting decryption of event ${event.getId()} in ${event.getRoomId()} from ${event.getSender()}`,
-        );
-
         // add the event to the pending list *before* attempting to decrypt.
         // then, if the key turns up while decryption is in progress (and
         // decryption fails), we will schedule a retry.

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -133,7 +133,6 @@ export class GroupCallEventHandler {
             break;
         }
 
-        logger.debug(`GroupCallEventHandler createGroupCallForRoom() processed room (roomId=${room.roomId})`);
         this.getRoomDeferred(room.roomId).resolve!();
     }
 


### PR DESCRIPTION
There's an awful lot going on in our console at the moment, making it hard to find important stuff, and contributing to poor performance and [poor log retention](https://github.com/vector-im/element-web/issues/26532).

A couple of different things in this PR:

 * Increase the `MaxListeners` setting on `MatrixClient` and `Thread`, so that we don't get "possible EventEmitter leak" warnings.

 * Disable a couple of warning/info lines that are just part of regular operation and are logged in large volumes.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->