### PR TITLE
Crypto: use a new error code for UTDs from device-relative historical events

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -469,6 +469,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
     });
 
     describe("Unable to decrypt error codes", function () {
+        beforeEach(() => {
+            jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+        });
+
         it("Decryption fails with UISI error", async () => {
             expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
             await startClientAndAwaitFirstSync();

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -108,6 +108,8 @@ afterEach(() => {
     // cf https://github.com/dumbmatter/fakeIndexedDB#wipingresetting-the-indexeddb-for-a-fresh-state
     // eslint-disable-next-line no-global-assign
     indexedDB = new IDBFactory();
+
+    jest.useRealTimers();
 });
 
 /**
@@ -996,10 +998,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
             ]);
             return encryptedMessage;
         }
-
-        afterEach(() => {
-            jest.useRealTimers();
-        });
 
         newBackendOnly("should rotate the session after 2 messages", async () => {
             expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
@@ -2184,10 +2182,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
             jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
         });
 
-        afterEach(() => {
-            jest.useRealTimers();
-        });
-
         function awaitKeyUploadRequest(): Promise<{ keysCount: number; fallbackKeysCount: number }> {
             return new Promise((resolve) => {
                 const listener = (url: string, options: RequestInit) => {
@@ -2250,10 +2244,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
     });
 
     describe("getUserDeviceInfo", () => {
-        afterEach(() => {
-            jest.useRealTimers();
-        });
-
         // From https://spec.matrix.org/v1.6/client-server-api/#post_matrixclientv3keysquery
         // Using extracted response from matrix.org, it needs to have real keys etc to pass old crypto verification
         const queryResponseBody = {
@@ -2740,10 +2730,6 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
             beforeEach(async () => {
                 // We want to use fake timers, but the wasm bindings of matrix-sdk-crypto rely on a working `queueMicrotask`.
                 jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
-            });
-
-            afterEach(() => {
-                jest.useRealTimers();
             });
 
             it("Should be able to restore from 4S after bootstrap", async () => {

--- a/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
+++ b/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
@@ -155,8 +155,11 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             downloader.onDecryptionKeyMissingError(roomId, sessionId);
 
+            // `isKeyBackupDownloadConfigured` is false until the config is proven.
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
             await expectAPICall;
             await awaitKeyImported.promise;
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(true);
             expect(mockRustBackupManager.createBackupDecryptor).toHaveBeenCalledTimes(1);
         });
 
@@ -313,6 +316,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             expect(getConfigSpy).toHaveBeenCalledTimes(1);
             expect(getConfigSpy).toHaveReturnedWith(Promise.resolve(null));
+
+            // isKeyBackupDownloadConfigured remains false
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
         });
 
         it("Should not query server if backup not active", async () => {
@@ -328,6 +334,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             expect(getConfigSpy).toHaveBeenCalledTimes(1);
             expect(getConfigSpy).toHaveReturnedWith(Promise.resolve(null));
+
+            // isKeyBackupDownloadConfigured remains false
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
         });
 
         it("Should stop if backup key is not cached", async () => {
@@ -344,6 +353,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             expect(getConfigSpy).toHaveBeenCalledTimes(1);
             expect(getConfigSpy).toHaveReturnedWith(Promise.resolve(null));
+
+            // isKeyBackupDownloadConfigured remains false
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
         });
 
         it("Should stop if backup key cached as wrong version", async () => {
@@ -363,6 +375,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             expect(getConfigSpy).toHaveBeenCalledTimes(1);
             expect(getConfigSpy).toHaveReturnedWith(Promise.resolve(null));
+
+            // isKeyBackupDownloadConfigured remains false
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
         });
 
         it("Should stop if backup key version does not match the active one", async () => {
@@ -382,6 +397,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             expect(getConfigSpy).toHaveBeenCalledTimes(1);
             expect(getConfigSpy).toHaveReturnedWith(Promise.resolve(null));
+
+            // isKeyBackupDownloadConfigured remains false
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
         });
     });
 
@@ -410,6 +428,7 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             // @ts-ignore access to private property
             expect(downloader.hasConfigurationProblem).toEqual(true);
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
 
             // Now the backup becomes trusted
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
@@ -423,6 +442,7 @@ describe("PerSessionKeyBackupDownloader", () => {
             mockEmitter.emit(CryptoEvent.KeyBackupStatus, true);
 
             await jest.runAllTimersAsync();
+            expect(downloader.isKeyBackupDownloadConfigured()).toBe(true);
 
             await a0Imported;
             await a1Imported;

--- a/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
+++ b/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
@@ -90,7 +90,7 @@ describe("PerSessionKeyBackupDownloader", () => {
 
         mockRustBackupManager = {
             getActiveBackupVersion: jest.fn(),
-            requestKeyBackupVersion: jest.fn(),
+            getServerBackupInfo: jest.fn(),
             importBackedUpRoomKeys: jest.fn(),
             createBackupDecryptor: jest.fn().mockReturnValue(mockBackupDecryptor),
             on: jest.fn().mockImplementation((event, listener) => {
@@ -135,7 +135,7 @@ describe("PerSessionKeyBackupDownloader", () => {
                 decryptionKey: RustSdkCryptoJs.BackupDecryptionKey.fromBase64(TestData.BACKUP_DECRYPTION_KEY_BASE64),
             } as unknown as RustSdkCryptoJs.BackupKeys);
 
-            mockRustBackupManager.requestKeyBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
+            mockRustBackupManager.getServerBackupInfo.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
         });
 
         it("Should download and import a missing key from backup", async () => {
@@ -406,7 +406,7 @@ describe("PerSessionKeyBackupDownloader", () => {
     describe("Given Backup state update", () => {
         it("After initial sync, when backup becomes trusted it should request keys for past requests", async () => {
             // there is a backup
-            mockRustBackupManager.requestKeyBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
+            mockRustBackupManager.getServerBackupInfo.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
 
             // but at this point it's not trusted and we don't have the key
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(null);
@@ -454,7 +454,7 @@ describe("PerSessionKeyBackupDownloader", () => {
     describe("Error cases", () => {
         beforeEach(async () => {
             // there is a backup
-            mockRustBackupManager.requestKeyBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
+            mockRustBackupManager.getServerBackupInfo.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
             // It's trusted
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
             // And we have the key in cache

--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -542,6 +542,24 @@ export enum DecryptionFailureCode {
     /** Message was encrypted with a Megolm session which has been shared with us, but in a later ratchet state. */
     OLM_UNKNOWN_MESSAGE_INDEX = "OLM_UNKNOWN_MESSAGE_INDEX",
 
+    /**
+     * Message was sent before the current device was created; there is no key backup on the server, so this
+     * decryption failure is expected.
+     */
+    HISTORICAL_MESSAGE_NO_KEY_BACKUP = "HISTORICAL_MESSAGE_NO_KEY_BACKUP",
+
+    /**
+     * Message was sent before the current device was created; there was a key backup on the server, but we don't
+     * seem to have access to the backup. (Probably we don't have the right key.)
+     */
+    HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED = "HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED",
+
+    /**
+     * Message was sent before the current device was created; there was a (usable) key backup on the server, but we
+     * still can't decrypt. (Either the session isn't in the backup, or we just haven't gotten around to checking yet.)
+     */
+    HISTORICAL_MESSAGE_WORKING_BACKUP = "HISTORICAL_MESSAGE_WORKING_BACKUP",
+
     /** Unknown or unclassified error. */
     UNKNOWN_ERROR = "UNKNOWN_ERROR",
 

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -76,7 +76,11 @@ type Configuration = {
 export class PerSessionKeyBackupDownloader {
     private stopped = false;
 
-    /** The version and decryption key to use with current backup if all set up correctly */
+    /**
+     * The version and decryption key to use with current backup if all set up correctly.
+     *
+     * Will not be set unless `hasConfigurationProblem` is `false`.
+     */
     private configuration: Configuration | null = null;
 
     /** We remember when a session was requested and not found in backup to avoid query again too soon.
@@ -117,6 +121,15 @@ export class PerSessionKeyBackupDownloader {
         backupManager.on(CryptoEvent.KeyBackupStatus, this.onBackupStatusChanged);
         backupManager.on(CryptoEvent.KeyBackupFailed, this.onBackupStatusChanged);
         backupManager.on(CryptoEvent.KeyBackupDecryptionKeyCached, this.onBackupStatusChanged);
+    }
+
+    /**
+     * Check if key download is successfully configured and active.
+     *
+     * @return `true` if key download is correctly configured and active; otherwise `false`.
+     */
+    public isKeyBackupDownloadConfigured(): boolean {
+        return this.configuration !== null;
     }
 
     /**

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Curve25519AuthData, KeyBackupSession } from "../crypto-api/keybackup";
+import { Curve25519AuthData, KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup";
 import { Logger } from "../logger";
 import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api";
 import { RustBackupManager } from "./backup";
@@ -130,6 +130,15 @@ export class PerSessionKeyBackupDownloader {
      */
     public isKeyBackupDownloadConfigured(): boolean {
         return this.configuration !== null;
+    }
+
+    /**
+     * Return the details of the latest backup on the server, when we last checked.
+     *
+     * This is just a convenience method to expose {@link RustBackupManager.getServerBackupInfo}.
+     */
+    public async getServerBackupInfo(): Promise<KeyBackupInfo | null | undefined> {
+        return await this.backupManager.getServerBackupInfo();
     }
 
     /**
@@ -423,7 +432,7 @@ export class PerSessionKeyBackupDownloader {
     private async internalCheckFromServer(): Promise<Configuration | null> {
         let currentServerVersion = null;
         try {
-            currentServerVersion = await this.backupManager.requestKeyBackupVersion();
+            currentServerVersion = await this.backupManager.getServerBackupInfo();
         } catch (e) {
             this.logger.debug(`Backup: error while checking server version: ${e}`);
             this.hasConfigurationProblem = true;


### PR DESCRIPTION
If an event was sent before our device was created, and backup is not configured, we have no hope of decrypting it. To reflect this, use a different error code for the decryption failure.

Part of https://github.com/element-hq/element-meta/issues/2313

Suggest review commit-by-commit