### PR TITLE
Bump matrix-sdk-crypto-wasm to 3.6.0 (take 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^3.5.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^3.6.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,10 +1674,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.5.0.tgz#997d63ae12304142513fe93c5e0872ff10ca30b4"
-  integrity sha512-7as0jJTje+rFu9AF8LEO0tmhtHcou2YQnZOtpiP+lS5rDfIPv5CL8/eb45fzDnbQybt9Jm5zdjBdiLBEaUg2dQ==
+"@matrix-org/matrix-sdk-crypto-wasm@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.6.0.tgz#385aa579d7b7546d85c9b20bf6ba780f799bdda3"
+  integrity sha512-fvuYczcp/r/MOkOAUbK+tMaTerEe7/QHGQcRJz3W3JuEma0YN59d35zTBlts7EkN6Ichw1vLSyM+GkcbuosuyA==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
Reverts matrix-org/matrix-js-sdk#3991, which itself was a revert of https://github.com/matrix-org/matrix-js-sdk/pull/3989, which bumped matrix-sdk-crypto-wasm to 3.6.0 providing (among other things) an indexeddb migration that [fixes](https://github.com/matrix-org/matrix-rust-sdk/pull/2957) a bug in the previous migration.

After investigation, we discovered that the problems I was seeing when migrating were caused by local changes I had made to my indexeddb, so this will not affect any other users.

Fixes https://github.com/element-hq/element-web/issues/26782

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->