### PR TITLE
Fix type error introduced by crypto-wasm 4.0.0

### DIFF
--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
-import { Emoji, QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
     GeneratedSas,

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -18,6 +18,7 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { Emoji, QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
+    GeneratedSas,
     ShowQrCodeCallbacks,
     ShowSasCallbacks,
     VerificationPhase,
@@ -659,18 +660,23 @@ export class RustSASVerifier extends BaseRustVerifer<RustSdkCryptoJs.Sas> implem
     /** if we can now show the callbacks, do so */
     protected onChange(): void {
         if (this.callbacks === null) {
-            const emoji: Array<Emoji> | undefined = this.inner.emoji();
-            const decimal = this.inner.decimals() as [number, number, number] | undefined;
+            const emoji = this.inner.emoji();
+            const decimal = this.inner.decimals();
 
             if (emoji === undefined && decimal === undefined) {
                 return;
             }
 
+            const sas: GeneratedSas = {};
+            if (emoji) {
+                sas.emoji = emoji.map((e) => [e.symbol, e.description]);
+            }
+            if (decimal) {
+                sas.decimal = [decimal[0], decimal[1], decimal[2]];
+            }
+
             this.callbacks = {
-                sas: {
-                    decimal: decimal,
-                    emoji: emoji?.map((e) => [e.symbol, e.description]),
-                },
+                sas,
                 confirm: async (): Promise<void> => {
                     const requests: Array<OutgoingRequest> = await this.inner.confirm();
                     for (const m of requests) {


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/82/files#diff-cf8f469cee769b4b3555833df9943f95a94dd55a4c6c5c8b8c7419e34fc8b5d8R341 changed the return type of `Sas.decimals()` from  `Array<any> | undefined` to `Uint16Array | undefined`. This can no longer be cast to `[number, number, number]` without causing a type error (for reasons I don't *really* understand, tbh).

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->