### PR TITLE
Element-R: fix `bootstrapSecretStorage` not resetting key backup when requested

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -57,7 +57,7 @@ import * as testData from "../../test-utils/test-data";
 import { defer } from "../../../src/utils";
 import { logger } from "../../../src/logger";
 import { OutgoingRequestsManager } from "../../../src/rust-crypto/OutgoingRequestsManager";
-import { ClientEvent, ClientEventHandlerMap } from "../../../src/client"
+import { ClientEvent, ClientEventHandlerMap } from "../../../src/client";
 import { Curve25519AuthData } from "../../../src/crypto-api/keybackup";
 
 const TEST_USER = "@alice:example.com";

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -38,7 +38,13 @@ import { mkEvent } from "../../test-utils/test-utils";
 import { CryptoBackend } from "../../../src/common-crypto/CryptoBackend";
 import { IEventDecryptionResult } from "../../../src/@types/crypto";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
-import { ServerSideSecretStorage } from "../../../src/secret-storage";
+import {
+    AccountDataClient,
+    AddSecretStorageKeyOpts,
+    SecretStorageCallbacks,
+    ServerSideSecretStorage,
+    ServerSideSecretStorageImpl,
+} from "../../../src/secret-storage";
 import {
     CryptoCallbacks,
     EventShieldColour,
@@ -51,6 +57,7 @@ import * as testData from "../../test-utils/test-data";
 import { defer } from "../../../src/utils";
 import { logger } from "../../../src/logger";
 import { OutgoingRequestsManager } from "../../../src/rust-crypto/OutgoingRequestsManager";
+import { ClientEvent, ClientEventHandlerMap } from "../../../src/client";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";
@@ -291,6 +298,60 @@ describe("RustCrypto", () => {
         rustCrypto.crossSigningIdentity = mockCrossSigningIdentity;
         await rustCrypto.bootstrapCrossSigning({});
         expect(mockCrossSigningIdentity.bootstrapCrossSigning).toHaveBeenCalledWith({});
+    });
+
+    it("bootstrapSecretStorage creates new backup when requested", async () => {
+        const secretStorageCallbacks = {
+            getSecretStorageKey: async (keys: any, name: string) => {
+                return [[...Object.keys(keys.keys)][0], new Uint8Array(32)];
+            },
+        } as SecretStorageCallbacks;
+        const secretStorage = new ServerSideSecretStorageImpl(new DummyAccountDataClient(), secretStorageCallbacks);
+
+        const outgoingRequestProcessor = {
+            makeOutgoingRequest: jest.fn(),
+        } as unknown as Mocked<OutgoingRequestProcessor>;
+
+        const rustCrypto = await makeTestRustCrypto(
+            new MatrixHttpApi(new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>(), {
+                baseUrl: "http://server/",
+                prefix: "",
+                onlyData: true,
+            }),
+            testData.TEST_USER_ID,
+            undefined,
+            secretStorage,
+        );
+
+        rustCrypto["checkKeyBackupAndEnable"] = async () => { return null; };
+        (rustCrypto["crossSigningIdentity"] as any)["outgoingRequestProcessor"] = outgoingRequestProcessor;
+        const resetKeyBackup = rustCrypto["resetKeyBackup"] = jest.fn();
+
+        async function createSecretStorageKey() {
+            return {
+                keyInfo: {} as AddSecretStorageKeyOpts,
+                privateKey: new Uint8Array(32),
+            };
+        }
+
+        // create initial secret storage
+        await rustCrypto.bootstrapCrossSigning({ setupNewCrossSigning: true });
+        await rustCrypto.bootstrapSecretStorage({
+            createSecretStorageKey,
+            setupNewSecretStorage: true,
+            setupNewKeyBackup: true,
+        });
+        // check that rustCrypto.resetKeyBackup was called
+        expect(resetKeyBackup.mock.calls).toHaveLength(1);
+
+        // reset secret storage
+        await rustCrypto.bootstrapSecretStorage({
+            createSecretStorageKey,
+            setupNewSecretStorage: true,
+            setupNewKeyBackup: true,
+        });
+        // check that rustCrypto.resetKeyBackup was called again
+        expect(resetKeyBackup.mock.calls).toHaveLength(2);
     });
 
     it("isSecretStorageReady", async () => {
@@ -946,4 +1007,33 @@ async function makeTestRustCrypto(
     cryptoCallbacks: CryptoCallbacks = {} as CryptoCallbacks,
 ): Promise<RustCrypto> {
     return await initRustCrypto(logger, http, userId, deviceId, secretStorage, cryptoCallbacks, null, undefined);
+}
+
+/** emulate account data, storing in memory
+ */
+class DummyAccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap> implements AccountDataClient {
+    private storage: Map<string, any> = new Map();
+
+    public constructor() {
+        super();
+    }
+
+    public async getAccountDataFromServer<T extends Record<string, any>>(eventType: string): Promise<T | null> {
+        const ret = this.storage.get(eventType);
+
+        if (eventType) {
+            return ret as T;
+        } else {
+            return null;
+        }
+    }
+
+    public async setAccountData(eventType: string, content: any): Promise<{}> {
+        this.storage.set(eventType, content);
+        this.emit(ClientEvent.AccountData, new MatrixEvent({
+            content,
+            type: eventType,
+        }));
+        return {};
+    }
 }

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -324,9 +324,11 @@ describe("RustCrypto", () => {
             secretStorage,
         );
 
-        rustCrypto["checkKeyBackupAndEnable"] = async () => { return null; };
+        rustCrypto["checkKeyBackupAndEnable"] = async () => {
+            return null;
+        };
         (rustCrypto["crossSigningIdentity"] as any)["outgoingRequestProcessor"] = outgoingRequestProcessor;
-        const resetKeyBackup = rustCrypto["resetKeyBackup"] = jest.fn();
+        const resetKeyBackup = (rustCrypto["resetKeyBackup"] = jest.fn());
 
         async function createSecretStorageKey() {
             return {
@@ -1054,7 +1056,10 @@ async function makeTestRustCrypto(
 
 /** emulate account data, storing in memory
  */
-class DummyAccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap> implements AccountDataClient {
+class DummyAccountDataClient
+    extends TypedEventEmitter<ClientEvent.AccountData, ClientEventHandlerMap>
+    implements AccountDataClient
+{
     private storage: Map<string, any> = new Map();
 
     public constructor() {
@@ -1073,10 +1078,13 @@ class DummyAccountDataClient extends TypedEventEmitter<ClientEvent.AccountData, 
 
     public async setAccountData(eventType: string, content: any): Promise<{}> {
         this.storage.set(eventType, content);
-        this.emit(ClientEvent.AccountData, new MatrixEvent({
-            content,
-            type: eventType,
-        }));
+        this.emit(
+            ClientEvent.AccountData,
+            new MatrixEvent({
+                content,
+                type: eventType,
+            }),
+        );
         return {};
     }
 }

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -804,10 +804,10 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             await this.secretStorage.store("m.cross_signing.master", crossSigningPrivateKeys.masterKey);
             await this.secretStorage.store("m.cross_signing.user_signing", crossSigningPrivateKeys.userSigningKey);
             await this.secretStorage.store("m.cross_signing.self_signing", crossSigningPrivateKeys.self_signing_key);
+        }
 
-            if (setupNewKeyBackup) {
-                await this.resetKeyBackup();
-            }
+        if (setupNewKeyBackup) {
+            await this.resetKeyBackup();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/26717

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Element-R: fix `bootstrapSecretStorage` not resetting key backup when requested ([\#3976](https://github.com/matrix-org/matrix-js-sdk/pull/3976)). Fixes element-hq/element-web#26717.<!-- CHANGELOG_PREVIEW_END -->