### PR TITLE
#22606 Fix "Remove" button  to users without "m.room.redaction"

### DIFF
--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -778,7 +778,9 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         // The user may have been the sender, but they can't redact their own message
         // if redactions are blocked.
         const canRedact = this.maySendEvent(EventType.RoomRedaction, userId);
-        if (mxEvent.getSender() === userId) return canRedact;
+        
+        if (!canRedact) return false;
+        if (mxEvent.getSender() === userId) return true;
 
         return this.hasSufficientPowerLevelFor("redact", member.powerLevel);
     }


### PR DESCRIPTION
This PR aims to fix issue `Type: [defect]` [#22606](https://github.com/element-hq/element-web/issues/22606) of making the remove button NOT available to users without the  "m.room.redaction" permission

Signed-off-by: Rashmit Pankhania <rashmitpankhania@gmail.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->
