### PR TITLE
fix IndexedDBStore API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Changes in [30.0.0](https://github.com/matrix-org/matrix-js-sdk/releases/tag/v30
 
 ## 🚨 BREAKING CHANGES
  * Refactor & make base64 functions browser-safe ([\#3818](https://github.com/matrix-org/matrix-js-sdk/pull/3818)).
+ * `IndexedDBStore.startup()` must be called after using it on `sdk.createClient` now.
 
 ## 🦖 Deprecations
  * Deprecate `MatrixEvent.toJSON` ([\#3801](https://github.com/matrix-org/matrix-js-sdk/pull/3801)).

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -90,10 +90,10 @@ export class IndexedDBStore extends MemoryStore {
      * ```
      * let opts = { indexedDB: window.indexedDB, localStorage: window.localStorage };
      * let store = new IndexedDBStore(opts);
-     * await store.startup(); // load from indexed db
      * let client = sdk.createClient({
      *     store: store,
      * });
+     * await store.startup(); // load from indexed db, must be called after createClient
      * client.startClient();
      * client.on("sync", function(state, prevState, data) {
      *     if (state === "PREPARED") {
@@ -140,7 +140,9 @@ export class IndexedDBStore extends MemoryStore {
                 logger.log(`IndexedDBStore.startup: processing presence events`);
                 userPresenceEvents.forEach(([userId, rawEvent]) => {
                     if (!this.createUser) {
-                        throw new Error("createUser is undefined, it should be set with setUserCreator()!");
+                        throw new Error(
+                            "`IndexedDBStore.startup` must be called after assigning it to the client, not before!",
+                        );
                     }
                     const u = this.createUser(userId);
                     if (rawEvent) {


### PR DESCRIPTION
Retroactively changes the changelog entry to include since when this change is needed as well, so that other people upgrading the SDK can more easily find what to change.

Fix #3986

Only documentation & error strings have changed so I have not adjusted any tests. A proper integration test would probably be nice, but I didn't have the time to look into how that is setup on this project.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->