### PR TITLE
Element-R: await `/keys/query` during Verification requests

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -933,6 +933,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             .map(
                 (request) =>
                     new RustVerificationRequest(
+                        this.olmMachine,
                         request,
                         this.outgoingRequestProcessor,
                         this._supportedVerificationMethods,
@@ -963,6 +964,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
 
         if (request) {
             return new RustVerificationRequest(
+                this.olmMachine,
                 request,
                 this.outgoingRequestProcessor,
                 this._supportedVerificationMethods,
@@ -998,6 +1000,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 methods,
             );
             return new RustVerificationRequest(
+                this.olmMachine,
                 request,
                 this.outgoingRequestProcessor,
                 this._supportedVerificationMethods,
@@ -1073,6 +1076,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 );
             await this.outgoingRequestProcessor.makeOutgoingRequest(outgoingRequest);
             return new RustVerificationRequest(
+                this.olmMachine,
                 request,
                 this.outgoingRequestProcessor,
                 this._supportedVerificationMethods,
@@ -1111,6 +1115,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 );
             await this.outgoingRequestProcessor.makeOutgoingRequest(outgoingRequest);
             return new RustVerificationRequest(
+                this.olmMachine,
                 request,
                 this.outgoingRequestProcessor,
                 this._supportedVerificationMethods,
@@ -1398,7 +1403,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         if (request) {
             this.emit(
                 CryptoEvent.VerificationRequestReceived,
-                new RustVerificationRequest(request, this.outgoingRequestProcessor, this._supportedVerificationMethods),
+                new RustVerificationRequest(
+                    this.olmMachine,
+                    request,
+                    this.outgoingRequestProcessor,
+                    this._supportedVerificationMethods,
+                ),
             );
         }
     }
@@ -1615,6 +1625,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 this.emit(
                     CryptoEvent.VerificationRequestReceived,
                     new RustVerificationRequest(
+                        this.olmMachine,
                         request,
                         this.outgoingRequestProcessor,
                         this._supportedVerificationMethods,

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -57,11 +57,13 @@ export class RustVerificationRequest
     /**
      * Construct a new RustVerificationRequest to wrap the rust-level `VerificationRequest`.
      *
-     * @param inner - VerificationRequest from the Rust SDK
-     * @param outgoingRequestProcessor - `OutgoingRequestProcessor` to use for making outgoing HTTP requests
-     * @param supportedVerificationMethods - Verification methods to use when `accept()` is called
+     * @param olmMachine - The `OlmMachine` from the underlying rust crypto sdk.
+     * @param inner - VerificationRequest from the Rust SDK.
+     * @param outgoingRequestProcessor - `OutgoingRequestProcessor` to use for making outgoing HTTP requests.
+     * @param supportedVerificationMethods - Verification methods to use when `accept()` is called.
      */
     public constructor(
+        private readonly olmMachine: RustSdkCryptoJs.OlmMachine,
         private readonly inner: RustSdkCryptoJs.VerificationRequest,
         private readonly outgoingRequestProcessor: OutgoingRequestProcessor,
         private readonly supportedVerificationMethods: string[],
@@ -133,6 +135,15 @@ export class RustVerificationRequest
     /** For verifications via to-device messages: the ID of the other device. Otherwise, undefined. */
     public get otherDeviceId(): string | undefined {
         return this.inner.otherDeviceId?.toString();
+    }
+
+    /** Get the other device involved in the verification, if it is known */
+    private async getOtherDevice(): Promise<undefined | RustSdkCryptoJs.Device> {
+        const otherDeviceId = this.inner.otherDeviceId;
+        if (!otherDeviceId) {
+            return undefined;
+        }
+        return await this.olmMachine.getDevice(this.inner.otherUserId, otherDeviceId, 5);
     }
 
     /** True if the other party in this request is one of this user's own devices. */
@@ -322,6 +333,10 @@ export class RustVerificationRequest
             throw new Error(`Unsupported verification method ${method}`);
         }
 
+        if (!(await this.getOtherDevice())) {
+            throw new Error("startVerification(): other device is unknown");
+        }
+
         const res:
             | [RustSdkCryptoJs.Sas, RustSdkCryptoJs.RoomMessageRequest | RustSdkCryptoJs.ToDeviceRequest]
             | undefined = await this.inner.startSas();
@@ -392,6 +407,11 @@ export class RustVerificationRequest
      * Implementation of {@link Crypto.VerificationRequest#generateQRCode}.
      */
     public async generateQRCode(): Promise<Buffer | undefined> {
+        // make sure that we have a list of the other user's devices (workaround https://github.com/matrix-org/matrix-rust-sdk/issues/2896)
+        if (!(await this.getOtherDevice())) {
+            throw new Error("generateQRCode(): other device is unknown");
+        }
+
         const innerVerifier: RustSdkCryptoJs.Qr | undefined = await this.inner.generateQrCode();
         // If we are unable to generate a QRCode, we return undefined
         if (!innerVerifier) return;

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -333,6 +333,7 @@ export class RustVerificationRequest
             throw new Error(`Unsupported verification method ${method}`);
         }
 
+        // make sure that we have a list of the other user's devices (workaround https://github.com/matrix-org/matrix-rust-sdk/issues/2896)
         if (!(await this.getOtherDevice())) {
             throw new Error("startVerification(): other device is unknown");
         }


### PR DESCRIPTION
If the acceptance of an incoming verification request races with a `/keys/query` for the other user, then subsequent operations can fail (see https://github.com/matrix-org/matrix-rust-sdk/issues/2896).

This is a slightly hacky workaround that means we wait for the devicelist to arrive for the relevant operations.

Required for a fix to https://github.com/vector-im/element-web/issues/26420.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->