### PR TITLE
Use encoded URI components when storing sessions in memory crypto store

### DIFF
--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -37,6 +37,17 @@ import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { InboundGroupSessionData } from "../OlmDevice";
 
+function encodeSessionKey(senderCurve25519Key: string, sessionId: string): string {
+    return encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
+}
+
+function decodeSessionKey(key: string): { senderKey: string; sessionId: string } {
+    const keyParts = key.split("/");
+    const senderKey = decodeURIComponent(keyParts[0]);
+    const sessionId = decodeURIComponent(keyParts[1]);
+    return { senderKey, sessionId };
+}
+
 /**
  * Internal module. in-memory storage for e2e.
  */
@@ -481,16 +492,14 @@ export class MemoryCryptoStore implements CryptoStore {
         txn: unknown,
         func: (groupSession: InboundGroupSessionData | null, groupSessionWithheld: IWithheld | null) => void,
     ): void {
-        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
+        const k = encodeSessionKey(senderCurve25519Key, sessionId);
         func(this.inboundGroupSessions[k] || null, this.inboundGroupSessionsWithheld[k] || null);
     }
 
     public getAllEndToEndInboundGroupSessions(txn: unknown, func: (session: ISession | null) => void): void {
         for (const key of Object.keys(this.inboundGroupSessions)) {
-            const keyParts = key.split("/");
             func({
-                senderKey: decodeURIComponent(keyParts[0]),
-                sessionId: decodeURIComponent(keyParts[1]),
+                ...decodeSessionKey(key),
                 sessionData: this.inboundGroupSessions[key],
             });
         }
@@ -503,7 +512,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: InboundGroupSessionData,
         txn: unknown,
     ): void {
-        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
+        const k = encodeSessionKey(senderCurve25519Key, sessionId);
         if (this.inboundGroupSessions[k] === undefined) {
             this.inboundGroupSessions[k] = sessionData;
         }
@@ -515,8 +524,8 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: InboundGroupSessionData,
         txn: unknown,
     ): void {
-        this.inboundGroupSessions[encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId)] =
-            sessionData;
+        const k = encodeSessionKey(senderCurve25519Key, sessionId);
+        this.inboundGroupSessions[k] = sessionData;
     }
 
     public storeEndToEndInboundGroupSessionWithheld(
@@ -525,7 +534,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: IWithheld,
         txn: unknown,
     ): void {
-        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
+        const k = encodeSessionKey(senderCurve25519Key, sessionId);
         this.inboundGroupSessionsWithheld[k] = sessionData;
     }
 
@@ -550,10 +559,8 @@ export class MemoryCryptoStore implements CryptoStore {
     public async getEndToEndInboundGroupSessionsBatch(): Promise<null | SessionExtended[]> {
         const result: SessionExtended[] = [];
         for (const [key, session] of Object.entries(this.inboundGroupSessions)) {
-            const keyParts = key.split("/");
             result.push({
-                senderKey: decodeURIComponent(keyParts[0]),
-                sessionId: decodeURIComponent(keyParts[1]),
+                ...decodeSessionKey(key),
                 sessionData: session,
                 needsBackup: key in this.sessionsNeedingBackup,
             });
@@ -582,7 +589,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessions: { senderKey: string; sessionId: string }[],
     ): Promise<void> {
         for (const { senderKey, sessionId } of sessions) {
-            const k = encodeURIComponent(senderKey) + "/" + encodeURIComponent(sessionId);
+            const k = encodeSessionKey(senderKey, sessionId);
             delete this.inboundGroupSessions[k];
         }
     }
@@ -611,10 +618,8 @@ export class MemoryCryptoStore implements CryptoStore {
         const sessions: ISession[] = [];
         for (const session in this.sessionsNeedingBackup) {
             if (this.inboundGroupSessions[session]) {
-                const keyParts = session.split("/");
                 sessions.push({
-                    senderKey: decodeURIComponent(keyParts[0]),
-                    sessionId: decodeURIComponent(keyParts[1]),
+                    ...decodeSessionKey(session),
                     sessionData: this.inboundGroupSessions[session],
                 });
                 if (limit && session.length >= limit) {
@@ -631,7 +636,7 @@ export class MemoryCryptoStore implements CryptoStore {
 
     public unmarkSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
         for (const session of sessions) {
-            const sessionKey = encodeURIComponent(session.senderKey) + "/" + encodeURIComponent(session.sessionId);
+            const sessionKey = encodeSessionKey(session.senderKey, session.sessionId);
             delete this.sessionsNeedingBackup[sessionKey];
         }
         return Promise.resolve();
@@ -639,7 +644,7 @@ export class MemoryCryptoStore implements CryptoStore {
 
     public markSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
         for (const session of sessions) {
-            const sessionKey = encodeURIComponent(session.senderKey) + "/" + encodeURIComponent(session.sessionId);
+            const sessionKey = encodeSessionKey(session.senderKey, session.sessionId);
             this.sessionsNeedingBackup[sessionKey] = true;
         }
         return Promise.resolve();

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -481,20 +481,16 @@ export class MemoryCryptoStore implements CryptoStore {
         txn: unknown,
         func: (groupSession: InboundGroupSessionData | null, groupSessionWithheld: IWithheld | null) => void,
     ): void {
-        const k = senderCurve25519Key + "/" + sessionId;
+        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
         func(this.inboundGroupSessions[k] || null, this.inboundGroupSessionsWithheld[k] || null);
     }
 
     public getAllEndToEndInboundGroupSessions(txn: unknown, func: (session: ISession | null) => void): void {
         for (const key of Object.keys(this.inboundGroupSessions)) {
-            // we can't use split, as the components we are trying to split out
-            // might themselves contain '/' characters. We rely on the
-            // senderKey being a (32-byte) curve25519 key, base64-encoded
-            // (hence 43 characters long).
-
+            const keyParts = key.split("/");
             func({
-                senderKey: key.slice(0, 43),
-                sessionId: key.slice(44),
+                senderKey: decodeURIComponent(keyParts[0]),
+                sessionId: decodeURIComponent(keyParts[1]),
                 sessionData: this.inboundGroupSessions[key],
             });
         }
@@ -507,7 +503,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: InboundGroupSessionData,
         txn: unknown,
     ): void {
-        const k = senderCurve25519Key + "/" + sessionId;
+        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
         if (this.inboundGroupSessions[k] === undefined) {
             this.inboundGroupSessions[k] = sessionData;
         }
@@ -519,7 +515,8 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: InboundGroupSessionData,
         txn: unknown,
     ): void {
-        this.inboundGroupSessions[senderCurve25519Key + "/" + sessionId] = sessionData;
+        this.inboundGroupSessions[encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId)] =
+            sessionData;
     }
 
     public storeEndToEndInboundGroupSessionWithheld(
@@ -528,7 +525,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessionData: IWithheld,
         txn: unknown,
     ): void {
-        const k = senderCurve25519Key + "/" + sessionId;
+        const k = encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
         this.inboundGroupSessionsWithheld[k] = sessionData;
     }
 
@@ -613,9 +610,10 @@ export class MemoryCryptoStore implements CryptoStore {
         const sessions: ISession[] = [];
         for (const session in this.sessionsNeedingBackup) {
             if (this.inboundGroupSessions[session]) {
+                const keyParts = session.split("/");
                 sessions.push({
-                    senderKey: session.slice(0, 43),
-                    sessionId: session.slice(44),
+                    senderKey: decodeURIComponent(keyParts[0]),
+                    sessionId: decodeURIComponent(keyParts[1]),
                     sessionData: this.inboundGroupSessions[session],
                 });
                 if (limit && session.length >= limit) {
@@ -632,7 +630,7 @@ export class MemoryCryptoStore implements CryptoStore {
 
     public unmarkSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
         for (const session of sessions) {
-            const sessionKey = session.senderKey + "/" + session.sessionId;
+            const sessionKey = encodeURIComponent(session.senderKey) + "/" + encodeURIComponent(session.sessionId);
             delete this.sessionsNeedingBackup[sessionKey];
         }
         return Promise.resolve();
@@ -640,7 +638,7 @@ export class MemoryCryptoStore implements CryptoStore {
 
     public markSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
         for (const session of sessions) {
-            const sessionKey = session.senderKey + "/" + session.sessionId;
+            const sessionKey = encodeURIComponent(session.senderKey) + "/" + encodeURIComponent(session.sessionId);
             this.sessionsNeedingBackup[sessionKey] = true;
         }
         return Promise.resolve();

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -550,9 +550,10 @@ export class MemoryCryptoStore implements CryptoStore {
     public async getEndToEndInboundGroupSessionsBatch(): Promise<null | SessionExtended[]> {
         const result: SessionExtended[] = [];
         for (const [key, session] of Object.entries(this.inboundGroupSessions)) {
+            const keyParts = key.split("/");
             result.push({
-                senderKey: key.slice(0, 43),
-                sessionId: key.slice(44),
+                senderKey: decodeURIComponent(keyParts[0]),
+                sessionId: decodeURIComponent(keyParts[1]),
                 sessionData: session,
                 needsBackup: key in this.sessionsNeedingBackup,
             });
@@ -581,7 +582,7 @@ export class MemoryCryptoStore implements CryptoStore {
         sessions: { senderKey: string; sessionId: string }[],
     ): Promise<void> {
         for (const { senderKey, sessionId } of sessions) {
-            const k = senderKey + "/" + sessionId;
+            const k = encodeURIComponent(senderKey) + "/" + encodeURIComponent(sessionId);
             delete this.inboundGroupSessions[k];
         }
     }


### PR DESCRIPTION
This replaces the index-legwork to retrieve the sender key and session ID with `encodeURIComponent` & `decodeURIComponent`. It's possibly a matter of taste but I'm finding this less brittle than hard-coding the indexes.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
