### PR TITLE
Fetch events that read receipts point to if we don't have them

### DIFF
--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -217,7 +217,7 @@ export abstract class ReadReceipt<
         return false;
     }
 
-    private getLatestReceipt(userId: string, ignoreSynthesized: boolean): WrappedReceipt | null {
+    protected getLatestReceipt(userId: string, ignoreSynthesized: boolean): WrappedReceipt | null {
         // XXX: This is very very ugly and I hope I won't have to ever add a new
         // receipt type here again. IMHO this should be done by the server in
         // some more intelligent manner or the client should just use timestamps


### PR DESCRIPTION
As the comment hopefully explains, this is a giant hack to work around lack of MSC3981 support and hopefully remove some spurious unread dots on threads. With this code, the unread dots appear briefly and then go away again once the event in question is fetched which is not fantastic but better then a perma-stuck dot.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
