### PR TITLE
ElementR | backup: call expensive `roomKeyCounts` less often

### DIFF
--- a/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
+++ b/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
@@ -104,7 +104,7 @@ describe("PerSessionKeyBackupDownloader", () => {
 
         mockOlmMachine.roomKeyCounts.mockResolvedValue({
             total: 602,
-            // first iteration don't call count, it will in second after 200 keys have been saved
+            // First iteration won't call roomKeyCounts(); it will be called on the second iteration after 200 keys have been saved.
             backedUp: 200,
         });
 

--- a/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
+++ b/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
@@ -1,8 +1,7 @@
 import { Mocked } from "jest-mock";
 import fetchMock from "fetch-mock-jest";
+import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import * as RustSdkCryptoJs from "../../../../matrix-rust-sdk-crypto-wasm";
-import { KeysBackupRequest, OlmMachine, SignatureVerification } from "../../../../matrix-rust-sdk-crypto-wasm";
 import { CryptoEvent, HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, TypedEventEmitter } from "../../../src";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import * as testData from "../../test-utils/test-data";
@@ -16,7 +15,7 @@ describe("PerSessionKeyBackupDownloader", () => {
     /** The backup manager under test */
     let rustBackupManager: RustBackupManager;
 
-    let mockOlmMachine: Mocked<OlmMachine>;
+    let mockOlmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;
 
     let outgoingRequestProcessor: Mocked<OutgoingRequestProcessor>;
 
@@ -27,7 +26,7 @@ describe("PerSessionKeyBackupDownloader", () => {
     });
 
     let idGenerator = 0;
-    function mockBackupRequest(keyCount: number): KeysBackupRequest {
+    function mockBackupRequest(keyCount: number): RustSdkCryptoJs.KeysBackupRequest {
         const requestBody: IKeyBackup = {
             rooms: {
                 "!room1:server": {
@@ -41,7 +40,7 @@ describe("PerSessionKeyBackupDownloader", () => {
         return {
             id: "id" + idGenerator++,
             body: JSON.stringify(requestBody),
-        } as unknown as Mocked<KeysBackupRequest>;
+        } as unknown as Mocked<RustSdkCryptoJs.KeysBackupRequest>;
     }
 
     beforeEach(async () => {
@@ -58,9 +57,9 @@ describe("PerSessionKeyBackupDownloader", () => {
             enableBackupV1: jest.fn(),
             verifyBackup: jest.fn().mockResolvedValue({
                 trusted: jest.fn().mockResolvedValue(true),
-            } as unknown as SignatureVerification),
+            } as unknown as RustSdkCryptoJs.SignatureVerification),
             roomKeyCounts: jest.fn(),
-        } as unknown as Mocked<OlmMachine>;
+        } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
         outgoingRequestProcessor = {
             makeOutgoingRequest: jest.fn(),

--- a/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
+++ b/spec/unit/rust-crypto/BackupKeyLoop.spec.ts
@@ -1,7 +1,6 @@
 import { Mocked } from "jest-mock";
 import fetchMock from "fetch-mock-jest";
 
-import { RustBackupManager } from "../../../src/rust-crypto/backup";
 import * as RustSdkCryptoJs from "../../../../matrix-rust-sdk-crypto-wasm";
 import { KeysBackupRequest, OlmMachine, SignatureVerification } from "../../../../matrix-rust-sdk-crypto-wasm";
 import { CryptoEvent, HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, TypedEventEmitter } from "../../../src";
@@ -11,6 +10,7 @@ import * as TestData from "../../test-utils/test-data";
 import { IKeyBackup } from "../../../src/crypto/backup";
 import { IKeyBackupSession } from "../../../src/crypto/keybackup";
 import { defer } from "../../../src/utils";
+import { RustBackupManager } from "../../../src/rust-crypto/backup";
 
 describe("PerSessionKeyBackupDownloader", () => {
     /** The backup manager under test */
@@ -69,6 +69,11 @@ describe("PerSessionKeyBackupDownloader", () => {
         rustBackupManager = new RustBackupManager(mockOlmMachine, httpAPi, outgoingRequestProcessor);
 
         fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+        jest.useRealTimers();
     });
 
     it("Should call expensive roomKeyCounts only once per loop", async () => {

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -10,7 +10,7 @@ import { IKeyBackup } from "../../../src/crypto/backup";
 import { IKeyBackupSession } from "../../../src/crypto/keybackup";
 import { RustBackupManager } from "../../../src/rust-crypto/backup";
 
-describe("Import keys from backup", () => {
+describe("Upload keys to backup", () => {
     /** The backup manager under test */
     let rustBackupManager: RustBackupManager;
 

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -410,7 +410,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                             // wait for that and then continue?
                             const waitTime = err.data.retry_after_ms;
                             if (waitTime > 0) {
-                                sleep(waitTime);
+                                await sleep(waitTime);
                                 continue;
                             } // else go to the normal backoff
                         }

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -377,6 +377,11 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     if (this.stopped) break;
                     if (remainingToUploadCount !== null) {
                         const keysCountInBatch = this.keysCountInBatch(request);
+                        // The `remainingToUploadCount` is computed only once for the current backupKeysLoop. But new
+                        // keys could be added during the current loop (after a sync for example).
+                        // So the count can get out of sync with the real number of remaining keys to upload.
+                        // Depending on the number of new keys imported and the time to complete the loop,
+                        // this could result in multiple events being emitted with a remaining key count of 0.
                         remainingToUploadCount = Math.max(remainingToUploadCount - keysCountInBatch, 0);
                         this.emit(CryptoEvent.KeyBackupSessionsRemaining, remainingToUploadCount);
                     }

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -364,6 +364,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     // Key count performance (`olmMachine.roomKeyCounts()`) can be pretty bad on some configurations.
                     // In particular, we detected on some M1 macs that when the object store reaches a threshold, the count
                     // performance stops growing in O(n) and suddenly becomes very slow (40s, 60s or more).
+                    // For reference, the performance drop occurs around 300-400k keys on the platforms where this issue is observed.
                     // Even on other configurations, the count can take several seconds.
                     // This will block other operations on the database, like sending messages.
                     //

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -326,8 +326,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         try {
             // number of consecutive network failures for exponential backoff
             let numFailures = 0;
-            // `olmMachine.roomKeyCounts()` is very slow on some configurations (see more comments below),
-            // we compute it only once per `backupKeysLoop` if necessary.
+            // The number of keys left to back up. (Populated lazily: see more comments below.)
             let remainingToUploadCount: number | null = null;
             // To avoid computing the key when only a few keys were added (after a sync for example),
             // we compute the count only when at least two iterations are needed.

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -356,10 +356,12 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     return;
                 }
 
-                // Keys count performance (`olmMachine.roomKeyCounts()`) can be pretty bad on some configurations (big database in FF).
-                // We detected on some M1 mac that when the object store reach a threshold, the count performances stops growing in O(n) and
-                // suddenly become very slow (40s, 60s or more). Even on other configurations, the count can take several seconds.
-                // This will block other operations on the database, like sending messages
+                // Key count performance (`olmMachine.roomKeyCounts()`) can be pretty bad on some configurations.
+                // In particular, we detected on some M1 macs that when the object store reaches a threshold, the count
+                // performance stops growing in O(n) and suddenly becomes very slow (40s, 60s or more). 
+                // Even on other configurations, the count can take several seconds.
+                // This will block other operations on the database, like sending messages.
+                // 
                 // This is a workaround to avoid calling `olmMachine.roomKeyCounts()` too often, and only when necessary.
                 // We don't call it on the first loop because there could be only a few keys to upload, and we don't want to wait for the count.
                 if (!isFirstIteration && remainingToUploadCount === null) {

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -380,6 +380,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     }
 
                     if (remainingToUploadCount !== null) {
+                        this.emit(CryptoEvent.KeyBackupSessionsRemaining, remainingToUploadCount);
                         const keysCountInBatch = this.keysCountInBatch(request);
                         // The `remainingToUploadCount` is computed only once for the current backupKeysLoop. But new
                         // keys could be added during the current loop (after a sync for example).
@@ -387,7 +388,6 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                         // Depending on the number of new keys imported and the time to complete the loop,
                         // this could result in multiple events being emitted with a remaining key count of 0.
                         remainingToUploadCount = Math.max(remainingToUploadCount - keysCountInBatch, 0);
-                        this.emit(CryptoEvent.KeyBackupSessionsRemaining, remainingToUploadCount);
                     }
                 } catch (err) {
                     numFailures++;

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -386,7 +386,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                     if (remainingToUploadCount !== null) {
                         this.emit(CryptoEvent.KeyBackupSessionsRemaining, remainingToUploadCount);
                         const keysCountInBatch = this.keysCountInBatch(request);
-                        // The `remainingToUploadCount` is computed only once for the current backupKeysLoop. But new
+                        // `OlmMachine.roomKeyCounts` is called only once for the current backupKeysLoop. But new
                         // keys could be added during the current loop (after a sync for example).
                         // So the count can get out of sync with the real number of remaining keys to upload.
                         // Depending on the number of new keys imported and the time to complete the loop,

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -430,8 +430,8 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
     private keysCountInBatch(batch: RustSdkCryptoJs.KeysBackupRequest): number {
         const parsedBody: IKeyBackup = JSON.parse(batch.body);
         let count = 0;
-        for (const entry of Object.entries(parsedBody.rooms)) {
-            count += Object.keys(entry[1].sessions).length;
+        for (const { sessions } of Object.values(parsedBody.rooms)) {
+            count += Object.keys(sessions).length;
         }
         return count;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/element-hq/element-web/issues/26893

Avoid calling the expensive room count at each backup iteration
## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * ElementR | backup: call expensive `roomKeyCounts` less often ([\#4015](https://github.com/matrix-org/matrix-js-sdk/pull/4015)). Fixes element-hq/element-web#26893.<!-- CHANGELOG_PREVIEW_END -->