### PR TITLE
Add expire_ts compatibility to matrixRTC

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -34,9 +34,12 @@ function makeMockEvent(originTs = 0): MatrixEvent {
 }
 
 describe("CallMembership", () => {
-    it("rejects membership with no expiry", () => {
+    it("rejects membership with no expiry and no expires_ts", () => {
         expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires: undefined }));
+            new CallMembership(
+                makeMockEvent(),
+                Object.assign({}, membershipTemplate, { expires: undefined, expires_ts: undefined }),
+            );
         }).toThrow();
     });
 
@@ -57,6 +60,16 @@ describe("CallMembership", () => {
             new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { scope: undefined }));
         }).toThrow();
     });
+    it("rejects with malformatted expires_ts", () => {
+        expect(() => {
+            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires_ts: "string" }));
+        }).toThrow();
+    });
+    it("rejects with malformatted expires", () => {
+        expect(() => {
+            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires: "string" }));
+        }).toThrow();
+    });
 
     it("uses event timestamp if no created_ts", () => {
         const membership = new CallMembership(makeMockEvent(12345), membershipTemplate);
@@ -71,8 +84,16 @@ describe("CallMembership", () => {
         expect(membership.createdTs()).toEqual(67890);
     });
 
-    it("computes absolute expiry time", () => {
+    it("computes absolute expiry time based on expires", () => {
         const membership = new CallMembership(makeMockEvent(1000), membershipTemplate);
+        expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
+    });
+
+    it("computes absolute expiry time based on expires_ts", () => {
+        const membership = new CallMembership(
+            makeMockEvent(1000),
+            Object.assign({}, membershipTemplate, { expires: undefined, expires_ts: 6000 }),
+        );
         expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
     });
 

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -214,8 +214,8 @@ describe("MatrixRTCSession", () => {
         });
 
         it("sends a membership event when joining a call", () => {
-            sess!.joinRoomSession([mockFocus]);
             jest.useFakeTimers();
+            sess!.joinRoomSession([mockFocus]);
             expect(client.sendStateEvent).toHaveBeenCalledWith(
                 mockRoom!.roomId,
                 EventType.GroupCallMemberPrefix,

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -215,7 +215,7 @@ describe("MatrixRTCSession", () => {
 
         it("sends a membership event when joining a call", () => {
             sess!.joinRoomSession([mockFocus]);
-
+            jest.useFakeTimers();
             expect(client.sendStateEvent).toHaveBeenCalledWith(
                 mockRoom!.roomId,
                 EventType.GroupCallMemberPrefix,
@@ -227,6 +227,7 @@ describe("MatrixRTCSession", () => {
                             call_id: "",
                             device_id: "AAAAAAA",
                             expires: 3600000,
+                            expires_ts: Date.now() + 3600000,
                             foci_active: [{ type: "mock" }],
                             membershipID: expect.stringMatching(".*"),
                         },
@@ -234,6 +235,7 @@ describe("MatrixRTCSession", () => {
                 },
                 "@alice:example.org",
             );
+            jest.useRealTimers();
         });
 
         it("does nothing if join called when already joined", () => {
@@ -291,6 +293,7 @@ describe("MatrixRTCSession", () => {
                                 call_id: "",
                                 device_id: "AAAAAAA",
                                 expires: 3600000 * 2,
+                                expires_ts: 1000 + 3600000 * 2,
                                 foci_active: [{ type: "mock" }],
                                 created_ts: 1000,
                                 membershipID: expect.stringMatching(".*"),
@@ -510,7 +513,7 @@ describe("MatrixRTCSession", () => {
         });
     });
 
-    it("Does not emits if no membership changes", () => {
+    it("Does not emit if no membership changes", () => {
         const mockRoom = makeMockRoom([membershipTemplate]);
         sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
 
@@ -591,6 +594,7 @@ describe("MatrixRTCSession", () => {
                             call_id: "",
                             device_id: "AAAAAAA",
                             expires: 3600000,
+                            expires_ts: Date.now() + 3600000,
                             foci_active: [mockFocus],
                             membershipID: expect.stringMatching(".*"),
                         },
@@ -605,7 +609,7 @@ describe("MatrixRTCSession", () => {
 
     it("fills in created_ts for other memberships on update", () => {
         client.sendStateEvent = jest.fn();
-
+        jest.useFakeTimers();
         const mockRoom = makeMockRoom([
             Object.assign({}, membershipTemplate, {
                 device_id: "OTHERDEVICE",
@@ -635,6 +639,7 @@ describe("MatrixRTCSession", () => {
                         call_id: "",
                         device_id: "AAAAAAA",
                         expires: 3600000,
+                        expires_ts: Date.now() + 3600000,
                         foci_active: [mockFocus],
                         membershipID: expect.stringMatching(".*"),
                     },
@@ -642,6 +647,7 @@ describe("MatrixRTCSession", () => {
             },
             "@alice:example.org",
         );
+        jest.useRealTimers();
     });
 
     it("collects keys from encryption events", () => {

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -101,16 +101,16 @@ export class CallMembership {
 
     // gets the expiry time of the event, converted into the device's local time
     public getLocalExpiry(): number {
-        if (this.data.expires_ts) {
-            // With expires_ts we cannot convert to local time.
-            // TODO: Check the server timestamp and compute a diff to local time.
-            return this.data.expires_ts;
-        } else {
+        if (this.data.expires) {
             const relativeCreationTime = this.parentEvent.getTs() - this.createdTs();
 
             const localCreationTs = this.parentEvent.localTimestamp - relativeCreationTime;
 
-            return localCreationTs + this.data.expires!;
+            return localCreationTs + this.data.expires;
+        } else {
+            // With expires_ts we cannot convert to local time.
+            // TODO: Check the server timestamp and compute a diff to local time.
+            return this.data.expires_ts!;
         }
     }
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -28,7 +28,7 @@ export interface CallMembershipData {
     device_id: string;
     created_ts?: number;
     expires?: number;
-    expire_ts?: number;
+    expires_ts?: number;
     foci_active?: Focus[];
     membershipID: string;
 }
@@ -45,11 +45,11 @@ export class CallMembership {
         if (data.expires && typeof data.expires !== "number") {
             throw new Error("Malformed membership: expires must be numeric");
         }
-        if (data.expire_ts && typeof data.expire_ts !== "number") {
-            throw new Error("Malformed membership: expire_ts must be numeric");
+        if (data.expires_ts && typeof data.expires_ts !== "number") {
+            throw new Error("Malformed membership: expires_ts must be numeric");
         }
-        if (!(data.expires || data.expire_ts)) {
-            throw new Error("Malformed membership: expire_ts or expires must be present");
+        if (!(data.expires || data.expires_ts)) {
+            throw new Error("Malformed membership: expires_ts or expires must be present");
         }
 
         if (typeof data.device_id !== "string") throw new Error("Malformed membership event: device_id must be string");
@@ -91,16 +91,16 @@ export class CallMembership {
             return this.createdTs() + this.data.expires;
         } else {
             // We know it exists because we check this in the constructor.
-            return this.data.expire_ts!;
+            return this.data.expires_ts!;
         }
     }
 
     // gets the expiry time of the event, converted into the device's local time
     public getLocalExpiry(): number {
-        if (this.data.expire_ts) {
-            // With expire_ts we cannot convert to local time.
+        if (this.data.expires_ts) {
+            // With expires_ts we cannot convert to local time.
             // TODO: Check the server timestamp and compute a diff to local time.
-            return this.data.expire_ts;
+            return this.data.expires_ts;
         } else {
             const relativeCreationTime = this.parentEvent.getTs() - this.createdTs();
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -42,14 +42,18 @@ export class CallMembership {
         private parentEvent: MatrixEvent,
         private data: CallMembershipData,
     ) {
-        if (data.expires && typeof data.expires !== "number") {
-            throw new Error("Malformed membership: expires must be numeric");
-        }
-        if (data.expires_ts && typeof data.expires_ts !== "number") {
-            throw new Error("Malformed membership: expires_ts must be numeric");
-        }
         if (!(data.expires || data.expires_ts)) {
             throw new Error("Malformed membership: expires_ts or expires must be present");
+        }
+        if (data.expires) {
+            if (typeof data.expires !== "number") {
+                throw new Error("Malformed membership: expires must be numeric");
+            }
+        }
+        if (data.expires_ts) {
+            if (typeof data.expires_ts !== "number") {
+                throw new Error("Malformed membership: expires_ts must be numeric");
+            }
         }
 
         if (typeof data.device_id !== "string") throw new Error("Malformed membership event: device_id must be string");

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -94,7 +94,7 @@ export class CallMembership {
         if (this.data.expires) {
             return this.createdTs() + this.data.expires;
         } else {
-            // We know it exists because we check this in the constructor.
+            // We know it exists because we checked for this in the constructor.
             return this.data.expires_ts!;
         }
     }

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -624,6 +624,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         };
 
         if (prevMembership) m.created_ts = prevMembership.createdTs();
+        if (m.created_ts) m.expire_ts = m.created_ts + (m.expires ?? 0);
+        else m.expire_ts = Date.now() + (m.expires ?? 0);
 
         return m;
     }

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -625,6 +625,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
 
         if (prevMembership) m.created_ts = prevMembership.createdTs();
         if (m.created_ts) m.expires_ts = m.created_ts + (m.expires ?? 0);
+        // TODO: Date.now() should be the origin_server_ts (now).
         else m.expires_ts = Date.now() + (m.expires ?? 0);
 
         return m;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -624,8 +624,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         };
 
         if (prevMembership) m.created_ts = prevMembership.createdTs();
-        if (m.created_ts) m.expire_ts = m.created_ts + (m.expires ?? 0);
-        else m.expire_ts = Date.now() + (m.expires ?? 0);
+        if (m.created_ts) m.expires_ts = m.created_ts + (m.expires ?? 0);
+        else m.expires_ts = Date.now() + (m.expires ?? 0);
 
         return m;
     }


### PR DESCRIPTION
Currenlty we use a combination of two fields in the Call member state events (`created_ts` + `expires`)
We want to move to just use a `expire_ts`.
This needs rethinking the logic behind syncing clients clocks. 
`created_ts` was mirring the `origin_server_timestamp` on update.
But `expire_ts` can only be known when the clock sync is known.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add expire_ts compatibility to matrixRTC ([\#4032](https://github.com/matrix-org/matrix-js-sdk/pull/4032)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->