### PR TITLE
Signal key backup in cache

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -1259,14 +1259,15 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
 
             const requestId = await requestPromises.get("m.megolm_backup.v1");
 
+            const keyBackupIsCached = new Promise<void>((resolve) => {
+                aliceClient.on(CryptoEvent.KeyBackupPrivateKeyCached, () => {
+                    resolve();
+                });
+            });
+
             await sendBackupGossipAndExpectVersion(requestId!, BACKUP_DECRYPTION_KEY_BASE64, matchingBackupInfo);
 
-            // We are lacking a way to signal that the secret has been received, so we wait a bit..
-            jest.useRealTimers();
-            await new Promise((resolve) => {
-                setTimeout(resolve, 500);
-            });
-            jest.useFakeTimers();
+            await keyBackupIsCached;
 
             // the backup secret should be cached
             const cachedKey = await aliceClient.getCrypto()!.getSessionBackupPrivateKey();

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -1260,8 +1260,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             const requestId = await requestPromises.get("m.megolm_backup.v1");
 
             const keyBackupIsCached = new Promise<void>((resolve) => {
-                aliceClient.on(CryptoEvent.KeyBackupPrivateKeyCached, () => {
-                    resolve();
+                aliceClient.on(CryptoEvent.KeyBackupDecryptionKeyCached, (version) => {
+                    if (version === matchingBackupInfo.version) {
+                        resolve();
+                    }
                 });
             });
 

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -1259,13 +1259,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
 
             const requestId = await requestPromises.get("m.megolm_backup.v1");
 
-            const keyBackupIsCached = new Promise<void>((resolve) => {
-                aliceClient.on(CryptoEvent.KeyBackupDecryptionKeyCached, (version) => {
-                    if (version === matchingBackupInfo.version) {
-                        resolve();
-                    }
-                });
-            });
+            const keyBackupIsCached = emitPromise(aliceClient, CryptoEvent.KeyBackupDecryptionKeyCached);
 
             await sendBackupGossipAndExpectVersion(requestId!, BACKUP_DECRYPTION_KEY_BASE64, matchingBackupInfo);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -951,7 +951,7 @@ type CryptoEvents =
     | CryptoEvent.KeyBackupStatus
     | CryptoEvent.KeyBackupFailed
     | CryptoEvent.KeyBackupSessionsRemaining
-    | CryptoEvent.KeyBackupPrivateKeyCached
+    | CryptoEvent.KeyBackupDecryptionKeyCached
     | CryptoEvent.RoomKeyRequest
     | CryptoEvent.RoomKeyRequestCancellation
     | CryptoEvent.VerificationRequest
@@ -2360,7 +2360,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             CryptoEvent.KeyBackupStatus,
             CryptoEvent.KeyBackupSessionsRemaining,
             CryptoEvent.KeyBackupFailed,
-            CryptoEvent.KeyBackupPrivateKeyCached,
+            CryptoEvent.KeyBackupDecryptionKeyCached,
         ]);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -951,6 +951,7 @@ type CryptoEvents =
     | CryptoEvent.KeyBackupStatus
     | CryptoEvent.KeyBackupFailed
     | CryptoEvent.KeyBackupSessionsRemaining
+    | CryptoEvent.KeyBackupPrivateKeyCached
     | CryptoEvent.RoomKeyRequest
     | CryptoEvent.RoomKeyRequestCancellation
     | CryptoEvent.VerificationRequest
@@ -2359,6 +2360,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             CryptoEvent.KeyBackupStatus,
             CryptoEvent.KeyBackupSessionsRemaining,
             CryptoEvent.KeyBackupFailed,
+            CryptoEvent.KeyBackupPrivateKeyCached,
         ]);
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -231,14 +231,18 @@ export enum CryptoEvent {
     KeyBackupStatus = "crypto.keyBackupStatus",
     KeyBackupFailed = "crypto.keyBackupFailed",
     KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
+
     /**
      * Fires when a new valid backup decryption key is in cache.
+     * This will happen when a secret is received from another session, from secret storage,
+     * or when a new backup is created from this session
      *
-     * The payload is the `KeyBackupInfo`.
+     * The payload is the version of the backup for which we have the key for.
      *
      * This event is only fired by the rust crypto backend.
      */
-    KeyBackupPrivateKeyCached = "crypto.KeyBackupPrivateKeyCached",
+    KeyBackupDecryptionKeyCached = "crypto.keyBackupDecryptionKeyCached",
+
     KeySignatureUploadFailure = "crypto.keySignatureUploadFailure",
     /** @deprecated Use `VerificationRequestReceived`. */
     VerificationRequest = "crypto.verification.request",
@@ -304,7 +308,13 @@ export type CryptoEventHandlerMap = {
     [CryptoEvent.KeyBackupStatus]: (enabled: boolean) => void;
     [CryptoEvent.KeyBackupFailed]: (errcode: string) => void;
     [CryptoEvent.KeyBackupSessionsRemaining]: (remaining: number) => void;
-    [CryptoEvent.KeyBackupPrivateKeyCached]: (info: KeyBackupInfo) => void;
+
+    /**
+     * Fires when the backup decryption key is received and cached.
+     *
+     * @param version - The version of the backup for which we have the key for.
+     */
+    [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
     [CryptoEvent.KeySignatureUploadFailure]: (
         failures: IUploadKeySignaturesResponse["failures"],
         source: "checkOwnCrossSigningTrust" | "afterCrossSigningLocalKeyChange" | "setDeviceVerification",

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -235,7 +235,7 @@ export enum CryptoEvent {
     /**
      * Fires when a new valid backup decryption key is in cache.
      * This will happen when a secret is received from another session, from secret storage,
-     * or when a new backup is created from this session
+     * or when a new backup is created from this session.
      *
      * The payload is the version of the backup for which we have the key for.
      *

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -231,6 +231,14 @@ export enum CryptoEvent {
     KeyBackupStatus = "crypto.keyBackupStatus",
     KeyBackupFailed = "crypto.keyBackupFailed",
     KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
+    /**
+     * Fires when a new valid backup decryption key is in cache.
+     *
+     * The payload is the `KeyBackupInfo`.
+     *
+     * This event is only fired by the rust crypto backend.
+     */
+    KeyBackupPrivateKeyCached = "crypto.KeyBackupPrivateKeyCached",
     KeySignatureUploadFailure = "crypto.keySignatureUploadFailure",
     /** @deprecated Use `VerificationRequestReceived`. */
     VerificationRequest = "crypto.verification.request",
@@ -296,6 +304,7 @@ export type CryptoEventHandlerMap = {
     [CryptoEvent.KeyBackupStatus]: (enabled: boolean) => void;
     [CryptoEvent.KeyBackupFailed]: (errcode: string) => void;
     [CryptoEvent.KeyBackupSessionsRemaining]: (remaining: number) => void;
+    [CryptoEvent.KeyBackupPrivateKeyCached]: (info: KeyBackupInfo) => void;
     [CryptoEvent.KeySignatureUploadFailure]: (
         failures: IUploadKeySignaturesResponse["failures"],
         source: "checkOwnCrossSigningTrust" | "afterCrossSigningLocalKeyChange" | "setDeviceVerification",

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -158,7 +158,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
             await this.olmMachine.saveBackupDecryptionKey(backupDecryptionKey, backupCheck.backupInfo.version);
             // Emit an event that we have a new backup decryption key, so that client can automatically
             // start importing all keys from the backup.
-            this.emit(CryptoEvent.KeyBackupPrivateKeyCached, backupCheck.backupInfo);
+            this.emit(CryptoEvent.KeyBackupDecryptionKeyCached, backupCheck.backupInfo.version);
             return true;
         } catch (e) {
             logger.warn("handleBackupSecretReceived: Invalid backup decryption key", e);
@@ -384,6 +384,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         );
 
         this.olmMachine.saveBackupDecryptionKey(randomKey, res.version);
+        this.emit(CryptoEvent.KeyBackupDecryptionKeyCached, res.version);
 
         return {
             version: res.version,
@@ -494,14 +495,11 @@ export type RustBackupCryptoEvents =
     | CryptoEvent.KeyBackupStatus
     | CryptoEvent.KeyBackupSessionsRemaining
     | CryptoEvent.KeyBackupFailed
-    | CryptoEvent.KeyBackupPrivateKeyCached;
+    | CryptoEvent.KeyBackupDecryptionKeyCached;
 
 export type RustBackupCryptoEventMap = {
     [CryptoEvent.KeyBackupStatus]: (enabled: boolean) => void;
     [CryptoEvent.KeyBackupSessionsRemaining]: (remaining: number) => void;
     [CryptoEvent.KeyBackupFailed]: (errCode: string) => void;
-    /**
-     * Fired when the backup decryption key is received via secret sharing and stored in cache.
-     */
-    [CryptoEvent.KeyBackupPrivateKeyCached]: (info: KeyBackupInfo) => void;
+    [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
 };

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -156,8 +156,8 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
             );
 
             await this.olmMachine.saveBackupDecryptionKey(backupDecryptionKey, backupCheck.backupInfo.version);
-            // Emit an event that we have a new backup decryption key, so that client can automatically
-            // start importing all keys from the backup.
+            // Emit an event that we have a new backup decryption key, so that the sdk can start
+            // importing keys from backup if needed.
             this.emit(CryptoEvent.KeyBackupDecryptionKeyCached, backupCheck.backupInfo.version);
             return true;
         } catch (e) {

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1130,11 +1130,10 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             throw new Error("storeSessionBackupPrivateKey: version is required");
         }
 
-        await this.olmMachine.saveBackupDecryptionKey(
+        await this.backupManager.saveBackupDecryptionKey(
             RustSdkCryptoJs.BackupDecryptionKey.fromBase64(base64Key),
             version,
         );
-        this.emit(CryptoEvent.KeyBackupDecryptionKeyCached, version);
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -149,6 +149,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             CryptoEvent.KeyBackupStatus,
             CryptoEvent.KeyBackupSessionsRemaining,
             CryptoEvent.KeyBackupFailed,
+            CryptoEvent.KeyBackupPrivateKeyCached,
         ]);
 
         this.crossSigningIdentity = new CrossSigningIdentity(olmMachine, this.outgoingRequestProcessor, secretStorage);
@@ -1827,4 +1828,9 @@ type RustCryptoEventMap = {
      * Fires when the trust status of a user changes.
      */
     [CryptoEvent.UserTrustStatusChanged]: (userId: string, userTrustLevel: UserVerificationStatus) => void;
+
+    /**
+     * Fires when the backup decryption key is received via secret sharing.
+     */
+    [CryptoEvent.KeyBackupPrivateKeyCached]: (info: KeyBackupInfo) => void;
 } & RustBackupCryptoEventMap;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -149,7 +149,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             CryptoEvent.KeyBackupStatus,
             CryptoEvent.KeyBackupSessionsRemaining,
             CryptoEvent.KeyBackupFailed,
-            CryptoEvent.KeyBackupPrivateKeyCached,
+            CryptoEvent.KeyBackupDecryptionKeyCached,
         ]);
 
         this.crossSigningIdentity = new CrossSigningIdentity(olmMachine, this.outgoingRequestProcessor, secretStorage);
@@ -1113,6 +1113,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             RustSdkCryptoJs.BackupDecryptionKey.fromBase64(base64Key),
             version,
         );
+        this.emit(CryptoEvent.KeyBackupDecryptionKeyCached, version);
     }
 
     /**
@@ -1829,8 +1830,5 @@ type RustCryptoEventMap = {
      */
     [CryptoEvent.UserTrustStatusChanged]: (userId: string, userTrustLevel: UserVerificationStatus) => void;
 
-    /**
-     * Fires when the backup decryption key is received via secret sharing.
-     */
-    [CryptoEvent.KeyBackupPrivateKeyCached]: (info: KeyBackupInfo) => void;
+    [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
 } & RustBackupCryptoEventMap;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Add a new crypto event to signal when the key backup decryption key is stored in cache.
Needed for new PRs around backup (would allow to start/resume downloading from a backup)

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->