### PR TITLE
Fix notifications appearing for old events

### DIFF
--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -839,7 +839,10 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
 
         const data: IRoomTimelineData = {
             timeline: timeline,
-            liveEvent: timeline == this.liveTimeline,
+            // The purpose of this method is inserting events in the middle of the
+            // timeline, so the events are, by definition, not live (whether or not
+            // we're adding them to the live timeline).
+            liveEvent: false,
         };
         this.emit(RoomEvent.Timeline, event, this.room, false, false, data);
     }


### PR DESCRIPTION
A method that we use for fetching recursive related events on homeservers without MSC3981 support injects events into the timeline in timestamp order using a special method on event-timeline-set. Injecting events using this method could cause on-screen notifications because it incorrectly set the 'liveEvent' flag to true if the events were added to the live timeline. These events are never live though as the point is that we're fetching them.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix notifications appearing for old events ([\#3946](https://github.com/matrix-org/matrix-js-sdk/pull/3946)).<!-- CHANGELOG_PREVIEW_END -->