### PR TITLE
Better fallback for the event `localTimestamp` calculation.

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -85,7 +85,7 @@ describe("CallMembership", () => {
 
     it("considers memberships expired when local age large", () => {
         const fakeEvent = makeMockEvent(1000);
-        fakeEvent.getLocalAge = jest.fn().mockReturnValue(6000);
+        fakeEvent.localTimestamp = Date.now() - 6000;
         const membership = new CallMembership(fakeEvent, membershipTemplate);
         expect(membership.isExpired()).toEqual(true);
     });

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -20,49 +20,27 @@ import { randomString } from "../../../src/randomstring";
 
 export function makeMockRoom(memberships: CallMembershipData[], localAge: number | null = null): Room {
     const roomId = randomString(8);
-    // If makeMockRoom is used instead of one of the other functions in this file,
-    // we store the localTimestamp so that subsequent calls calculate the expiration based on the localTimestamp
-    // using Date.now(). So, jest.advanceTimersByTime() can be used to simulate the passage of time.
-
-    // The actual time of the underlying mocked events will be: localTimestamp ?? localAge ?? 0
-    const localTimestamp = Date.now() - (localAge ?? 10);
+    // Caching roomState here so it does not get recreated when calling `getLiveTimeline.getState()`
+    const roomState = makeMockRoomState(memberships, roomId, localAge);
     return {
         roomId: roomId,
         getLiveTimeline: jest.fn().mockReturnValue({
-            // When setting up `makeMockRoomState` we always want to use the localTimestamp instead of localAge.
-            getState: jest.fn().mockReturnValue(makeMockRoomState(memberships, roomId, null, localTimestamp)),
+            getState: jest.fn().mockReturnValue(roomState),
         }),
     } as unknown as Room;
 }
 
-export function makeMockRoomState(
-    memberships: CallMembershipData[],
-    roomId: string,
-    /**`localAge` is ignored if localTimestamp is present.*/
-    localAge: number | null = null,
-    localTimestamp: number | null = null,
-) {
+export function makeMockRoomState(memberships: CallMembershipData[], roomId: string, localAge: number | null = null) {
+    const event = mockRTCEvent(memberships, roomId, localAge);
     return {
         getStateEvents: (_: string, stateKey: string) => {
-            // If localTimestamp is present mockRTCEvent does not recompute
-            // the localTimestamp based on Date.now() when `getStateEvents` is called.
-            const event = mockRTCEvent(memberships, roomId, localAge, localTimestamp);
-
             if (stateKey !== undefined) return event;
             return [event];
         },
     };
 }
 
-export function mockRTCEvent(
-    memberships: CallMembershipData[],
-    roomId: string,
-    /**`localAge` is ignored if localTimestamp is present.*/
-    localAge: number | null,
-    localTimestamp: number | null = null,
-): MatrixEvent {
-    const _localTimestamp = localTimestamp ?? Date.now() - (localAge ?? 10);
-
+export function mockRTCEvent(memberships: CallMembershipData[], roomId: string, localAge: number | null): MatrixEvent {
     return {
         getType: jest.fn().mockReturnValue(EventType.GroupCallMemberPrefix),
         getContent: jest.fn().mockReturnValue({
@@ -70,7 +48,7 @@ export function mockRTCEvent(
         }),
         getSender: jest.fn().mockReturnValue("@mock:user.example"),
         getTs: jest.fn().mockReturnValue(1000),
-        localTimestamp: _localTimestamp,
+        localTimestamp: Date.now() - (localAge ?? 10),
         getRoomId: jest.fn().mockReturnValue(roomId),
         sender: {
             userId: "@mock:user.example",

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -60,8 +60,7 @@ export function mockRTCEvent(
         }),
         getSender: jest.fn().mockReturnValue("@mock:user.example"),
         getTs: jest.fn().mockReturnValue(1000),
-        getLocalAge: getLocalAgeFn,
-        localTimestamp: Date.now(),
+        localTimestamp: Date.now() - getLocalAgeFn(),
         getRoomId: jest.fn().mockReturnValue(roomId),
         sender: {
             userId: "@mock:user.example",

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -91,7 +91,7 @@ export class CallMembership {
     }
 
     public isExpired(): boolean {
-        return this.getAbsoluteExpiry() < this.parentEvent.getTs() + this.parentEvent.getLocalAge();
+        return this.getMsUntilExpiry() <= 0;
     }
 
     public getActiveFoci(): Focus[] {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -410,7 +410,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         // The fallback in these cases will be to use the origin_server_ts.
         // For EDUs, the origin_server_ts also is not defined so we use Date.now().
         const age = this.getAge();
-        this.localTimestamp = age ? Date.now() - age : this.getTs() ?? Date.now();
+        this.localTimestamp = age !== undefined ? Date.now() - age : this.getTs() ?? Date.now();
         this.reEmitter = new TypedReEmitter(this);
     }
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -404,7 +404,8 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         });
 
         this.txnId = event.txn_id;
-        this.localTimestamp = Date.now() - (this.getAge() ?? 0);
+        const age = this.getAge();
+        this.localTimestamp = age ? Date.now() - age : this.getTs() ?? 0;
         this.reEmitter = new TypedReEmitter(this);
     }
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -405,7 +405,8 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
 
         this.txnId = event.txn_id;
         // The localTimestamp is calculated using the age.
-        // Some homeserver don't provide the unsigned field for state events.
+        // Some events lack an `age` property, either because they are EDUs such as typing events,
+        // or due to server-side bugs such as https://github.com/matrix-org/synapse/issues/8429.
         // The fallback in these cases will be to use the origin_server_ts.
         // For EDUs, the origin_server_ts also is not defined so we use Date.now().
         const age = this.getAge();

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -404,8 +404,12 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         });
 
         this.txnId = event.txn_id;
+        // The localTimestamp is calculated using the age.
+        // Some homeserver don't provide the unsigned field for state events.
+        // The fallback in these cases will be to use the origin_server_ts.
+        // For EDUs, the origin_server_ts also is not defined so we use Date.now().
         const age = this.getAge();
-        this.localTimestamp = age ? Date.now() - age : this.getTs() ?? 0;
+        this.localTimestamp = age ? Date.now() - age : this.getTs() ?? Date.now();
         this.reEmitter = new TypedReEmitter(this);
     }
 


### PR DESCRIPTION
Signed-off-by: Timo K <toger5@hotmail.de>
State events from a couple of home servers dont return an `age` proptery in their unsigned field. (including element.io).
For an actual exampe, this room: https://matrix.to/#/#thisweekinmatrix:matrix.org can be checked (lots of member events from other homeservers are not featuring a unsigned.age field): 
<img width="854" alt="Screenshot 2023-11-17 at 19 36 16" src="https://github.com/matrix-org/matrix-js-sdk/assets/16718859/5f4688c2-b288-4663-9c7e-ad8f6b048b7e">


Call state events are relying on this property to determin if they are expired or not.

Before a non existent age property in the unsigned field resulted in falling back to 0. The `localTimestamp` was then `Date.now()` at the time of loading this event. Which made it always really recent -> never expired.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Better fallback for the event `localTimestamp` calculation. ([\#3900](https://github.com/matrix-org/matrix-js-sdk/pull/3900)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->