### PR TITLE
Make `timeline` a getter

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1460,7 +1460,7 @@ describe("Room", function () {
                 it("should reset the unread count when our non-synthetic receipt points to the latest event", () => {
                     // Given a room with 2 events, and an unread count set.
                     room.client.isInitialSyncComplete = jest.fn().mockReturnValue(true);
-                    room.timeline = [event1, event2];
+                    jest.spyOn(room, "timeline", "get").mockReturnValue([event1, event2]);
                     room.setUnread(NotificationCountType.Total, 45);
                     room.setUnread(NotificationCountType.Highlight, 57);
                     // Sanity check:
@@ -1479,7 +1479,7 @@ describe("Room", function () {
                 it("should not reset the unread count when someone else's receipt points to the latest event", () => {
                     // Given a room with 2 events, and an unread count set.
                     room.client.isInitialSyncComplete = jest.fn().mockReturnValue(true);
-                    room.timeline = [event1, event2];
+                    jest.spyOn(room, "timeline", "get").mockReturnValue([event1, event2]);
                     room.setUnread(NotificationCountType.Total, 45);
                     room.setUnread(NotificationCountType.Highlight, 57);
                     // Sanity check:
@@ -1498,7 +1498,7 @@ describe("Room", function () {
                 it("should not reset the unread count when our non-synthetic receipt points to an earlier event", () => {
                     // Given a room with 2 events, and an unread count set.
                     room.client.isInitialSyncComplete = jest.fn().mockReturnValue(true);
-                    room.timeline = [event1, event2];
+                    jest.spyOn(room, "timeline", "get").mockReturnValue([event1, event2]);
                     room.setUnread(NotificationCountType.Total, 45);
                     room.setUnread(NotificationCountType.Highlight, 57);
                     // Sanity check:
@@ -1517,7 +1517,7 @@ describe("Room", function () {
                 it("should not reset the unread count when our a synthetic receipt points to the latest event", () => {
                     // Given a room with 2 events, and an unread count set.
                     room.client.isInitialSyncComplete = jest.fn().mockReturnValue(true);
-                    room.timeline = [event1, event2];
+                    jest.spyOn(room, "timeline", "get").mockReturnValue([event1, event2]);
                     room.setUnread(NotificationCountType.Total, 45);
                     room.setUnread(NotificationCountType.Highlight, 57);
                     // Sanity check:

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -79,7 +79,7 @@ export abstract class ReadReceipt<
     private receiptCacheByEventId: ReceiptCache = new Map();
 
     public abstract getUnfilteredTimelineSet(): EventTimelineSet;
-    public abstract timeline: MatrixEvent[];
+    public abstract get timeline(): MatrixEvent[];
 
     /**
      * Gets the latest receipt for a given user in the room

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -382,13 +382,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public summary: RoomSummary | null = null;
     /**
-     * The live event timeline for this room, with the oldest event at index 0.
-     *
-     * @deprecated Present for backwards compatibility.
-     *             Use getLiveTimeline().getEvents() instead
-     */
-    public timeline!: MatrixEvent[];
-    /**
      * oldState The state of the room at the time of the oldest event in the live timeline.
      *
      * @deprecated Present for backwards compatibility.
@@ -791,6 +784,16 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public getLiveTimeline(): EventTimeline {
         return this.getUnfilteredTimelineSet().getLiveTimeline();
+    }
+
+    /**
+     * The live event timeline for this room, with the oldest event at index 0.
+     *
+     * @deprecated Present for backwards compatibility.
+     *             Use getLiveTimeline().getEvents() instead
+     */
+    public get timeline(): MatrixEvent[] {
+        return this.getLiveTimeline().getEvents();
     }
 
     /**
@@ -1221,11 +1224,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const previousOldState = this.oldState;
         const previousCurrentState = this.currentState;
 
-        // maintain this.timeline as a reference to the live timeline,
-        // and this.oldState and this.currentState as references to the
+        // maintain this.oldState and this.currentState as references to the
         // state at the start and end of that timeline. These are more
         // for backwards-compatibility than anything else.
-        this.timeline = this.getLiveTimeline().getEvents();
         this.oldState = this.getLiveTimeline().getState(EventTimeline.BACKWARDS)!;
         this.currentState = this.getLiveTimeline().getState(EventTimeline.FORWARDS)!;
 

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -84,7 +84,6 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
      * A reference to all the events ID at the bottom of the threads
      */
     public readonly timelineSet: EventTimelineSet;
-    public timeline: MatrixEvent[] = [];
 
     private _currentUserParticipated = false;
 
@@ -323,7 +322,6 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
                 fromCache: false,
                 roomState: this.roomState,
             });
-            this.timeline = this.events;
         }
     }
 
@@ -350,9 +348,6 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             return;
         }
         this.timelineSet.insertEventIntoTimeline(event, this.liveTimeline, this.roomState);
-
-        // As far as we know, timeline should always be the same as events
-        this.timeline = this.events;
     }
 
     public addEvents(events: MatrixEvent[], toStartOfTimeline: boolean): void {
@@ -483,7 +478,6 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             this.setEventMetadata(event);
             await this.fetchEditsWhereNeeded(event);
         }
-        this.timeline = this.events;
     }
 
     /**
@@ -725,6 +719,16 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
      */
     public get replyToEvent(): Optional<MatrixEvent> {
         return this.lastPendingEvent ?? this.lastEvent ?? this.lastReply();
+    }
+
+    /**
+     * The live event timeline for this thread.
+     * @deprecated Present for backwards compatibility.
+     *             Use this.events instead
+     * @returns The live event timeline for this thread.
+     */
+    public get timeline(): MatrixEvent[] {
+        return this.events;
     }
 
     public get events(): MatrixEvent[] {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->

When looking for stuck unreads, we saw the sometimes `timeline` and `this.getLiveTimeline().getEvents()` are different.

`timeline` is a copy of the `this.getLiveTimeline().getEvents()` which is manually updated. To avoid missing copy, `timeline` becomes a getter to `this.getLiveTimeline().getEvents()`.

Also make `timeline` deprecated.

After some days of testing it, it seems to get rid of the remaining stuck unreads and make disappear some of the zombie notifications.

Closes https://github.com/element-hq/element-web/issues/26878
Part of https://github.com/element-hq/element-web/issues/24392

Notes: Fix cases of stuck unreads and zombie notifications (comes back after a refresh)


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Fix cases of stuck unreads and zombie notifications (comes back after a refresh) ([\#4022](https://github.com/matrix-org/matrix-js-sdk/pull/4022)). Fixes element-hq/element-web#26878. Contributed by @florianduros.<!-- CHANGELOG_PREVIEW_END -->