### PR TITLE
Bump matrix-sdk-crypto-wasm to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^4.9.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^5.0.0",
         "another-json": "^0.2.0",
         "bs58": "^5.0.0",
         "content-type": "^1.0.4",

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1391,8 +1391,7 @@ describe("RustCrypto", () => {
             expect(await keyBackupStatusPromise).toBe(true);
         });
 
-        // XXX: disabled until https://github.com/matrix-org/matrix-rust-sdk/issues/3447 is fixed
-        it.skip("does not back up keys that came from backup", async () => {
+        it("does not back up keys that came from backup", async () => {
             const rustCrypto = await makeTestRustCrypto();
             const olmMachine: OlmMachine = rustCrypto["olmMachine"];
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1396,14 +1396,15 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto();
             const olmMachine: OlmMachine = rustCrypto["olmMachine"];
 
+            const backupVersion = testData.SIGNED_BACKUP_DATA.version!;
             await olmMachine.enableBackupV1(
                 (testData.SIGNED_BACKUP_DATA.auth_data as Curve25519AuthData).public_key,
-                testData.SIGNED_BACKUP_DATA.version!,
+                backupVersion,
             );
 
             // we import two keys: one "from backup", and one "from export"
             const [backedUpRoomKey, exportedRoomKey] = testData.MEGOLM_SESSION_DATA_ARRAY;
-            await rustCrypto.importBackedUpRoomKeys([backedUpRoomKey]);
+            await rustCrypto.importBackedUpRoomKeys([backedUpRoomKey], backupVersion);
             await rustCrypto.importRoomKeys([exportedRoomKey]);
 
             // we ask for the keys that should be backed up
@@ -1438,16 +1439,17 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto();
             const olmMachine: OlmMachine = rustCrypto["olmMachine"];
 
+            const backupVersion = testData.SIGNED_BACKUP_DATA.version!;
             await olmMachine.enableBackupV1(
                 (testData.SIGNED_BACKUP_DATA.auth_data as Curve25519AuthData).public_key,
-                testData.SIGNED_BACKUP_DATA.version!,
+                backupVersion,
             );
 
             const backup = Array.from(testData.MEGOLM_SESSION_DATA_ARRAY);
             // in addition to correct keys, we restore an invalid key
             backup.push({ room_id: "!roomid", session_id: "sessionid" } as IMegolmSessionData);
             const progressCallback = jest.fn();
-            await rustCrypto.importBackedUpRoomKeys(backup, { progressCallback });
+            await rustCrypto.importBackedUpRoomKeys(backup, backupVersion, { progressCallback });
             expect(progressCallback).toHaveBeenCalledWith({
                 total: 3,
                 successes: 0,

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -113,10 +113,11 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * Import a list of room keys restored from backup
      *
      * @param keys - a list of session export objects
+     * @param backupVersion - the version of the backup these keys came from.
      * @param opts - options object
      * @returns a promise which resolves once the keys have been imported
      */
-    importBackedUpRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void>;
+    importBackedUpRoomKeys(keys: IMegolmSessionData[], backupVersion: string, opts?: ImportRoomKeysOpts): Promise<void>;
 }
 
 /** The methods which crypto implementations should expose to the Sync api

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1888,7 +1888,11 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Implementation of {@link CryptoBackend#importBackedUpRoomKeys}.
      */
-    public importBackedUpRoomKeys(keys: IMegolmSessionData[], opts: ImportRoomKeysOpts = {}): Promise<void> {
+    public importBackedUpRoomKeys(
+        keys: IMegolmSessionData[],
+        backupVersion: string,
+        opts: ImportRoomKeysOpts = {},
+    ): Promise<void> {
         opts.source = "backup";
         return this.importRoomKeys(keys, opts);
     }

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -57,10 +57,14 @@ class KeyDownloadRateLimitError extends Error {
 /** Details of a megolm session whose key we are trying to fetch. */
 type SessionInfo = { roomId: string; megolmSessionId: string };
 
-/** Holds the current backup decryptor and version that should be used. */
+/** Holds the current backup decryptor and version that should be used.
+ *
+ * This is intended to be used as an immutable object (a new instance should be created if the configuration changes),
+ * and some of the logic relies on that, so the properties are marked as `readonly`.
+ */
 type Configuration = {
-    backupVersion: string;
-    decryptor: BackupDecryptor;
+    readonly backupVersion: string;
+    readonly decryptor: BackupDecryptor;
 };
 
 /**
@@ -392,7 +396,7 @@ export class PerSessionKeyBackupDownloader {
         for (const k of keys) {
             k.room_id = sessionInfo.roomId;
         }
-        await this.backupManager.importBackedUpRoomKeys(keys);
+        await this.backupManager.importBackedUpRoomKeys(keys, configuration.backupVersion);
     }
 
     /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -263,6 +263,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
                 };
                 opts?.progressCallback?.(importOpt);
             },
+            backupVersion,
         );
     }
 

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -239,7 +239,11 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
     /**
      * Implementation of {@link CryptoBackend#importBackedUpRoomKeys}.
      */
-    public async importBackedUpRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void> {
+    public async importBackedUpRoomKeys(
+        keys: IMegolmSessionData[],
+        backupVersion: string,
+        opts?: ImportRoomKeysOpts,
+    ): Promise<void> {
         const keysByRoom: Map<RustSdkCryptoJs.RoomId, Map<string, IMegolmSessionData>> = new Map();
         for (const key of keys) {
             const roomId = new RustSdkCryptoJs.RoomId(key.room_id);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1217,8 +1217,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     /**
      * Implementation of {@link CryptoBackend#importBackedUpRoomKeys}.
      */
-    public async importBackedUpRoomKeys(keys: IMegolmSessionData[], opts?: ImportRoomKeysOpts): Promise<void> {
-        return await this.backupManager.importBackedUpRoomKeys(keys, opts);
+    public async importBackedUpRoomKeys(
+        keys: IMegolmSessionData[],
+        backupVersion: string,
+        opts?: ImportRoomKeysOpts,
+    ): Promise<void> {
+        return await this.backupManager.importBackedUpRoomKeys(keys, backupVersion, opts);
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,10 +1772,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^4.9.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-4.10.0.tgz#324211b9bad3d2aa640800f62ba9478ce2845097"
-  integrity sha512-zOqKVAYPfzs6Hav/Km9F5xWwoQ0bxDuoUU0/121m03Fg2VnfcHk43TjKImZolFc7IlgXwVGoda9Pp9Z/eTVKJA==
+"@matrix-org/matrix-sdk-crypto-wasm@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-5.0.0.tgz#f45a7bccaad218c05bcf9e7c8ca783c9d9a07af4"
+  integrity sha512-37ASjCKSTU5ycGfkP+LUXG4Ok6OAf6vE+1qU6uwWhe6FwadCS3vVWzJYd/3d9BQFwsx4GhFTIAXrW4iLG85rmQ==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
Slightly more involved than normal because it requires us to pass a backup version into `OlmMachine.importBackedUpRoomKeys`.

On the other hand we can now re-enable the test that was disabled in https://github.com/matrix-org/matrix-js-sdk/pull/4214 due to https://github.com/matrix-org/matrix-rust-sdk/issues/3447

Fixes: https://github.com/element-hq/element-web/issues/27165

element-web notes: Fix a bug in the Rust crypto implementation which caused repeated HTTP requests to `/keys/query` when the session was unverified.