### PR TITLE
Explicitly free some Rust-side objects

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -871,7 +871,7 @@ describe("RustCrypto", () => {
         });
 
         it("returns a verified UserVerificationStatus when the UserIdentity is verified", async () => {
-            olmMachine.getIdentity.mockResolvedValue({ isVerified: jest.fn().mockReturnValue(true) });
+            olmMachine.getIdentity.mockResolvedValue({ free: jest.fn(), isVerified: jest.fn().mockReturnValue(true) });
 
             const userVerificationStatus = await rustCrypto.getUserVerificationStatus(testData.TEST_USER_ID);
             expect(userVerificationStatus.isVerified()).toBeTruthy();

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -645,6 +645,7 @@ describe("RustCrypto", () => {
 
         it("should call getDevice", async () => {
             olmMachine.getDevice.mockResolvedValue({
+                free: jest.fn(),
                 isCrossSigningTrusted: jest.fn().mockReturnValue(false),
                 isLocallyTrusted: jest.fn().mockReturnValue(false),
                 isCrossSignedByOwner: jest.fn().mockReturnValue(false),

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -91,10 +91,13 @@ export class CrossSigningIdentity {
                     this.olmMachine.userId,
                     this.olmMachine.deviceId,
                 );
-
-                // Sign the device with our cross-signing key and upload the signature
-                const request: RustSdkCryptoJs.SignatureUploadRequest = await device.verify();
-                await this.outgoingRequestProcessor.makeOutgoingRequest(request);
+                try {
+                    // Sign the device with our cross-signing key and upload the signature
+                    const request: RustSdkCryptoJs.SignatureUploadRequest = await device.verify();
+                    await this.outgoingRequestProcessor.makeOutgoingRequest(request);
+                } finally {
+                    device.free();
+                }
             } else {
                 logger.log(
                     "bootStrapCrossSigning: Cross-signing private keys not found locally or in secret storage, creating new keys",


### PR DESCRIPTION
Finalization in Javascript is not guaranteed - sometimes the FinalizationRegistry just forgets to call the finalizers on some objects. This is problematic because it means we leak references on the Rust side, which (as well as causing memory leaks) ultimately leads to us holding open the indexeddb, which then means we can't successfully log in/out.

This isn't meant to be a comprehensive fix, but it does add explicit `free` calls in a number of places which seem particularly prone to leaking, and empirically it was enough for me to get a Cypress test which logs out and back in working again.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->