### PR TITLE
Add "AsJson" forms of the key import/export methods

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -1379,7 +1379,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         });
         expect(decryptedEvent.getContent().body).toEqual("42");
 
-        const exported = await aliceClient.exportRoomKeys();
+        const exported = await aliceClient.getCrypto()!.exportRoomKeysAsJson();
 
         // start a new client
         await aliceClient.stopClient();
@@ -1395,7 +1395,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
         keyReceiver = new E2EKeyReceiver(homeserverUrl);
         syncResponder = new SyncResponder(homeserverUrl);
         await initCrypto(aliceClient);
-        await aliceClient.importRoomKeys(exported);
+        await aliceClient.getCrypto()!.importRoomKeysAsJson(exported);
         expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
         await startClientAndAwaitFirstSync();
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -383,7 +383,7 @@ describe("RustCrypto", () => {
         );
     });
 
-    describe(".importRoomKeys and .exportRoomKeys", () => {
+    describe("importing and exporting room keys", () => {
         let rustCrypto: RustCrypto;
 
         beforeEach(
@@ -407,6 +407,29 @@ describe("RustCrypto", () => {
             expect(importTotal).toBe(someRoomKeys.length);
 
             const keys = await rustCrypto.exportRoomKeys();
+            expect(Array.isArray(keys)).toBeTruthy();
+            expect(keys.length).toBe(someRoomKeys.length);
+
+            const aSession = someRoomKeys[0];
+
+            const exportedKey = keys.find((k) => k.session_id == aSession.session_id);
+
+            expect(aSession).toStrictEqual(exportedKey);
+        });
+
+        it("should import and export keys as JSON", async () => {
+            const someRoomKeys = testData.MEGOLM_SESSION_DATA_ARRAY;
+            let importTotal = 0;
+            const opt: ImportRoomKeysOpts = {
+                progressCallback: (stage) => {
+                    importTotal = stage.total ?? 0;
+                },
+            };
+            await rustCrypto.importRoomKeysAsJson(JSON.stringify(someRoomKeys), opt);
+
+            expect(importTotal).toBe(someRoomKeys.length);
+
+            const keys: Array<IMegolmSessionData> = JSON.parse(await rustCrypto.exportRoomKeysAsJson());
             expect(Array.isArray(keys)).toBeTruthy();
             expect(keys.length).toBe(someRoomKeys.length);
 

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -97,6 +97,17 @@ export interface CryptoApi {
     exportRoomKeys(): Promise<IMegolmSessionData[]>;
 
     /**
+     * Get a JSON list containing all of the room keys
+     *
+     * This should be encrypted before returning it to the user.
+     *
+     * @returns a promise which resolves to a JSON string
+     *    encoding a list of session export objects,
+     *    each of which is an IMegolmSessionData
+     */
+    exportRoomKeysAsJson(): Promise<string>;
+
+    /**
      * Import a list of room keys previously exported by exportRoomKeys
      *
      * @param keys - a list of session export objects
@@ -104,6 +115,17 @@ export interface CryptoApi {
      * @returns a promise which resolves once the keys have been imported
      */
     importRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void>;
+
+    /**
+     * Import a JSON string encoding a list of room keys previously
+     * exported by exportRoomKeysAsJson
+     *
+     * @param keys - a JSON string encoding a list of session export
+     *    objects, each of which is an IMegolmSessionData
+     * @param opts - options object
+     * @returns a promise which resolves once the keys have been imported
+     */
+    importRoomKeysAsJson(keys: string, opts?: ImportRoomKeysOpts): Promise<void>;
 
     /**
      * Check if the given user has published cross-signing keys.
@@ -593,7 +615,8 @@ export class DeviceVerificationStatus {
 
 /**
  * Room key import progress report.
- * Used when calling {@link CryptoApi#importRoomKeys} as the parameter of
+ * Used when calling {@link CryptoApi#importRoomKeys} or
+ * {@link CryptoApi#importRoomKeysAsJson} as the parameter of
  * the progressCallback. Used to display feedback.
  */
 export interface ImportRoomKeyProgressData {
@@ -604,7 +627,8 @@ export interface ImportRoomKeyProgressData {
 }
 
 /**
- * Options object for {@link CryptoApi#importRoomKeys}.
+ * Options object for {@link CryptoApi#importRoomKeys} and
+ * {@link CryptoApi#importRoomKeysAsJson}.
  */
 export interface ImportRoomKeysOpts {
     /** Reports ongoing progress of the import process. Can be used for feedback. */

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -3143,6 +3143,16 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
+     * Get a JSON list containing all of the room keys
+     *
+     * @returns a JSON string encoding a list of session
+     *    export objects, each of which is an IMegolmSessionData
+     */
+    public async exportRoomKeysAsJson(): Promise<string> {
+        return JSON.stringify(await this.exportRoomKeys());
+    }
+
+    /**
      * Import a list of room keys previously exported by exportRoomKeys
      *
      * @param keys - a list of session export objects
@@ -3182,6 +3192,19 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
                 });
             }),
         ).then();
+    }
+
+    /**
+     * Import a JSON string encoding a list of room keys previously
+     * exported by exportRoomKeysAsJson
+     *
+     * @param keys - a JSON string encoding a list of session export
+     *    objects, each of which is an IMegolmSessionData
+     * @param opts - options object
+     * @returns a promise which resolves once the keys have been imported
+     */
+    public async importRoomKeysAsJson(keys: string, opts?: ImportRoomKeysOpts): Promise<void> {
+        return await this.importRoomKeys(JSON.parse(keys));
     }
 
     /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -188,7 +188,18 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      * @returns a promise which resolves once the keys have been imported
      */
     public async importRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void> {
-        const jsonKeys = JSON.stringify(keys);
+        await this.importRoomKeysAsJson(JSON.stringify(keys), opts);
+    }
+
+    /**
+     * Import a list of room keys previously exported by exportRoomKeysAsJson
+     *
+     * @param keys - a JSON string encoding a list of session export objects,
+     *    each of which is an IMegolmSessionData
+     * @param opts - options object
+     * @returns a promise which resolves once the keys have been imported
+     */
+    public async importRoomKeysAsJson(jsonKeys: string, opts?: ImportRoomKeysOpts): Promise<void> {
         await this.olmMachine.importExportedRoomKeys(jsonKeys, (progress: BigInt, total: BigInt): void => {
             const importOpt: ImportRoomKeyProgressData = {
                 total: Number(total),

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -346,8 +346,16 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
         return JSON.parse(raw);
     }
 
+    public async exportRoomKeysAsJson(): Promise<string> {
+        return await this.olmMachine.exportRoomKeys(() => true);
+    }
+
     public async importRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void> {
         return await this.backupManager.importRoomKeys(keys, opts);
+    }
+
+    public async importRoomKeysAsJson(keys: string, opts?: ImportRoomKeysOpts): Promise<void> {
+        return await this.backupManager.importRoomKeysAsJson(keys, opts);
     }
 
     /**


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/26681

When we export keys with Rust encryption, we serialise them into JSON to cross the Rust/JS boundary, then we deserialise them in `RustCrypto` to match the `CryptoApi` interface, then serialise them again in matrix-react-sdk's ExportE2eKeysDialog so that we can encrypt the information and save it to disk.

By providing an `exportRoomKeysAsJson` method, we can provide the keys as a string immediately, avoiding the need to deserialise and re-serialise them, and similarly in the import case.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add "AsJson" forms of the key import/export methods ([\#4057](https://github.com/matrix-org/matrix-js-sdk/pull/4057)). Contributed by @andybalaam.<!-- CHANGELOG_PREVIEW_END -->