### PR TITLE
`initRustCrypto`: allow app to pass in the store key directly

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -85,6 +85,44 @@ describe("MatrixClient.initRustCrypto", () => {
         );
     });
 
+    it("should create the meta db if given a storageKey", async () => {
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+        });
+
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
+        await matrixClient.initRustCrypto({ storageKey: new Uint8Array(32) });
+
+        // should have two indexed dbs now
+        const databaseNames = (await indexedDB.databases()).map((db) => db.name);
+        expect(databaseNames).toEqual(
+            expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto", "matrix-js-sdk::matrix-sdk-crypto-meta"]),
+        );
+    });
+
+    it("should create the meta db if given a storagePassword", async () => {
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+        });
+
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
+        await matrixClient.initRustCrypto({ storagePassword: "the cow is on the moon" });
+
+        // should have two indexed dbs now
+        const databaseNames = (await indexedDB.databases()).map((db) => db.name);
+        expect(databaseNames).toEqual(
+            expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto", "matrix-js-sdk::matrix-sdk-crypto-meta"]),
+        );
+    });
+
     it("should ignore a second call", async () => {
         const matrixClient = createClient({
             baseUrl: "http://test.server",

--- a/src/client.ts
+++ b/src/client.ts
@@ -357,7 +357,7 @@ export interface ICreateClientOpts {
     deviceToImport?: IExportedDevice;
 
     /**
-     * Encryption key used for encrypting sensitive data (such as e2ee keys) in {@link #cryptoStore}.
+     * Encryption key used for encrypting sensitive data (such as e2ee keys) in {@link ICreateClientOpts#cryptoStore}.
      *
      * This must be set to the same value every time the client is initialised for the same device.
      *

--- a/src/client.ts
+++ b/src/client.ts
@@ -357,14 +357,14 @@ export interface ICreateClientOpts {
     deviceToImport?: IExportedDevice;
 
     /**
-     * Encryption key used for encrypting sensitive data (such as e2ee keys) in storage.
+     * Encryption key used for encrypting sensitive data (such as e2ee keys) in {@link #cryptoStore}.
      *
      * This must be set to the same value every time the client is initialised for the same device.
      *
-     * If unset, either a hardcoded key or no encryption at all is used, depending on the Crypto implementation.
-     *
-     * No particular requirement is placed on the key data (it is fed into an HKDF to generate the actual encryption
-     * keys).
+     * This is only used for the legacy crypto implementation (as used by {@link MatrixClient#initCrypto}),
+     * but if you use the rust crypto implementation ({@link MatrixClient#initRustCrypto}) and the device
+     * previously used legacy crypto (so must be migrated), then this must still be provided, so that the
+     * data can be migrated from the legacy store.
      */
     pickleKey?: string;
 
@@ -2229,17 +2229,24 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * An alternative to {@link initCrypto}.
      *
-     * *WARNING*: this API is very experimental, should not be used in production, and may change without notice!
-     *    Eventually it will be deprecated and `initCrypto` will do the same thing.
-     *
-     * @experimental
-     *
-     * @param useIndexedDB - True to use an indexeddb store, false to use an in-memory store. Defaults to 'true'.
+     * @param args.useIndexedDB - True to use an indexeddb store, false to use an in-memory store. Defaults to 'true'.
+     * @param args.storageKey - A key with which to encrypt the indexeddb store. If provided, it must be exactly
+     *    32 bytes of data, and must be the same each time the client is initialised for a given device.
+     *    If both this and `storagePassword` are unspecified, the store will be unencrypted.
+     * @param args.storagePassword - An alternative to `storageKey`. A password which will be used to derive a key to
+     *    encrypt the store with. Deriving a key from a password is (deliberately) a slow operation, so prefer
+     *    to pass a `storageKey` directly where possible.
      *
      * @returns a Promise which will resolve when the crypto layer has been
      *    successfully initialised.
      */
-    public async initRustCrypto({ useIndexedDB = true }: { useIndexedDB?: boolean } = {}): Promise<void> {
+    public async initRustCrypto(
+        args: {
+            useIndexedDB?: boolean;
+            storageKey?: Uint8Array;
+            storagePassword?: string;
+        } = {},
+    ): Promise<void> {
         if (this.cryptoBackend) {
             this.logger.warn("Attempt to re-initialise e2e encryption on MatrixClient");
             return;
@@ -2272,11 +2279,15 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             deviceId: deviceId,
             secretStorage: this.secretStorage,
             cryptoCallbacks: this.cryptoCallbacks,
-            storePrefix: useIndexedDB ? RUST_SDK_STORE_PREFIX : null,
-            storePassphrase: this.pickleKey,
+            storePrefix: args.useIndexedDB === false ? null : RUST_SDK_STORE_PREFIX,
+            storeKey: args.storageKey,
+
+            // temporary compatibility hack: if there is no storageKey nor storagePassword, fall back to the pickleKey
+            storePassphrase: args.storagePassword ?? this.pickleKey,
+
             legacyCryptoStore: this.cryptoStore,
             legacyPickleKey: this.pickleKey ?? "DEFAULT_KEY",
-            legacyMigrationProgressListener: (progress, total) => {
+            legacyMigrationProgressListener: (progress: number, total: number): void => {
                 this.emit(CryptoEvent.LegacyCryptoStoreMigrationProgress, progress, total);
             },
         });


### PR DESCRIPTION
... instead of using the pickleKey. This allows us to avoid a slow PBKDF operation.

Part of https://github.com/element-hq/element-web/issues/26821.