### PR TITLE
MSC 3266 compliance

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -865,7 +865,7 @@ interface IThirdPartyUser {
     fields: object;
 }
 
-interface IRoomSummary extends Omit<IPublicRoomsChunkRoom, "canonical_alias" | "aliases"> {
+export interface IRoomSummary extends Omit<IPublicRoomsChunkRoom, "canonical_alias" | "aliases"> {
     membership?: Membership;
     "im.nheko.summary.room_version"?: string;
     "im.nheko.summary.encryption"?: boolean;

--- a/src/client.ts
+++ b/src/client.ts
@@ -866,9 +866,9 @@ interface IThirdPartyUser {
 }
 
 interface IRoomSummary extends Omit<IPublicRoomsChunkRoom, "canonical_alias" | "aliases"> {
-    room_type?: RoomType;
     membership?: Membership;
-    is_encrypted: boolean;
+    "im.nheko.summary.room_version"?: string;
+    "im.nheko.summary.encryption"?: boolean;
 }
 
 interface IRoomKeysResponse {

--- a/src/client.ts
+++ b/src/client.ts
@@ -9787,7 +9787,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param via - The list of servers which know about the room if only an ID was provided.
      */
     public async getRoomSummary(roomIdOrAlias: string, via?: string[]): Promise<IRoomSummary> {
-        const path = utils.encodeUri("/rooms/$roomid/summary", { $roomid: roomIdOrAlias });
+        const path = utils.encodeUri("/summary/$roomid", { $roomid: roomIdOrAlias });
         return this.http.authedRequest(Method.Get, path, { via }, undefined, {
             prefix: "/_matrix/client/unstable/im.nheko.summary",
         });

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -77,6 +77,7 @@ export * from "./@types/extensible_events";
 export * from "./@types/IIdentityServerProvider";
 export * from "./models/room-summary";
 export * from "./models/event-status";
+export { IRoomSummary } from "./client";
 export * as ContentHelpers from "./content-helpers";
 export * as SecretStorage from "./secret-storage";
 export type { ICryptoCallbacks } from "./crypto"; // used to be located here


### PR DESCRIPTION
This fixes some non-compliance with [MSC 3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266), and exports the payload type.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
