### PR TITLE
Update git-get-release action

### DIFF
--- a/.github/workflows/release-make.yml
+++ b/.github/workflows/release-make.yml
@@ -59,7 +59,7 @@ jobs:
 
             - name: Get draft release
               id: draft-release
-              uses: cardinalby/git-get-release-action@cedef2faf69cb7c55b285bad07688d04430b7ada # v1
+              uses: cardinalby/git-get-release-action@5172c3a026600b1d459b117738c605fabc9e4e44 # v1
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:


### PR DESCRIPTION
which appears to be breaking renovate somehow, and could probably use and update anyway.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
