### PR TITLE
Remove deprecated methods and fields

### DIFF
--- a/spec/unit/crypto/cross-signing.spec.ts
+++ b/spec/unit/crypto/cross-signing.spec.ts
@@ -23,12 +23,12 @@ import HttpBackend from "matrix-mock-request";
 import * as olmlib from "../../../src/crypto/olmlib";
 import { MatrixError } from "../../../src/http-api";
 import { logger } from "../../../src/logger";
-import { ICrossSigningKey, ICreateClientOpts, ISignedKey, MatrixClient } from "../../../src/client";
+import { ICreateClientOpts, ISignedKey, MatrixClient } from "../../../src/client";
 import { CryptoEvent } from "../../../src/crypto";
 import { IDevice } from "../../../src/crypto/deviceinfo";
 import { TestClient } from "../../TestClient";
 import { resetCrossSigningKeys } from "./crypto-utils";
-import { BootstrapCrossSigningOpts } from "../../../src/crypto-api";
+import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../../../src/crypto-api";
 
 const PUSH_RULES_RESPONSE: Response = {
     method: "GET",
@@ -377,7 +377,7 @@ describe("Cross Signing", function () {
         const bobSigning = new global.Olm.PkSigning();
         const bobPrivkey = bobSigning.generate_seed();
         const bobPubkey = bobSigning.init_with_seed(bobPrivkey);
-        const bobSSK: ICrossSigningKey = {
+        const bobSSK: CrossSigningKeyInfo = {
             user_id: "@bob:example.com",
             usage: ["self_signing"],
             keys: {
@@ -515,7 +515,7 @@ describe("Cross Signing", function () {
         };
         olmlib.pkSign(bobDevice, selfSigningKey as unknown as PkSigning, "@bob:example.com", "");
 
-        const bobMaster: ICrossSigningKey = {
+        const bobMaster: CrossSigningKeyInfo = {
             user_id: "@bob:example.com",
             usage: ["master"],
             keys: {
@@ -630,7 +630,7 @@ describe("Cross Signing", function () {
         const bobSigning = new global.Olm.PkSigning();
         const bobPrivkey = bobSigning.generate_seed();
         const bobPubkey = bobSigning.init_with_seed(bobPrivkey);
-        const bobSSK: ICrossSigningKey = {
+        const bobSSK: CrossSigningKeyInfo = {
             user_id: "@bob:example.com",
             usage: ["self_signing"],
             keys: {
@@ -696,7 +696,7 @@ describe("Cross Signing", function () {
         const bobSigning = new global.Olm.PkSigning();
         const bobPrivkey = bobSigning.generate_seed();
         const bobPubkey = bobSigning.init_with_seed(bobPrivkey);
-        const bobSSK: ICrossSigningKey = {
+        const bobSSK: CrossSigningKeyInfo = {
             user_id: "@bob:example.com",
             usage: ["self_signing"],
             keys: {
@@ -763,7 +763,7 @@ describe("Cross Signing", function () {
         const bobSigning2 = new global.Olm.PkSigning();
         const bobPrivkey2 = bobSigning2.generate_seed();
         const bobPubkey2 = bobSigning2.init_with_seed(bobPrivkey2);
-        const bobSSK2: ICrossSigningKey = {
+        const bobSSK2: CrossSigningKeyInfo = {
             user_id: "@bob:example.com",
             usage: ["self_signing"],
             keys: {
@@ -913,7 +913,7 @@ describe("Cross Signing", function () {
         const aliceSigning = new global.Olm.PkSigning();
         const alicePrivkey = aliceSigning.generate_seed();
         const alicePubkey = aliceSigning.init_with_seed(alicePrivkey);
-        const aliceSSK: ICrossSigningKey = {
+        const aliceSSK: CrossSigningKeyInfo = {
             user_id: "@alice:example.com",
             usage: ["self_signing"],
             keys: {
@@ -988,7 +988,7 @@ describe("Cross Signing", function () {
         const aliceSigning = new global.Olm.PkSigning();
         const alicePrivkey = aliceSigning.generate_seed();
         const alicePubkey = aliceSigning.init_with_seed(alicePrivkey);
-        const aliceSSK: ICrossSigningKey = {
+        const aliceSSK: CrossSigningKeyInfo = {
             user_id: "@alice:example.com",
             usage: ["self_signing"],
             keys: {
@@ -1048,7 +1048,7 @@ describe("Cross Signing", function () {
         const aliceSigning = new global.Olm.PkSigning();
         const alicePrivkey = aliceSigning.generate_seed();
         const alicePubkey = aliceSigning.init_with_seed(alicePrivkey);
-        const aliceSSK: ICrossSigningKey = {
+        const aliceSSK: CrossSigningKeyInfo = {
             user_id: "@alice:example.com",
             usage: ["self_signing"],
             keys: {

--- a/spec/unit/crypto/secrets.spec.ts
+++ b/spec/unit/crypto/secrets.spec.ts
@@ -23,12 +23,13 @@ import { makeTestClients } from "./verification/util";
 import { encryptAES } from "../../../src/crypto/aes";
 import { createSecretStorageKey, resetCrossSigningKeys } from "./crypto-utils";
 import { logger } from "../../../src/logger";
-import { ClientEvent, ICreateClientOpts, ICrossSigningKey, MatrixClient } from "../../../src/client";
+import { ClientEvent, ICreateClientOpts, MatrixClient } from "../../../src/client";
 import { DeviceInfo } from "../../../src/crypto/deviceinfo";
 import { ISignatures } from "../../../src/@types/signed";
 import { ICurve25519AuthData } from "../../../src/crypto/keybackup";
 import { SecretStorageKeyDescription, SECRET_STORAGE_ALGORITHM_V1_AES } from "../../../src/secret-storage";
 import { decodeBase64 } from "../../../src/base64";
+import { CrossSigningKeyInfo } from "../../../src/crypto-api";
 
 async function makeTestClient(
     userInfo: { userId: string; deviceId: string },
@@ -475,7 +476,7 @@ describe("Secrets", function () {
                             [`ed25519:${XSPubKey}`]: XSPubKey,
                         },
                     },
-                    self_signing: sign<ICrossSigningKey>(
+                    self_signing: sign<CrossSigningKeyInfo>(
                         {
                             user_id: "@alice:example.com",
                             usage: ["self_signing"],
@@ -486,7 +487,7 @@ describe("Secrets", function () {
                         XSK,
                         "@alice:example.com",
                     ),
-                    user_signing: sign<ICrossSigningKey>(
+                    user_signing: sign<CrossSigningKeyInfo>(
                         {
                             user_id: "@alice:example.com",
                             usage: ["user_signing"],
@@ -631,7 +632,7 @@ describe("Secrets", function () {
                             [`ed25519:${XSPubKey}`]: XSPubKey,
                         },
                     },
-                    self_signing: sign<ICrossSigningKey>(
+                    self_signing: sign<CrossSigningKeyInfo>(
                         {
                             user_id: "@alice:example.com",
                             usage: ["self_signing"],
@@ -642,7 +643,7 @@ describe("Secrets", function () {
                         XSK,
                         "@alice:example.com",
                     ),
-                    user_signing: sign<ICrossSigningKey>(
+                    user_signing: sign<CrossSigningKeyInfo>(
                         {
                             user_id: "@alice:example.com",
                             usage: ["user_signing"],

--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -148,11 +148,6 @@ export interface LoginRequest {
      */
     type: "m.login.password" | "m.login.token" | string;
     /**
-     * Third-party identifier for the user.
-     * @deprecated in favour of `identifier`.
-     */
-    address?: string;
-    /**
      * ID of the client device.
      * If this does not correspond to a known client device, a new device will be created.
      * The given device ID must not be the same as a cross-signing key ID.

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -56,7 +56,6 @@ import {
     SDPStreamMetadataKey,
 } from "../webrtc/callEventTypes";
 import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types";
-import { EncryptedFile } from "./media";
 import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls";
 
 export enum EventType {
@@ -304,11 +303,6 @@ export const UNSIGNED_THREAD_ID_FIELD = new UnstableValue("thread_id", "org.matr
  * @experimental
  */
 export const UNSIGNED_MEMBERSHIP_FIELD = new UnstableValue("membership", "io.element.msc4115.membership");
-
-/**
- * @deprecated in favour of {@link EncryptedFile}
- */
-export type IEncryptedFile = EncryptedFile;
 
 /**
  * Mapped type from event type to content type for all specified non-state room events.

--- a/src/@types/registration.ts
+++ b/src/@types/registration.ts
@@ -107,10 +107,4 @@ export interface RegisterResponse {
      * Omitted if the inhibit_login option is true.
      */
     refresh_token?: string;
-    /**
-     * The server_name of the homeserver on which the account has been registered.
-     *
-     * @deprecated Clients should extract the server_name from user_id (by splitting at the first colon) if they require it.
-     */
-    home_server?: string;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -560,16 +560,13 @@ export interface Capabilities {
     "org.matrix.msc3882.get_login_token"?: IGetLoginTokenCapability;
 }
 
-/** @deprecated prefer {@link CrossSigningKeyInfo}. */
-export type ICrossSigningKey = CrossSigningKeyInfo;
-
 enum CrossSigningKeyType {
     MasterKey = "master_key",
     SelfSigningKey = "self_signing_key",
     UserSigningKey = "user_signing_key",
 }
 
-export type CrossSigningKeys = Record<CrossSigningKeyType, ICrossSigningKey>;
+export type CrossSigningKeys = Record<CrossSigningKeyType, CrossSigningKeyInfo>;
 
 export type SendToDeviceContentMap = Map<string, Map<string, Record<string, any>>>;
 
@@ -581,7 +578,7 @@ export interface ISignedKey {
     device_id: string;
 }
 
-export type KeySignatures = Record<string, Record<string, ICrossSigningKey | ISignedKey>>;
+export type KeySignatures = Record<string, Record<string, CrossSigningKeyInfo | ISignedKey>>;
 export interface IUploadKeySignaturesResponse {
     failures: Record<
         string,

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -20,22 +20,15 @@ import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
 import { Method, ClientPrefix } from "../http-api";
 import { Crypto, ICryptoCallbacks } from "./index";
-import {
-    ClientEvent,
-    ClientEventHandlerMap,
-    CrossSigningKeys,
-    ICrossSigningKey,
-    ISignedKey,
-    KeySignatures,
-} from "../client";
+import { ClientEvent, ClientEventHandlerMap, CrossSigningKeys, ISignedKey, KeySignatures } from "../client";
 import { IKeyBackupInfo } from "./keybackup";
 import { TypedEventEmitter } from "../models/typed-event-emitter";
 import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage";
-import { BootstrapCrossSigningOpts } from "../crypto-api";
+import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../crypto-api";
 
 interface ICrossSigningKeys {
     authUpload: BootstrapCrossSigningOpts["authUploadDeviceSigningKeys"];
-    keys: Record<"master" | "self_signing" | "user_signing", ICrossSigningKey>;
+    keys: Record<"master" | "self_signing" | "user_signing", CrossSigningKeyInfo>;
 }
 
 /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -56,14 +56,7 @@ import { Room, RoomEvent } from "../models/room";
 import { RoomMember, RoomMemberEvent } from "../models/room-member";
 import { EventStatus, IContent, IEvent, MatrixEvent, MatrixEventEvent } from "../models/event";
 import { ToDeviceBatch } from "../models/ToDeviceMessage";
-import {
-    ClientEvent,
-    ICrossSigningKey,
-    IKeysUploadResponse,
-    ISignedKey,
-    IUploadKeySignaturesResponse,
-    MatrixClient,
-} from "../client";
+import { ClientEvent, IKeysUploadResponse, ISignedKey, IUploadKeySignaturesResponse, MatrixClient } from "../client";
 import { IRoomEncryption, RoomList } from "./RoomList";
 import { IKeyBackupInfo } from "./keybackup";
 import { ISyncStateData } from "../sync";
@@ -89,6 +82,7 @@ import { ISecretRequest } from "./SecretSharing";
 import {
     BackupTrustInfo,
     BootstrapCrossSigningOpts,
+    CrossSigningKeyInfo,
     CrossSigningStatus,
     DecryptionFailureCode,
     DeviceVerificationStatus,
@@ -1527,7 +1521,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      */
     private async checkForValidDeviceSignature(
         userId: string,
-        key: ICrossSigningKey,
+        key: CrossSigningKeyInfo,
         devices: Record<string, IDevice>,
     ): Promise<string[]> {
         const deviceIds: string[] = [];
@@ -1904,7 +1898,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @param keys - The new trusted set of keys
      */
-    private async storeTrustedSelfKeys(keys: Record<string, ICrossSigningKey> | null): Promise<void> {
+    private async storeTrustedSelfKeys(keys: Record<string, CrossSigningKeyInfo> | null): Promise<void> {
         if (keys) {
             this.crossSigningInfo.setKeys(keys);
         } else {
@@ -2390,7 +2384,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         blocked: boolean | null = null,
         known: boolean | null = null,
         keys?: Record<string, string>,
-    ): Promise<DeviceInfo | CrossSigningInfo | ICrossSigningKey | undefined> {
+    ): Promise<DeviceInfo | CrossSigningInfo | CrossSigningKeyInfo | undefined> {
         // Check if the 'device' is actually a cross signing key
         // The js-sdk's verification treats cross-signing keys as devices
         // and so uses this method to mark them verified.

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index";
 import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager";
-import { ICrossSigningKey } from "../../client";
 import { IOlmDevice } from "../algorithms/megolm";
 import { TrackingStatus } from "../DeviceList";
 import { IRoomEncryption } from "../RoomList";
@@ -27,6 +26,7 @@ import { InboundGroupSessionData } from "../OlmDevice";
 import { MatrixEvent } from "../../models/event";
 import { DehydrationManager } from "../dehydration";
 import { IEncryptedPayload } from "../aes";
+import { CrossSigningKeyInfo } from "../../crypto-api";
 
 /**
  * Internal module. Definitions for storage for the crypto module
@@ -100,13 +100,13 @@ export interface CryptoStore {
     // Olm Account
     getAccount(txn: unknown, func: (accountPickle: string | null) => void): void;
     storeAccount(txn: unknown, accountPickle: string): void;
-    getCrossSigningKeys(txn: unknown, func: (keys: Record<string, ICrossSigningKey> | null) => void): void;
+    getCrossSigningKeys(txn: unknown, func: (keys: Record<string, CrossSigningKeyInfo> | null) => void): void;
     getSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
         txn: unknown,
         func: (key: SecretStorePrivateKeys[K] | null) => void,
         type: K,
     ): void;
-    storeCrossSigningKeys(txn: unknown, keys: Record<string, ICrossSigningKey>): void;
+    storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void;
     storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
         txn: unknown,
         type: K,

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -33,11 +33,11 @@ import {
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base";
 import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index";
-import { ICrossSigningKey } from "../../client";
 import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { InboundGroupSessionData } from "../OlmDevice";
 import { IndexedDBCryptoStore } from "./indexeddb-crypto-store";
+import { CrossSigningKeyInfo } from "../../crypto-api";
 
 const PROFILE_TRANSACTIONS = false;
 
@@ -418,7 +418,7 @@ export class Backend implements CryptoStore {
 
     public getCrossSigningKeys(
         txn: IDBTransaction,
-        func: (keys: Record<string, ICrossSigningKey> | null) => void,
+        func: (keys: Record<string, CrossSigningKeyInfo> | null) => void,
     ): void {
         const objectStore = txn.objectStore("account");
         const getReq = objectStore.get("crossSigningKeys");
@@ -447,7 +447,7 @@ export class Backend implements CryptoStore {
         };
     }
 
-    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, ICrossSigningKey>): void {
+    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, CrossSigningKeyInfo>): void {
         const objectStore = txn.objectStore("account");
         objectStore.put(keys, "crossSigningKeys");
     }

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -36,10 +36,10 @@ import {
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base";
 import { IRoomKeyRequestBody } from "../index";
-import { ICrossSigningKey } from "../../client";
 import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { InboundGroupSessionData } from "../OlmDevice";
+import { CrossSigningKeyInfo } from "../../crypto-api";
 
 /*
  * Internal module. indexeddb storage for e2e.
@@ -420,7 +420,7 @@ export class IndexedDBCryptoStore implements CryptoStore {
      */
     public getCrossSigningKeys(
         txn: IDBTransaction,
-        func: (keys: Record<string, ICrossSigningKey> | null) => void,
+        func: (keys: Record<string, CrossSigningKeyInfo> | null) => void,
     ): void {
         this.backend!.getCrossSigningKeys(txn, func);
     }
@@ -444,7 +444,7 @@ export class IndexedDBCryptoStore implements CryptoStore {
      * @param txn - An active transaction. See doTxn().
      * @param keys - keys object as getCrossSigningKeys()
      */
-    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, ICrossSigningKey>): void {
+    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, CrossSigningKeyInfo>): void {
         this.backend!.storeCrossSigningKeys(txn, keys);
     }
 

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -31,9 +31,9 @@ import {
 } from "./base";
 import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
-import { ICrossSigningKey } from "../../client";
 import { InboundGroupSessionData } from "../OlmDevice";
 import { safeSet } from "../../utils";
+import { CrossSigningKeyInfo } from "../../crypto-api";
 
 /**
  * Internal module. Partial localStorage backed storage for e2e.
@@ -531,8 +531,8 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         setJsonItem(this.store, KEY_END_TO_END_ACCOUNT, accountPickle);
     }
 
-    public getCrossSigningKeys(txn: unknown, func: (keys: Record<string, ICrossSigningKey> | null) => void): void {
-        const keys = getJsonItem<Record<string, ICrossSigningKey>>(this.store, KEY_CROSS_SIGNING_KEYS);
+    public getCrossSigningKeys(txn: unknown, func: (keys: Record<string, CrossSigningKeyInfo> | null) => void): void {
+        const keys = getJsonItem<Record<string, CrossSigningKeyInfo>>(this.store, KEY_CROSS_SIGNING_KEYS);
         func(keys);
     }
 
@@ -545,7 +545,7 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         func(key);
     }
 
-    public storeCrossSigningKeys(txn: unknown, keys: Record<string, ICrossSigningKey>): void {
+    public storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void {
         setJsonItem(this.store, KEY_CROSS_SIGNING_KEYS, keys);
     }
 

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -32,10 +32,10 @@ import {
     SESSION_BATCH_SIZE,
 } from "./base";
 import { IRoomKeyRequestBody } from "../index";
-import { ICrossSigningKey } from "../../client";
 import { IOlmDevice } from "../algorithms/megolm";
 import { IRoomEncryption } from "../RoomList";
 import { InboundGroupSessionData } from "../OlmDevice";
+import { CrossSigningKeyInfo } from "../../crypto-api";
 
 function encodeSessionKey(senderCurve25519Key: string, sessionId: string): string {
     return encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);
@@ -56,7 +56,7 @@ export class MemoryCryptoStore implements CryptoStore {
     private migrationState: MigrationState = MigrationState.NOT_STARTED;
     private outgoingRoomKeyRequests: OutgoingRoomKeyRequest[] = [];
     private account: string | null = null;
-    private crossSigningKeys: Record<string, ICrossSigningKey> | null = null;
+    private crossSigningKeys: Record<string, CrossSigningKeyInfo> | null = null;
     private privateKeys: Partial<SecretStorePrivateKeys> = {};
 
     private sessions: { [deviceKey: string]: { [sessionId: string]: ISessionInfo } } = {};
@@ -319,7 +319,7 @@ export class MemoryCryptoStore implements CryptoStore {
         this.account = accountPickle;
     }
 
-    public getCrossSigningKeys(txn: unknown, func: (keys: Record<string, ICrossSigningKey> | null) => void): void {
+    public getCrossSigningKeys(txn: unknown, func: (keys: Record<string, CrossSigningKeyInfo> | null) => void): void {
         func(this.crossSigningKeys);
     }
 
@@ -332,7 +332,7 @@ export class MemoryCryptoStore implements CryptoStore {
         func(result || null);
     }
 
-    public storeCrossSigningKeys(txn: unknown, keys: Record<string, ICrossSigningKey>): void {
+    public storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void {
         this.crossSigningKeys = keys;
     }
 

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -121,10 +121,6 @@ interface ThreepidCreds {
 type EmailIdentityDict = {
     type: AuthType.Email;
     threepid_creds: ThreepidCreds;
-    /**
-     * @deprecated in favour of `threepid_creds` - kept for backwards compatibility
-     */
-    threepidCreds?: ThreepidCreds;
     session: string;
 };
 
@@ -347,11 +343,7 @@ export class InteractiveAuth<T> {
                 creds.id_server = idServerParsedUrl.host;
                 authDict = {
                     type: EMAIL_STAGE_TYPE,
-                    // TODO: Remove `threepid_creds` once servers support proper UIA
-                    // See https://github.com/matrix-org/synapse/issues/5665
-                    // See https://github.com/matrix-org/matrix-doc/issues/2220
                     threepid_creds: creds,
-                    threepidCreds: creds,
                 };
             }
         }

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -105,10 +105,6 @@ export { IdentityProviderBrand, SSOAction } from "./@types/auth";
 export type { ISSOFlow as SSOFlow, LoginFlow } from "./@types/auth";
 export type { IHierarchyRelation as HierarchyRelation, IHierarchyRoom as HierarchyRoom } from "./@types/spaces";
 export { LocationAssetType } from "./@types/location";
-/**
- * @deprecated in favour of RoomJoinRulesEventContent on the types export
- */
-export type { RoomJoinRulesEventContent as IJoinRuleEventContent } from "./@types/state_events";
 
 /**
  * Types supporting cryptography.

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -606,27 +606,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
-     * Determines whether this room needs to be upgraded to a new version
-     * @returns What version the room should be upgraded to, or null if
-     *     the room does not require upgrading at this time.
-     * @deprecated Use #getRecommendedVersion() instead
-     */
-    public shouldUpgradeToVersion(): string | null {
-        // TODO: Remove this function.
-        // This makes assumptions about which versions are safe, and can easily
-        // be wrong. Instead, people are encouraged to use getRecommendedVersion
-        // which determines a safer value. This function doesn't use that function
-        // because this is not async-capable, and to avoid breaking the contract
-        // we're deprecating this.
-
-        if (!SAFE_ROOM_VERSIONS.includes(this.getVersion())) {
-            return KNOWN_SAFE_ROOM_VERSION;
-        }
-
-        return null;
-    }
-
-    /**
      * Determines the recommended room version for the room. This returns an
      * object with 3 properties: `version` as the new version the
      * room should be upgraded to (may be the same as the current version);


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/12524

+ Removes `threepidCreds` on `EmailIdentityDict` - should use `threepid_creds`
+ Removes `Room::shouldUpgradeToVersion` - should use `Room::getRecommendedVersion` instead
+ Removes `user` field on UIA calls, uses `identifier` instead
+ Removes `address` field on Login request interface - should use `identifier` instead
+ Removes `IEncryptedFile` - should use `EncryptedFile` on types export instead
+ Removes `ICrossSigningKey` - should use `CrossSigningKeyInfo`
+ Removes `IJoinRuleEventContent` - should use `RoomJoinRulesEventContent`
+ Removes `home_server` field on RegisterResponse - should derive from `user_id` by splitting at the first colon instead