### PR TITLE
move get device key API from client to crypto

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -397,6 +397,19 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         expect(aliceClient.getCrypto()).toHaveProperty("globalBlacklistUnverifiedDevices");
     });
 
+    it("CryptoAPI.getOwnedDeviceKeys returns the correct values", async () => {
+        const homeserverUrl = aliceClient.getHomeserverUrl();
+
+        keyResponder = new E2EKeyResponder(homeserverUrl);
+        await startClientAndAwaitFirstSync();
+        keyResponder.addKeyReceiver("@alice:localhost", keyReceiver);
+
+        const deviceKeys = await aliceClient.getCrypto()!.getOwnDeviceKeys();
+
+        expect(deviceKeys.curve25519).toEqual(keyReceiver.getDeviceKey());
+        expect(deviceKeys.ed25519).toEqual(keyReceiver.getSigningKey());
+    });
+
     it("Alice receives a megolm message", async () => {
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();
@@ -2951,17 +2964,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         it("Cross signing keys are not available for an unknown user", async () => {
             const hasCrossSigningKeysForUser = await aliceClient.getCrypto()!.userHasCrossSigningKeys("@unknown:xyz");
             expect(hasCrossSigningKeysForUser).toBe(false);
-        });
-    });
-
-    describe("Crypto API OwnDeviceKeys", function () {
-        it("CryptoAPI.getOwnedDeviceKeys returns the correct values", async () => {
-            await startClientAndAwaitFirstSync();
-
-            const deviceKeys = await aliceClient.getCrypto()!.getOwnDeviceKeys();
-
-            expect(deviceKeys.curve25519).toEqual(keyReceiver.getDeviceKey());
-            expect(deviceKeys.ed25519).toEqual(keyReceiver.getSigningKey());
         });
     });
 });

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -397,15 +397,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         expect(aliceClient.getCrypto()).toHaveProperty("globalBlacklistUnverifiedDevices");
     });
 
-    it("MatrixClient.getOwnedDeviceKeys returns the correct values", async () => {
-        await startClientAndAwaitFirstSync();
-
-        const deviceKeys = await aliceClient.getCrypto()!.getOwnDeviceKeys();
-
-        expect(deviceKeys.curve25519).toEqual(keyReceiver.getDeviceKey());
-        expect(deviceKeys.ed25519).toEqual(keyReceiver.getSigningKey());
-    });
-
     it("Alice receives a megolm message", async () => {
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();
@@ -2960,6 +2951,17 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         it("Cross signing keys are not available for an unknown user", async () => {
             const hasCrossSigningKeysForUser = await aliceClient.getCrypto()!.userHasCrossSigningKeys("@unknown:xyz");
             expect(hasCrossSigningKeysForUser).toBe(false);
+        });
+    });
+
+    describe("Crypto API OwnDeviceKeys", function () {
+        it("CryptoAPI.getOwnedDeviceKeys returns the correct values", async () => {
+            await startClientAndAwaitFirstSync();
+
+            const deviceKeys = await aliceClient.getCrypto()!.getOwnDeviceKeys();
+
+            expect(deviceKeys.curve25519).toEqual(keyReceiver.getDeviceKey());
+            expect(deviceKeys.ed25519).toEqual(keyReceiver.getSigningKey());
         });
     });
 });

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -397,6 +397,15 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         expect(aliceClient.getCrypto()).toHaveProperty("globalBlacklistUnverifiedDevices");
     });
 
+    it("MatrixClient.getOwnedDeviceKeys returns the correct values", async () => {
+        await startClientAndAwaitFirstSync();
+
+        const deviceKeys = await aliceClient.getCrypto()!.getOwnDeviceKeys();
+
+        expect(deviceKeys.curve25519).toEqual(keyReceiver.getDeviceKey());
+        expect(deviceKeys.ed25519).toEqual(keyReceiver.getSigningKey());
+    });
+
     it("Alice receives a megolm message", async () => {
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();

--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -71,11 +71,3 @@ export interface IOneTimeKey {
     fallback?: boolean;
     signatures?: ISignatures;
 }
-
-/** The result of a call to {@link CryptoApi.getOwnDeviceKeys} */
-export interface OwnDeviceKeys {
-    /** Ed25519 fingerprint public key of the current device, base64 encoded. */
-    ed25519: string;
-    /** Curve25519 identity key of the current device, base64 encoded. */
-    curve25519: string;
-}

--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -71,3 +71,11 @@ export interface IOneTimeKey {
     fallback?: boolean;
     signatures?: ISignatures;
 }
+
+/** The result of a call to {@link CryptoAPI.getOwnDeviceKeys} */
+export interface OwnDeviceKeys {
+    /** Ed25519 fingerprint public key of the current device, base64 encoded. */
+    ed25519: string;
+    /** Curve25519 identity key of the current device, base64 encoded. */
+    curve25519: string;
+}

--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -72,7 +72,7 @@ export interface IOneTimeKey {
     signatures?: ISignatures;
 }
 
-/** The result of a call to {@link CryptoAPI.getOwnDeviceKeys} */
+/** The result of a call to {@link CryptoApi.getOwnDeviceKeys} */
 export interface OwnDeviceKeys {
     /** Ed25519 fingerprint public key of the current device, base64 encoded. */
     ed25519: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -2391,7 +2391,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns base64-encoded ed25519 key. Null if crypto is
      *    disabled.
      *
-     * @deprecated Use {@link CryptoAPI.getOwnDeviceKeys}
+     * @deprecated Use {@link CryptoApi.getOwnDeviceKeys}
      */
 
     public getDeviceEd25519Key(): string | null {
@@ -2404,7 +2404,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns base64-encoded curve25519 key. Null if crypto is
      *    disabled.
      *
-     * @deprecated Use {@link CryptoAPI.getOwnDeviceKeys}
+     * @deprecated Use {@link CryptoApi.getOwnDeviceKeys}
      */
     public getDeviceCurve25519Key(): string | null {
         return this.crypto?.getDeviceCurve25519Key() ?? null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -2394,7 +2394,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns base64-encoded ed25519 key. Null if crypto is
      *    disabled.
      *
-     * @deprecated Use {@link CryptoApi.getOwnDeviceKeys}
+     * @deprecated Prefer {@link CryptoApi.getOwnDeviceKeys}
      */
     public getDeviceEd25519Key(): string | null {
         return this.crypto?.getDeviceEd25519Key() ?? null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -2393,7 +2393,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @deprecated Use {@link CryptoApi.getOwnDeviceKeys}
      */
-
     public getDeviceEd25519Key(): string | null {
         return this.crypto?.getDeviceEd25519Key() ?? null;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -2390,7 +2390,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @returns base64-encoded ed25519 key. Null if crypto is
      *    disabled.
+     *
+     * @deprecated Use {@link CryptoAPI.getOwnDeviceKeys}
      */
+
     public getDeviceEd25519Key(): string | null {
         return this.crypto?.getDeviceEd25519Key() ?? null;
     }
@@ -2400,6 +2403,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @returns base64-encoded curve25519 key. Null if crypto is
      *    disabled.
+     *
+     * @deprecated Use {@link CryptoAPI.getOwnDeviceKeys}
      */
     public getDeviceCurve25519Key(): string | null {
         return this.crypto?.getDeviceCurve25519Key() ?? null;

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -49,7 +49,7 @@ export interface CryptoApi {
     /**
      * Get the public part of the device keys for the current device.
      *
-     * @returns The device keys as a `OwnDeviceKeys` object
+     * @returns The public device keys.
      */
     getOwnDeviceKeys(): Promise<OwnDeviceKeys>;
 

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -760,7 +760,7 @@ export enum EventShieldReason {
 export interface OwnDeviceKeys {
     /** Public part of the Ed25519 fingerprint key for the current device, base64 encoded. */
     ed25519: string;
-    /** Public part of the Curve25519 identity key of the current device, base64 encoded. */
+    /** Public part of the Curve25519 identity key for the current device, base64 encoded. */
     curve25519: string;
 }
 

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -23,6 +23,7 @@ import { VerificationRequest } from "./crypto-api/verification";
 import { BackupTrustInfo, KeyBackupCheck, KeyBackupInfo } from "./crypto-api/keybackup";
 import { ISignatures } from "./@types/signed";
 import { MatrixEvent } from "./models/event";
+import { OwnDeviceKeys } from "./@types/crypto";
 
 /**
  * Public interface to the cryptography parts of the js-sdk
@@ -200,6 +201,13 @@ export interface CryptoApi {
      * @returns If cross-signing has been initialised on this device, the ID of the given key. Otherwise, null
      */
     getCrossSigningKeyId(type?: CrossSigningKey): Promise<string | null>;
+
+    /**
+     * Get the public part of the device keys for the current device.
+     *
+     * @returns The device keys as a `OwnDeviceKeys` object
+     */
+    getOwnDeviceKeys(): Promise<OwnDeviceKeys>;
 
     /**
      * Bootstrap cross-signing by creating keys if needed.

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -23,7 +23,6 @@ import { VerificationRequest } from "./crypto-api/verification";
 import { BackupTrustInfo, KeyBackupCheck, KeyBackupInfo } from "./crypto-api/keybackup";
 import { ISignatures } from "./@types/signed";
 import { MatrixEvent } from "./models/event";
-import { OwnDeviceKeys } from "./@types/crypto";
 
 /**
  * Public interface to the cryptography parts of the js-sdk
@@ -46,6 +45,13 @@ export interface CryptoApi {
      * @returns the formatted version
      */
     getVersion(): string;
+
+    /**
+     * Get the public part of the device keys for the current device.
+     *
+     * @returns The device keys as a `OwnDeviceKeys` object
+     */
+    getOwnDeviceKeys(): Promise<OwnDeviceKeys>;
 
     /**
      * Perform any background tasks that can be done before a message is ready to
@@ -201,13 +207,6 @@ export interface CryptoApi {
      * @returns If cross-signing has been initialised on this device, the ID of the given key. Otherwise, null
      */
     getCrossSigningKeyId(type?: CrossSigningKey): Promise<string | null>;
-
-    /**
-     * Get the public part of the device keys for the current device.
-     *
-     * @returns The device keys as a `OwnDeviceKeys` object
-     */
-    getOwnDeviceKeys(): Promise<OwnDeviceKeys>;
 
     /**
      * Bootstrap cross-signing by creating keys if needed.
@@ -755,6 +754,14 @@ export enum EventShieldReason {
      * decryption keys.
      */
     MISMATCHED_SENDER_KEY,
+}
+
+/** The result of a call to {@link CryptoApi.getOwnDeviceKeys} */
+export interface OwnDeviceKeys {
+    /** Public part of the Ed25519 fingerprint key for the current device, base64 encoded. */
+    ed25519: string;
+    /** Public part of the Curve25519 identity key of the current device, base64 encoded. */
+    curve25519: string;
 }
 
 export * from "./crypto-api/verification";

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -20,13 +20,7 @@ limitations under the License.
 import anotherjson from "another-json";
 import { v4 as uuidv4 } from "uuid";
 
-import type {
-    IDeviceKeys,
-    IEventDecryptionResult,
-    IMegolmSessionData,
-    IOneTimeKey,
-    OwnDeviceKeys,
-} from "../@types/crypto";
+import type { IDeviceKeys, IEventDecryptionResult, IMegolmSessionData, IOneTimeKey } from "../@types/crypto";
 import type { PkDecryption, PkSigning } from "@matrix-org/olm";
 import { EventType, ToDeviceMessageId } from "../@types/event";
 import { TypedReEmitter } from "../ReEmitter";
@@ -104,6 +98,7 @@ import {
     KeyBackupCheck,
     KeyBackupInfo,
     VerificationRequest as CryptoApiVerificationRequest,
+    OwnDeviceKeys,
 } from "../crypto-api";
 import { Device, DeviceMap } from "../models/device";
 import { deviceInfoToDevice } from "./device-converter";
@@ -1975,7 +1970,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns base64-encoded ed25519 key.
      *
-     * @deprecated "Prefer getOwnDeviceKeys (async)"
+     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}
      */
     public getDeviceEd25519Key(): string | null {
         return this.olmDevice.deviceEd25519Key;
@@ -1986,7 +1981,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns base64-encoded curve25519 key.
      *
-     * @deprecated "Prefer getOwnDeviceKeys (async)"
+     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}
      */
     public getDeviceCurve25519Key(): string | null {
         return this.olmDevice.deviceCurve25519Key;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -20,7 +20,13 @@ limitations under the License.
 import anotherjson from "another-json";
 import { v4 as uuidv4 } from "uuid";
 
-import type { IDeviceKeys, IEventDecryptionResult, IMegolmSessionData, IOneTimeKey } from "../@types/crypto";
+import type {
+    IDeviceKeys,
+    IEventDecryptionResult,
+    IMegolmSessionData,
+    IOneTimeKey,
+    OwnDeviceKeys,
+} from "../@types/crypto";
 import type { PkDecryption, PkSigning } from "@matrix-org/olm";
 import { EventType, ToDeviceMessageId } from "../@types/event";
 import { TypedReEmitter } from "../ReEmitter";
@@ -1968,6 +1974,8 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * Get the Ed25519 key for this device
      *
      * @returns base64-encoded ed25519 key.
+     *
+     * @deprecated "Prefer getOwnDeviceKeys (async)"
      */
     public getDeviceEd25519Key(): string | null {
         return this.olmDevice.deviceEd25519Key;
@@ -1977,9 +1985,24 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * Get the Curve25519 key for this device
      *
      * @returns base64-encoded curve25519 key.
+     *
+     * @deprecated "Prefer getOwnDeviceKeys (async)"
      */
     public getDeviceCurve25519Key(): string | null {
         return this.olmDevice.deviceCurve25519Key;
+    }
+
+    public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
+        if (!this.olmDevice.deviceCurve25519Key) {
+            throw new Error("Curve25519 key not yet created");
+        }
+        if (!this.olmDevice.deviceEd25519Key) {
+            throw new Error("Ed25519 key not yet created");
+        }
+        return {
+            ed25519: this.olmDevice.deviceEd25519Key,
+            curve25519: this.olmDevice.deviceCurve25519Key,
+        };
     }
 
     /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1987,6 +1987,9 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         return this.olmDevice.deviceCurve25519Key;
     }
 
+    /**
+     * Implementation of {@link CryptoApi#getOwnDeviceKeys}.
+     */
     public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
         if (!this.olmDevice.deviceCurve25519Key) {
             throw new Error("Curve25519 key not yet created");

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1970,7 +1970,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns base64-encoded ed25519 key.
      *
-     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}
+     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}.
      */
     public getDeviceEd25519Key(): string | null {
         return this.olmDevice.deviceEd25519Key;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -389,6 +389,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         }
         throw new Error("Device keys not found");
     }
+
     public prepareToEncrypt(room: Room): void {
         const encryptor = this.roomEncryptors[room.roomId];
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import anotherjson from "another-json";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import type { IEventDecryptionResult, IMegolmSessionData, OwnDeviceKeys } from "../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
 import type { IEncryptedEventInfo } from "../crypto/api";
 import { IContent, MatrixEvent, MatrixEventEvent } from "../models/event";
@@ -49,6 +49,7 @@ import {
     KeyBackupCheck,
     KeyBackupInfo,
     KeyBackupSession,
+    OwnDeviceKeys,
     UserVerificationStatus,
     VerificationRequest,
 } from "../crypto-api";
@@ -155,21 +156,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
         // Check and start in background the key backup connection
         this.checkKeyBackupAndEnable();
-    }
-
-    public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
-        const device: RustSdkCryptoJs.Device = await this.olmMachine.getDevice(
-            this.olmMachine.userId,
-            this.olmMachine.deviceId,
-        );
-        // could be undefined if there is no such algorithm for that device.
-        if (device.curve25519Key && device.ed25519Key) {
-            return {
-                ed25519: device.ed25519Key.toBase64(),
-                curve25519: device.curve25519Key.toBase64(),
-            };
-        }
-        throw new Error("Device keys not found");
     }
 
     /**
@@ -386,6 +372,23 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         return `Rust SDK ${versions.matrix_sdk_crypto} (${versions.git_sha}), Vodozemac ${versions.vodozemac}`;
     }
 
+    /**
+     * Implementation of {@link CryptoApi#getOwnDeviceKeys}.
+     */
+    public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
+        const device: RustSdkCryptoJs.Device = await this.olmMachine.getDevice(
+            this.olmMachine.userId,
+            this.olmMachine.deviceId,
+        );
+        // could be undefined if there is no such algorithm for that device.
+        if (device.curve25519Key && device.ed25519Key) {
+            return {
+                ed25519: device.ed25519Key.toBase64(),
+                curve25519: device.curve25519Key.toBase64(),
+            };
+        }
+        throw new Error("Device keys not found");
+    }
     public prepareToEncrypt(room: Room): void {
         const encryptor = this.roomEncryptors[room.roomId];
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import anotherjson from "another-json";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
+import type { IEventDecryptionResult, IMegolmSessionData, OwnDeviceKeys } from "../@types/crypto";
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
 import type { IEncryptedEventInfo } from "../crypto/api";
 import { IContent, MatrixEvent, MatrixEventEvent } from "../models/event";
@@ -155,6 +155,21 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
         // Check and start in background the key backup connection
         this.checkKeyBackupAndEnable();
+    }
+
+    public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
+        const device: RustSdkCryptoJs.Device = await this.olmMachine.getDevice(
+            this.olmMachine.userId,
+            this.olmMachine.deviceId,
+        );
+        // could be undefined if there is no such algorithm for that device.
+        if (device.curve25519Key && device.ed25519Key) {
+            return {
+                ed25519: device.ed25519Key.toBase64(),
+                curve25519: device.curve25519Key.toBase64(),
+            };
+        }
+        throw new Error("Device keys not found");
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

`MatrixClient` API was exposing two methods that only worked for legacy crypto:
    - `getDeviceEd25519Key`
    - `getDeviceCurve25519Key`

=> These are used in the react-sdk for some functionality (rageshake, sentry, rendez-vous).

I have deprectaded those calls from `MatrixClient` and created a new API in `CryptoApi` (where it belongs):

`getOwnDeviceKeys(): Promise<OwnDeviceKeys>`


## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->