### PR TITLE
Add guards against `MatrixClient.stopClient` calls

### DIFF
--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -284,6 +284,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     await this.outgoingRequestProcessor.makeOutgoingRequest(request);
                     numFailures = 0;
 
+                    if (this.stopped) break;
                     const keyCount: RustSdkCryptoJs.RoomKeyCounts = await this.olmMachine.roomKeyCounts();
                     const remaining = keyCount.total - keyCount.backedUp;
                     this.emit(CryptoEvent.KeyBackupSessionsRemaining, remaining);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -454,7 +454,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
      */
     public async getUserDeviceInfo(userIds: string[], downloadUncached = false): Promise<DeviceMap> {
         const deviceMapByUserId = new Map<string, Map<string, Device>>();
-        const rustTrackedUsers: Set<RustSdkCryptoJs.UserId> = await this.olmMachine.trackedUsers();
+        const rustTrackedUsers: Set<RustSdkCryptoJs.UserId> = await this.getOlmMachineOrThrow().trackedUsers();
 
         // Convert RustSdkCryptoJs.UserId to a `Set<string>`
         const trackedUsers = new Set<string>();
@@ -592,7 +592,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
      */
     public async getUserVerificationStatus(userId: string): Promise<UserVerificationStatus> {
         const userIdentity: RustSdkCryptoJs.UserIdentity | RustSdkCryptoJs.OwnUserIdentity | undefined =
-            await this.olmMachine.getIdentity(new RustSdkCryptoJs.UserId(userId));
+            await this.getOlmMachineOrThrow().getIdentity(new RustSdkCryptoJs.UserId(userId));
         if (userIdentity === undefined) {
             return new UserVerificationStatus(false, false, false);
         }


### PR DESCRIPTION
If we call methods on `OlmMachine` after `MatrixClient.stopClient` is called, we will end up with a "use of moved value" error. We can turn these into something more useful with judicious use of `getOlmMachineOrThrow`.

Alternatively, we can sidestep the issue by bailing out sooner.