### PR TITLE
Bump minimum spec version to v1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This is the [Matrix](https://matrix.org) Client-Server SDK for JavaScript and TypeScript. This SDK can be run in a
 browser or in Node.js.
 
-#### Minimum Matrix server version: v1.1
+#### Minimum Matrix server version: v1.5
 
 The Matrix specification is constantly evolving - while this SDK aims for maximum backwards compatibility, it only
 guarantees that a feature will be supported for at least 4 spec releases. For example, if a feature the js-sdk supports

--- a/spec/unit/autodiscovery.spec.ts
+++ b/spec/unit/autodiscovery.spec.ts
@@ -351,7 +351,7 @@ describe("AutoDiscovery", function () {
         function () {
             const httpBackend = getHttpBackend();
             httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
-                not_matrix_versions: ["v1.1"],
+                not_matrix_versions: ["v1.5"],
             });
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
                 "m.homeserver": {
@@ -388,7 +388,7 @@ describe("AutoDiscovery", function () {
                 expect(req.path).toEqual("https://example.org/_matrix/client/versions");
             })
             .respond(200, {
-                versions: ["v1.1"],
+                versions: ["v1.5"],
             });
         httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
             "m.homeserver": {
@@ -428,7 +428,7 @@ describe("AutoDiscovery", function () {
                 expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
             })
             .respond(200, {
-                versions: ["v1.1"],
+                versions: ["v1.5"],
             });
         httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
             "m.homeserver": {
@@ -469,7 +469,7 @@ describe("AutoDiscovery", function () {
                 expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
             })
             .respond(200, {
-                versions: ["v1.1"],
+                versions: ["v1.5"],
             });
         httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
             "m.homeserver": {
@@ -515,7 +515,7 @@ describe("AutoDiscovery", function () {
                     expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
                 })
                 .respond(200, {
-                    versions: ["v1.1"],
+                    versions: ["v1.5"],
                 });
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
                 "m.homeserver": {
@@ -560,7 +560,7 @@ describe("AutoDiscovery", function () {
                     expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
                 })
                 .respond(200, {
-                    versions: ["v1.1"],
+                    versions: ["v1.5"],
                 });
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
                 "m.homeserver": {
@@ -606,7 +606,7 @@ describe("AutoDiscovery", function () {
                     expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
                 })
                 .respond(200, {
-                    versions: ["v1.1"],
+                    versions: ["v1.5"],
                 });
             httpBackend.when("GET", "/_matrix/identity/v2").respond(404, {});
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
@@ -653,7 +653,7 @@ describe("AutoDiscovery", function () {
                     expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
                 })
                 .respond(200, {
-                    versions: ["v1.1"],
+                    versions: ["v1.5"],
                 });
             httpBackend.when("GET", "/_matrix/identity/v2").respond(500, {});
             httpBackend.when("GET", "/.well-known/matrix/client").respond(200, {
@@ -697,7 +697,7 @@ describe("AutoDiscovery", function () {
                 expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
             })
             .respond(200, {
-                versions: ["v1.1"],
+                versions: ["v1.5"],
             });
         httpBackend
             .when("GET", "/_matrix/identity/v2")
@@ -747,7 +747,7 @@ describe("AutoDiscovery", function () {
                 expect(req.path).toEqual("https://chat.example.org/_matrix/client/versions");
             })
             .respond(200, {
-                versions: ["v1.1"],
+                versions: ["v1.5"],
             });
         httpBackend
             .when("GET", "/_matrix/identity/v2")
@@ -910,7 +910,7 @@ describe("AutoDiscovery", function () {
 
         beforeEach(() => {
             fetchMock.resetBehavior();
-            fetchMock.get(`${homeserverUrl}_matrix/client/versions`, { versions: ["v1.1"] });
+            fetchMock.get(`${homeserverUrl}_matrix/client/versions`, { versions: ["v1.5"] });
 
             fetchMock.get("https://example.org/.well-known/matrix/client", {
                 "m.homeserver": {

--- a/src/version-support.ts
+++ b/src/version-support.ts
@@ -16,5 +16,8 @@ limitations under the License.
 
 /**
  * The minimum Matrix specification version the js-sdk supports.
+ *
+ * (This means that we require any servers we connect to to declare support for this spec version, so it is important
+ * for it not to be too old, as well as not too new.)
  */
-export const MINIMUM_MATRIX_VERSION = "v1.1";
+export const MINIMUM_MATRIX_VERSION = "v1.5";


### PR DESCRIPTION
We only claim to support a year of spec releases, so this should be fine.

Part of: https://github.com/matrix-org/matrix-js-sdk/issues/3915

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🚨 BREAKING CHANGES
 * Bump minimum spec version to v1.5 ([\#3970](https://github.com/matrix-org/matrix-js-sdk/pull/3970)).<!-- CHANGELOG_PREVIEW_END -->