### PR TITLE
Remove obsolete references to device-specific push rules

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8805,8 +8805,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         ruleId: Exclude<string, RuleId>,
         body: Pick<IPushRule, "actions" | "conditions" | "pattern">,
     ): Promise<{}> {
-        // NB. Scope not uri encoded because devices need the '/'
-        const path = utils.encodeUri("/pushrules/" + scope + "/$kind/$ruleId", {
+        const path = utils.encodeUri("/pushrules/$scope/$kind/$ruleId", {
+            $scope: scope,
             $kind: kind,
             $ruleId: ruleId,
         });
@@ -8818,8 +8818,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Rejects: with an error response.
      */
     public deletePushRule(scope: string, kind: PushRuleKind, ruleId: Exclude<string, RuleId>): Promise<{}> {
-        // NB. Scope not uri encoded because devices need the '/'
-        const path = utils.encodeUri("/pushrules/" + scope + "/$kind/$ruleId", {
+        const path = utils.encodeUri("/pushrules/$scope/$kind/$ruleId", {
+            $scope: scope,
             $kind: kind,
             $ruleId: ruleId,
         });
@@ -8837,7 +8837,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         ruleId: RuleId | string,
         enabled: boolean,
     ): Promise<{}> {
-        const path = utils.encodeUri("/pushrules/" + scope + "/$kind/$ruleId/enabled", {
+        const path = utils.encodeUri("/pushrules/$scope/$kind/$ruleId/enabled", {
+            $scope: scope,
             $kind: kind,
             $ruleId: ruleId,
         });
@@ -8855,7 +8856,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         ruleId: RuleId | string,
         actions: PushRuleAction[],
     ): Promise<{}> {
-        const path = utils.encodeUri("/pushrules/" + scope + "/$kind/$ruleId/actions", {
+        const path = utils.encodeUri("/pushrules/$scope/$kind/$ruleId/actions", {
+            $scope: scope,
             $kind: kind,
             $ruleId: ruleId,
         });


### PR DESCRIPTION
## Checklist

-   [x] Tests written for new code (and old code if feasible) **Should be covered by existing tests, if any**
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

Been reading up on push rules, and specifically how the only supported (as per the spec) scope is `global`, e.g. here: https://github.com/matrix-org/matrix-spec/issues/637

I also found [this old PR](https://github.com/matrix-org/matrix-js-sdk/pull/1404) which did the most important parts, but then ran across some parts that unnecessarily catered for a no longer supported use case. Figured it could be a good opportunity to make a minor contribution to a much appreciated repo.

I also considered the possibility to adjust the function signatures to either not take `scope`, or to force it to be the literal `"global"`, but I'm not sure if that is desirable, with regards to API stability, etc.

Type: [task]

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->