### PR TITLE
Revert "Bump matrix-sdk-crypto-wasm to 3.6.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^3.6.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^3.5.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,10 +1675,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.6.0.tgz#385aa579d7b7546d85c9b20bf6ba780f799bdda3"
-  integrity sha512-fvuYczcp/r/MOkOAUbK+tMaTerEe7/QHGQcRJz3W3JuEma0YN59d35zTBlts7EkN6Ichw1vLSyM+GkcbuosuyA==
+"@matrix-org/matrix-sdk-crypto-wasm@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.5.0.tgz#997d63ae12304142513fe93c5e0872ff10ca30b4"
+  integrity sha512-7as0jJTje+rFu9AF8LEO0tmhtHcou2YQnZOtpiP+lS5rDfIPv5CL8/eb45fzDnbQybt9Jm5zdjBdiLBEaUg2dQ==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#3989

Since it appears to cause https://github.com/matrix-org/element-web-rageshakes/issues/23557:

```
2024-01-08T15:59:21.961Z I INFO matrix_sdk_indexeddb::crypto_store::migrations: Fixing inbound group session data keys
    row_count=153771
    at /home/runner/.cargo/git/checkouts/matrix-rust-sdk-1f4927f82a3d27bb/3e17fc2/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs:327
2024-01-08T15:59:21.981Z E Unable to load session Error: invalid type: boolean `false`, expected u8
```

(This is a failure to upgrade the DB when using Element R.)

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Revert "Bump matrix-sdk-crypto-wasm to 3.6.0" ([\#3991](https://github.com/matrix-org/matrix-js-sdk/pull/3991)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->