### PR TITLE
Remove m.thread filter from relations API call

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -623,9 +623,7 @@ describe("MatrixClient event timelines", function () {
                     "GET",
                     "/rooms/!foo%3Abar/relations/" +
                         encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        buildRelationPaginationQuery({ dir: Direction.Backward, limit: 1 }),
+                        buildRelationPaginationQuery({ dir: Direction.Backward }),
                 )
                 .respond(200, function () {
                     return {
@@ -1154,10 +1152,7 @@ describe("MatrixClient event timelines", function () {
         httpBackend
             .when(
                 "GET",
-                "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                    encodeURIComponent(THREAD_ROOT_UPDATED.event_id!) +
-                    "/" +
-                    encodeURIComponent(THREAD_RELATION_TYPE.name),
+                "/_matrix/client/v1/rooms/!foo%3Abar/relations/" + encodeURIComponent(THREAD_ROOT_UPDATED.event_id!),
             )
             .respond(200, {
                 chunk: [THREAD_REPLY3.event, THREAD_REPLY2.event, THREAD_REPLY],
@@ -1262,11 +1257,8 @@ describe("MatrixClient event timelines", function () {
                 "GET",
                 "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
                     encodeURIComponent(THREAD_ROOT_UPDATED.event_id!) +
-                    "/" +
-                    encodeURIComponent(THREAD_RELATION_TYPE.name) +
                     buildRelationPaginationQuery({
                         dir: Direction.Backward,
-                        limit: 3,
                         recurse: true,
                     }),
             )
@@ -1321,11 +1313,7 @@ describe("MatrixClient event timelines", function () {
         function respondToThread(root: Partial<IEvent>, replies: Partial<IEvent>[]): ExpectedHttpRequest {
             const request = httpBackend.when(
                 "GET",
-                "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
-                    encodeURIComponent(root.event_id!) +
-                    "/" +
-                    encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                    "?dir=b&limit=1",
+                "/_matrix/client/v1/rooms/!foo%3Abar/relations/" + encodeURIComponent(root.event_id!) + "?dir=b",
             );
             request.respond(200, function () {
                 return {
@@ -2034,9 +2022,7 @@ describe("MatrixClient event timelines", function () {
                     "GET",
                     "/_matrix/client/v1/rooms/!foo%3Abar/relations/" +
                         encodeURIComponent(THREAD_ROOT.event_id!) +
-                        "/" +
-                        encodeURIComponent(THREAD_RELATION_TYPE.name) +
-                        buildRelationPaginationQuery({ dir: Direction.Backward, limit: 1 }),
+                        buildRelationPaginationQuery({ dir: Direction.Backward }),
                 )
                 .respond(200, function () {
                     return {

--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -33,7 +33,7 @@ import {
 import { logger } from "../../src/logger";
 import { encodeParams, encodeUri, QueryDict, replaceParam } from "../../src/utils";
 import { TestClient } from "../TestClient";
-import { FeatureSupport, Thread, THREAD_RELATION_TYPE, ThreadEvent } from "../../src/models/thread";
+import { FeatureSupport, Thread, ThreadEvent } from "../../src/models/thread";
 import { emitPromise } from "../test-utils/test-utils";
 import { Feature, ServerSupport } from "../../src/feature";
 

--- a/spec/unit/thread-utils.spec.ts
+++ b/spec/unit/thread-utils.spec.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IEvent } from "../../src";
+import { randomString } from "../../src/randomstring";
+import { getRelationsThreadFilter } from "../../src/thread-utils";
+
+function makeEvent(relatesToEvent: string, relType: string): Partial<IEvent> {
+    return {
+        event_id: randomString(10),
+        type: "m.room.message",
+        content: {
+            "msgtype": "m.text",
+            "body": "foo",
+            "m.relates_to": {
+                rel_type: relType,
+                event_id: relatesToEvent,
+            },
+        },
+    };
+}
+
+describe("getRelationsThreadFilter", () => {
+    it("should filter out relations directly to the thread root event", () => {
+        const threadId = "thisIsMyThreadRoot";
+
+        const reactionToRoot = makeEvent(threadId, "m.annotation");
+        const editToRoot = makeEvent(threadId, "m.replace");
+        const firstThreadedReply = makeEvent(threadId, "m.thread");
+        const reactionToThreadedEvent = makeEvent(firstThreadedReply.event_id!, "m.annotation");
+
+        const filteredEvents = [reactionToRoot, editToRoot, firstThreadedReply, reactionToThreadedEvent].filter(
+            getRelationsThreadFilter(threadId),
+        );
+
+        expect(filteredEvents).toEqual([firstThreadedReply, reactionToThreadedEvent]);
+    });
+});

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -609,7 +609,6 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
                 } else {
                     await this.client.paginateEventTimeline(this.liveTimeline, {
                         backwards: true,
-                        limit: Math.max(1, this.length),
                     });
                 }
                 for (const event of this.replayEvents!) {

--- a/src/thread-utils.ts
+++ b/src/thread-utils.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IEvent, THREAD_RELATION_TYPE } from "./matrix";
+
+/**
+ * Returns a filter function for the /relations endpoint to filter out relations directly
+ * to the thread root event that should not live in the thread timeline
+ *
+ * @param threadId - the thread ID (ie. the event ID of the root event of the thread)
+ * @returns the filtered list of events
+ */
+export function getRelationsThreadFilter(threadId: string): (e: Partial<IEvent>) => boolean {
+    return (e: Partial<IEvent>) =>
+        e.content?.["m.relates_to"]?.event_id !== threadId ||
+        e.content?.["m.relates_to"]?.rel_type === THREAD_RELATION_TYPE.name;
+}

--- a/src/thread-utils.ts
+++ b/src/thread-utils.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IEvent, THREAD_RELATION_TYPE } from "./matrix";
+import { THREAD_RELATION_TYPE } from "./models/thread";
+import { IEvent } from "./models/event";
 
 /**
  * Returns a filter function for the /relations endpoint to filter out relations directly


### PR DESCRIPTION
We used MSC3981 to pass the recurse param to the /relations endpoint so that we could get relations to events in a thread, but we kept the rel_type filter on (as m.thread) so no second-order relations would ever have been returned (a nested thread isn't a thing).

This removes the filter and does some filtering on the client side to remove any events that shouldn't live in the threaded timeline (ie. non-thread relations to the thread root event).

This should help fix stuck unreads because it will avoid the event that the receipt refers to going missing (but only on HSes that support MSC3981).

For https://github.com/vector-im/element-web/issues/26718

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Remove m.thread filter from relations API call ([\#3959](https://github.com/matrix-org/matrix-js-sdk/pull/3959)).<!-- CHANGELOG_PREVIEW_END -->