### PR TITLE
Await encrypted messages

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
@@ -87,7 +87,7 @@ describe("MatrixRTCSessionManager", () => {
         expect(onEnded).toHaveBeenCalledWith(room1.roomId, client.matrixRTC.getActiveRoomSession(room1));
     });
 
-    it("Calls onCallEncryption on encryption keys event", () => {
+    it("Calls onCallEncryption on encryption keys event", async () => {
         const room1 = makeMockRoom([membershipTemplate]);
         jest.spyOn(client, "getRooms").mockReturnValue([room1]);
         jest.spyOn(client, "getRoom").mockReturnValue(room1);
@@ -95,18 +95,18 @@ describe("MatrixRTCSessionManager", () => {
         client.emit(ClientEvent.Room, room1);
         const onCallEncryptionMock = jest.fn();
         client.matrixRTC.getRoomSession(room1).onCallEncryption = onCallEncryptionMock;
-
+        client.decryptEventIfNeeded = () => Promise.resolve();
         const timelineEvent = {
             getType: jest.fn().mockReturnValue(EventType.CallEncryptionKeysPrefix),
             getContent: jest.fn().mockReturnValue({}),
             getSender: jest.fn().mockReturnValue("@mock:user.example"),
             getRoomId: jest.fn().mockReturnValue("!room:id"),
-            shouldAttemptDecryption: jest.fn().mockReturnValue(false),
             sender: {
                 userId: "@mock:user.example",
             },
         } as unknown as MatrixEvent;
         client.emit(RoomEvent.Timeline, timelineEvent, undefined, undefined, false, {} as IRoomTimelineData);
+        await new Promise(process.nextTick);
         expect(onCallEncryptionMock).toHaveBeenCalled();
     });
 });

--- a/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
@@ -101,6 +101,7 @@ describe("MatrixRTCSessionManager", () => {
             getContent: jest.fn().mockReturnValue({}),
             getSender: jest.fn().mockReturnValue("@mock:user.example"),
             getRoomId: jest.fn().mockReturnValue("!room:id"),
+            shouldAttemptDecryption: jest.fn().mockReturnValue(false),
             sender: {
                 userId: "@mock:user.example",
             },

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -176,7 +176,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     }
 
     /**
-     * Return a the MatrixRTC for the room, whether there are currently active members or not
+     * Return the MatrixRTC session for the room, whether there are currently active members or not
      */
     public static roomSessionForRoom(client: MatrixClient, room: Room): MatrixRTCSession {
         const callMemberships = MatrixRTCSession.callMembershipsForRoom(room);
@@ -506,7 +506,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             return;
         }
 
-        // We currently only handle callId = ""
+        // We currently only handle callId = "" (which is the default for room scoped calls)
         if (callId !== "") {
             logger.warn(
                 `Received m.call.encryption_keys with unsupported callId: userId=${userId}, deviceId=${deviceId}, callId=${callId}`,

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -98,17 +98,20 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
         return this.roomSessions.get(room.roomId)!;
     }
 
-    private onTimeline = async (event: MatrixEvent): Promise<void> => {
+    private async consumeCallEncryptionEvent(event: MatrixEvent): Promise<void> {
         await this.client.decryptEventIfNeeded(event);
-        if (event.getType() !== EventType.CallEncryptionKeysPrefix) return;
+        if (event.getType() !== EventType.CallEncryptionKeysPrefix) return Promise.resolve();
 
         const room = this.client.getRoom(event.getRoomId());
         if (!room) {
             logger.error(`Got room state event for unknown room ${event.getRoomId()}!`);
-            return;
+            return Promise.resolve();
         }
 
         this.getRoomSession(room).onCallEncryption(event);
+    }
+    private onTimeline = (event: MatrixEvent): void => {
+        this.consumeCallEncryptionEvent(event);
     };
 
     private onRoom = (room: Room): void => {

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -98,7 +98,8 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
         return this.roomSessions.get(room.roomId)!;
     }
 
-    private onTimeline = (event: MatrixEvent): void => {
+    private onTimeline = async (event: MatrixEvent): Promise<void> => {
+        await this.client.decryptEventIfNeeded(event);
         if (event.getType() !== EventType.CallEncryptionKeysPrefix) return;
 
         const room = this.client.getRoom(event.getRoomId());


### PR DESCRIPTION
Encrypted Timeline messages need to be awaited before they can be checked for their type.

Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## 🐛 Bug Fixes
 * Await encrypted messages ([\#4063](https://github.com/matrix-org/matrix-js-sdk/pull/4063)). Contributed by @toger5.<!-- CHANGELOG_PREVIEW_END -->