### PR TITLE
Only check lazyLoadMembers with previous session if there was one

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -601,7 +601,7 @@ export class SyncApi {
         if (!isStoreNewlyCreated) {
             const prevClientOptions = await this.client.store.getClientOptions();
             if (prevClientOptions) {
-                let lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
+                const lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
                 return lazyLoadMembersBefore !== lazyLoadMembers;
             }
         }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -595,18 +595,15 @@ export class SyncApi {
     /**
      * Is the lazy loading option different than in previous session?
      * @param lazyLoadMembers - current options for lazy loading
-     * @returns whether or not the option has changed compared to the previous session */
+     * @returns whether or not the lazyLoadMembers option has changed compared to the previous session (if there was one) */
     private async wasLazyLoadingToggled(lazyLoadMembers = false): Promise<boolean> {
-        // assume it was turned off before
-        // if we don't know any better
-        let lazyLoadMembersBefore = false;
         const isStoreNewlyCreated = await this.client.store.isNewlyCreated();
         if (!isStoreNewlyCreated) {
             const prevClientOptions = await this.client.store.getClientOptions();
             if (prevClientOptions) {
-                lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
+                let lazyLoadMembersBefore = !!prevClientOptions.lazyLoadMembers;
+                return lazyLoadMembersBefore !== lazyLoadMembers;
             }
-            return lazyLoadMembersBefore !== lazyLoadMembers;
         }
         return false;
     }


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27195

Previously this function would return true if `lazyLoadMembers` changed or if the clientOptions did not exist on the last store and `lazyLoadMembers` was now true.

I think the only case `clientOptions` doesn't exist is the case described in the bug where the execution is halted before the options are stored. 

The options are [stored directly after this function is called](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/sync.ts#L682).

The previous session never progressed to starting the actual sync, therefore I don't think think we need to do a full reset but just allow execution to continue.

