### PR TITLE
Remove various deprecated methods & re-exports

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1528,8 +1528,6 @@ describe("MatrixClient", function () {
             { startOpts: {}, hasThreadSupport: false },
             { startOpts: { threadSupport: true }, hasThreadSupport: true },
             { startOpts: { threadSupport: false }, hasThreadSupport: false },
-            { startOpts: { experimentalThreadSupport: true }, hasThreadSupport: true },
-            { startOpts: { experimentalThreadSupport: true, threadSupport: false }, hasThreadSupport: false },
         ])("enabled thread support for the SDK instance", async ({ startOpts, hasThreadSupport }) => {
             await client.startClient(startOpts);
             expect(client.supportsThreads()).toBe(hasThreadSupport);

--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -469,52 +469,6 @@ describe("MatrixEvent", () => {
             default: false,
             enabled: true,
         } as IAnnotatedPushRule;
-        describe("setPushActions()", () => {
-            it("sets actions on event", () => {
-                const actions = { notify: false, tweaks: {} };
-                const event = new MatrixEvent({
-                    type: "com.example.test",
-                    content: {
-                        isTest: true,
-                    },
-                });
-                event.setPushActions(actions);
-
-                expect(event.getPushActions()).toBe(actions);
-            });
-
-            it("sets actions to undefined", () => {
-                const event = new MatrixEvent({
-                    type: "com.example.test",
-                    content: {
-                        isTest: true,
-                    },
-                });
-                event.setPushActions(null);
-
-                // undefined is set on state
-                expect(event.getPushDetails().actions).toBe(undefined);
-                // but pushActions getter returns null when falsy
-                expect(event.getPushActions()).toBe(null);
-            });
-
-            it("clears existing push rule", () => {
-                const prevActions = { notify: true, tweaks: { highlight: true } };
-                const actions = { notify: false, tweaks: {} };
-                const event = new MatrixEvent({
-                    type: "com.example.test",
-                    content: {
-                        isTest: true,
-                    },
-                });
-                event.setPushDetails(prevActions, pushRule);
-
-                event.setPushActions(actions);
-
-                // rule is not in event push cache
-                expect(event.getPushDetails()).toEqual({ actions });
-            });
-        });
 
         describe("setPushDetails()", () => {
             it("sets actions and rule on event", () => {
@@ -543,7 +497,7 @@ describe("MatrixEvent", () => {
                 });
                 event.setPushDetails(prevActions, pushRule);
 
-                event.setPushActions(actions);
+                event.setPushDetails(actions);
 
                 // rule is not in event push cache
                 expect(event.getPushDetails()).toEqual({ actions });

--- a/src/@types/partials.ts
+++ b/src/@types/partials.ts
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ImageInfo } from "./media";
-
-/**
- * @deprecated use {@link ImageInfo} instead.
- */
-export type IImageInfo = ImageInfo;
-
 export enum Visibility {
     Public = "public",
     Private = "private",

--- a/src/@types/uia.ts
+++ b/src/@types/uia.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IAuthDict, IAuthData } from "../interactive-auth";
+import { AuthDict, IAuthData } from "../interactive-auth";
 
 /**
  * Helper type to represent HTTP request body for a UIA enabled endpoint
  */
 export type UIARequest<T> = T & {
-    auth?: IAuthDict;
+    auth?: AuthDict;
 };
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -4484,7 +4484,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param roomId - the room to update power levels in
      * @param userId - the ID of the user or users to update power levels of
      * @param powerLevel - the numeric power level to update given users to
-     * @param event - deprecated and no longer used.
      * @returns Promise which resolves: to an ISendEventResponse object
      * @returns Rejects: with an error response.
      */
@@ -4492,10 +4491,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         roomId: string,
         userId: string | string[],
         powerLevel: number | undefined,
-        /**
-         * @deprecated no longer needed, unused.
-         */
-        event?: MatrixEvent | null,
     ): Promise<ISendEventResponse> {
         let content: IPowerLevelsContent | undefined;
         if (this.clientRunning && this.isInitialSyncComplete()) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -509,11 +509,6 @@ export interface IStartClientOpts {
     clientWellKnownPollPeriod?: number;
 
     /**
-     * @deprecated use `threadSupport` instead
-     */
-    experimentalThreadSupport?: boolean;
-
-    /**
      * Will organises events in threaded conversations when
      * a thread relation is encountered
      */
@@ -1533,19 +1528,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             );
         } else {
             this.syncApi = new SyncApi(this, this.clientOpts, this.buildSyncApiOptions());
-        }
-
-        if (this.clientOpts.hasOwnProperty("experimentalThreadSupport")) {
-            this.logger.warn("`experimentalThreadSupport` has been deprecated, use `threadSupport` instead");
-        }
-
-        // If `threadSupport` is omitted and the deprecated `experimentalThreadSupport` has been passed
-        // We should fallback to that value for backwards compatibility purposes
-        if (
-            !this.clientOpts.hasOwnProperty("threadSupport") &&
-            this.clientOpts.hasOwnProperty("experimentalThreadSupport")
-        ) {
-            this.clientOpts.threadSupport = this.clientOpts.experimentalThreadSupport;
         }
 
         this.syncApi.sync().catch((e) => this.logger.info("Sync startup aborted with an error:", e));
@@ -9798,14 +9780,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             localTimeoutMs: clientTimeout,
             abortSignal,
         });
-    }
-
-    /**
-     * @deprecated use supportsThreads() instead
-     */
-    public supportsExperimentalThreads(): boolean {
-        this.logger.warn(`supportsExperimentalThreads() is deprecated, use supportThreads() instead`);
-        return this.clientOpts?.experimentalThreadSupport || false;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -8512,17 +8512,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * @returns Promise which resolves: Object with room_id and servers.
-     * @returns Rejects: with an error response.
-     * @deprecated use `getRoomIdForAlias` instead
-     */
-    // eslint-disable-next-line camelcase
-    public resolveRoomAlias(roomAlias: string): Promise<{ room_id: string; servers: string[] }> {
-        const path = utils.encodeUri("/directory/room/$alias", { $alias: roomAlias });
-        return this.http.request(Method.Get, path);
-    }
-
-    /**
      * Get the visibility of a room in the current HS's room directory
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.

--- a/src/client.ts
+++ b/src/client.ts
@@ -150,15 +150,7 @@ import {
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
 } from "./@types/event";
-import {
-    GuestAccess,
-    HistoryVisibility,
-    IdServerUnbindResult,
-    IImageInfo,
-    JoinRule,
-    Preset,
-    Visibility,
-} from "./@types/partials";
+import { GuestAccess, HistoryVisibility, IdServerUnbindResult, JoinRule, Preset, Visibility } from "./@types/partials";
 import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper";
 import { randomString } from "./randomstring";
 import { BackupManager, IKeyBackup, IKeyBackupCheck, IPreparedKeyBackupVersion, TrustInfo } from "./crypto/backup";
@@ -232,6 +224,7 @@ import { RegisterRequest, RegisterResponse } from "./@types/registration";
 import { MatrixRTCSessionManager } from "./matrixrtc/MatrixRTCSessionManager";
 import { getRelationsThreadFilter } from "./thread-utils";
 import { KnownMembership, Membership } from "./@types/membership";
+import { ImageInfo } from "./@types/media";
 
 export type Store = IStore;
 
@@ -5068,24 +5061,24 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: to a ISendEventResponse object
      * @returns Rejects: with an error response.
      */
-    public sendImageMessage(roomId: string, url: string, info?: IImageInfo, text?: string): Promise<ISendEventResponse>;
+    public sendImageMessage(roomId: string, url: string, info?: ImageInfo, text?: string): Promise<ISendEventResponse>;
     public sendImageMessage(
         roomId: string,
         threadId: string | null,
         url: string,
-        info?: IImageInfo,
+        info?: ImageInfo,
         text?: string,
     ): Promise<ISendEventResponse>;
     public sendImageMessage(
         roomId: string,
         threadId: string | null,
-        url?: string | IImageInfo,
-        info?: IImageInfo | string,
+        url?: string | ImageInfo,
+        info?: ImageInfo | string,
         text = "Image",
     ): Promise<ISendEventResponse> {
         if (!threadId?.startsWith(EVENT_ID_PREFIX) && threadId !== null) {
             text = (info as string) || "Image";
-            info = url as IImageInfo;
+            info = url as ImageInfo;
             url = threadId as string;
             threadId = null;
         }
@@ -5105,26 +5098,26 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public sendStickerMessage(
         roomId: string,
         url: string,
-        info?: IImageInfo,
+        info?: ImageInfo,
         text?: string,
     ): Promise<ISendEventResponse>;
     public sendStickerMessage(
         roomId: string,
         threadId: string | null,
         url: string,
-        info?: IImageInfo,
+        info?: ImageInfo,
         text?: string,
     ): Promise<ISendEventResponse>;
     public sendStickerMessage(
         roomId: string,
         threadId: string | null,
-        url?: string | IImageInfo,
-        info?: IImageInfo | string,
+        url?: string | ImageInfo,
+        info?: ImageInfo | string,
         text = "Sticker",
     ): Promise<ISendEventResponse> {
         if (!threadId?.startsWith(EVENT_ID_PREFIX) && threadId !== null) {
             text = (info as string) || "Sticker";
-            info = url as IImageInfo;
+            info = url as ImageInfo;
             url = threadId as string;
             threadId = null;
         }
@@ -8524,7 +8517,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Set the visbility of a room in the current HS's room directory
+     * Set the visibility of a room in the current HS's room directory
      * @param visibility - "public" to make the room visible
      *                 in the public directory, or "private" to make
      *                 it invisible.

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -140,12 +140,6 @@ export type AuthDict =
     | { type: Exclude<string, AuthType>; [key: string]: any }
     | {};
 
-/**
- * Backwards compatible export
- * @deprecated in favour of AuthDict
- */
-export type IAuthDict = AuthDict;
-
 export class NoAuthFlowFoundError extends Error {
     public name = "NoAuthFlowFoundError";
 
@@ -168,7 +162,7 @@ export class NoAuthFlowFoundError extends Error {
  *
  * The generic parameter `T` is the type of the response of the endpoint, once it is eventually successful.
  */
-export type UIAuthCallback<T> = (makeRequest: (authData: IAuthDict | null) => Promise<UIAResponse<T>>) => Promise<T>;
+export type UIAuthCallback<T> = (makeRequest: (authData: AuthDict | null) => Promise<UIAResponse<T>>) => Promise<T>;
 
 interface IOpts<T> {
     /**
@@ -340,7 +334,7 @@ export class InteractiveAuth<T> {
         // another just to check what the status is
         if (this.submitPromise) return;
 
-        let authDict: IAuthDict = {};
+        let authDict: AuthDict = {};
         if (this.currentStage == EMAIL_STAGE_TYPE) {
             // The email can be validated out-of-band, but we need to provide the
             // creds so the HS can go & check it.
@@ -410,7 +404,7 @@ export class InteractiveAuth<T> {
      *    in the attemptAuth promise being rejected. This can be set to true
      *    for requests that just poll to see if auth has been completed elsewhere.
      */
-    public async submitAuthDict(authData: IAuthDict, background = false): Promise<void> {
+    public async submitAuthDict(authData: AuthDict, background = false): Promise<void> {
         if (!this.attemptAuthDeferred) {
             throw new Error("submitAuthDict() called before attemptAuth()");
         }
@@ -431,7 +425,7 @@ export class InteractiveAuth<T> {
         }
 
         // use the sessionid from the last request, if one is present.
-        let auth: IAuthDict;
+        let auth: AuthDict;
         if ((this.data as IAuthData)?.session) {
             auth = {
                 session: (this.data as IAuthData).session,
@@ -515,7 +509,7 @@ export class InteractiveAuth<T> {
      *    This can be set to true for requests that just poll to see if auth has
      *    been completed elsewhere.
      */
-    private async doRequest(auth: IAuthDict | null, background = false): Promise<void> {
+    private async doRequest(auth: AuthDict | null, background = false): Promise<void> {
         try {
             const result = await this.requestCallback(auth, background);
             this.attemptAuthDeferred!.resolve(result);

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1634,6 +1634,36 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         return JSON.stringify(myProps) === JSON.stringify(theirProps);
     }
 
+    /**
+     * Summarise the event as JSON.
+     *
+     * If encrypted, include both the decrypted and encrypted view of the event.
+     *
+     * This is named `toJSON` for use with `JSON.stringify` which checks objects
+     * for functions named `toJSON` and will call them to customise the output
+     * if they are defined.
+     *
+     * **WARNING** Do not log the result of this method; otherwise, it will end up
+     * in rageshakes, leading to a privacy violation.
+     *
+     * @deprecated Prefer to use {@link MatrixEvent#getEffectiveEvent} or similar.
+     * This method will be removed soon; it is too easy to use it accidentally
+     * and cause a privacy violation (cf https://github.com/vector-im/element-web/issues/26380).
+     * In any case, the value it returns is not a faithful serialization of the object.
+     */
+    public toJSON(): object {
+        const event = this.getEffectiveEvent();
+
+        if (!this.isEncrypted()) {
+            return event;
+        }
+
+        return {
+            decrypted: event,
+            encrypted: this.event,
+        };
+    }
+
     public setVerificationRequest(request: VerificationRequest): void {
         this.verificationRequest = request;
     }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1161,18 +1161,13 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
     }
 
     /**
-     * @deprecated In favor of the overload that includes a Room argument
-     */
-    public makeRedacted(redactionEvent: MatrixEvent): void;
-    /**
      * Update the content of an event in the same way it would be by the server
      * if it were redacted before it was sent to us
      *
      * @param redactionEvent - event causing the redaction
      * @param room - the room in which the event exists
      */
-    public makeRedacted(redactionEvent: MatrixEvent, room: Room): void;
-    public makeRedacted(redactionEvent: MatrixEvent, room?: Room): void {
+    public makeRedacted(redactionEvent: MatrixEvent, room: Room): void {
         // quick sanity-check
         if (!redactionEvent.event) {
             throw new Error("invalid redactionEvent in makeRedacted");
@@ -1218,7 +1213,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
 
         // If the redacted event was in a thread (but not thread root), move it
         // to the main timeline. This will change if MSC3389 is merged.
-        if (room && !this.isThreadRoot && this.threadRootId && this.threadRootId !== this.getId()) {
+        if (!this.isThreadRoot && this.threadRootId && this.threadRootId !== this.getId()) {
             this.moveAllRelatedToMainTimeline(room);
             redactionEvent.moveToMainTimeline(room);
         }
@@ -1353,19 +1348,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     public getPushDetails(): PushDetails {
         return this.pushDetails;
-    }
-
-    /**
-     * Set the push actions for this event.
-     * Clears rule from push details if present
-     * @deprecated use `setPushDetails`
-     *
-     * @param pushActions - push actions
-     */
-    public setPushActions(pushActions: IActionsObject | null): void {
-        this.pushDetails = {
-            actions: pushActions || undefined,
-        };
     }
 
     /**
@@ -1570,14 +1552,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
 
     /**
      * Checks if this event is associated with another event. See `getAssociatedId`.
-     * @deprecated use hasAssociation instead.
-     */
-    public hasAssocation(): boolean {
-        return !!this.getAssociatedId();
-    }
-
-    /**
-     * Checks if this event is associated with another event. See `getAssociatedId`.
      */
     public hasAssociation(): boolean {
         return !!this.getAssociatedId();
@@ -1658,36 +1632,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         const myProps = deepSortedObjectEntries(this.event);
         const theirProps = deepSortedObjectEntries(otherEvent.event);
         return JSON.stringify(myProps) === JSON.stringify(theirProps);
-    }
-
-    /**
-     * Summarise the event as JSON.
-     *
-     * If encrypted, include both the decrypted and encrypted view of the event.
-     *
-     * This is named `toJSON` for use with `JSON.stringify` which checks objects
-     * for functions named `toJSON` and will call them to customise the output
-     * if they are defined.
-     *
-     * **WARNING** Do not log the result of this method; otherwise, it will end up
-     * in rageshakes, leading to a privacy violation.
-     *
-     * @deprecated Prefer to use {@link MatrixEvent#getEffectiveEvent} or similar.
-     * This method will be removed soon; it is too easy to use it accidentally
-     * and cause a privacy violation (cf https://github.com/vector-im/element-web/issues/26380).
-     * In any case, the value it returns is not a faithful serialization of the object.
-     */
-    public toJSON(): object {
-        const event = this.getEffectiveEvent();
-
-        if (!this.isEncrypted()) {
-            return event;
-        }
-
-        return {
-            decrypted: event,
-            encrypted: this.event,
-        };
     }
 
     public setVerificationRequest(request: VerificationRequest): void {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3065,7 +3065,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                 [[], [], []],
             );
         } else {
-            // When `experimentalThreadSupport` is disabled treat all events as timelineEvents
+            // When `threadSupport` is disabled treat all events as timelineEvents
             return [events as MatrixEvent[], [] as MatrixEvent[], [] as MatrixEvent[]];
         }
     }

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -47,11 +47,6 @@ export type ThreadEventHandlerMap = {
     [ThreadEvent.Delete]: (thread: Thread) => void;
 } & EventTimelineSetHandlerMap;
 
-/**
- * @deprecated please use ThreadEventHandlerMap instead
- */
-export type EventHandlerMap = ThreadEventHandlerMap;
-
 interface IThreadOpts {
     room: Room;
     client: MatrixClient;

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -20,12 +20,6 @@ import { OidcMetadata, SigninResponse } from "oidc-client-ts";
 import { logger } from "../logger";
 import { OidcError } from "./error";
 
-/**
- * re-export for backwards compatibility
- * @deprecated use OidcError
- */
-export { OidcError as OidcDiscoveryError };
-
 export type ValidatedIssuerConfig = {
     authorizationEndpoint: string;
     tokenEndpoint: string;

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -29,7 +29,7 @@ import {
 import { logger } from "../logger";
 import { calculateRetryBackoff, IHttpOpts, MatrixHttpApi, Method } from "../http-api";
 import { logDuration, QueryDict, sleep } from "../utils";
-import { IAuthDict, UIAuthCallback } from "../interactive-auth";
+import { AuthDict, UIAuthCallback } from "../interactive-auth";
 import { UIAResponse } from "../@types/uia";
 import { ToDeviceMessageId } from "../@types/event";
 
@@ -169,7 +169,7 @@ export class OutgoingRequestProcessor {
         }
 
         const parsedBody = JSON.parse(body);
-        const makeRequest = async (auth: IAuthDict | null): Promise<UIAResponse<T>> => {
+        const makeRequest = async (auth: AuthDict | null): Promise<UIAResponse<T>> => {
             const newBody: Record<string, any> = {
                 ...parsedBody,
             };


### PR DESCRIPTION
+ Removes deprecated `experimentalThreadSupport` field on the start client options in favour of `threadSupport`
+ Removed deprecated method `supportsExperimentalThreads` on `MatrixClient` in favour of `supportsThreads`
+ Remove deprecated method `resolveRoomAlias` on `MatrixClient` in favour of `getRoomIdForAlias`
+ Remove deprecated method `setPushActions` on `MatrixEvent` in favour of `setPushDetails`
+ Remove deprecated method `hasAssocation` on `MatrixEvent` in favour of `hasAssociation`
+ Remove deprecated overload `makeRedacted` on `MatrixEvent`, `room` param is now required
+ Remove deprecated symbol `IImageInfo` - use `ImageInfo` instead
+ Remove deprecated symbol `IAuthDict` - use `AuthDict` instead
+ Remove deprecated symbol `OidcDiscoveryError` - use `OidcError` instead
+ Remove deprecated overload `setPowerLevel` on `MatrixClient`, `event` param no longer specified

Requires https://github.com/matrix-org/matrix-react-sdk/pull/12359