### PR TITLE
Fix "mark_skipped" action for end-to-end tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -70,7 +70,7 @@ jobs:
                   authToken: "${{ secrets.GITHUB_TOKEN }}"
                   state: success
                   description: Cypress skipped
-                  context: "Cypress End to End Tests / cypress"
+                  context: "${{ github.workflow }} / Cypress"
                   sha: "${{ github.event.workflow_run.head_sha }}"
 
             - uses: Sibz/github-status-action@071b5370da85afbb16637d6eed8524a06bc2053e # v1
@@ -78,5 +78,5 @@ jobs:
                   authToken: "${{ secrets.GITHUB_TOKEN }}"
                   state: success
                   description: Playwright skipped
-                  context: "End to End Tests / end-to-end-tests"
+                  context: "${{ github.workflow }} / Playwright"
                   sha: "${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
This seems to have been broken by https://github.com/matrix-org/matrix-js-sdk/pull/3914, which changed the name of the status check that is updated.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->