### PR TITLE
Make the js-sdk compatible with MSC preferred foci and active focus.

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -111,14 +111,14 @@ describe("CallMembership", () => {
         expect(membership.isExpired()).toEqual(true);
     });
 
-    it("returns active foci", () => {
+    it("returns preferred foci", () => {
         const fakeEvent = makeMockEvent();
         const mockFocus = { type: "this_is_a_mock_focus" };
         const membership = new CallMembership(
             fakeEvent,
             Object.assign({}, membershipTemplate, { foci_active: [mockFocus] }),
         );
-        expect(membership.getActiveFoci()).toEqual([mockFocus]);
+        expect(membership.getPreferredFoci()).toEqual([mockFocus]);
     });
 
     describe("expiry calculation", () => {

--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -93,7 +93,7 @@ describe("CallMembership", () => {
     it("computes absolute expiry time based on expires_ts", () => {
         const membership = new CallMembership(
             makeMockEvent(1000),
-            Object.assign({}, membershipTemplate, { expires: undefined, expires_ts: 6000 }),
+            Object.assign({}, membershipTemplate, { expires_ts: 6000 }),
         );
         expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
     });

--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -24,6 +24,7 @@ const membershipTemplate: CallMembershipData = {
     device_id: "AAAAAAA",
     expires: 5000,
     membershipID: "bloop",
+    foci_active: [{ type: "livekit" }],
 };
 
 function makeMockEvent(originTs = 0): MatrixEvent {
@@ -55,10 +56,10 @@ describe("CallMembership", () => {
         }).toThrow();
     });
 
-    it("rejects membership with no scope", () => {
+    it("allow membership with no scope", () => {
         expect(() => {
             new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { scope: undefined }));
-        }).toThrow();
+        }).not.toThrow();
     });
     it("rejects with malformatted expires_ts", () => {
         expect(() => {

--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -129,7 +129,7 @@ describe("CallMembership", () => {
             scope: "m.room",
             application: "m.call",
             device_id: "AAAAAAA",
-            foci_active: { type: "livekit" },
+            focus_active: { type: "livekit" },
             foci_preferred: [{ type: "livekit" }],
         };
 

--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -15,17 +15,7 @@ limitations under the License.
 */
 
 import { MatrixEvent } from "../../../src";
-import { CallMembership, CallMembershipData } from "../../../src/matrixrtc/CallMembership";
-
-const membershipTemplate: CallMembershipData = {
-    call_id: "",
-    scope: "m.room",
-    application: "m.call",
-    device_id: "AAAAAAA",
-    expires: 5000,
-    membershipID: "bloop",
-    foci_active: [{ type: "livekit" }],
-};
+import { CallMembership, CallMembershipDataLegacy, SessionMembershipData } from "../../../src/matrixrtc/CallMembership";
 
 function makeMockEvent(originTs = 0): MatrixEvent {
     return {
@@ -35,96 +25,175 @@ function makeMockEvent(originTs = 0): MatrixEvent {
 }
 
 describe("CallMembership", () => {
-    it("rejects membership with no expiry and no expires_ts", () => {
-        expect(() => {
-            new CallMembership(
-                makeMockEvent(),
-                Object.assign({}, membershipTemplate, { expires: undefined, expires_ts: undefined }),
+    describe("CallMembershipDataLegacy", () => {
+        const membershipTemplate: CallMembershipDataLegacy = {
+            call_id: "",
+            scope: "m.room",
+            application: "m.call",
+            device_id: "AAAAAAA",
+            expires: 5000,
+            membershipID: "bloop",
+            foci_active: [{ type: "livekit" }],
+        };
+        it("rejects membership with no expiry and no expires_ts", () => {
+            expect(() => {
+                new CallMembership(
+                    makeMockEvent(),
+                    Object.assign({}, membershipTemplate, { expires: undefined, expires_ts: undefined }),
+                );
+            }).toThrow();
+        });
+
+        it("rejects membership with no device_id", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { device_id: undefined }));
+            }).toThrow();
+        });
+
+        it("rejects membership with no call_id", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { call_id: undefined }));
+            }).toThrow();
+        });
+
+        it("allow membership with no scope", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { scope: undefined }));
+            }).not.toThrow();
+        });
+        it("rejects with malformatted expires_ts", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires_ts: "string" }));
+            }).toThrow();
+        });
+        it("rejects with malformatted expires", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires: "string" }));
+            }).toThrow();
+        });
+
+        it("uses event timestamp if no created_ts", () => {
+            const membership = new CallMembership(makeMockEvent(12345), membershipTemplate);
+            expect(membership.createdTs()).toEqual(12345);
+        });
+
+        it("uses created_ts if present", () => {
+            const membership = new CallMembership(
+                makeMockEvent(12345),
+                Object.assign({}, membershipTemplate, { created_ts: 67890 }),
             );
-        }).toThrow();
+            expect(membership.createdTs()).toEqual(67890);
+        });
+
+        it("computes absolute expiry time based on expires", () => {
+            const membership = new CallMembership(makeMockEvent(1000), membershipTemplate);
+            expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
+        });
+
+        it("computes absolute expiry time based on expires_ts", () => {
+            const membership = new CallMembership(
+                makeMockEvent(1000),
+                Object.assign({}, membershipTemplate, { expires_ts: 6000 }),
+            );
+            expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
+        });
+
+        it("considers memberships unexpired if local age low enough", () => {
+            const fakeEvent = makeMockEvent(1000);
+            fakeEvent.getLocalAge = jest.fn().mockReturnValue(3000);
+            const membership = new CallMembership(fakeEvent, membershipTemplate);
+            expect(membership.isExpired()).toEqual(false);
+        });
+
+        it("considers memberships expired when local age large", () => {
+            const fakeEvent = makeMockEvent(1000);
+            fakeEvent.localTimestamp = Date.now() - 6000;
+            const membership = new CallMembership(fakeEvent, membershipTemplate);
+            expect(membership.isExpired()).toEqual(true);
+        });
+
+        it("returns preferred foci", () => {
+            const fakeEvent = makeMockEvent();
+            const mockFocus = { type: "this_is_a_mock_focus" };
+            const membership = new CallMembership(
+                fakeEvent,
+                Object.assign({}, membershipTemplate, { foci_active: [mockFocus] }),
+            );
+            expect(membership.getPreferredFoci()).toEqual([mockFocus]);
+        });
     });
 
-    it("rejects membership with no device_id", () => {
-        expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { device_id: undefined }));
-        }).toThrow();
-    });
+    describe("SessionMembershipData", () => {
+        const membershipTemplate: SessionMembershipData = {
+            call_id: "",
+            scope: "m.room",
+            application: "m.call",
+            device_id: "AAAAAAA",
+            foci_active: { type: "livekit" },
+            foci_preferred: [{ type: "livekit" }],
+        };
 
-    it("rejects membership with no call_id", () => {
-        expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { call_id: undefined }));
-        }).toThrow();
-    });
+        it("rejects membership with no device_id", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { device_id: undefined }));
+            }).toThrow();
+        });
 
-    it("allow membership with no scope", () => {
-        expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { scope: undefined }));
-        }).not.toThrow();
-    });
-    it("rejects with malformatted expires_ts", () => {
-        expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires_ts: "string" }));
-        }).toThrow();
-    });
-    it("rejects with malformatted expires", () => {
-        expect(() => {
-            new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { expires: "string" }));
-        }).toThrow();
-    });
+        it("rejects membership with no call_id", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { call_id: undefined }));
+            }).toThrow();
+        });
 
-    it("uses event timestamp if no created_ts", () => {
-        const membership = new CallMembership(makeMockEvent(12345), membershipTemplate);
-        expect(membership.createdTs()).toEqual(12345);
-    });
+        it("allow membership with no scope", () => {
+            expect(() => {
+                new CallMembership(makeMockEvent(), Object.assign({}, membershipTemplate, { scope: undefined }));
+            }).not.toThrow();
+        });
 
-    it("uses created_ts if present", () => {
-        const membership = new CallMembership(
-            makeMockEvent(12345),
-            Object.assign({}, membershipTemplate, { created_ts: 67890 }),
-        );
-        expect(membership.createdTs()).toEqual(67890);
-    });
+        it("uses event timestamp if no created_ts", () => {
+            const membership = new CallMembership(makeMockEvent(12345), membershipTemplate);
+            expect(membership.createdTs()).toEqual(12345);
+        });
 
-    it("computes absolute expiry time based on expires", () => {
-        const membership = new CallMembership(makeMockEvent(1000), membershipTemplate);
-        expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
-    });
+        it("uses created_ts if present", () => {
+            const membership = new CallMembership(
+                makeMockEvent(12345),
+                Object.assign({}, membershipTemplate, { created_ts: 67890 }),
+            );
+            expect(membership.createdTs()).toEqual(67890);
+        });
 
-    it("computes absolute expiry time based on expires_ts", () => {
-        const membership = new CallMembership(
-            makeMockEvent(1000),
-            Object.assign({}, membershipTemplate, { expires_ts: 6000 }),
-        );
-        expect(membership.getAbsoluteExpiry()).toEqual(5000 + 1000);
-    });
+        it("considers memberships unexpired if local age low enough", () => {
+            const fakeEvent = makeMockEvent(1000);
+            fakeEvent.getLocalAge = jest.fn().mockReturnValue(3000);
+            const membership = new CallMembership(fakeEvent, membershipTemplate);
+            expect(membership.isExpired()).toEqual(false);
+        });
 
-    it("considers memberships unexpired if local age low enough", () => {
-        const fakeEvent = makeMockEvent(1000);
-        fakeEvent.getLocalAge = jest.fn().mockReturnValue(3000);
-        const membership = new CallMembership(fakeEvent, membershipTemplate);
-        expect(membership.isExpired()).toEqual(false);
-    });
-
-    it("considers memberships expired when local age large", () => {
-        const fakeEvent = makeMockEvent(1000);
-        fakeEvent.localTimestamp = Date.now() - 6000;
-        const membership = new CallMembership(fakeEvent, membershipTemplate);
-        expect(membership.isExpired()).toEqual(true);
-    });
-
-    it("returns preferred foci", () => {
-        const fakeEvent = makeMockEvent();
-        const mockFocus = { type: "this_is_a_mock_focus" };
-        const membership = new CallMembership(
-            fakeEvent,
-            Object.assign({}, membershipTemplate, { foci_active: [mockFocus] }),
-        );
-        expect(membership.getPreferredFoci()).toEqual([mockFocus]);
+        it("returns preferred foci", () => {
+            const fakeEvent = makeMockEvent();
+            const mockFocus = { type: "this_is_a_mock_focus" };
+            const membership = new CallMembership(
+                fakeEvent,
+                Object.assign({}, membershipTemplate, { foci_preferred: [mockFocus] }),
+            );
+            expect(membership.getPreferredFoci()).toEqual([mockFocus]);
+        });
     });
 
     describe("expiry calculation", () => {
         let fakeEvent: MatrixEvent;
         let membership: CallMembership;
+        const membershipTemplate: CallMembershipDataLegacy = {
+            call_id: "",
+            scope: "m.room",
+            application: "m.call",
+            device_id: "AAAAAAA",
+            expires: 5000,
+            membershipID: "bloop",
+            foci_active: [{ type: "livekit" }],
+        };
 
         beforeEach(() => {
             // server origin timestamp for this event is 1000

--- a/spec/unit/matrixrtc/LivekitFocus.spec.ts
+++ b/spec/unit/matrixrtc/LivekitFocus.spec.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { isLivekitFocus, isLivekitFocusActive, isLivekitFocusConfig } from "../../../src/matrixrtc/LivekitFocus";
+
+describe("LivekitFocus", () => {
+    it("isLivekitFocus", () => {
+        expect(
+            isLivekitFocus({
+                type: "livekit",
+                livekit_service_url: "http://test.com",
+                livekit_alias: "test",
+            }),
+        ).toBeTruthy();
+        expect(isLivekitFocus({ type: "livekit" })).toBeFalsy();
+        expect(
+            isLivekitFocus({ type: "not-livekit", livekit_service_url: "http://test.com", livekit_alias: "test" }),
+        ).toBeFalsy();
+        expect(
+            isLivekitFocus({ type: "livekit", other_service_url: "http://test.com", livekit_alias: "test" }),
+        ).toBeFalsy();
+        expect(
+            isLivekitFocus({ type: "livekit", livekit_service_url: "http://test.com", other_alias: "test" }),
+        ).toBeFalsy();
+    });
+    it("isLivekitFocusActive", () => {
+        expect(
+            isLivekitFocusActive({
+                type: "livekit",
+                focus_selection: "oldest_membership",
+            }),
+        ).toBeTruthy();
+        expect(isLivekitFocusActive({ type: "livekit" })).toBeFalsy();
+        expect(isLivekitFocusActive({ type: "not-livekit", focus_selection: "oldest_membership" })).toBeFalsy();
+    });
+    it("isLivekitFocusConfig", () => {
+        expect(
+            isLivekitFocusConfig({
+                type: "livekit",
+                livekit_service_url: "http://test.com",
+            }),
+        ).toBeTruthy();
+        expect(isLivekitFocusConfig({ type: "livekit" })).toBeFalsy();
+        expect(isLivekitFocusConfig({ type: "not-livekit", livekit_service_url: "http://test.com" })).toBeFalsy();
+        expect(isLivekitFocusConfig({ type: "livekit", other_service_url: "oldest_membership" })).toBeFalsy();
+    });
+});

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -29,7 +29,7 @@ const membershipTemplate: CallMembershipData = {
     device_id: "AAAAAAA",
     expires: 60 * 60 * 1000,
     membershipID: "bloop",
-    foci_active: [{ type: "livekit" }],
+    foci_active: [{ type: "livekit", livekit_service_url: "https://lk.url" }],
 };
 
 const mockFocus = { type: "mock" };
@@ -199,6 +199,64 @@ describe("MatrixRTCSession", () => {
         });
     });
 
+    describe("getsActiveFocus", () => {
+        const activeFociConfig = { type: "livekit", livekit_service_url: "https://active.url" };
+        it("gets the correct active focus with oldest_membership", () => {
+            const mockRoom = makeMockRoom([
+                Object.assign({}, membershipTemplate, {
+                    device_id: "foo",
+                    created_ts: 500,
+                    foci_active: [activeFociConfig],
+                }),
+                Object.assign({}, membershipTemplate, { device_id: "old", created_ts: 1000 }),
+                Object.assign({}, membershipTemplate, { device_id: "bar", created_ts: 2000 }),
+            ]);
+
+            sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
+
+            sess.joinRoomSession([{ type: "livekit", livekit_service_url: "htts://test.org" }], {
+                type: "livekit",
+                focus_selection: "oldest_membership",
+            });
+            expect(sess.getActiveFocus()).toBe(activeFociConfig);
+        });
+        it("does not provide focus if the selction method is unknown", () => {
+            const mockRoom = makeMockRoom([
+                Object.assign({}, membershipTemplate, {
+                    device_id: "foo",
+                    created_ts: 500,
+                    foci_active: [activeFociConfig],
+                }),
+                Object.assign({}, membershipTemplate, { device_id: "old", created_ts: 1000 }),
+                Object.assign({}, membershipTemplate, { device_id: "bar", created_ts: 2000 }),
+            ]);
+
+            sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
+
+            sess.joinRoomSession([{ type: "livekit", livekit_service_url: "htts://test.org" }], {
+                type: "livekit",
+                focus_selection: "unknown",
+            });
+            expect(sess.getActiveFocus()).toBe(undefined);
+        });
+        it("gets the correct active focus legacy", () => {
+            const mockRoom = makeMockRoom([
+                Object.assign({}, membershipTemplate, {
+                    device_id: "foo",
+                    created_ts: 500,
+                    foci_active: [activeFociConfig],
+                }),
+                Object.assign({}, membershipTemplate, { device_id: "old", created_ts: 1000 }),
+                Object.assign({}, membershipTemplate, { device_id: "bar", created_ts: 2000 }),
+            ]);
+
+            sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
+
+            sess.joinRoomSession([{ type: "livekit", livekit_service_url: "htts://test.org" }]);
+            expect(sess.getActiveFocus()).toBe(activeFociConfig);
+        });
+    });
+
     describe("joining", () => {
         let mockRoom: Room;
         let sendStateEventMock: jest.Mock;
@@ -224,13 +282,13 @@ describe("MatrixRTCSession", () => {
         });
 
         it("shows joined once join is called", () => {
-            sess!.joinRoomSession(mockFocus, [mockFocus]);
+            sess!.joinRoomSession([mockFocus], mockFocus);
             expect(sess!.isJoined()).toEqual(true);
         });
 
         it("sends a membership event when joining a call", () => {
             jest.useFakeTimers();
-            sess!.joinRoomSession(mockFocus, [mockFocus]);
+            sess!.joinRoomSession([mockFocus], mockFocus);
             expect(client.sendStateEvent).toHaveBeenCalledWith(
                 mockRoom!.roomId,
                 EventType.GroupCallMemberPrefix,
@@ -255,11 +313,11 @@ describe("MatrixRTCSession", () => {
         });
 
         it("does nothing if join called when already joined", () => {
-            sess!.joinRoomSession(mockFocus, [mockFocus]);
+            sess!.joinRoomSession([mockFocus], mockFocus);
 
             expect(client.sendStateEvent).toHaveBeenCalledTimes(1);
 
-            sess!.joinRoomSession(mockFocus, [mockFocus]);
+            sess!.joinRoomSession([mockFocus], mockFocus);
             expect(client.sendStateEvent).toHaveBeenCalledTimes(1);
         });
 
@@ -276,7 +334,7 @@ describe("MatrixRTCSession", () => {
                 const sendStateEventMock = jest.fn().mockImplementation(resolveFn);
                 client.sendStateEvent = sendStateEventMock;
 
-                sess!.joinRoomSession(mockFocus, [mockFocus]);
+                sess!.joinRoomSession([mockFocus], mockFocus);
 
                 const eventContent = await eventSentPromise;
 
@@ -324,7 +382,7 @@ describe("MatrixRTCSession", () => {
         });
 
         it("creates a key when joining", () => {
-            sess!.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+            sess!.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
             const keys = sess?.getKeysForParticipant("@alice:example.org", "AAAAAAA");
             expect(keys).toHaveLength(1);
 
@@ -338,7 +396,7 @@ describe("MatrixRTCSession", () => {
                 sendEventMock.mockImplementation(resolve);
             });
 
-            sess!.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+            sess!.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
 
             await eventSentPromise;
 
@@ -374,7 +432,7 @@ describe("MatrixRTCSession", () => {
                     });
                 });
 
-                sess!.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+                sess!.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
                 jest.advanceTimersByTime(10000);
 
                 await eventSentPromise;
@@ -396,7 +454,7 @@ describe("MatrixRTCSession", () => {
                 throw e;
             });
 
-            sess!.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+            sess!.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
 
             expect(client.cancelPendingEvent).toHaveBeenCalledWith(eventSentinel);
         });
@@ -411,7 +469,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockImplementation(resolve);
                 });
 
-                sess.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+                sess.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
                 await keysSentPromise1;
 
                 sendEventMock.mockClear();
@@ -464,7 +522,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockImplementation((_roomId, _evType, payload) => resolve(payload));
                 });
 
-                sess.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+                sess.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
                 const firstKeysPayload = await keysSentPromise1;
                 expect(firstKeysPayload.keys).toHaveLength(1);
 
@@ -501,7 +559,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockImplementation(resolve);
                 });
 
-                sess.joinRoomSession(mockFocus, [mockFocus], { manageMediaKeys: true });
+                sess.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
                 await keysSentPromise1;
 
                 sendEventMock.mockClear();
@@ -597,7 +655,7 @@ describe("MatrixRTCSession", () => {
 
             jest.advanceTimersByTime(10000);
 
-            sess.joinRoomSession(mockFocus, [mockFocus]);
+            sess.joinRoomSession([mockFocus], mockFocus);
 
             expect(client.sendStateEvent).toHaveBeenCalledWith(
                 mockRoomNoExpired!.roomId,
@@ -633,7 +691,7 @@ describe("MatrixRTCSession", () => {
         ]);
         sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
 
-        sess.joinRoomSession(mockFocus, [mockFocus]);
+        sess.joinRoomSession([mockFocus], mockFocus);
 
         expect(client.sendStateEvent).toHaveBeenCalledWith(
             mockRoom!.roomId,

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -705,7 +705,7 @@ describe("MatrixRTCSession", () => {
                         device_id: "OTHERDEVICE",
                         expires: 3600000,
                         created_ts: 1000,
-                        foci_active: [{ type: "livekit" }],
+                        foci_active: [{ type: "livekit", livekit_service_url: "https://lk.url" }],
                         membershipID: expect.stringMatching(".*"),
                     },
                     {

--- a/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSessionManager.spec.ts
@@ -35,6 +35,7 @@ const membershipTemplate: CallMembershipData = {
     device_id: "AAAAAAA",
     expires: 60 * 60 * 1000,
     membershipID: "bloop",
+    foci_active: [{ type: "test" }],
 };
 
 describe("MatrixRTCSessionManager", () => {

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -358,8 +358,8 @@ export interface StateEvents {
     // MSC3401
     [EventType.GroupCallPrefix]: IGroupCallRoomState;
     [EventType.GroupCallMemberPrefix]: XOR<
-        IGroupCallRoomMemberState,
-        ExperimentalGroupCallRoomMemberState | {} | SessionMembershipData
+        XOR<IGroupCallRoomMemberState, ExperimentalGroupCallRoomMemberState>,
+        XOR<SessionMembershipData, {}>
     >;
 
     // MSC3089

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -57,6 +57,7 @@ import {
 } from "../webrtc/callEventTypes";
 import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types";
 import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls";
+import { SessionMembershipData } from "../matrixrtc/CallMembership";
 
 export enum EventType {
     // Room state events
@@ -356,7 +357,10 @@ export interface StateEvents {
 
     // MSC3401
     [EventType.GroupCallPrefix]: IGroupCallRoomState;
-    [EventType.GroupCallMemberPrefix]: XOR<IGroupCallRoomMemberState, ExperimentalGroupCallRoomMemberState>;
+    [EventType.GroupCallMemberPrefix]: XOR<
+        IGroupCallRoomMemberState,
+        ExperimentalGroupCallRoomMemberState | {} | SessionMembershipData
+    >;
 
     // MSC3089
     [UNSTABLE_MSC3089_BRANCH.name]: MSC3089EventContent;

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -29,7 +29,8 @@ export interface CallMembershipData {
     created_ts?: number;
     expires?: number;
     expires_ts?: number;
-    foci_active?: Focus[];
+    foci_active?: Focus;
+    foci_preferred?: Focus[];
     membershipID: string;
 }
 
@@ -122,7 +123,7 @@ export class CallMembership {
         return this.getMsUntilExpiry() <= 0;
     }
 
-    public getActiveFoci(): Focus[] {
-        return this.data.foci_active ?? [];
+    public getPreferredFoci(): Focus[] {
+        return this.data.foci_preferred ?? [];
     }
 }

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -24,6 +24,7 @@ type CallScope = "m.room" | "m.user";
 // There are two different data interfaces. One for the Legacy types and one complient with MSC4143
 
 // MSC4143 (MatrixRTC) session membership data
+
 export interface SessionMembershipData {
     application: string;
     call_id: string;
@@ -36,6 +37,7 @@ export interface SessionMembershipData {
     // Application specific data
     scope?: CallScope;
 }
+
 export const isSessionMembershipData = (data: CallMembershipData): data is SessionMembershipData =>
     "foci_active" in data &&
     "foci_preferred" in data &&
@@ -58,6 +60,7 @@ const checkSessionsMembershipData = (data: SessionMembershipData): void => {
 };
 
 // Legacy session membership data
+
 export interface CallMembershipDataLegacy {
     application: string;
     call_id: string;
@@ -69,8 +72,10 @@ export interface CallMembershipDataLegacy {
     expires_ts?: number;
     foci_active?: Focus[];
 }
+
 export const isLegacyCallMembershipData = (data: CallMembershipData): data is CallMembershipDataLegacy =>
     "membershipID" in data && "foci_active" in data && Array.isArray(data.foci_active);
+
 const checkCallMembershipDataLegacy = (data: CallMembershipDataLegacy): void => {
     const prefix = "Malformed legacy rtc membership event: ";
     if (!(data.expires || data.expires_ts)) {

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -23,7 +23,7 @@ type CallScope = "m.room" | "m.user";
 
 // There are two different data interfaces. One for the Legacy types and one complient with MSC4143
 
-// Current MSC4143 session membership data
+// MSC4143 (MatrixRTC) session membership data
 export interface SessionMembershipData {
     application: string;
     call_id: string;
@@ -36,12 +36,13 @@ export interface SessionMembershipData {
     // Application specific data
     scope?: CallScope;
 }
-const isSessionsMembershipData = (data: CallMembershipData): data is SessionMembershipData =>
+const isSessionMembershipData = (data: CallMembershipData): data is SessionMembershipData =>
     "foci_active" in data &&
     "foci_preferred" in data &&
     "membership_id" in data &&
     !Array.isArray(data.foci_active) &&
     Array.isArray(data.foci_preferred);
+
 const checkSessionsMembershipData = (data: SessionMembershipData): void => {
     const prefix = "Malformed session membership event: ";
     if (typeof data.device_id !== "string") throw new Error(prefix + "device_id must be string");
@@ -108,7 +109,7 @@ export class CallMembership {
         private data: CallMembershipData,
     ) {
         if (isLegacyCallMembershipData(data)) checkCallMembershipDataLegacy(data);
-        else if (isSessionsMembershipData(data)) checkSessionsMembershipData(data);
+        else if (isSessionMembershipData(data)) checkSessionsMembershipData(data);
         else throw Error("unknown CallMembership data. Does not match legacy call.member events nor MSC4143");
         if (!parentEvent.getSender()) throw new Error("Invalid parent event: sender is null");
     }
@@ -183,12 +184,13 @@ export class CallMembership {
 
     public isExpired(): boolean {
         if (isLegacyCallMembershipData(this.data)) return this.getMsUntilExpiry()! <= 0;
-        // MSC4143 events expire by beeing updated. So if the event exists, its not expired.
+
+        // MSC4143 events expire by being updated. So if the event exists, its not expired.
         return false;
     }
 
     public getPreferredFoci(): Focus[] {
-        // To support both, the new and the old matrix rtc memberships have two cases based
+        // To support both, the new and the old MatrixRTC memberships have two cases based
         // on the availablitiy of `foci_preferred`
         if (isLegacyCallMembershipData(this.data)) return this.data.foci_active ?? [];
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { EitherAnd } from "matrix-events-sdk/lib/types";
+
 import { MatrixEvent } from "../matrix";
 import { deepCompare } from "../utils";
 import { Focus } from "./focus";
@@ -61,32 +63,30 @@ const checkSessionsMembershipData = (data: SessionMembershipData): void => {
 
 // Legacy session membership data
 
-export interface CallMembershipDataLegacy {
+export type CallMembershipDataLegacy = {
     application: string;
     call_id: string;
     scope: CallScope;
     device_id: string;
     membershipID: string;
     created_ts?: number;
-    expires?: number;
-    expires_ts?: number;
     foci_active?: Focus[];
-}
+} & EitherAnd<{ expires: number }, { expires_ts: number }>;
 
 export const isLegacyCallMembershipData = (data: CallMembershipData): data is CallMembershipDataLegacy =>
-    "membershipID" in data && "foci_active" in data && Array.isArray(data.foci_active);
+    "membershipID" in data;
 
 const checkCallMembershipDataLegacy = (data: CallMembershipDataLegacy): void => {
     const prefix = "Malformed legacy rtc membership event: ";
-    if (!(data.expires || data.expires_ts)) {
+    if (!("expires" in data || "expires_ts" in data)) {
         throw new Error(prefix + "expires_ts or expires must be present");
     }
-    if (data.expires) {
+    if ("expires" in data) {
         if (typeof data.expires !== "number") {
             throw new Error(prefix + "expires must be numeric");
         }
     }
-    if (data.expires_ts) {
+    if ("expires_ts" in data) {
         if (typeof data.expires_ts !== "number") {
             throw new Error(prefix + "expires_ts must be numeric");
         }

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { EitherAnd } from "matrix-events-sdk/lib/types";
 
-import { IContent, MatrixEvent } from "../matrix";
+import { MatrixEvent } from "../matrix";
 import { deepCompare } from "../utils";
 import { Focus } from "./focus";
 
@@ -27,7 +27,7 @@ type CallScope = "m.room" | "m.user";
 
 // MSC4143 (MatrixRTC) session membership data
 
-export interface SessionMembershipData {
+export type SessionMembershipData = {
     application: string;
     call_id: string;
     device_id: string;
@@ -38,7 +38,7 @@ export interface SessionMembershipData {
 
     // Application specific data
     scope?: CallScope;
-}
+};
 
 export const isSessionMembershipData = (data: any): data is SessionMembershipData =>
     "foci_active" in data &&
@@ -109,7 +109,7 @@ export class CallMembership {
 
     public constructor(
         private parentEvent: MatrixEvent,
-        private data: IContent,
+        private data: any,
     ) {
         if (isLegacyCallMembershipData(data)) checkCallMembershipDataLegacy(data);
         else if (isSessionMembershipData(data)) checkSessionsMembershipData(data);

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -24,7 +24,7 @@ import { isLivekitFocusActive } from "./LivekitFocus";
 type CallScope = "m.room" | "m.user";
 // Represents an entry in the memberships section of an m.call.member event as it is on the wire
 
-// There are two different data interfaces. One for the Legacy types and one complient with MSC4143
+// There are two different data interfaces. One for the Legacy types and one compliant with MSC4143
 
 // MSC4143 (MatrixRTC) session membership data
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -43,7 +43,6 @@ export interface SessionMembershipData {
 export const isSessionMembershipData = (data: any): data is SessionMembershipData =>
     "foci_active" in data &&
     "foci_preferred" in data &&
-    "membership_id" in data &&
     !Array.isArray(data.foci_active) &&
     Array.isArray(data.foci_preferred);
 
@@ -53,7 +52,7 @@ const checkSessionsMembershipData = (data: SessionMembershipData): void => {
     if (typeof data.call_id !== "string") throw new Error(prefix + "call_id must be string");
     if (typeof data.application !== "string") throw new Error(prefix + "application must be a string");
     if (typeof data.foci_active?.type !== "string") throw new Error(prefix + "foci_active.type must be a string");
-    if (Array.isArray(data.foci_preferred)) throw new Error(prefix + "foci_preferred must be an array");
+    if (!Array.isArray(data.foci_preferred)) throw new Error(prefix + "foci_preferred must be an array");
     // optional elements
     if (data.created_ts && typeof data.created_ts !== "number") throw new Error(prefix + "created_ts must be number");
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -36,7 +36,7 @@ export interface SessionMembershipData {
     // Application specific data
     scope?: CallScope;
 }
-const isSessionMembershipData = (data: CallMembershipData): data is SessionMembershipData =>
+export const isSessionMembershipData = (data: CallMembershipData): data is SessionMembershipData =>
     "foci_active" in data &&
     "foci_preferred" in data &&
     "membership_id" in data &&
@@ -69,7 +69,7 @@ export interface CallMembershipDataLegacy {
     expires_ts?: number;
     foci_active?: Focus[];
 }
-const isLegacyCallMembershipData = (data: CallMembershipData): data is CallMembershipDataLegacy =>
+export const isLegacyCallMembershipData = (data: CallMembershipData): data is CallMembershipDataLegacy =>
     "membershipID" in data && "foci_active" in data && Array.isArray(data.foci_active);
 const checkCallMembershipDataLegacy = (data: CallMembershipDataLegacy): void => {
     const prefix = "Malformed legacy rtc membership event: ";

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Focus } from "./focus";
+
+export interface LivekitFocus extends Focus {
+    type: "livekit";
+    livekit_service_url: string;
+    livekit_alias: string;
+}
+export const isLivekitFocus = (object: Focus): object is LivekitFocus =>
+    object.type === "livekit" && "livekit_service_url" in object && "livekit_alias" in object;
+
+export interface LivekitFocusConfig extends Focus {
+    type: "livekit";
+    livekit_service_url: string;
+}
+export const isLivekitFocusConfig = (object: Focus): object is LivekitFocusConfig =>
+    object.type === "livekit" && "livekit_service_url" in object;
+
+export interface LivekitFocusActive extends Focus {
+    type: "livekit";
+    focus_selection: "oldest_membership";
+}
+export const isLivekitFocusActive = (object: Focus): object is LivekitFocusActive =>
+    object.type === "livekit" && "focus_selection" in object;

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -16,20 +16,21 @@ limitations under the License.
 
 import { Focus } from "./focus";
 
-export interface LivekitFocus extends Focus {
-    type: "livekit";
-    livekit_service_url: string;
-    livekit_alias: string;
-}
-export const isLivekitFocus = (object: Focus): object is LivekitFocus =>
-    object.type === "livekit" && "livekit_service_url" in object && "livekit_alias" in object;
-
 export interface LivekitFocusConfig extends Focus {
     type: "livekit";
     livekit_service_url: string;
 }
+
 export const isLivekitFocusConfig = (object: Focus): object is LivekitFocusConfig =>
     object.type === "livekit" && "livekit_service_url" in object;
+
+export interface LivekitFocus extends LivekitFocusConfig {
+    type: "livekit";
+    livekit_alias: string;
+}
+
+export const isLivekitFocus = (object: Focus): object is LivekitFocus =>
+    isLivekitFocusConfig(object) && "livekit_alias" in object;
 
 export interface LivekitFocusActive extends Focus {
     type: "livekit";

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -25,7 +25,6 @@ export const isLivekitFocusConfig = (object: Focus): object is LivekitFocusConfi
     object.type === "livekit" && "livekit_service_url" in object;
 
 export interface LivekitFocus extends LivekitFocusConfig {
-    type: "livekit";
     livekit_alias: string;
 }
 

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -21,19 +21,19 @@ export interface LivekitFocusConfig extends Focus {
     livekit_service_url: string;
 }
 
-export const isLivekitFocusConfig = (object: Focus): object is LivekitFocusConfig =>
+export const isLivekitFocusConfig = (object: any): object is LivekitFocusConfig =>
     object.type === "livekit" && "livekit_service_url" in object;
 
 export interface LivekitFocus extends LivekitFocusConfig {
     livekit_alias: string;
 }
 
-export const isLivekitFocus = (object: Focus): object is LivekitFocus =>
+export const isLivekitFocus = (object: any): object is LivekitFocus =>
     isLivekitFocusConfig(object) && "livekit_alias" in object;
 
 export interface LivekitFocusActive extends Focus {
     type: "livekit";
     focus_selection: "oldest_membership";
 }
-export const isLivekitFocusActive = (object: Focus): object is LivekitFocusActive =>
+export const isLivekitFocusActive = (object: any): object is LivekitFocusActive =>
     object.type === "livekit" && "focus_selection" in object;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -716,7 +716,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         myPrevMembershipData?: CallMembershipData,
         myPrevMembership?: CallMembership,
     ): boolean {
-        if (myPrevMembership?.getMsUntilExpiry() === undefined) return false;
+        if (myPrevMembership && myPrevMembership.getMsUntilExpiry() === undefined) return false;
 
         // Need to update if there's a membership for us but we're not joined (valid or otherwise)
         if (!this.isJoined()) return !!myPrevMembershipData;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -65,7 +65,7 @@ export enum MatrixRTCSessionEvent {
     MembershipsChanged = "memberships_changed",
     // We joined or left the session: our own local idea of whether we are joined,
     // separate from MembershipsChanged, ie. independent of whether our member event
-    // has succesfully gone through.
+    // has successfully gone through.
     JoinStateChanged = "join_state_changed",
     // The key used to encrypt media has changed
     EncryptionKeyChanged = "encryption_key_changed",
@@ -123,7 +123,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     private makeNewKeyTimeout?: ReturnType<typeof setTimeout>;
     private setNewKeyTimeouts = new Set<ReturnType<typeof setTimeout>>();
 
-    // This is a Focus with the specifid fields for an ActiveFocus (e.g. LivekitFocusActive for type="livekit")
+    // This is a Focus with the specified fields for an ActiveFocus (e.g. LivekitFocusActive for type="livekit")
     private ownFocusActive?: Focus;
     // This is a Foci array that contains the Focus objects this user is aware of and proposes to use.
     private ownFociPreferred?: Focus[];
@@ -401,7 +401,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      * @param userId - The user ID of the participant
      * @param deviceId - Device ID of the participant
      * @param encryptionKeyIndex - The index of the key to set
-     * @param encryptionKeyString - The string represenation of the key to set in base64
+     * @param encryptionKeyString - The string representation of the key to set in base64
      * @param delayBeforeuse - If true, delay before emitting a key changed event. Useful when setting
      *                         encryption keys for the local participant to allow time for the key to
      *                         be distributed.
@@ -436,7 +436,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
 
     /**
      * Generate a new sender key and add it at the next available index
-     * @param delayBeforeUse - If true, wait for a short period before settign the key for the
+     * @param delayBeforeUse - If true, wait for a short period before setting the key for the
      *                         media encryptor to use. If false, set the key immediately.
      */
     private makeNewSenderKey(delayBeforeUse = false): void {
@@ -545,7 +545,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         let soonestExpiry;
         for (const membership of this.memberships) {
             const thisExpiry = membership.getMsUntilExpiry();
-            // If getMsUntilExpiry is undefined we have a MSC3143 complient event - it never expires
+            // If getMsUntilExpiry is undefined we have a MSC3143 compliant event - it never expires
             // but will be reliably resent on disconnect.
             if (thisExpiry !== undefined && (soonestExpiry === undefined || thisExpiry < soonestExpiry)) {
                 soonestExpiry = thisExpiry;
@@ -672,7 +672,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      * Constructs our own membership
      * @param prevMembership - The previous value of our call membership, if any
      */
-    private makeMyMembershipLegacy(prevMembership?: CallMembership): CallMembershipDataLegacy {
+    private makeMyMembershipLegacy(deviceId: string, prevMembership?: CallMembership): CallMembershipDataLegacy {
         if (this.relativeExpiry === undefined) {
             throw new Error("Tried to create our own membership event when we're not joined!");
         }
@@ -684,7 +684,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             call_id: "",
             scope: "m.room",
             application: "m.call",
-            device_id: this.client.getDeviceId()!,
+            device_id: deviceId,
             expires: this.relativeExpiry,
             // TODO: Date.now() should be the origin_server_ts (now).
             expires_ts: this.relativeExpiry + (createdTs ?? Date.now()),
@@ -779,7 +779,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
 
         // If we're joined, add our own
         if (this.isJoined()) {
-            newMemberships.push(this.makeMyMembershipLegacy(myPrevMembership));
+            newMemberships.push(this.makeMyMembershipLegacy(localDeviceId, myPrevMembership));
         }
 
         return { memberships: newMemberships };

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -545,7 +545,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         let soonestExpiry;
         for (const membership of this.memberships) {
             const thisExpiry = membership.getMsUntilExpiry();
-            // If getMsUntilExpiry is undefined we have a MSC3143 compliant event - it never expires
+            // If getMsUntilExpiry is undefined we have a MSC4143 (MatrixRTC) compliant event - it never expires
             // but will be reliably resent on disconnect.
             if (thisExpiry !== undefined && (soonestExpiry === undefined || thisExpiry < soonestExpiry)) {
                 soonestExpiry = thisExpiry;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -684,7 +684,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         if (this.membershipId === undefined) {
             throw new Error("Tried to create our own membership event when we have no membership ID!");
         }
-        const created_ts = prevMembership?.createdTs();
+        const createdTs = prevMembership?.createdTs();
         return {
             call_id: "",
             scope: "m.room",
@@ -692,11 +692,12 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             device_id: this.client.getDeviceId()!,
             expires: this.relativeExpiry,
             // TODO: Date.now() should be the origin_server_ts (now).
-            expires_ts: this.relativeExpiry + (created_ts ?? Date.now()),
+            expires_ts: this.relativeExpiry + (createdTs ?? Date.now()),
             // we use the fociPreferred since this is the list of foci.
             // it is named wrong in the Legacy events.
             foci_active: this.ownFociPreferred,
             membershipID: this.membershipId,
+            ...(createdTs ? { created_ts: createdTs } : {}),
         };
     }
     /**

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -561,6 +561,13 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         return this.memberships[0];
     }
 
+    public getFocusInUse(): Focus | undefined {
+        const oldestMembership = this.getOldestMembership();
+        if (oldestMembership?.getFocusSelection() === "oldest_membership") {
+            return oldestMembership.getPreferredFoci()[0];
+        }
+    }
+
     public onCallEncryption = (event: MatrixEvent): void => {
         const userId = event.getSender();
         const content = event.getContent<EncryptionKeysEventContent>();
@@ -704,7 +711,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             scope: "m.room",
             application: "m.call",
             device_id: deviceId,
-            foci_active: { type: "livekit", focus_selection: "oldest_membership" },
+            focus_active: { type: "livekit", focus_selection: "oldest_membership" },
             foci_preferred: this.ownFociPreferred ?? [],
         };
     }

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -301,7 +301,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
         // We don't wait for this, mostly because it may fail and schedule a retry, so this
         // function returning doesn't really mean anything at all.
-        await this.triggerCallMembershipEventUpdate();
+        this.triggerCallMembershipEventUpdate();
         this.emit(MatrixRTCSessionEvent.JoinStateChanged, true);
     }
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -164,11 +164,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             // We first decide if its a MSC4143 event (per device state key)
             if ("memberships" in content) {
                 // we have a legacy (one event for all devices) event
-                membershipContents = content["memberships"];
-                if (!Array.isArray(membershipContents)) {
+                if (!Array.isArray(content["memberships"])) {
                     logger.warn(`Malformed member event from ${memberEvent.getSender()}: memberships is not an array`);
                     continue;
                 }
+                membershipContents = content["memberships"];
             } else {
                 // We have a MSC4143 event membership event
                 if (Object.keys(content).length !== 0) {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -276,11 +276,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      *                        or optionally other room members homeserver well known.
      * @param joinConfig - Additional configuration for the joined session.
      */
-    public async joinRoomSession(
-        fociPreferred: Focus[],
-        fociActive?: Focus,
-        joinConfig?: JoinSessionConfig,
-    ): Promise<void> {
+    public joinRoomSession(fociPreferred: Focus[], fociActive?: Focus, joinConfig?: JoinSessionConfig): void {
         if (this.isJoined()) {
             logger.info(`Already joined to session in room ${this.room.roomId}: ignoring join call`);
             return;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -35,7 +35,7 @@ import { decodeBase64, encodeUnpaddedBase64 } from "../base64";
 import { KnownMembership } from "../@types/membership";
 import { MatrixError } from "../http-api/errors";
 import { MatrixEvent } from "../models/event";
-import { LivekitFocusActive, isLivekitFocusActive } from "./LivekitFocus";
+import { isLivekitFocusActive } from "./LivekitFocus";
 import { ExperimentalGroupCallRoomMemberState } from "../webrtc/groupCall";
 
 const MEMBERSHIP_EXPIRY_TIME = 60 * 60 * 1000;
@@ -160,7 +160,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         const callMemberships: CallMembership[] = [];
         for (const memberEvent of callMemberEvents) {
             const content = memberEvent.getContent();
-            let membershipContents: CallMembershipData[] = [];
+            let membershipContents: any[] = [];
             // We first decide if its a MSC4143 event (per device state key)
             if ("memberships" in content) {
                 // we have a legacy (one event for all devices) event
@@ -173,7 +173,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 // We have a MSC4143 event membership event
                 if (Object.keys(content).length !== 0) {
                     // We checked for empty content to not try to construct CallMembership's with {}.
-                    membershipContents.push(content as CallMembershipData);
+                    membershipContents.push(content);
                 }
             }
             if (membershipContents.length === 0) {
@@ -277,8 +277,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      * @param joinConfig - Additional configuration for the joined session.
      */
     public async joinRoomSession(
-        fociActive: Focus,
         fociPreferred: Focus[],
+        fociActive?: Focus,
         joinConfig?: JoinSessionConfig,
     ): Promise<void> {
         if (this.isJoined()) {
@@ -709,7 +709,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             scope: "m.room",
             application: "m.call",
             device_id: this.client.getDeviceId()!,
-            foci_active: { type: "livekit", focus_selection: "oldest_membership" } as LivekitFocusActive as Focus,
+            foci_active: { type: "livekit", focus_selection: "oldest_membership" },
             foci_preferred: this.ownFociPreferred ?? [],
         };
     }

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -73,9 +73,9 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
         }
         this.roomSessions.clear();
 
-        this.client.removeListener(ClientEvent.Room, this.onRoom);
-        this.client.removeListener(RoomEvent.Timeline, this.onTimeline);
-        this.client.removeListener(RoomStateEvent.Events, this.onRoomState);
+        this.client.off(ClientEvent.Room, this.onRoom);
+        this.client.off(RoomEvent.Timeline, this.onTimeline);
+        this.client.off(RoomStateEvent.Events, this.onRoomState);
     }
 
     /**

--- a/src/matrixrtc/focus.ts
+++ b/src/matrixrtc/focus.ts
@@ -21,4 +21,5 @@ limitations under the License.
  */
 export interface Focus {
     type: string;
+    [key: string]: unknown;
 }


### PR DESCRIPTION
The call.member events are refactored in a backwards compatible way to not only have one array: `foci_active: Focus[]` but instead one array:
`foci_preferred: Focus[]`
and a single:
`focus_active: Focus`

Foci active should just be one field describing what you are currently using. In a fully cascading world this is your own foci. In the livekit scenario this describes how you connect to the correct livekit session. (using the oldest session member should be the default, but if someone is using sth else everyone should connect to the other livekit session as well. Not yet implemented)

`foci_preferred` is what `foci_active` has been. The list of possible foci this user knows about or can use.

fixes https://github.com/element-hq/element-call/issues/1737

Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
