### PR TITLE
Fix race condition with sliding sync extensions

### DIFF
--- a/spec/integ/sliding-sync.spec.ts
+++ b/spec/integ/sliding-sync.spec.ts
@@ -107,8 +107,8 @@ describe("SlidingSync", () => {
                 onRequest: (initial) => {
                     return { initial: initial };
                 },
-                onResponse: (res) => {
-                    return {};
+                onResponse: async (res) => {
+                    return;
                 },
                 when: () => ExtensionState.PreProcess,
             };
@@ -1572,7 +1572,7 @@ describe("SlidingSync", () => {
             onPreExtensionRequest = () => {
                 return extReq;
             };
-            onPreExtensionResponse = (resp) => {
+            onPreExtensionResponse = async (resp) => {
                 extensionOnResponseCalled = true;
                 callbackOrder.push("onPreExtensionResponse");
                 expect(resp).toEqual(extResp);
@@ -1613,7 +1613,7 @@ describe("SlidingSync", () => {
                 return undefined;
             };
             let responseCalled = false;
-            onPreExtensionResponse = (resp) => {
+            onPreExtensionResponse = async (resp) => {
                 responseCalled = true;
             };
             httpBackend!
@@ -1649,7 +1649,7 @@ describe("SlidingSync", () => {
             };
             let responseCalled = false;
             const callbackOrder: string[] = [];
-            onPostExtensionResponse = (resp) => {
+            onPostExtensionResponse = async (resp) => {
                 expect(resp).toEqual(extResp);
                 responseCalled = true;
                 callbackOrder.push("onPostExtensionResponse");

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -218,7 +218,7 @@ class ExtensionAccountData implements Extension<ExtensionAccountDataRequest, Ext
         };
     }
 
-    public onResponse(data: ExtensionAccountDataResponse): void {
+    public async onResponse(data: ExtensionAccountDataResponse): Promise<void> {
         if (data.global && data.global.length > 0) {
             this.processGlobalAccountData(data.global);
         }
@@ -288,7 +288,7 @@ class ExtensionTyping implements Extension<ExtensionTypingRequest, ExtensionTypi
         };
     }
 
-    public onResponse(data: ExtensionTypingResponse): void {
+    public async onResponse(data: ExtensionTypingResponse): Promise<void> {
         if (!data?.rooms) {
             return;
         }
@@ -327,7 +327,7 @@ class ExtensionReceipts implements Extension<ExtensionReceiptsRequest, Extension
         return undefined; // don't send a JSON object for subsequent requests, we don't need to.
     }
 
-    public onResponse(data: ExtensionReceiptsResponse): void {
+    public async onResponse(data: ExtensionReceiptsResponse): Promise<void> {
         if (!data?.rooms) {
             return;
         }

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -547,19 +547,23 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
     }
 
     private async onPreExtensionsResponse(ext: Record<string, object>): Promise<void> {
-        await Promise.all(Object.keys(ext).map(async (extName) => {
-            if (this.extensions[extName].when() == ExtensionState.PreProcess) {
-                await this.extensions[extName].onResponse(ext[extName]);
-            }
-        }));
+        await Promise.all(
+            Object.keys(ext).map(async (extName) => {
+                if (this.extensions[extName].when() == ExtensionState.PreProcess) {
+                    await this.extensions[extName].onResponse(ext[extName]);
+                }
+            }),
+        );
     }
 
     private async onPostExtensionsResponse(ext: Record<string, object>): Promise<void> {
-        await Promise.all(Object.keys(ext).map(async (extName) => {
-            if (this.extensions[extName].when() == ExtensionState.PostProcess) {
-                await this.extensions[extName].onResponse(ext[extName]);
-            }
-        }));
+        await Promise.all(
+            Object.keys(ext).map(async (extName) => {
+                if (this.extensions[extName].when() == ExtensionState.PostProcess) {
+                    await this.extensions[extName].onResponse(ext[extName]);
+                }
+            }),
+        );
     }
 
     /**

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -282,7 +282,7 @@ export interface Extension<Req extends {}, Res extends {}> {
      * A function which is called when there is response JSON under this extension.
      * @param data - The response JSON under the extension name.
      */
-    onResponse(data: Res): void;
+    onResponse(data: Res): Promise<void>;
     /**
      * Controls when onResponse should be called.
      * @returns The state when it should be called.
@@ -546,20 +546,20 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
         return ext;
     }
 
-    private onPreExtensionsResponse(ext: Record<string, object>): void {
-        Object.keys(ext).forEach((extName) => {
+    private async onPreExtensionsResponse(ext: Record<string, object>): Promise<void> {
+        await Promise.all(Object.keys(ext).map(async (extName) => {
             if (this.extensions[extName].when() == ExtensionState.PreProcess) {
-                this.extensions[extName].onResponse(ext[extName]);
+                await this.extensions[extName].onResponse(ext[extName]);
             }
-        });
+        }));
     }
 
-    private onPostExtensionsResponse(ext: Record<string, object>): void {
-        Object.keys(ext).forEach((extName) => {
+    private async onPostExtensionsResponse(ext: Record<string, object>): Promise<void> {
+        await Promise.all(Object.keys(ext).map(async (extName) => {
             if (this.extensions[extName].when() == ExtensionState.PostProcess) {
-                this.extensions[extName].onResponse(ext[extName]);
+                await this.extensions[extName].onResponse(ext[extName]);
             }
-        });
+        }));
     }
 
     /**
@@ -921,7 +921,7 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
             if (!resp) {
                 continue;
             }
-            this.onPreExtensionsResponse(resp.extensions);
+            await this.onPreExtensionsResponse(resp.extensions);
 
             for (const roomId in resp.rooms) {
                 await this.invokeRoomDataListeners(roomId, resp!.rooms[roomId]);
@@ -938,7 +938,7 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
                 }
             }
             this.invokeLifecycleListeners(SlidingSyncState.Complete, resp);
-            this.onPostExtensionsResponse(resp.extensions);
+            await this.onPostExtensionsResponse(resp.extensions);
             listKeysWithUpdates.forEach((listKey: string) => {
                 const list = this.lists.get(listKey);
                 if (!list) {


### PR DESCRIPTION
While debugging verification when using sliding sync, I encountered the same events being processed multiple times, causing the VerificationRequest state machine to break (some events are reentrant, but ready -> ready is a cancellable error). 

I noticed that the `onResponse` for `ExtensionToDevice` was declared `void` but overridden as `Promise<void>`, with the `nextBatch` cursor getting updated at the END of the function (after an await). In local testing, it was observed that next `onRequest` would sometimes start before the previous `onResponse` was finished, leading to the same `since` parameter being sent, leading to the same events being processed multiple times.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [X] Linter and other CI checks pass
-   [X] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md))
