### PR TITLE
ElementR: Ensure there is only one call to shareRoomKeys in flight at once

### DIFF
--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -46,7 +46,7 @@ export class RoomEncryptor {
     private lazyLoadedMembersResolved = false;
 
     /** Ensures that there is only one call to shareRoomKeys at a time */
-    private currentShareRoomKeyPromise: Promise<void>;
+    private currentShareRoomKeyPromise = Promise.resolve();
 
     /**
      * @param olmMachine - The rust-sdk's OlmMachine
@@ -63,8 +63,6 @@ export class RoomEncryptor {
         private encryptionSettings: IContent,
     ) {
         this.prefixedLogger = logger.getChild(`[${room.roomId} encryption]`);
-
-        this.currentShareRoomKeyPromise = Promise.resolve();
 
         // start tracking devices for any users already known to be in this room.
         // Do not load members here, would defeat lazy loading.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

According to rust sdk documentation there should only be one call in flight to shareRoomKeys, it was not the case.

If `prepareToEncrypt` is called in background (when starting to type a message), and the message is sent before it completes there could be 2 in flight.


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->