### PR TITLE
Add new `decryptExistingEvent` test helper

### DIFF
--- a/spec/unit/testing.spec.ts
+++ b/spec/unit/testing.spec.ts
@@ -14,7 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { mkDecryptionFailureMatrixEvent, mkEncryptedMatrixEvent, mkMatrixEvent } from "../../src/testing";
+import {
+    decryptExistingEvent,
+    mkDecryptionFailureMatrixEvent,
+    mkEncryptedMatrixEvent,
+    mkMatrixEvent,
+} from "../../src/testing";
 import { EventType } from "../../src";
 import { DecryptionFailureCode } from "../../src/crypto-api";
 
@@ -86,6 +91,30 @@ describe("testing", () => {
             });
             expect(event.getType()).toEqual("m.room.message");
             expect(event.isState()).toBe(false);
+        });
+    });
+
+    describe("decryptExistingEvent", () => {
+        it("decrypts an event", async () => {
+            const event = await mkDecryptionFailureMatrixEvent({
+                sender: "@alice:test",
+                roomId: "!test:room",
+                code: DecryptionFailureCode.UNKNOWN_ERROR,
+                msg: "blah",
+            });
+
+            expect(event.isEncrypted()).toBe(true);
+            expect(event.isDecryptionFailure()).toBe(true);
+            await decryptExistingEvent(event, {
+                plainContent: { body: "blah" },
+                plainType: "m.room.test",
+            });
+
+            expect(event.isEncrypted()).toBe(true);
+            expect(event.isDecryptionFailure()).toBe(false);
+            expect(event.decryptionFailureReason).toBe(null);
+            expect(event.getContent()).toEqual({ body: "blah" });
+            expect(event.getType()).toEqual("m.room.test");
         });
     });
 });

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -25,9 +25,9 @@ limitations under the License.
 import { IContent, IEvent, IUnsigned, MatrixEvent } from "./models/event";
 import { RoomMember } from "./models/room-member";
 import { EventType } from "./@types/event";
-import { IEventDecryptionResult } from "./@types/crypto";
 import { DecryptionError } from "./crypto/algorithms";
 import { DecryptionFailureCode } from "./crypto-api";
+import { EventDecryptionResult } from "./common-crypto/CryptoBackend";
 
 /**
  * Create a {@link MatrixEvent}.
@@ -113,7 +113,7 @@ export async function mkEncryptedMatrixEvent(opts: {
         content: { algorithm: "m.megolm.v1.aes-sha2" },
     });
 
-    const decryptionResult: IEventDecryptionResult = {
+    const decryptionResult: EventDecryptionResult = {
         claimedEd25519Key: "",
         clearEvent: {
             type: opts.plainType,
@@ -157,7 +157,7 @@ export async function mkDecryptionFailureMatrixEvent(opts: {
     });
 
     const mockCrypto = {
-        decryptEvent: async (_ev): Promise<IEventDecryptionResult> => {
+        decryptEvent: async (_ev): Promise<EventDecryptionResult> => {
             throw new DecryptionError(opts.code, opts.msg);
         },
     } as Parameters<MatrixEvent["attemptDecryption"]>[0];

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -102,6 +102,9 @@ export async function mkEncryptedMatrixEvent(opts: {
 
     /** The content the event will have, once it has been decrypted. */
     plainContent: IContent;
+
+    /** Optional `event_id` for the event. If provided will be used as event ID; else an ID is generated. */
+    eventId?: string;
 }): Promise<MatrixEvent> {
     // we construct an event which has been decrypted by stubbing out CryptoBackend.decryptEvent and then
     // calling MatrixEvent.attemptDecryption.
@@ -111,6 +114,7 @@ export async function mkEncryptedMatrixEvent(opts: {
         roomId: opts.roomId,
         sender: opts.sender,
         content: { algorithm: "m.megolm.v1.aes-sha2" },
+        eventId: opts.eventId,
     });
 
     const decryptionResult: EventDecryptionResult = {
@@ -148,12 +152,16 @@ export async function mkDecryptionFailureMatrixEvent(opts: {
 
     /** A textual reason for the failure */
     msg: string;
+
+    /** Optional `event_id` for the event. If provided will be used as event ID; else an ID is generated. */
+    eventId?: string;
 }): Promise<MatrixEvent> {
     const mxEvent = mkMatrixEvent({
         type: EventType.RoomMessageEncrypted,
         roomId: opts.roomId,
         sender: opts.sender,
         content: { algorithm: "m.megolm.v1.aes-sha2" },
+        eventId: opts.eventId,
     });
 
     const mockCrypto = {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -17,7 +17,7 @@ limitations under the License.
 /**
  * This file is a secondary entrypoint for the js-sdk library, exposing utilities which might be useful for writing tests.
  *
- * In general it should not be included in runtime applications.
+ * In general, it should not be included in runtime applications.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
Followup to https://github.com/matrix-org/matrix-js-sdk/pull/4127: adds another test helper method. Also a couple of other additions.