### PR TITLE
Don't fetch the root events of a thread if we already have it

### DIFF
--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -200,12 +200,14 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
     private async fetchRootEvent(): Promise<void> {
         this.rootEvent = this.room.findEventById(this.id);
         // If the rootEvent does not exist in the local stores, then fetch it from the server.
-        try {
-            const eventData = await this.client.fetchRoomEvent(this.roomId, this.id);
-            const mapper = this.client.getEventMapper();
-            this.rootEvent = mapper(eventData); // will merge with existing event object if such is known
-        } catch (e) {
-            logger.error("Failed to fetch thread root to construct thread with", e);
+        if (!this.rootEvent) {
+            try {
+                const eventData = await this.client.fetchRoomEvent(this.roomId, this.id);
+                const mapper = this.client.getEventMapper();
+                this.rootEvent = mapper(eventData); // will merge with existing event object if such is known
+            } catch (e) {
+                logger.error("Failed to fetch thread root to construct thread with", e);
+            }
         }
         await this.processEvent(this.rootEvent);
     }


### PR DESCRIPTION
The comment said it was checking, but it didn't, it just fetched it anyway.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))
