### PR TITLE
Move code for processing our own receipts to Room

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -1805,16 +1805,15 @@ describe("MatrixClient syncing", () => {
                 const firstEventId = syncData.rooms.join[roomId].timeline.events[1].event_id;
 
                 // add a receipt for the first event in the room (let's say the user has already read that one)
-                const receipt: Record<string, any> = {};
-                receipt[firstEventId] = {
-                    "m.read": {},
-                };
-                receipt[firstEventId]["m.read"][myUserId] = {
-                    ts: 1,
-                };
                 syncData.rooms.join[roomId].ephemeral.events = [
                     {
-                        content: receipt,
+                        content: {
+                            [firstEventId]: {
+                                "m.read": {
+                                    [myUserId]: { ts: 1 },
+                                },
+                            },
+                        },
                         type: "m.receipt",
                     },
                 ];

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -46,6 +46,7 @@ import * as utils from "../test-utils/test-utils";
 import { TestClient } from "../TestClient";
 import { emitPromise, mkEvent, mkMessage } from "../test-utils/test-utils";
 import { THREAD_RELATION_TYPE } from "../../src/models/thread";
+import { IActionsObject } from "../../src/pushprocessor";
 
 describe("MatrixClient syncing", () => {
     const selfUserId = "@alice:localhost";
@@ -1732,64 +1733,123 @@ describe("MatrixClient syncing", () => {
             });
         });
 
-        it("should apply encrypted notification logic for events within the same sync blob", async () => {
-            const roomId = "!room123:server";
-            const syncData = {
-                rooms: {
-                    join: {
-                        [roomId]: {
-                            ephemeral: {
-                                events: [],
-                            },
-                            timeline: {
-                                events: [
-                                    utils.mkEvent({
-                                        room: roomId,
-                                        event: true,
-                                        skey: "",
-                                        type: EventType.RoomEncryption,
-                                        content: {},
-                                    }),
-                                    utils.mkMessage({
-                                        room: roomId,
-                                        user: otherUserId,
-                                        msg: "hello",
-                                    }),
-                                ],
-                            },
-                            state: {
-                                events: [
-                                    utils.mkMembership({
-                                        room: roomId,
-                                        mship: "join",
-                                        user: otherUserId,
-                                    }),
-                                    utils.mkMembership({
-                                        room: roomId,
-                                        mship: "join",
-                                        user: selfUserId,
-                                    }),
-                                    utils.mkEvent({
-                                        type: "m.room.create",
-                                        room: roomId,
-                                        user: selfUserId,
-                                        content: {},
-                                    }),
-                                ],
+        describe("encrypted notification logic", () => {
+            let roomId: string;
+            let syncData: ISyncResponse;
+
+            beforeEach(() => {
+                roomId = "!room123:server";
+                syncData = {
+                    rooms: {
+                        join: {
+                            [roomId]: {
+                                ephemeral: {
+                                    events: [],
+                                },
+                                timeline: {
+                                    events: [
+                                        utils.mkEvent({
+                                            room: roomId,
+                                            event: true,
+                                            skey: "",
+                                            type: EventType.RoomEncryption,
+                                            content: {},
+                                        }),
+                                        utils.mkMessage({
+                                            room: roomId,
+                                            user: otherUserId,
+                                            msg: "hello",
+                                        }),
+                                    ],
+                                },
+                                state: {
+                                    events: [
+                                        utils.mkMembership({
+                                            room: roomId,
+                                            mship: "join",
+                                            user: otherUserId,
+                                        }),
+                                        utils.mkMembership({
+                                            room: roomId,
+                                            mship: "join",
+                                            user: selfUserId,
+                                        }),
+                                        utils.mkEvent({
+                                            type: "m.room.create",
+                                            room: roomId,
+                                            user: selfUserId,
+                                            content: {},
+                                        }),
+                                    ],
+                                },
                             },
                         },
                     },
-                },
-            } as unknown as ISyncResponse;
+                } as unknown as ISyncResponse;
+            });
 
-            httpBackend!.when("GET", "/sync").respond(200, syncData);
-            client!.startClient();
+            it("should apply encrypted notification logic for events within the same sync blob", async () => {
+                httpBackend!.when("GET", "/sync").respond(200, syncData);
+                client!.startClient();
 
-            await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent()]);
+                await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent()]);
 
-            const room = client!.getRoom(roomId)!;
-            expect(room).toBeInstanceOf(Room);
-            expect(room.getRoomUnreadNotificationCount(NotificationCountType.Total)).toBe(0);
+                const room = client!.getRoom(roomId)!;
+                expect(room).toBeInstanceOf(Room);
+                expect(room.getRoomUnreadNotificationCount(NotificationCountType.Total)).toBe(0);
+            });
+
+            it("should recalculate highlights on receipt for encrypted rooms", async () => {
+                const myUserId = client!.getUserId()!;
+
+                const firstEventId = syncData.rooms.join[roomId].timeline.events[1].event_id;
+
+                // add a receipt for the first event in the room (let's say the user has already read that one)
+                const receipt: Record<string, any> = {};
+                receipt[firstEventId] = {
+                    "m.read": {},
+                };
+                receipt[firstEventId]["m.read"][myUserId] = {
+                    ts: 1,
+                };
+                syncData.rooms.join[roomId].ephemeral.events = [
+                    {
+                        content: receipt,
+                        type: "m.receipt",
+                    },
+                ];
+
+                // Now add a highlighting event after that receipt
+                const pingEvent = utils.mkMessage({
+                    room: roomId,
+                    user: otherUserId,
+                    msg: client?.getUserId() + " ping",
+                }) as IRoomEvent;
+                syncData.rooms.join[roomId].timeline.events.push(pingEvent);
+
+                // fudge this to make it a highlight
+                client!.getPushActionsForEvent = (ev: MatrixEvent): IActionsObject | null => {
+                    if (ev.getId() === pingEvent.event_id) {
+                        return {
+                            notify: true,
+                            tweaks: {
+                                highlight: true,
+                            },
+                        };
+                    }
+                    return null;
+                };
+
+                httpBackend!.when("GET", "/sync").respond(200, syncData);
+                client!.startClient();
+
+                await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent()]);
+
+                const room = client!.getRoom(roomId)!;
+                expect(room).toBeInstanceOf(Room);
+                // the room should now have one highlight since our receipt was before the ping message
+                expect(room.getRoomUnreadNotificationCount(NotificationCountType.Highlight)).toBe(1);
+            });
         });
     });
 


### PR DESCRIPTION
This is some code to process our own receipts and recalculate our notification counts.

There was no reason for this to be in client. Room is still rather large, but at least it makes somewhat more sense there.

Moving as a refactor before I start work on it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
