### PR TITLE
Add getAuthIssuer method for MSC2965

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -3012,4 +3012,22 @@ describe("MatrixClient", function () {
             expect(result).toEqual({});
         });
     });
+
+    describe("getAuthIssuer", () => {
+        it("should use unstable prefix", async () => {
+            httpLookups = [
+                {
+                    method: "GET",
+                    path: `/auth_issuer`,
+                    data: {
+                        issuer: "https://issuer/",
+                    },
+                    prefix: "/_matrix/client/unstable/org.matrix.msc2965",
+                },
+            ];
+
+            await expect(client.getAuthIssuer()).resolves.toEqual({ issuer: "https://issuer/" });
+            expect(httpLookups.length).toEqual(0);
+        });
+    });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -9974,6 +9974,20 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             throw err;
         }
     }
+
+    /**
+     * Get the OIDC issuer responsible for authentication on this server, if any
+     * @returns Resolves: A promise of an object containing the OIDC issuer if configured
+     * @returns Rejects: when the request fails (module:http-api.MatrixError)
+     * @experimental - part of MSC2965
+     */
+    public async getAuthIssuer(): Promise<{
+        issuer: string;
+    }> {
+        return this.http.request(Method.Get, "/auth_issuer", undefined, undefined, {
+            prefix: ClientPrefix.Unstable + "/org.matrix.msc2965",
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
Picked out from https://github.com/matrix-org/matrix-js-sdk/pull/4064

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Add getAuthIssuer method for MSC2965 ([\#4071](https://github.com/matrix-org/matrix-js-sdk/pull/4071)).<!-- CHANGELOG_PREVIEW_END -->