### PR TITLE
Add new methods to `CryptoStore` for Rust Crypto migration

### DIFF
--- a/spec/unit/crypto/store/CryptoStore.spec.ts
+++ b/spec/unit/crypto/store/CryptoStore.spec.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "fake-indexeddb/auto";
+import "jest-localstorage-mock";
+import { IndexedDBCryptoStore, LocalStorageCryptoStore, MemoryCryptoStore } from "../../../../src";
+import { CryptoStore } from "../../../../src/crypto/store/base";
+
+describe.each([
+    ["IndexedDBCryptoStore", () => new IndexedDBCryptoStore(global.indexedDB, "tests")],
+    ["LocalStorageCryptoStore", () => new LocalStorageCryptoStore(localStorage)],
+    ["MemoryCryptoStore", () => new MemoryCryptoStore()],
+])("CryptoStore tests for %s", function (name, dbFactory) {
+    let store: CryptoStore;
+
+    beforeEach(async () => {
+        store = dbFactory();
+    });
+
+    describe("containsData", () => {
+        it("returns false at first", async () => {
+            expect(await store.containsData()).toBe(false);
+        });
+
+        it("returns true after startup and account setup", async () => {
+            await store.startup();
+            await store.doTxn("readwrite", [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
+                store.storeAccount(txn, "not a real account");
+            });
+            expect(await store.containsData()).toBe(true);
+        });
+    });
+});

--- a/spec/unit/crypto/store/CryptoStore.spec.ts
+++ b/spec/unit/crypto/store/CryptoStore.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import "fake-indexeddb/auto";
 import "jest-localstorage-mock";
 import { IndexedDBCryptoStore, LocalStorageCryptoStore, MemoryCryptoStore } from "../../../../src";
-import { CryptoStore } from "../../../../src/crypto/store/base";
+import { CryptoStore, MigrationState } from "../../../../src/crypto/store/base";
 
 describe.each([
     ["IndexedDBCryptoStore", () => new IndexedDBCryptoStore(global.indexedDB, "tests")],
@@ -41,6 +41,21 @@ describe.each([
                 store.storeAccount(txn, "not a real account");
             });
             expect(await store.containsData()).toBe(true);
+        });
+    });
+
+    describe("migrationState", () => {
+        beforeEach(async () => {
+            await store.startup();
+        });
+
+        it("returns 0 at first", async () => {
+            expect(await store.getMigrationState()).toEqual(MigrationState.NOT_STARTED);
+        });
+
+        it("stores updates", async () => {
+            await store.setMigrationState(MigrationState.INITIAL_DATA_MIGRATED);
+            expect(await store.getMigrationState()).toEqual(MigrationState.INITIAL_DATA_MIGRATED);
         });
     });
 });

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -132,6 +132,14 @@ export interface CryptoStore {
     getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null>;
     filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]>;
 
+    /**
+     * Get a batch of end-to-end sessions from the database.
+     *
+     * @returns A batch of Olm Sessions, or `null` if no sessions are left.
+     * @internal
+     */
+    getEndToEndSessionsBatch(): Promise<ISessionInfo[] | null>;
+
     // Inbound Group Sessions
     getEndToEndInboundGroupSession(
         senderCurve25519Key: string,
@@ -159,6 +167,14 @@ export interface CryptoStore {
         txn: unknown,
     ): void;
 
+    /**
+     * Get a batch of Megolm sessions from the database.
+     *
+     * @returns A batch of Megolm Sessions, or `null` if no sessions are left.
+     * @internal
+     */
+    getEndToEndInboundGroupSessionsBatch(): Promise<ISession[] | null>;
+
     // Device Data
     getEndToEndDeviceData(txn: unknown, func: (deviceData: IDeviceData | null) => void): void;
     storeEndToEndDeviceData(deviceData: IDeviceData, txn: unknown): void;
@@ -182,12 +198,14 @@ export interface CryptoStore {
 
 export type Mode = "readonly" | "readwrite";
 
+/** Data on a Megolm session */
 export interface ISession {
     senderKey: string;
     sessionId: string;
     sessionData?: InboundGroupSessionData;
 }
 
+/** Data on an Olm session */
 export interface ISessionInfo {
     deviceKey?: string;
     sessionId?: string;
@@ -278,3 +296,9 @@ export enum MigrationState {
     /** OLM_SESSIONS_MIGRATED, and in addition, we have migrated all the Megolm sessions. */
     MEGOLM_SESSIONS_MIGRATED,
 }
+
+/**
+ * The size of batches to be returned by {@link CryptoStore#getEndToEndSessionsBatch} and
+ * {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+ */
+export const SESSION_BATCH_SIZE = 50;

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -66,6 +66,21 @@ export interface CryptoStore {
     startup(): Promise<CryptoStore>;
 
     deleteAllData(): Promise<void>;
+
+    /**
+     * Get data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * @internal
+     */
+    getMigrationState(): Promise<MigrationState>;
+
+    /**
+     * Set data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * @internal
+     */
+    setMigrationState(migrationState: MigrationState): Promise<void>;
+
     getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest>;
     getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null>;
     getOutgoingRoomKeyRequestByState(wantedStates: number[]): Promise<OutgoingRoomKeyRequest | null>;
@@ -241,4 +256,25 @@ export interface ParkedSharedHistory {
     sessionKey: string;
     keysClaimed: ReturnType<MatrixEvent["getKeysClaimed"]>; // XXX: Less type dependence on MatrixEvent
     forwardingCurve25519KeyChain: string[];
+}
+
+/**
+ * A record of which steps have been completed in the libolm to Rust Crypto migration.
+ *
+ * Used by {@link CryptoStore#getMigrationState} and {@link CryptoStore#setMigrationState}.
+ *
+ * @internal
+ */
+export enum MigrationState {
+    /** No migration steps have yet been completed. */
+    NOT_STARTED,
+
+    /** We have migrated the account data, cross-signing keys, etc. */
+    INITIAL_DATA_MIGRATED,
+
+    /** INITIAL_DATA_MIGRATED, and in addition, we have migrated all the Olm sessions. */
+    OLM_SESSIONS_MIGRATED,
+
+    /** OLM_SESSIONS_MIGRATED, and in addition, we have migrated all the Megolm sessions. */
+    MEGOLM_SESSIONS_MIGRATED,
 }

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -140,6 +140,15 @@ export interface CryptoStore {
      */
     getEndToEndSessionsBatch(): Promise<ISessionInfo[] | null>;
 
+    /**
+     * Delete a batch of end-to-end sessions from the database.
+     *
+     * Any sessions in the list which are not found are silently ignored.
+     *
+     * @internal
+     */
+    deleteEndToEndSessionsBatch(sessions: { deviceKey?: string; sessionId?: string }[]): Promise<void>;
+
     // Inbound Group Sessions
     getEndToEndInboundGroupSession(
         senderCurve25519Key: string,
@@ -174,6 +183,15 @@ export interface CryptoStore {
      * @internal
      */
     getEndToEndInboundGroupSessionsBatch(): Promise<ISession[] | null>;
+
+    /**
+     * Delete a batch of Megolm sessions from the database.
+     *
+     * Any sessions in the list which are not found are silently ignored.
+     *
+     * @internal
+     */
+    deleteEndToEndInboundGroupSessionsBatch(sessions: { senderKey: string; sessionId: string }[]): Promise<void>;
 
     // Device Data
     getEndToEndDeviceData(txn: unknown, func: (deviceData: IDeviceData | null) => void): void;

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -46,7 +46,25 @@ export interface SecretStorePrivateKeys {
  * Abstraction of things that can store data required for end-to-end encryption
  */
 export interface CryptoStore {
+    /**
+     * Returns true if this CryptoStore has ever been initialised (ie, it might contain data).
+     *
+     * Unlike the rest of the methods in this interface, can be called before {@link CryptoStore#startup}.
+     *
+     * @internal
+     */
+    containsData(): Promise<boolean>;
+
+    /**
+     * Initialise this crypto store.
+     *
+     * Typically, this involves provisioning storage, and migrating any existing data to the current version of the
+     * storage schema where appropriate.
+     *
+     * Must be called before any of the rest of the methods in this interface.
+     */
     startup(): Promise<CryptoStore>;
+
     deleteAllData(): Promise<void>;
     getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest>;
     getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null>;

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -40,6 +40,8 @@ const PROFILE_TRANSACTIONS = false;
  * Implementation of a CryptoStore which is backed by an existing
  * IndexedDB connection. Generally you want IndexedDBCryptoStore
  * which connects to the database and defers to one of these.
+ *
+ * @internal
  */
 export class Backend implements CryptoStore {
     private nextTxnId = 0;
@@ -56,11 +58,16 @@ export class Backend implements CryptoStore {
         };
     }
 
+    public async containsData(): Promise<boolean> {
+        throw Error("Not implemented for Backend");
+    }
+
     public async startup(): Promise<CryptoStore> {
         // No work to do, as the startup is done by the caller (e.g IndexedDBCryptoStore)
         // by passing us a ready IDBDatabase instance
         return this;
     }
+
     public async deleteAllData(): Promise<void> {
         throw Error("This is not implemented, call IDBFactory::deleteDatabase(dbName) instead.");
     }

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -633,7 +633,7 @@ export class Backend implements CryptoStore {
     /**
      * Fetch a batch of Olm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndSessionsBatch}.
      */
     public async getEndToEndSessionsBatch(): Promise<null | ISessionInfo[]> {
         const result: ISessionInfo[] = [];
@@ -813,7 +813,7 @@ export class Backend implements CryptoStore {
     /**
      * Fetch a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndInboundGroupSessionsBatch}.
      */
     public async getEndToEndInboundGroupSessionsBatch(): Promise<null | ISession[]> {
         const result: ISession[] = [];
@@ -850,7 +850,7 @@ export class Backend implements CryptoStore {
     /**
      * Delete a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.deleteEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -27,6 +27,7 @@ import {
     ISession,
     ISessionInfo,
     IWithheld,
+    MigrationState,
     Mode,
     OutgoingRoomKeyRequest,
     ParkedSharedHistory,
@@ -206,6 +207,28 @@ export class IndexedDBCryptoStore implements CryptoStore {
             // still use the app.
             logger.warn(`unable to delete IndexedDBCryptoStore: ${e}`);
         });
+    }
+
+    /**
+     * Get data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.getMigrationState}.
+     *
+     * @internal
+     */
+    public getMigrationState(): Promise<MigrationState> {
+        return this.backend!.getMigrationState();
+    }
+
+    /**
+     * Set data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.setMigrationState}.
+     *
+     * @internal
+     */
+    public setMigrationState(migrationState: MigrationState): Promise<void> {
+        return this.backend!.setMigrationState(migrationState);
     }
 
     /**

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -513,6 +513,17 @@ export class IndexedDBCryptoStore implements CryptoStore {
         return this.backend!.getEndToEndSessionsBatch();
     }
 
+    /**
+     * Delete a batch of Olm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore.deleteEndToEndSessionsBatch}.
+     *
+     * @internal
+     */
+    public deleteEndToEndSessionsBatch(sessions: { deviceKey: string; sessionId: string }[]): Promise<void> {
+        return this.backend!.deleteEndToEndSessionsBatch(sessions);
+    }
+
     // Inbound group sessions
 
     /**
@@ -598,6 +609,19 @@ export class IndexedDBCryptoStore implements CryptoStore {
      */
     public getEndToEndInboundGroupSessionsBatch(): Promise<ISession[] | null> {
         return this.backend!.getEndToEndInboundGroupSessionsBatch();
+    }
+
+    /**
+     * Delete a batch of Megolm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     *
+     * @internal
+     */
+    public deleteEndToEndInboundGroupSessionsBatch(
+        sessions: { senderKey: string; sessionId: string }[],
+    ): Promise<void> {
+        return this.backend!.deleteEndToEndInboundGroupSessionsBatch(sessions);
     }
 
     // End-to-end device tracking

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -38,7 +38,7 @@ import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { InboundGroupSessionData } from "../OlmDevice";
 
-/**
+/*
  * Internal module. indexeddb storage for e2e.
  */
 
@@ -71,6 +71,17 @@ export class IndexedDBCryptoStore implements CryptoStore {
      * @param dbName -   name of db to connect to
      */
     public constructor(private readonly indexedDB: IDBFactory, private readonly dbName: string) {}
+
+    /**
+     * Returns true if this CryptoStore has ever been initialised (ie, it might contain data).
+     *
+     * Implementation of {@link CryptoStore.containsData}.
+     *
+     * @internal
+     */
+    public async containsData(): Promise<boolean> {
+        return IndexedDBCryptoStore.exists(this.indexedDB, this.dbName);
+    }
 
     /**
      * Ensure the database exists and is up-to-date, or fall back to

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -505,7 +505,7 @@ export class IndexedDBCryptoStore implements CryptoStore {
     /**
      * Fetch a batch of Olm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndSessionsBatch}.
      *
      * @internal
      */
@@ -603,7 +603,7 @@ export class IndexedDBCryptoStore implements CryptoStore {
     /**
      * Fetch a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */
@@ -614,7 +614,7 @@ export class IndexedDBCryptoStore implements CryptoStore {
     /**
      * Delete a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.deleteEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -502,6 +502,17 @@ export class IndexedDBCryptoStore implements CryptoStore {
         return this.backend!.filterOutNotifiedErrorDevices(devices);
     }
 
+    /**
+     * Fetch a batch of Olm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore#getEndToEndSessionsBatch}.
+     *
+     * @internal
+     */
+    public getEndToEndSessionsBatch(): Promise<null | ISessionInfo[]> {
+        return this.backend!.getEndToEndSessionsBatch();
+    }
+
     // Inbound group sessions
 
     /**
@@ -576,6 +587,17 @@ export class IndexedDBCryptoStore implements CryptoStore {
         txn: IDBTransaction,
     ): void {
         this.backend!.storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn);
+    }
+
+    /**
+     * Fetch a batch of Megolm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+     *
+     * @internal
+     */
+    public getEndToEndInboundGroupSessionsBatch(): Promise<ISession[] | null> {
+        return this.backend!.getEndToEndInboundGroupSessionsBatch();
     }
 
     // End-to-end device tracking

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -16,7 +16,16 @@ limitations under the License.
 
 import { logger } from "../../logger";
 import { MemoryCryptoStore } from "./memory-crypto-store";
-import { IDeviceData, IProblem, ISession, ISessionInfo, IWithheld, Mode, SecretStorePrivateKeys } from "./base";
+import {
+    IDeviceData,
+    IProblem,
+    ISession,
+    ISessionInfo,
+    IWithheld,
+    MigrationState,
+    Mode,
+    SecretStorePrivateKeys,
+} from "./base";
 import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { ICrossSigningKey } from "../../client";
@@ -32,6 +41,7 @@ import { safeSet } from "../../utils";
  */
 
 const E2E_PREFIX = "crypto.";
+const KEY_END_TO_END_MIGRATION_STATE = E2E_PREFIX + "migration";
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_CROSS_SIGNING_KEYS = E2E_PREFIX + "cross_signing_keys";
 const KEY_NOTIFIED_ERROR_DEVICES = E2E_PREFIX + "notified_error_devices";
@@ -85,6 +95,28 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
      */
     public async containsData(): Promise<boolean> {
         return LocalStorageCryptoStore.exists(this.store);
+    }
+
+    /**
+     * Get data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.getMigrationState}.
+     *
+     * @internal
+     */
+    public async getMigrationState(): Promise<MigrationState> {
+        return getJsonItem(this.store, KEY_END_TO_END_MIGRATION_STATE) ?? MigrationState.NOT_STARTED;
+    }
+
+    /**
+     * Set data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.setMigrationState}.
+     *
+     * @internal
+     */
+    public async setMigrationState(migrationState: MigrationState): Promise<void> {
+        setJsonItem(this.store, KEY_END_TO_END_MIGRATION_STATE, migrationState);
     }
 
     // Olm Sessions

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -76,6 +76,17 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
         super();
     }
 
+    /**
+     * Returns true if this CryptoStore has ever been initialised (ie, it might contain data).
+     *
+     * Implementation of {@link CryptoStore.containsData}.
+     *
+     * @internal
+     */
+    public async containsData(): Promise<boolean> {
+        return LocalStorageCryptoStore.exists(this.store);
+    }
+
     // Olm Sessions
 
     public countEndToEndSessions(txn: unknown, func: (count: number) => void): void {

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { logger } from "../../logger";
 import { MemoryCryptoStore } from "./memory-crypto-store";
 import {
+    CryptoStore,
     IDeviceData,
     IProblem,
     ISession,
@@ -72,7 +73,7 @@ function keyEndToEndRoomsPrefix(roomId: string): string {
     return KEY_ROOMS_PREFIX + roomId;
 }
 
-export class LocalStorageCryptoStore extends MemoryCryptoStore {
+export class LocalStorageCryptoStore extends MemoryCryptoStore implements CryptoStore {
     public static exists(store: Storage): boolean {
         const length = store.length;
         for (let i = 0; i < length; i++) {
@@ -239,7 +240,7 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
     /**
      * Fetch a batch of Olm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndSessionsBatch}.
      *
      * @internal
      */
@@ -352,7 +353,7 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
     /**
      * Fetch a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */
@@ -390,7 +391,7 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore {
     /**
      * Delete a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.deleteEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -450,6 +450,24 @@ export class MemoryCryptoStore implements CryptoStore {
         return result;
     }
 
+    /**
+     * Delete a batch of Olm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore.deleteEndToEndSessionsBatch}.
+     *
+     * @internal
+     */
+    public async deleteEndToEndSessionsBatch(sessions: { deviceKey: string; sessionId: string }[]): Promise<void> {
+        for (const { deviceKey, sessionId } of sessions) {
+            const deviceSessions = this.sessions[deviceKey] || {};
+            delete deviceSessions[sessionId];
+            if (Object.keys(deviceSessions).length === 0) {
+                // No more sessions for this device.
+                delete this.sessions[deviceKey];
+            }
+        }
+    }
+
     // Inbound Group Sessions
 
     public getEndToEndInboundGroupSession(
@@ -536,6 +554,22 @@ export class MemoryCryptoStore implements CryptoStore {
 
         // There are fewer sessions than the batch size; return the final batch of sessions.
         return result;
+    }
+
+    /**
+     * Delete a batch of Megolm sessions from the database.
+     *
+     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     *
+     * @internal
+     */
+    public async deleteEndToEndInboundGroupSessionsBatch(
+        sessions: { senderKey: string; sessionId: string }[],
+    ): Promise<void> {
+        for (const { senderKey, sessionId } of sessions) {
+            const k = senderKey + "/" + sessionId;
+            delete this.inboundGroupSessions[k];
+        }
     }
 
     // Device Data

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -57,6 +57,18 @@ export class MemoryCryptoStore implements CryptoStore {
     private parkedSharedHistory = new Map<string, ParkedSharedHistory[]>(); // keyed by room ID
 
     /**
+     * Returns true if this CryptoStore has ever been initialised (ie, it might contain data).
+     *
+     * Implementation of {@link CryptoStore.containsData}.
+     *
+     * @internal
+     */
+    public async containsData(): Promise<boolean> {
+        // If it contains anything, it should contain an account.
+        return this.account !== null;
+    }
+
+    /**
      * Ensure the database exists and is up-to-date.
      *
      * This must be called before the store can be used.

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { logger } from "../../logger";
-import { safeSet, deepCompare, promiseTry } from "../../utils";
+import { deepCompare, promiseTry, safeSet } from "../../utils";
 import {
     CryptoStore,
     IDeviceData,
@@ -23,6 +23,7 @@ import {
     ISession,
     ISessionInfo,
     IWithheld,
+    MigrationState,
     Mode,
     OutgoingRoomKeyRequest,
     ParkedSharedHistory,
@@ -39,6 +40,7 @@ import { InboundGroupSessionData } from "../OlmDevice";
  */
 
 export class MemoryCryptoStore implements CryptoStore {
+    private migrationState: MigrationState = MigrationState.NOT_STARTED;
     private outgoingRoomKeyRequests: OutgoingRoomKeyRequest[] = [];
     private account: string | null = null;
     private crossSigningKeys: Record<string, ICrossSigningKey> | null = null;
@@ -87,6 +89,28 @@ export class MemoryCryptoStore implements CryptoStore {
      */
     public deleteAllData(): Promise<void> {
         return Promise.resolve();
+    }
+
+    /**
+     * Get data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.getMigrationState}.
+     *
+     * @internal
+     */
+    public async getMigrationState(): Promise<MigrationState> {
+        return this.migrationState;
+    }
+
+    /**
+     * Set data on how much of the libolm to Rust Crypto migration has been done.
+     *
+     * Implementation of {@link CryptoStore.setMigrationState}.
+     *
+     * @internal
+     */
+    public async setMigrationState(migrationState: MigrationState): Promise<void> {
+        this.migrationState = migrationState;
     }
 
     /**

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -426,7 +426,7 @@ export class MemoryCryptoStore implements CryptoStore {
     /**
      * Fetch a batch of Olm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndSessionsBatch}.
      *
      * @internal
      */
@@ -530,7 +530,7 @@ export class MemoryCryptoStore implements CryptoStore {
     /**
      * Fetch a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#getEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.getEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */
@@ -559,7 +559,7 @@ export class MemoryCryptoStore implements CryptoStore {
     /**
      * Delete a batch of Megolm sessions from the database.
      *
-     * Implementation of {@link CryptoStore#deleteEndToEndInboundGroupSessionsBatch}.
+     * Implementation of {@link CryptoStore.deleteEndToEndInboundGroupSessionsBatch}.
      *
      * @internal
      */


### PR DESCRIPTION
Some groundwork for https://github.com/element-hq/element-web/issues/26678: add a bunch of methods to Legacy `CryptoStore` to support reading the migration data.

Suggest review commit-by-commit.

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/3963

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->