### PR TITLE
ci: support matching branch names in complement-crypto

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
         uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@main
         with:
             use_js_sdk: "."
+            use_complement_crypto: "MATCHING_BRANCH"
 
     # we need this so the job is reported properly when run in a merge queue
     downstream-complement-crypto:


### PR DESCRIPTION
So you can make a branch `foo` and having CI run tests against the same named branch `foo` on the complement-crypto repo. This allows tests to be added during the PR process.
