### PR TITLE
Only await key query after lazy members resolved

### DIFF
--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -157,13 +157,14 @@ export class RoomEncryptor {
             logger.debug(`Processing outgoing requests`);
             await this.outgoingRequestManager.doProcessOutgoingRequests();
         } else {
-            // if members are already loaded it's less critical to await on key queries.
-            // We might still want to trigger a processOutgoingRequests here, if the
-            // query is done timely enough, the freshly tracked users will get the room key.
+            // If members are already loaded it's less critical to await on key queries.
+            // We might still want to trigger a processOutgoingRequests here.
+            // The next call to ensureSessions will wait a bit on in flight key queries we are
+            // interested in. If a sync handling happens in the meantime, and some new members are added to the room
+            // or have new devices it would give us a chance to query them before sending.
+            // It's less critical due to the racy nature of this process.
             logger.debug(`Processing outgoing requests in background`);
-            this.outgoingRequestManager.doProcessOutgoingRequests().then(() => {
-                // nop
-            });
+            this.outgoingRequestManager.doProcessOutgoingRequests();
         }
 
         logger.debug(

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -159,7 +159,7 @@ export class RoomEncryptor {
         } else {
             // If members are already loaded it's less critical to await on key queries.
             // We might still want to trigger a processOutgoingRequests here.
-            // The next call to ensureSessions will wait a bit on in flight key queries we are
+            // The call to `ensureSessionsForUsers` below will wait a bit on in-flight key queries we are
             // interested in. If a sync handling happens in the meantime, and some new members are added to the room
             // or have new devices it would give us a chance to query them before sending.
             // It's less critical due to the racy nature of this process.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->


Quick improvment on send message performance.

Previously we were waiting on all `key/query` to be processed before sharing the room keys (to ensure having the most up to date device list).

It's a bit too aggressive, and in some case was impacting time to send for no benefits.

In this change we will only wait for `key/query` if the list of member (lazy loading) was just resolved in this send cycle. Because in this case several users might be added to the tracked user list and there is a high risk that their list of devices won't be known yet. And as they might be in the room since long it would be bad that they don't get the key.

If the member list is not just resolved, we don't want to wait on all `key/query`, we just trigger a launch in background. Freshly joined users will get the key if the request is fast enough. If not they will get it for the next message.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->