### PR TITLE
Add missing (and common-ish) HTTP method verbs to types

### DIFF
--- a/src/http-api/method.ts
+++ b/src/http-api/method.ts
@@ -19,4 +19,7 @@ export enum Method {
     Put = "PUT",
     Post = "POST",
     Delete = "DELETE",
+    Options = "OPTIONS",
+    Head = "HEAD",
+    Patch = "PATCH",
 }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods

We notably don't include the following:

* `CONNECT` - Matrix doesn't use this, and is unlikely to foreseeably use it.
* `TRACE` - Same as above

We add the following, though:

* `OPTIONS` - Valid thing to use under https://spec.matrix.org/v1.10/client-server-api/#web-browser-clients
* `PATCH` - Plausibly useful while we're here. May be used in the near-ish future.
* `HEAD` - Could be used by https://github.com/matrix-org/matrix-spec-proposals/pull/4120

We add them now instead of later to avoid relatively tiny PRs needing to go through heavyweight process. Instead, other layers can just use these verbs if and as needed.

It was briefly considered to use https://github.com/jrylan/http-method-enum instead, though the supply chain vulnerability risk doesn't feel worth it.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
