### PR TITLE
Update to matrix-sdk-crypto-wasm 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^3.0.1",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^3.1.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1632,10 +1632,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.0.1.tgz#56a0376f8a389264bcf4d5325b378a71f18b7664"
-  integrity sha512-r0PBfUKlLHm67+fpIV21netX5+DujbY2XjJy7JUGJ55oW4XWBNbSf9vElfaQkrdt/iDscL/8I5PoD5lCuVW6zA==
+"@matrix-org/matrix-sdk-crypto-wasm@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.1.0.tgz#38d8707dd5bdad4e98a0a66bf266accfc401b3cd"
+  integrity sha512-jFl8jeL16u9pyo1NIdg6US4r+Srm7KixL+cMYVbRG8EwB4UpF4Bt+3TdBUhWGbVc1Qte1htdBjPs8ZB+gZWkYw==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
There are a bunch of improvements in 3.1.0 ([changelog](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/blob/main/CHANGELOG.md#matrix-sdk-crypto-wasm-v310)), but in particular this should fix [#26375](https://github.com/vector-im/element-web/issues/26375). 

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->