### PR TITLE
add resignKeyBackup, updateBackupSignature, resignKeyBackup

### DIFF
--- a/src/crypto-api.ts
+++ b/src/crypto-api.ts
@@ -491,6 +491,15 @@ export interface CryptoApi {
     resetKeyBackup(): Promise<void>;
 
     /**
+     * Update the signature of the backup specified via privateKey and uploaded this change to the server.
+     * This is an altered copy of {@link @./rust-crypto/rust-crypto.ts#RustCrypto#resetKeyBackup}.
+     * 
+     * @param privateKey The privat key of the backup which should be updated.
+     * @param version The version of the backup that should be updated.
+     */
+    resignKeyBackup(privateKey: Uint8Array, version: string): Promise<void>;
+
+    /**
      * Deletes the given key backup.
      *
      * @param version - The backup version to delete.


### PR DESCRIPTION
When using key backups without 4s (secure secret storage and sharing) and signing in with the web-client then no migration is performed and the session cannot backup keys without any further user interaction (resetting cross signing (and key backup)).
This seems to be related to: https://github.com/element-hq/element-web/issues/27100
ToDo: If the above is correct then a note for the Changelog will be added.

The changes here depend on the changes in [matrix-react-sdk PR 12441](https://github.com/matrix-org/matrix-react-sdk/pull/12441) .

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).



Signed-off-by: Michael Schrader michael.schrader@connext.de