### PR TITLE
Extend logic for local notification processing to threads

### DIFF
--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1317,46 +1317,79 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         // This fixes https://github.com/vector-im/element-web/issues/9421
 
         // Figure out if we've read something or if it's just informational
+        // We need to work out what threads we've just recieved receipts for, so we
+        // know which ones to update. If we've received an unthreaded receipt, we'll
+        // need to update all threads.
+        let threadIds: string[] = [];
+        let hasUnthreadedReceipt = false;
+
         const content = event.getContent();
-        const isSelf =
-            Object.keys(content).filter((eid) => {
-                for (const [key, value] of Object.entries(content[eid])) {
-                    if (!utils.isSupportedReceiptType(key)) continue;
-                    if (!value) continue;
 
-                    if (Object.keys(value).includes(this.client.getUserId()!)) return true;
+        for (const receiptGroup of Object.values(content)) {
+            for (const [receiptType, userReceipt] of Object.entries(receiptGroup)) {
+                if (!utils.isSupportedReceiptType(receiptType)) continue;
+                if (!userReceipt) continue;
+
+                for (const [userId, singleReceipt] of Object.entries(userReceipt)) {
+                    if (!singleReceipt || typeof singleReceipt !== "object") continue;
+                    const typedSingleReceipt = singleReceipt as Record<string, any>;
+                    if (userId !== this.client.getUserId()) continue;
+                    if (typedSingleReceipt.thread_id === undefined) {
+                        hasUnthreadedReceipt = true;
+                    } else if (typeof typedSingleReceipt.thread_id === "string") {
+                        threadIds.push(typedSingleReceipt.thread_id);
+                    }
                 }
-
-                return false;
-            }).length > 0;
-
-        if (!isSelf) return;
-
-        // Work backwards to determine how many events are unread. We also set
-        // a limit for how back we'll look to avoid spinning CPU for too long.
-        // If we hit the limit, we assume the count is unchanged.
-        const maxHistory = 20;
-        const events = this.getLiveTimeline().getEvents();
-
-        let highlightCount = 0;
-
-        for (let i = events.length - 1; i >= 0; i--) {
-            if (i === events.length - maxHistory) return; // limit reached
-
-            const event = events[i];
-
-            if (this.hasUserReadEvent(this.client.getUserId()!, event.getId()!)) {
-                // If the user has read the event, then the counting is done.
-                break;
             }
-
-            const pushActions = this.client.getPushActionsForEvent(event);
-            highlightCount += pushActions?.tweaks?.highlight ? 1 : 0;
         }
 
-        // Note: we don't need to handle 'total' notifications because the counts
-        // will come from the server.
-        this.setUnreadNotificationCount(NotificationCountType.Highlight, highlightCount);
+        if (hasUnthreadedReceipt) {
+            // If we have an untheaded receipt, we need to update any threads that have a notification
+            // in them (because we know the receipt can't go backwards so we don't need to check any with
+            // no notifications: the number can only decrease from a receipt).
+            threadIds = this.getThreads()
+                .filter(
+                    (thread) =>
+                        this.getThreadUnreadNotificationCount(thread.id, NotificationCountType.Total) > 0 ||
+                        this.getThreadUnreadNotificationCount(thread.id, NotificationCountType.Highlight) > 0,
+                )
+                .map((thread) => thread.id);
+            threadIds.push("main");
+        }
+
+        for (const threadId of threadIds) {
+            // Work backwards to determine how many events are unread. We also set
+            // a limit for how back we'll look to avoid spinning CPU for too long.
+            // If we hit the limit, we assume the count is unchanged.
+            const maxHistory = 20;
+            const timeline = threadId === "main" ? this.getLiveTimeline() : this.getThread(threadId)!.liveTimeline;
+
+            const events = timeline.getEvents();
+
+            let highlightCount = 0;
+
+            for (let i = events.length - 1; i >= 0; i--) {
+                if (i === events.length - maxHistory) return; // limit reached
+
+                const event = events[i];
+
+                if (this.hasUserReadEvent(this.client.getUserId()!, event.getId()!)) {
+                    // If the user has read the event, then the counting is done.
+                    break;
+                }
+
+                const pushActions = this.client.getPushActionsForEvent(event);
+                highlightCount += pushActions?.tweaks?.highlight ? 1 : 0;
+            }
+
+            // Note: we don't need to handle 'total' notifications because the counts
+            // will come from the server.
+            if (threadId === "main") {
+                this.setUnreadNotificationCount(NotificationCountType.Highlight, highlightCount);
+            } else {
+                this.setThreadUnreadNotificationCount(threadId, NotificationCountType.Highlight, highlightCount);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
There's collection of logic for for processing receipts and recomputing notifications for encrypted rooms, but we didn't do the same for threads. As a reasult, when I tried pulling some of the logic over in https://github.com/matrix-org/matrix-js-sdk/pull/4106 clearing notifications on threads just broke.

This extends the logic of reprocessing local notifications when a receipt arrives to threads.

Based on https://github.com/matrix-org/matrix-js-sdk/pull/4109

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
