### PR TITLE
Broaden spec version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This is the [Matrix](https://matrix.org) Client-Server SDK for JavaScript and TypeScript. This SDK can be run in a
 browser or in Node.js.
 
-#### Minimum Matrix server version: v1.5
+#### Minimum Matrix server version: v1.1
 
 The Matrix specification is constantly evolving - while this SDK aims for maximum backwards compatibility, it only
 guarantees that a feature will be supported for at least 4 spec releases. For example, if a feature the js-sdk supports

--- a/src/version-support.ts
+++ b/src/version-support.ts
@@ -15,9 +15,22 @@ limitations under the License.
 */
 
 /**
- * The minimum Matrix specification version the js-sdk supports.
+ * A list of the spec versions which the js-sdk is compatible with.
  *
- * (This means that we require any servers we connect to to declare support for this spec version, so it is important
- * for it not to be too old, as well as not too new.)
+ * In practice, this means: when we connect to a server, it must declare support for one of the versions in this list.
+ *
+ * Note that it does not *necessarily* mean that the js-sdk has good support for all the features in the listed spec
+ * versions; only that we should be able to provide a base level of functionality with a server that offers support for
+ * any of the listed versions.
  */
-export const MINIMUM_MATRIX_VERSION = "v1.5";
+export const SUPPORTED_MATRIX_VERSIONS = ["v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9"];
+
+/**
+ * The oldest Matrix specification version the js-sdk supports.
+ */
+export const MINIMUM_MATRIX_VERSION = SUPPORTED_MATRIX_VERSIONS[0];
+
+/**
+ * The most recent Matrix specification version the js-sdk supports.
+ */
+export const MAXIMUM_MATRIX_VERSION = SUPPORTED_MATRIX_VERSIONS[SUPPORTED_MATRIX_VERSIONS.length - 1];


### PR DESCRIPTION
This PR does two things:

 * It puts the "minimum supported matrix version" from v1.5 back down to v1.1. In other words, it is a partial revert of https://github.com/matrix-org/matrix-js-sdk/pull/3970. (Partial, because we don't need to update the tests.)

   We're doing this largely because https://github.com/matrix-org/matrix-js-sdk/pull/3970 was introduced without a suitable announcement and deprecation policy. We haven't yet decided if the js-sdk's spec support policy needs to change, or if we will re-introduce this change in future in a more graceful manner.

 * It increases the "maximum supported matrix version" from v1.5 up to v1.9. Previously, the two concepts were tied together, but as discussed at length in https://github.com/matrix-org/matrix-js-sdk/issues/3915#issuecomment-1865221366, this is incorrect.

   Unfortunately, we have no real way of testing whether it is true that the js-sdk actually works with a server which supports *only* v1.9, but as per the comment above, we can't do much about that.

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/3915.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Broaden spec version support ([\#4014](https://github.com/matrix-org/matrix-js-sdk/pull/4014)). Fixes #3915.<!-- CHANGELOG_PREVIEW_END -->