### PR TITLE
ElementR: Ensure Encryption order per room

### DIFF
--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -144,7 +144,7 @@ describe("RoomEncryptor", () => {
 
             mockOlmMachine.shareRoomKey.mockResolvedValue(undefined);
 
-            // Took this method to demonstrate the race condition
+            // Hook into this method to demonstrate the race condition
             mockRoom.getEncryptionTargetMembers
                 .mockImplementationOnce(async () => {
                     await firstTargetMembers.promise;

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -186,7 +186,6 @@ describe("RoomEncryptor", () => {
             await Promise.all([firstRequest, secondRequest]);
 
             expect(firstMessageFinished).toBe("hello");
-
         });
     });
 });

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -70,7 +70,6 @@ describe("RoomEncryptor", () => {
         }
 
         beforeEach(() => {
-            jest.useFakeTimers();
             mockOlmMachine = {
                 identityKeys: {
                     curve25519: {
@@ -109,10 +108,6 @@ describe("RoomEncryptor", () => {
                 mockRoom,
                 { algorithm: "m.megolm.v1.aes-sha2" },
             );
-        });
-
-        afterEach(() => {
-            jest.useRealTimers();
         });
 
         it("should ensure that there is only one shareRoomKey at a time", async () => {
@@ -178,10 +173,7 @@ describe("RoomEncryptor", () => {
 
             // suppose the second getEncryptionTargetMembers call returns first
             secondTargetMembers.resolve();
-            await jest.runAllTimersAsync();
-
             firstTargetMembers.resolve();
-            await jest.runAllTimersAsync();
 
             await Promise.all([firstRequest, secondRequest]);
 

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -137,6 +137,7 @@ describe("RoomEncryptor", () => {
             expect(mockOlmMachine.shareRoomKey).toHaveBeenCalledTimes(6);
         });
 
+        // Regression test for https://github.com/element-hq/element-web/issues/26684
         it("Should maintain order of encryption requests", async () => {
             const firstTargetMembers = defer<void>();
             const secondTargetMembers = defer<void>();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,7 +29,7 @@ export interface Logger extends BaseLogger {
 }
 
 /** The basic interface for a logger which doesn't support children */
-interface BaseLogger {
+export interface BaseLogger {
     /**
      * Output trace message to the logger, with stack trace.
      *

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -136,7 +136,7 @@ export class RoomEncryptor {
      * This will ensure that we have a megolm session for this room, share it with the devices in the room, and
      * then, if an event is provided, encrypt it using the session.
      *
-     * @param event - Event to be encrypted or null if only preparing for encryption (pre share room key)
+     * @param event - Event to be encrypted, or null if only preparing for encryption (in which case we will pre-share the room key).
      * @param globalBlacklistUnverifiedDevices - When `true`, it will not send encrypted messages to unverified devices
      */
     public encryptEvent(event: MatrixEvent | null, globalBlacklistUnverifiedDevices: boolean): Promise<void> {

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -145,7 +145,7 @@ export class RoomEncryptor {
         const logger = new LogSpan(this.prefixedLogger, event ? event.getTxnId() ?? "" : "prepareForEncryption");
         const prom = this.currentEncryptionPromise
             .catch(() => {
-                // any errors in the previous claim will have been reported already, so there is nothing to do here.
+                // Any errors in the previous call will have been reported already, so there is nothing to do here.
                 // we just throw away the error and start anew.
             })
             .then(async () => {

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -135,7 +135,9 @@ export class RoomEncryptor {
         // Usually this is called when the user starts typing, so we want to make sure we have keys ready when the
         // message is finally sent. The actual event encryption request will arrive after wait for the prepareForEncryption
         // promise to resolve, and then do again an ensureEncryptionSession that should be no op as we already share the room key.
-        return this.enqueueOperation({ globalBlacklistUnverifiedDevices });
+        return await logDuration(this.prefixedLogger, "prepareForEncryption", async () => {
+            await this.enqueueOperation({ globalBlacklistUnverifiedDevices });
+        });
     }
 
     /**

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -126,8 +126,8 @@ export class RoomEncryptor {
         // even if it doesn't send an event.
         // Usually this is called when the user starts typing, so we want to make sure we have keys ready when the
         // message is finally sent.
-        // If `encryptEvent` is invoked before `prepareForEncryption` as completed, the `encryptEvent` call will wait for
-        // `prepareForEncryption` to have completed before executing.
+        // If `encryptEvent` is invoked before `prepareForEncryption` has completed, the `encryptEvent` call will wait for
+        // `prepareForEncryption` to complete before executing.
         // The part where `encryptEvent` shares the room key would be no op as it was already performed by prepareForEncryption.
         await this.encryptEvent(null, globalBlacklistUnverifiedDevices);
     }

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -140,9 +140,9 @@ export class RoomEncryptor {
      * @param globalBlacklistUnverifiedDevices - When `true`, it will not send encrypted messages to unverified devices
      */
     public encryptEvent(event: MatrixEvent | null, globalBlacklistUnverifiedDevices: boolean): Promise<void> {
+        const logger = new LogSpan(this.prefixedLogger, event ? event.getTxnId() ?? "" : "prepareForEncryption");
         // Ensure order of encryption to avoid message ordering issues, as the scheduler only ensures
         // events order after they have been encrypted.
-        const logger = new LogSpan(this.prefixedLogger, event ? event.getTxnId() ?? "" : "prepareForEncryption");
         const prom = this.currentEncryptionPromise
             .catch(() => {
                 // Any errors in the previous call will have been reported already, so there is nothing to do here.

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -130,7 +130,7 @@ export class RoomEncryptor {
     }
 
     /**
-     * Encrypt an event for this room.
+     * Encrypt an event for this room, or prepare for encryption.
      *
      * This will ensure that we have a megolm session for this room, share it with the devices in the room, and
      * then encrypt the event using the session.

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -128,7 +128,7 @@ export class RoomEncryptor {
         // message is finally sent.
         // If `encryptEvent` is invoked before `prepareForEncryption` has completed, the `encryptEvent` call will wait for
         // `prepareForEncryption` to complete before executing.
-        // The part where `encryptEvent` shares the room key would be no op as it was already performed by prepareForEncryption.
+        // The part where `encryptEvent` shares the room key will then usually be a no-op as it was already performed by `prepareForEncryption`.
         await this.encryptEvent(null, globalBlacklistUnverifiedDevices);
     }
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -191,7 +191,9 @@ export class RoomEncryptor {
         // This could end up being racy (if two calls to ensureEncryptionSession happen at the same time), but that's
         // not a particular problem, since `OlmMachine.updateTrackedUsers` just adds any users that weren't already tracked.
         if (!this.lazyLoadedMembersResolved) {
-            await this.olmMachine.updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId)));
+            await logDuration(this.prefixedLogger, "loadMembersIfNeeded: updateTrackedUsers", async () => {
+                await this.olmMachine.updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId)));
+            });
             logger.debug(`Updated tracked users`);
             this.lazyLoadedMembersResolved = true;
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -125,8 +125,10 @@ export class RoomEncryptor {
         // We consider a prepareForEncryption as an encryption promise as it will potentially share keys
         // even if it doesn't send an event.
         // Usually this is called when the user starts typing, so we want to make sure we have keys ready when the
-        // message is finally sent. The actual event encryption request will arrive after wait for the prepareForEncryption
-        // promise to resolve, and then do again an ensureEncryptionSession that should be no op as we already share the room key.
+        // message is finally sent.
+        // If `encryptEvent` is invoked before `prepareForEncryption` as completed, the `encryptEvent` call will wait for
+        // `prepareForEncryption` to have completed before executing.
+        // The part where `encryptEvent` shares the room key would be no op as it was already performed by prepareForEncryption.
         await this.encryptEvent(null, globalBlacklistUnverifiedDevices);
     }
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -49,7 +49,7 @@ export class RoomEncryptor {
     /**
      * Ensures that there is only one encryption operation at a time for that room.
      *
-     * An encryption operation is either a  {@link prepareForEncryption} or an {@link encryptEvent} call.
+     * An encryption operation is either a {@link prepareForEncryption} or an {@link encryptEvent} call.
      */
     private currentEncryptionPromise: Promise<void> = Promise.resolve();
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -47,8 +47,9 @@ export class RoomEncryptor {
     private lazyLoadedMembersResolved = false;
 
     /**
-     * Ensures that there is only one encryption operation at a time for that room
-     * An encryption operation is either a prepareForEncryption or an encryptEvent call.
+     * Ensures that there is only one encryption operation at a time for that room.
+     *
+     * An encryption operation is either a  {@link #prepareForEncryption} or an {@link #encryptEvent} call.
      */
     private currentEncryptionPromise: Promise<void> = Promise.resolve();
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -269,9 +269,6 @@ export class RoomEncryptor {
      * Discard any existing group session for this room
      */
     public async forceDiscardSession(): Promise<void> {
-        // XXX Clarify if also need to ensure order for that call to.
-        // It will mark the session as invalidated but not delete it, so if the current encryption promise
-        // has already check for rotation it will not be affected.
         const r = await this.olmMachine.invalidateGroupSession(new RoomId(this.room.roomId));
         if (r) {
             this.prefixedLogger.info("Discarded existing group session");

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -49,7 +49,7 @@ export class RoomEncryptor {
     /**
      * Ensures that there is only one encryption operation at a time for that room.
      *
-     * An encryption operation is either a  {@link #prepareForEncryption} or an {@link #encryptEvent} call.
+     * An encryption operation is either a  {@link prepareForEncryption} or an {@link encryptEvent} call.
      */
     private currentEncryptionPromise: Promise<void> = Promise.resolve();
 

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -134,7 +134,7 @@ export class RoomEncryptor {
      * Encrypt an event for this room, or prepare for encryption.
      *
      * This will ensure that we have a megolm session for this room, share it with the devices in the room, and
-     * then encrypt the event using the session.
+     * then, if an event is provided, encrypt it using the session.
      *
      * @param event - Event to be encrypted or null if only preparing for encryption (pre share room key)
      * @param globalBlacklistUnverifiedDevices - When `true`, it will not send encrypted messages to unverified devices

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ import { Optional } from "matrix-events-sdk";
 import { IEvent, MatrixEvent } from "./models/event";
 import { M_TIMESTAMP } from "./@types/location";
 import { ReceiptType } from "./@types/read_receipts";
-import { Logger } from "./logger";
+import { BaseLogger } from "./logger";
 
 const interns = new Map<string, string>();
 
@@ -395,7 +395,7 @@ export function sleep<T>(ms: number, value?: T): Promise<T> {
  * @param name - The name of the operation.
  * @param block - The block to execute.
  */
-export async function logDuration<T>(logger: Logger, name: string, block: () => Promise<T>): Promise<T> {
+export async function logDuration<T>(logger: BaseLogger, name: string, block: () => Promise<T>): Promise<T> {
     const start = Date.now();
     try {
         return await block();


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/element-hq/element-web/issues/26684

Encryption order was not ensured with the existing code. So in some case editing an inflight message would encrypt the edit first and schedule it first. That will cause an error because it will send an edit of an unknown event.
It can also invert the message order.

There is a sheduler currently but it doesn't handle encryption, it only queues the event for sending.
The scheduler should probably handle the encryption, but for now I modified RoomEncryptor to ensure order.

Notice that there was already a ordering mechanism but only to ensure order of `olmMachine.shareRoomKey` but it was not enough.

Added a test to reproduce the problem if the fix is not present.

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * ElementR: Ensure Encryption order per room ([\#3973](https://github.com/matrix-org/matrix-js-sdk/pull/3973)). Fixes element-hq/element-web#26684.<!-- CHANGELOG_PREVIEW_END -->