### PR TITLE
Remove 'Ignoring receipt' log line that logs very often'

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -3165,7 +3165,6 @@ describe("Room", function () {
                 // When we ask what they have read
                 // Then we say "nothing"
                 expect(room.getEventReadUpTo(userA)).toBeNull();
-                expect(logger.warn).toHaveBeenCalledWith("Ignoring receipt for missing event with id missingEventId");
             });
 
             it("ignores receipts pointing at the wrong thread", () => {

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -143,7 +143,6 @@ export abstract class ReadReceipt<
             //
             // 4. The receipt had the incorrect thread ID (due to a bug in a
             // client, or malicious behaviour).
-            logger.warn(`Ignoring receipt for missing event with id ${receipt.eventId}`);
 
             // This receipt is not "valid" because it doesn't point at an event
             // we have. We want to pretend it doesn't exist.


### PR DESCRIPTION
This log line fires whenever we check for receipt for any user that points too far back in history for us to have the event loaded. It's far too noisy to be useful.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->