### PR TITLE
Element R: Bump matrix-rust-sdk-crypto-wasm to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^3.6.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^4.0.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/unit/rust-crypto/KeyClaimManager.spec.ts
+++ b/spec/unit/rust-crypto/KeyClaimManager.spec.ts
@@ -97,7 +97,10 @@ describe("KeyClaimManager", () => {
         await keyClaimManager.ensureSessionsForUsers(new LogSpan(logger, "test"), [u1, u2]);
 
         // check that all the calls were made
-        expect(olmMachine.getMissingSessions).toHaveBeenCalledWith([u1, u2]);
+        // We can't use directly toHaveBeenCalledWith because the UserId are cloned in the process.
+        const calledWith = olmMachine.getMissingSessions.mock.calls[0][0].map((u) => u.toString());
+        expect(calledWith).toEqual([u1.toString(), u2.toString()]);
+
         expect(fetchMock).toHaveFetched("https://example.com/_matrix/client/v3/keys/claim", {
             method: "POST",
             body: { k1: "v1" },
@@ -135,7 +138,10 @@ describe("KeyClaimManager", () => {
 
         // at this point, there should have been a single call to getMissingSessions, and a single fetch; and neither
         // call to ensureSessionsAsUsers should have completed
-        expect(olmMachine.getMissingSessions).toHaveBeenCalledWith([u1]);
+        // check that all the calls were made
+        // We can't use directly toHaveBeenCalledWith because the UserId are cloned in the process.
+        const calledWith = olmMachine.getMissingSessions.mock.calls[0][0].map((u) => u.toString());
+        expect(calledWith).toEqual([u1.toString()]);
         expect(olmMachine.getMissingSessions).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(req1Resolved).toBe(false);
@@ -147,7 +153,9 @@ describe("KeyClaimManager", () => {
         resolveMarkRequestAsSentCallback = await markRequestAsSentPromise;
 
         // the first request should now have completed, and we should have more calls and fetches
-        expect(olmMachine.getMissingSessions).toHaveBeenCalledWith([u2]);
+        // We can't use directly toHaveBeenCalledWith because the UserId are cloned in the process.
+        const calledWith2 = olmMachine.getMissingSessions.mock.calls[1][0].map((u) => u.toString());
+        expect(calledWith2).toEqual([u2.toString()]);
         expect(olmMachine.getMissingSessions).toHaveBeenCalledTimes(2);
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(req1Resolved).toBe(true);

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -100,7 +100,7 @@ describe("initRustCrypto", () => {
         jest.spyOn(StoreHandle, "open").mockResolvedValue(mockStore);
 
         const testOlmMachine = makeTestOlmMachine();
-        jest.spyOn(OlmMachine, "init_from_store").mockResolvedValue(testOlmMachine);
+        jest.spyOn(OlmMachine, "initFromStore").mockResolvedValue(testOlmMachine);
 
         await initRustCrypto({
             logger,
@@ -114,7 +114,7 @@ describe("initRustCrypto", () => {
         });
 
         expect(StoreHandle.open).toHaveBeenCalledWith("storePrefix", "storePassphrase");
-        expect(OlmMachine.init_from_store).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
+        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
     });
 
     it("suppresses the storePassphrase if storePrefix is unset", async () => {
@@ -122,7 +122,7 @@ describe("initRustCrypto", () => {
         jest.spyOn(StoreHandle, "open").mockResolvedValue(mockStore);
 
         const testOlmMachine = makeTestOlmMachine();
-        jest.spyOn(OlmMachine, "init_from_store").mockResolvedValue(testOlmMachine);
+        jest.spyOn(OlmMachine, "initFromStore").mockResolvedValue(testOlmMachine);
 
         await initRustCrypto({
             logger,
@@ -136,7 +136,7 @@ describe("initRustCrypto", () => {
         });
 
         expect(StoreHandle.open).toHaveBeenCalledWith(undefined, undefined);
-        expect(OlmMachine.init_from_store).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
+        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
     });
 
     it("Should get secrets from inbox on start", async () => {
@@ -144,7 +144,7 @@ describe("initRustCrypto", () => {
         jest.spyOn(StoreHandle, "open").mockResolvedValue(mockStore);
 
         const testOlmMachine = makeTestOlmMachine();
-        jest.spyOn(OlmMachine, "init_from_store").mockResolvedValue(testOlmMachine);
+        jest.spyOn(OlmMachine, "initFromStore").mockResolvedValue(testOlmMachine);
 
         await initRustCrypto({
             logger,
@@ -189,7 +189,7 @@ describe("initRustCrypto", () => {
             jest.spyOn(Migration, "migrateMegolmSessions").mockResolvedValue(undefined);
 
             const testOlmMachine = makeTestOlmMachine();
-            jest.spyOn(OlmMachine, "init_from_store").mockResolvedValue(testOlmMachine);
+            jest.spyOn(OlmMachine, "initFromStore").mockResolvedValue(testOlmMachine);
 
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", { version: "45" });
 

--- a/src/rust-crypto/KeyClaimManager.ts
+++ b/src/rust-crypto/KeyClaimManager.ts
@@ -73,7 +73,10 @@ export class KeyClaimManager {
             throw new Error(`Cannot ensure Olm sessions: shutting down`);
         }
         logger.info("Checking for missing Olm sessions");
-        const claimRequest = await this.olmMachine.getMissingSessions(userList);
+        // By passing the userId array to rust we transfer ownership of the items to rust, this
+        // will drop them on the JS side as soon as the method is called.
+        // As we haven't created the `userList` let's clone it to not break the caller from re-using it.
+        const claimRequest = await this.olmMachine.getMissingSessions(userList.map((u) => u.clone()));
         if (claimRequest) {
             logger.info("Making /keys/claim request");
             await this.outgoingRequestProcessor.makeOutgoingRequest(claimRequest);

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -258,6 +258,7 @@ export class RoomEncryptor {
         await logDuration(this.prefixedLogger, "shareRoomKey", async () => {
             const shareMessages: ToDeviceRequest[] = await this.olmMachine.shareRoomKey(
                 new RoomId(this.room.roomId),
+                // safe to pass without cloning, as it's not reused here (before or after)
                 userList,
                 rustEncryptionSettings,
             );

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -131,7 +131,7 @@ async function initOlmMachine(
 ): Promise<RustCrypto> {
     logger.debug("Init OlmMachine");
 
-    const olmMachine = await RustSdkCryptoJs.OlmMachine.init_from_store(
+    const olmMachine = await RustSdkCryptoJs.OlmMachine.initFromStore(
         new RustSdkCryptoJs.UserId(userId),
         new RustSdkCryptoJs.DeviceId(deviceId),
         storeHandle,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -365,8 +365,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 );
                 await this.outgoingRequestProcessor.makeOutgoingRequest(request);
             }
-            // rust layer will take ownership of rustTrackedUser and drops it from the JS side.
             const userIdentity = await this.olmMachine.getIdentity(rustTrackedUser);
+            userIdentity?.free();
             return userIdentity !== undefined;
         } else if (downloadUncached) {
             // Download the cross signing keys and check if the master key is available

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -359,11 +359,14 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
                 /* make sure we have an *up-to-date* idea of the user's cross-signing keys. This is important, because if we
                  * return "false" here, we will end up generating new cross-signing keys and replacing the existing ones.
                  */
-                const request = this.olmMachine.queryKeysForUsers([rustTrackedUser]);
+                const request = this.olmMachine.queryKeysForUsers(
+                    // clone as rust layer will take ownership and it's reused later
+                    [rustTrackedUser.clone()],
+                );
                 await this.outgoingRequestProcessor.makeOutgoingRequest(request);
             }
+            // rust layer will take ownership of rustTrackedUser and drops it from the JS side.
             const userIdentity = await this.olmMachine.getIdentity(rustTrackedUser);
-            userIdentity?.free();
             return userIdentity !== undefined;
         } else if (downloadUncached) {
             // Download the cross signing keys and check if the master key is available

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,10 +1674,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-3.6.0.tgz#385aa579d7b7546d85c9b20bf6ba780f799bdda3"
-  integrity sha512-fvuYczcp/r/MOkOAUbK+tMaTerEe7/QHGQcRJz3W3JuEma0YN59d35zTBlts7EkN6Ichw1vLSyM+GkcbuosuyA==
+"@matrix-org/matrix-sdk-crypto-wasm@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-4.0.0.tgz#b33bae9c418c5516d0dbce29662c6db803003626"
+  integrity sha512-a883HchJViPo6ukM0fEDmBgvMI6lWEujqAjMZgwaKEYNZTPgezN5PQvSNz2d+b96/R1y4QOC71zXM1yNylXA6Q==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes https://github.com/element-hq/element-web/issues/26900, https://github.com/element-hq/element-web/issues/26714 and https://github.com/element-hq/element-web/issues/26774

- [x] Source breaking change: OlmMachine `init_from_store` renamed as `initFromStore`

Side effects of https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/82

> New thing with Vec<_> support in wasm-bindgen: it drops the items on the JS side as soon as the method is called. Basically, the ownership of the JS values are transferred to Rust.

Impacted Methods

- [x] `shareRoomKeys` - Udpated (RoomEncryptor)
- [x] `queryKeysForUsers` - Updated (`userHasCrossSigningKeys`)
- [x]  `getMissingSessions` - Updated (KeyClaimManager))
- [x]  `updateTrackedUsers` - Usage was fine
- [x]  `migrateOlmSession`- no changes usage is fine
- [x]  `migrateMegolmSession` - no changes usage is fine
- [x] `DeviceList` constructor - no changes usage is fine
- [x] `requestKeyVerification`, `verificationRequestContent`, `acceptWithMethod` - Ok because is just an int 


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->