### PR TITLE
Remove more deprecated methods, fields, and exports

### DIFF
--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -21,7 +21,7 @@ import { Mocked } from "jest-mock";
 
 import {
     createClient,
-    CryptoApi,
+    Crypto,
     CryptoEvent,
     ICreateClientOpts,
     IEvent,
@@ -310,7 +310,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
     });
 
     describe("recover from backup", () => {
-        let aliceCrypto: CryptoApi;
+        let aliceCrypto: Crypto.CryptoApi;
 
         beforeEach(async () => {
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1825,7 +1825,6 @@ function withThreadId(event: MatrixEvent, newThreadId: string): MatrixEvent {
 
 const buildEventMessageInThread = (root: MatrixEvent) =>
     new MatrixEvent({
-        age: 80098509,
         content: {
             "algorithm": "m.megolm.v1.aes-sha2",
             "ciphertext": "ENCRYPTEDSTUFF",
@@ -1846,12 +1845,10 @@ const buildEventMessageInThread = (root: MatrixEvent) =>
         sender: "@andybalaam-test1:matrix.org",
         type: "m.room.encrypted",
         unsigned: { age: 80098509 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventPollResponseReference = () =>
     new MatrixEvent({
-        age: 80098509,
         content: {
             "algorithm": "m.megolm.v1.aes-sha2",
             "ciphertext": "ENCRYPTEDSTUFF",
@@ -1869,7 +1866,6 @@ const buildEventPollResponseReference = () =>
         sender: "@andybalaam-test1:matrix.org",
         type: "m.room.encrypted",
         unsigned: { age: 80106237 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventReaction = (event: MatrixEvent) =>
@@ -1909,7 +1905,6 @@ const buildEventRedaction = (event: MatrixEvent) =>
 
 const buildEventPollStartThreadRoot = () =>
     new MatrixEvent({
-        age: 80108647,
         content: {
             algorithm: "m.megolm.v1.aes-sha2",
             ciphertext: "ENCRYPTEDSTUFF",
@@ -1923,12 +1918,10 @@ const buildEventPollStartThreadRoot = () =>
         sender: "@andybalaam-test1:matrix.org",
         type: "m.room.encrypted",
         unsigned: { age: 80108647 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventReply = (target: MatrixEvent) =>
     new MatrixEvent({
-        age: 80098509,
         content: {
             "algorithm": "m.megolm.v1.aes-sha2",
             "ciphertext": "ENCRYPTEDSTUFF",
@@ -1947,12 +1940,10 @@ const buildEventReply = (target: MatrixEvent) =>
         sender: "@andybalaam-test1:matrix.org",
         type: "m.room.encrypted",
         unsigned: { age: 80098509 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventRoomName = () =>
     new MatrixEvent({
-        age: 80123249,
         content: {
             name: "1 poll, 1 vote, 1 thread",
         },
@@ -1963,12 +1954,10 @@ const buildEventRoomName = () =>
         state_key: "",
         type: "m.room.name",
         unsigned: { age: 80123249 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventEncryption = () =>
     new MatrixEvent({
-        age: 80123383,
         content: {
             algorithm: "m.megolm.v1.aes-sha2",
         },
@@ -1979,12 +1968,10 @@ const buildEventEncryption = () =>
         state_key: "",
         type: "m.room.encryption",
         unsigned: { age: 80123383 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventGuestAccess = () =>
     new MatrixEvent({
-        age: 80123473,
         content: {
             guest_access: "can_join",
         },
@@ -1995,12 +1982,10 @@ const buildEventGuestAccess = () =>
         state_key: "",
         type: "m.room.guest_access",
         unsigned: { age: 80123473 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventHistoryVisibility = () =>
     new MatrixEvent({
-        age: 80123556,
         content: {
             history_visibility: "shared",
         },
@@ -2011,12 +1996,10 @@ const buildEventHistoryVisibility = () =>
         state_key: "",
         type: "m.room.history_visibility",
         unsigned: { age: 80123556 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventJoinRules = () =>
     new MatrixEvent({
-        age: 80123696,
         content: {
             join_rule: KnownMembership.Invite,
         },
@@ -2027,12 +2010,10 @@ const buildEventJoinRules = () =>
         state_key: "",
         type: "m.room.join_rules",
         unsigned: { age: 80123696 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventPowerLevels = () =>
     new MatrixEvent({
-        age: 80124105,
         content: {
             ban: 50,
             events: {
@@ -2063,12 +2044,10 @@ const buildEventPowerLevels = () =>
         state_key: "",
         type: "m.room.power_levels",
         unsigned: { age: 80124105 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventMember = () =>
     new MatrixEvent({
-        age: 80125279,
         content: {
             avatar_url: "mxc://matrix.org/aNtbVcFfwotudypZcHsIcPOc",
             displayname: "andybalaam-test1",
@@ -2081,12 +2060,10 @@ const buildEventMember = () =>
         state_key: "@andybalaam-test1:matrix.org",
         type: "m.room.member",
         unsigned: { age: 80125279 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 const buildEventCreate = () =>
     new MatrixEvent({
-        age: 80126105,
         content: {
             room_version: "6",
         },
@@ -2097,7 +2074,6 @@ const buildEventCreate = () =>
         state_key: "",
         type: "m.room.create",
         unsigned: { age: 80126105 },
-        user_id: "@andybalaam-test1:matrix.org",
     });
 
 function assertObjectContains(obj: Record<string, any>, expected: any): void {

--- a/spec/integ/matrix-client-room-timeline.spec.ts
+++ b/spec/integ/matrix-client-room-timeline.spec.ts
@@ -333,7 +333,7 @@ describe("MatrixClient room timelines", function () {
                 name: userName,
                 url: "mxc://some/url",
             });
-            oldMshipEvent.prev_content = {
+            oldMshipEvent.unsigned!.prev_content = {
                 displayname: "Old Alice",
                 avatar_url: undefined,
                 membership: KnownMembership.Join,

--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -173,8 +173,10 @@ export function mkEvent(opts: IEventOpts & { event?: boolean }, client?: MatrixC
         room_id: opts.room,
         sender: opts.sender || opts.user, // opts.user for backwards-compat
         content: opts.content,
-        prev_content: opts.prev_content,
-        unsigned: opts.unsigned || {},
+        unsigned: {
+            ...opts.unsigned,
+            prev_content: opts.prev_content,
+        },
         event_id: "$" + testEventIndex++ + "-" + Math.random() + "-" + Math.random(),
         txn_id: "~" + Math.random(),
         redacts: opts.redacts,

--- a/spec/unit/autodiscovery.spec.ts
+++ b/spec/unit/autodiscovery.spec.ts
@@ -857,7 +857,7 @@ describe("AutoDiscovery", function () {
                 const expected = {
                     "m.homeserver": {
                         state: AutoDiscoveryAction.FAIL_ERROR,
-                        error: AutoDiscovery.ERROR_HOMESERVER_TOO_OLD,
+                        error: AutoDiscovery.ERROR_UNSUPPORTED_HOMESERVER_SPEC_VERSION,
                         base_url: "https://example.org",
                     },
                     "m.identity_server": {

--- a/spec/unit/event-timeline-set.spec.ts
+++ b/spec/unit/event-timeline-set.spec.ts
@@ -136,11 +136,6 @@ describe("EventTimelineSet", () => {
             expect(eventsInLiveTimeline.length).toStrictEqual(1);
             expect(eventsInLiveTimeline[0]).toStrictEqual(duplicateMessageEvent);
         });
-
-        it("Make sure legacy overload passing options directly as parameters still works", () => {
-            expect(() => eventTimelineSet.addLiveEvent(messageEvent, DuplicateStrategy.Replace, false)).not.toThrow();
-            expect(() => eventTimelineSet.addLiveEvent(messageEvent, DuplicateStrategy.Ignore, true)).not.toThrow();
-        });
     });
 
     describe("addEventToTimeline", () => {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1560,7 +1560,6 @@ describe("MatrixClient", function () {
                     },
                 },
                 event_id: "$ev1",
-                user_id: "@alice:matrix.org",
             });
 
             expect(rootEvent.isThreadRoot).toBe(true);

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -22,7 +22,7 @@ import { mocked } from "jest-mock";
 import { M_POLL_KIND_DISCLOSED, M_POLL_RESPONSE, M_POLL_START, Optional, PollStartEvent } from "matrix-events-sdk";
 
 import * as utils from "../test-utils/test-utils";
-import { emitPromise } from "../test-utils/test-utils";
+import { emitPromise, IMessageOpts } from "../test-utils/test-utils";
 import {
     Direction,
     DuplicateStrategy,
@@ -54,7 +54,6 @@ import { Crypto } from "../../src/crypto";
 import * as threadUtils from "../test-utils/thread";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../test-utils/client";
 import { logger } from "../../src/logger";
-import { IMessageOpts } from "../test-utils/test-utils";
 import { flushPromises } from "../test-utils/flushPromises";
 import { KnownMembership } from "../../src/@types/membership";
 
@@ -339,24 +338,6 @@ describe("Room", function () {
             }),
         ];
 
-        it("Make sure legacy overload passing options directly as parameters still works", async () => {
-            await expect(room.addLiveEvents(events, DuplicateStrategy.Replace, false)).resolves.not.toThrow();
-            await expect(room.addLiveEvents(events, DuplicateStrategy.Ignore, true)).resolves.not.toThrow();
-            await expect(
-                // @ts-ignore
-                room.addLiveEvents(events, "shouldfailbecauseinvalidduplicatestrategy", false),
-            ).rejects.toThrow();
-        });
-
-        it("should throw if duplicateStrategy isn't 'replace' or 'ignore'", async function () {
-            return expect(
-                // @ts-ignore
-                room.addLiveEvents(events, {
-                    duplicateStrategy: "foo",
-                }),
-            ).rejects.toThrow();
-        });
-
         it("should replace a timeline event if dupe strategy is 'replace'", async function () {
             // make a duplicate
             const dupe = utils.mkMessage({
@@ -387,7 +368,7 @@ describe("Room", function () {
             expect(room.timeline[0]).toEqual(events[0]);
             // @ts-ignore
             await room.addLiveEvents([dupe], {
-                duplicateStrategy: "ignore",
+                duplicateStrategy: DuplicateStrategy.Ignore,
             });
             expect(room.timeline[0]).toEqual(events[0]);
         });

--- a/src/@types/registration.ts
+++ b/src/@types/registration.ts
@@ -56,7 +56,7 @@ export interface RegisterRequest {
      * but specifying the additional POST parameter guest_access_token containing the guest’s access token.
      * They are also required to specify the username parameter to the value of the local part of their username,
      * which is otherwise optional.
-     * {@see https://spec.matrix.org/v1.10/client-server-api/#guest-access}
+     * @see https://spec.matrix.org/v1.10/client-server-api/#guest-access
      */
     guest_access_token?: string;
 }

--- a/src/@types/registration.ts
+++ b/src/@types/registration.ts
@@ -52,21 +52,13 @@ export interface RegisterRequest {
      */
     initial_device_display_name?: string;
     /**
-     * @deprecated missing in the spec
+     * Guest users can also upgrade their account by going through the ordinary register flow,
+     * but specifying the additional POST parameter guest_access_token containing the guest’s access token.
+     * They are also required to specify the username parameter to the value of the local part of their username,
+     * which is otherwise optional.
+     * {@see https://spec.matrix.org/v1.10/client-server-api/#guest-access}
      */
     guest_access_token?: string;
-    /**
-     * @deprecated missing in the spec
-     */
-    x_show_msisdn?: boolean;
-    /**
-     * @deprecated missing in the spec
-     */
-    bind_msisdn?: boolean;
-    /**
-     * @deprecated missing in the spec
-     */
-    bind_email?: boolean;
 }
 
 /**

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -43,8 +43,6 @@ export enum AutoDiscoveryError {
     InvalidJson = "Invalid JSON",
     UnsupportedHomeserverSpecVersion = "The homeserver does not meet the version requirements",
 
-    /** @deprecated Replaced by `UnsupportedHomeserverSpecVersion` */
-    HomeserverTooOld = UnsupportedHomeserverSpecVersion,
     // TODO: Implement when Sydent supports the `/versions` endpoint - https://github.com/matrix-org/sydent/issues/424
     //IdentityServerTooOld = "The identity server does not meet the minimum version requirements",
 }
@@ -90,9 +88,6 @@ export class AutoDiscovery {
 
     public static readonly ERROR_UNSUPPORTED_HOMESERVER_SPEC_VERSION =
         AutoDiscoveryError.UnsupportedHomeserverSpecVersion;
-
-    /** @deprecated Replaced by ERROR_UNSUPPORTED_HOMESERVER_SPEC_VERSION */
-    public static readonly ERROR_HOMESERVER_TOO_OLD = AutoDiscovery.ERROR_UNSUPPORTED_HOMESERVER_SPEC_VERSION;
 
     public static readonly ALL_ERRORS = Object.keys(AutoDiscoveryError) as AutoDiscoveryError[];
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2895,7 +2895,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param event - event to be checked
      * @returns The event information.
-     * @deprecated Prefer {@link CryptoApi.getEncryptionInfoForEvent | `CryptoApi.getEncryptionInfoForEvent`}.
+     * @deprecated Prefer {@link Crypto.CryptoApi.getEncryptionInfoForEvent | `CryptoApi.getEncryptionInfoForEvent`}.
      */
     public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
         if (!this.cryptoBackend) {
@@ -3313,7 +3313,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *     trust information (as returned by isKeyBackupTrusted)
      *     in trustInfo.
      *
-     * @deprecated Prefer {@link CryptoApi.checkKeyBackupAndEnable}.
+     * @deprecated Prefer {@link Crypto.CryptoApi.checkKeyBackupAndEnable}.
      */
     public checkKeyBackup(): Promise<IKeyBackupCheck | null> {
         if (!this.crypto) {
@@ -3370,7 +3370,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *     the server, otherwise false. If we haven't completed a successful check
      *     of key backup status yet, returns null.
      *
-     * @deprecated Prefer direct access to {@link CryptoApi.getActiveSessionBackupVersion}:
+     * @deprecated Prefer direct access to {@link Crypto.CryptoApi.getActiveSessionBackupVersion}:
      *
      * ```javascript
      * let enabled = (await client.getCrypto().getActiveSessionBackupVersion()) !== null;
@@ -3390,7 +3390,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param info - Backup information object as returned by getKeyBackupVersion
      * @returns Promise which resolves when complete.
      *
-     * @deprecated Do not call this directly. Instead call {@link CryptoApi.checkKeyBackupAndEnable}.
+     * @deprecated Do not call this directly. Instead call {@link Crypto.CryptoApi.checkKeyBackupAndEnable}.
      */
     public enableKeyBackup(info: IKeyBackupInfo): Promise<void> {
         if (!this.crypto) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1480,13 +1480,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.on(ClientEvent.Sync, this.startMatrixRTC);
 
-        // backwards compat for when 'opts' was 'historyLen'.
-        if (typeof opts === "number") {
-            opts = {
-                initialSyncLimit: opts,
-            };
-        }
-
         // Create our own user object artificially (instead of waiting for sync)
         // so it's always available, even if the user is not in any rooms etc.
         const userId = this.getUserId();
@@ -7888,16 +7881,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         password: string,
         sessionId: string | null,
         auth: { session?: string; type: string },
-        bindThreepids?: boolean | null | { email?: boolean; msisdn?: boolean },
+        bindThreepids?: { email?: boolean; msisdn?: boolean },
         guestAccessToken?: string,
         inhibitLogin?: boolean,
     ): Promise<RegisterResponse> {
-        // backwards compat
-        if (bindThreepids === true) {
-            bindThreepids = { email: true };
-        } else if (bindThreepids === null || bindThreepids === undefined || bindThreepids === false) {
-            bindThreepids = {};
-        }
         if (sessionId) {
             auth.session = sessionId;
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -7912,26 +7912,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (password !== undefined && password !== null) {
             params.password = password;
         }
-        if (bindThreepids.email) {
-            params.bind_email = true;
-        }
-        if (bindThreepids.msisdn) {
-            params.bind_msisdn = true;
-        }
         if (guestAccessToken !== undefined && guestAccessToken !== null) {
             params.guest_access_token = guestAccessToken;
         }
         if (inhibitLogin !== undefined && inhibitLogin !== null) {
             params.inhibit_login = inhibitLogin;
-        }
-        // Temporary parameter added to make the register endpoint advertise
-        // msisdn flows. This exists because there are clients that break
-        // when given stages they don't recognise. This parameter will cease
-        // to be necessary once these old clients are gone.
-        // Only send it if we send any params at all (the password param is
-        // mandatory, so if we send any params, we'll send the password param)
-        if (password !== undefined && password !== null) {
-            params.x_show_msisdn = true;
         }
 
         return this.registerRequest(params);

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -63,7 +63,7 @@ export interface BackupTrustInfo {
 }
 
 /**
- * The result of {@link CryptoApi.checkKeyBackupAndEnable}.
+ * The result of {@link Crypto.CryptoApi.checkKeyBackupAndEnable}.
  */
 export interface KeyBackupCheck {
     backupInfo: KeyBackupInfo;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -643,7 +643,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi#getVersion}.
+     * Implementation of {@link Crypto.CryptoApi#getVersion}.
      */
     public getVersion(): string {
         const olmVersionTuple = Crypto.getOlmVersion();
@@ -803,7 +803,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi#getCrossSigningStatus}
+     * Implementation of {@link Crypto.CryptoApi#getCrossSigningStatus}
      */
     public async getCrossSigningStatus(): Promise<CrossSigningStatus> {
         const publicKeysOnDevice = Boolean(this.crossSigningInfo.getId());
@@ -1167,7 +1167,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi#resetKeyBackup}.
+     * Implementation of {@link Crypto.CryptoApi#resetKeyBackup}.
      */
     public async resetKeyBackup(): Promise<void> {
         // Delete existing ones
@@ -1203,7 +1203,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi#deleteKeyBackupVersion}.
+     * Implementation of {@link Crypto.CryptoApi#deleteKeyBackupVersion}.
      */
     public async deleteKeyBackupVersion(version: string): Promise<void> {
         await this.backupManager.deleteKeyBackupVersion(version);
@@ -1350,7 +1350,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Get the current status of key backup.
      *
-     * Implementation of {@link CryptoApi.getActiveSessionBackupVersion}.
+     * Implementation of {@link Crypto.CryptoApi.getActiveSessionBackupVersion}.
      */
     public async getActiveSessionBackupVersion(): Promise<string | null> {
         if (this.backupManager.getKeyBackupEnabled()) {
@@ -1372,7 +1372,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Force a re-check of the key backup and enable/disable it as appropriate.
      *
-     * Implementation of {@link CryptoApi.checkKeyBackupAndEnable}.
+     * Implementation of {@link Crypto.CryptoApi.checkKeyBackupAndEnable}.
      */
     public async checkKeyBackupAndEnable(): Promise<KeyBackupCheck | null> {
         const checkResult = await this.backupManager.checkKeyBackup();
@@ -1589,7 +1589,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi.getUserVerificationStatus}.
+     * Implementation of {@link Crypto.CryptoApi.getUserVerificationStatus}.
      */
     public async getUserVerificationStatus(userId: string): Promise<UserTrustLevel> {
         return this.checkUserTrust(userId);
@@ -1986,7 +1986,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns base64-encoded ed25519 key.
      *
-     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}.
+     * @deprecated Use {@link Crypto.CryptoApi#getOwnDeviceKeys}.
      */
     public getDeviceEd25519Key(): string | null {
         return this.olmDevice.deviceEd25519Key;
@@ -1997,14 +1997,14 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      *
      * @returns base64-encoded curve25519 key.
      *
-     * @deprecated Use {@link CryptoApi#getOwnDeviceKeys}
+     * @deprecated Use {@link Crypto.CryptoApi#getOwnDeviceKeys}
      */
     public getDeviceCurve25519Key(): string | null {
         return this.olmDevice.deviceCurve25519Key;
     }
 
     /**
-     * Implementation of {@link CryptoApi#getOwnDeviceKeys}.
+     * Implementation of {@link Crypto.CryptoApi#getOwnDeviceKeys}.
      */
     public async getOwnDeviceKeys(): Promise<OwnDeviceKeys> {
         if (!this.olmDevice.deviceCurve25519Key) {
@@ -2340,7 +2340,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Mark the given device as locally verified.
      *
-     * Implementation of {@link CryptoApi#setDeviceVerified}.
+     * Implementation of {@link Crypto.CryptoApi#setDeviceVerified}.
      */
     public async setDeviceVerified(userId: string, deviceId: string, verified = true): Promise<void> {
         await this.setDeviceVerification(userId, deviceId, verified);
@@ -2349,7 +2349,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Blindly cross-sign one of our other devices.
      *
-     * Implementation of {@link CryptoApi#crossSignDevice}.
+     * Implementation of {@link Crypto.CryptoApi#crossSignDevice}.
      */
     public async crossSignDevice(deviceId: string): Promise<void> {
         await this.setDeviceVerified(this.userId, deviceId, true);
@@ -2785,7 +2785,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi.getEncryptionInfoForEvent}.
+     * Implementation of {@link Crypto.CryptoApi.getEncryptionInfoForEvent}.
      */
     public async getEncryptionInfoForEvent(event: MatrixEvent): Promise<EventEncryptionInfo | null> {
         const encryptionInfo = this.getEventEncryptionInfo(event);
@@ -4268,7 +4268,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Implementation of {@link CryptoApi#isEncryptionEnabledInRoom}.
+     * Implementation of {@link Crypto.CryptoApi#isEncryptionEnabledInRoom}.
      */
     public async isEncryptionEnabledInRoom(roomId: string): Promise<boolean> {
         return this.isRoomEncrypted(roomId);

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -114,20 +114,6 @@ export { LocationAssetType } from "./@types/location";
  */
 export * as Crypto from "./crypto-api";
 
-/**
- * Backwards compatibility re-export
- * @internal
- * @deprecated use {@link Crypto.CryptoApi}
- */
-export type { CryptoApi } from "./crypto-api";
-
-/**
- * Backwards compatibility re-export
- * @internal
- * @deprecated use {@link Crypto.DeviceVerificationStatus}
- */
-export { DeviceVerificationStatus } from "./crypto-api";
-
 let cryptoStoreFactory = (): CryptoStore => new MemoryCryptoStore();
 
 /**

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -592,43 +592,8 @@ export class EventTimelineSet extends TypedEventEmitter<EmittedEvents, EventTime
      */
     public addLiveEvent(
         event: MatrixEvent,
-        { duplicateStrategy, fromCache, roomState, timelineWasEmpty }: IAddLiveEventOptions,
-    ): void;
-    /**
-     * @deprecated In favor of the overload with `IAddLiveEventOptions`
-     */
-    public addLiveEvent(
-        event: MatrixEvent,
-        duplicateStrategy?: DuplicateStrategy,
-        fromCache?: boolean,
-        roomState?: RoomState,
-    ): void;
-    public addLiveEvent(
-        event: MatrixEvent,
-        duplicateStrategyOrOpts?: DuplicateStrategy | IAddLiveEventOptions,
-        fromCache = false,
-        roomState?: RoomState,
+        { duplicateStrategy, fromCache, roomState, timelineWasEmpty }: IAddLiveEventOptions = {},
     ): void {
-        let duplicateStrategy = (duplicateStrategyOrOpts as DuplicateStrategy) || DuplicateStrategy.Ignore;
-        let timelineWasEmpty: boolean | undefined;
-        if (typeof duplicateStrategyOrOpts === "object") {
-            ({
-                duplicateStrategy = DuplicateStrategy.Ignore,
-                fromCache = false,
-                roomState,
-                timelineWasEmpty,
-            } = duplicateStrategyOrOpts);
-        } else if (duplicateStrategyOrOpts !== undefined) {
-            // Deprecation warning
-            // FIXME: Remove after 2023-06-01 (technical debt)
-            logger.warn(
-                "Overload deprecated: " +
-                    "`EventTimelineSet.addLiveEvent(event, duplicateStrategy?, fromCache?, roomState?)` " +
-                    "is deprecated in favor of the overload with " +
-                    "`EventTimelineSet.addLiveEvent(event, IAddLiveEventOptions)`",
-            );
-        }
-
         if (this.filter) {
             const events = this.filter.filterRoomTimeline([event]);
             if (!events.length) {

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../logger";
 import { IMarkerFoundOptions, RoomState } from "./room-state";
 import { EventTimelineSet } from "./event-timeline-set";
 import { MatrixEvent } from "./event";
@@ -361,30 +360,10 @@ export class EventTimeline {
      * @param event - new event
      * @param options - addEvent options
      */
-    public addEvent(event: MatrixEvent, { toStartOfTimeline, roomState, timelineWasEmpty }: IAddEventOptions): void;
-    /**
-     * @deprecated In favor of the overload with `IAddEventOptions`
-     */
-    public addEvent(event: MatrixEvent, toStartOfTimeline: boolean, roomState?: RoomState): void;
     public addEvent(
         event: MatrixEvent,
-        toStartOfTimelineOrOpts: boolean | IAddEventOptions,
-        roomState?: RoomState,
+        { toStartOfTimeline, roomState, timelineWasEmpty }: IAddEventOptions = { toStartOfTimeline: false },
     ): void {
-        let toStartOfTimeline = !!toStartOfTimelineOrOpts;
-        let timelineWasEmpty: boolean | undefined;
-        if (typeof toStartOfTimelineOrOpts === "object") {
-            ({ toStartOfTimeline, roomState, timelineWasEmpty } = toStartOfTimelineOrOpts);
-        } else if (toStartOfTimelineOrOpts !== undefined) {
-            // Deprecation warning
-            // FIXME: Remove after 2023-06-01 (technical debt)
-            logger.warn(
-                "Overload deprecated: " +
-                    "`EventTimeline.addEvent(event, toStartOfTimeline, roomState?)` " +
-                    "is deprecated in favor of the overload with `EventTimeline.addEvent(event, IAddEventOptions)`",
-            );
-        }
-
         if (!roomState) {
             roomState = toStartOfTimeline ? this.startState : this.endState;
         }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1071,7 +1071,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * signing the public curve25519 key with the ed25519 key.
      *
      * In general, applications should not use this method directly, but should
-     * instead use {@link CryptoApi#getEncryptionInfoForEvent}.
+     * instead use {@link Crypto.CryptoApi#getEncryptionInfoForEvent}.
      */
     public getClaimedEd25519Key(): string | null {
         return this.claimedEd25519Key;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -98,19 +98,6 @@ export interface IEvent {
     membership?: Membership;
     unsigned: IUnsigned;
     redacts?: string;
-
-    /**
-     * @deprecated in favour of `sender`
-     */
-    user_id?: string;
-    /**
-     * @deprecated in favour of `unsigned.prev_content`
-     */
-    prev_content?: IContent;
-    /**
-     * @deprecated in favour of `origin_server_ts`
-     */
-    age?: number;
 }
 
 export interface IAggregatedRelation {
@@ -495,7 +482,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * @returns The user ID, e.g. `@alice:matrix.org`
      */
     public getSender(): string | undefined {
-        return this.event.sender || this.event.user_id; // v2 / v1
+        return this.event.sender; // v2 / v1
     }
 
     /**
@@ -669,7 +656,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     public getPrevContent(): IContent {
         // v2 then v1 then default
-        return this.getUnsigned().prev_content || this.event.prev_content || {};
+        return this.getUnsigned().prev_content || {};
     }
 
     /**
@@ -693,7 +680,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * @returns The age of this event in milliseconds.
      */
     public getAge(): number | undefined {
-        return this.getUnsigned().age || this.event.age; // v2 / v1
+        return this.getUnsigned().age;
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3198,7 +3198,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                                 content: strippedEvent.content,
                                 event_id: "$fake" + Date.now(),
                                 room_id: this.roomId,
-                                user_id: this.myUserId, // technically a lie
+                                sender: this.myUserId, // technically a lie
                             }),
                         ]);
                     }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2856,7 +2856,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @throws If `duplicateStrategy` is not falsey, 'replace' or 'ignore'.
      */
     public async addLiveEvents(events: MatrixEvent[], addLiveEventOptions?: IAddLiveEventOptions): Promise<void> {
-        const { duplicateStrategy, fromCache, timelineWasEmpty } = addLiveEventOptions ?? {};
+        const { duplicateStrategy, fromCache, timelineWasEmpty = false } = addLiveEventOptions ?? {};
         if (duplicateStrategy && ["replace", "ignore"].indexOf(duplicateStrategy) === -1) {
             throw new Error("duplicateStrategy MUST be either 'replace' or 'ignore'");
         }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -406,12 +406,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private threads = new Map<string, Thread>();
 
     /**
-     * @deprecated This value is unreliable. It may not contain the last thread.
-     *             Use {@link Room.getLastThread} instead.
-     */
-    public lastThread?: Thread;
-
-    /**
      * A mapping of eventId to all visibility changes to apply
      * to the event, by chronological order, as per
      * https://github.com/matrix-org/matrix-doc/pull/3531
@@ -2457,15 +2451,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         // nor any thread event are loaded yet, we'll load the event as well as the thread root, create the thread,
         // and pass the event through this.
         thread.addEvents(events, false);
-
-        const isNewer =
-            this.lastThread?.rootEvent &&
-            rootEvent?.localTimestamp &&
-            this.lastThread.rootEvent?.localTimestamp < rootEvent?.localTimestamp;
-
-        if (!this.lastThread || isNewer) {
-            this.lastThread = thread;
-        }
 
         // We need to update the thread root events, but the thread may not be ready yet.
         // If it isn't, it will fire ThreadEvent.Update when it is and we'll call updateThreadRootEvents then.

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1377,32 +1377,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
-     * Returns whether there are any devices in the room that are unverified
-     *
-     * Note: Callers should first check if crypto is enabled on this device. If it is
-     * disabled, then we aren't tracking room devices at all, so we can't answer this, and an
-     * error will be thrown.
-     *
-     * @returns the result
-     *
-     * @deprecated Not supported under rust crypto. Instead, call {@link Room.getEncryptionTargetMembers},
-     * {@link CryptoApi.getUserDeviceInfo}, and {@link CryptoApi.getDeviceVerificationStatus}.
-     */
-    public async hasUnverifiedDevices(): Promise<boolean> {
-        if (!this.hasEncryptionStateEvent()) {
-            return false;
-        }
-        const e2eMembers = await this.getEncryptionTargetMembers();
-        for (const member of e2eMembers) {
-            const devices = this.client.getStoredDevicesForUser(member.userId);
-            if (devices.some((device) => device.isUnverified())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Return the timeline sets for this room.
      * @returns array of timeline sets for this room
      */

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2896,39 +2896,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @param addLiveEventOptions - addLiveEvent options
      * @throws If `duplicateStrategy` is not falsey, 'replace' or 'ignore'.
      */
-    public async addLiveEvents(events: MatrixEvent[], addLiveEventOptions?: IAddLiveEventOptions): Promise<void>;
-    /**
-     * @deprecated In favor of the overload with `IAddLiveEventOptions`
-     */
-    public async addLiveEvents(
-        events: MatrixEvent[],
-        duplicateStrategy?: DuplicateStrategy,
-        fromCache?: boolean,
-    ): Promise<void>;
-    public async addLiveEvents(
-        events: MatrixEvent[],
-        duplicateStrategyOrOpts?: DuplicateStrategy | IAddLiveEventOptions,
-        fromCache = false,
-    ): Promise<void> {
-        let duplicateStrategy: DuplicateStrategy | undefined = duplicateStrategyOrOpts as DuplicateStrategy;
-        let timelineWasEmpty: boolean | undefined = false;
-        if (typeof duplicateStrategyOrOpts === "object") {
-            ({
-                duplicateStrategy,
-                fromCache = false,
-                /* roomState, (not used here) */
-                timelineWasEmpty,
-            } = duplicateStrategyOrOpts);
-        } else if (duplicateStrategyOrOpts !== undefined) {
-            // Deprecation warning
-            // FIXME: Remove after 2023-06-01 (technical debt)
-            logger.warn(
-                "Overload deprecated: " +
-                    "`Room.addLiveEvents(events, duplicateStrategy?, fromCache?)` " +
-                    "is deprecated in favor of the overload with `Room.addLiveEvents(events, IAddLiveEventOptions)`",
-            );
-        }
-
+    public async addLiveEvents(events: MatrixEvent[], addLiveEventOptions?: IAddLiveEventOptions): Promise<void> {
+        const { duplicateStrategy, fromCache, timelineWasEmpty } = addLiveEventOptions ?? {};
         if (duplicateStrategy && ["replace", "ignore"].indexOf(duplicateStrategy) === -1) {
             throw new Error("duplicateStrategy MUST be either 'replace' or 'ignore'");
         }

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -865,7 +865,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
     }
 
     /**
-     * Implementation of {@link CryptoApi.getEncryptionInfoForEvent}.
+     * Implementation of {@link Crypto.CryptoApi.getEncryptionInfoForEvent}.
      */
     public async getEncryptionInfoForEvent(event: MatrixEvent): Promise<EventEncryptionInfo | null> {
         return this.eventDecryptor.getEncryptionInfoForEvent(event);

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -58,8 +58,6 @@ export interface IRoomEvent extends IMinimalEvent {
     event_id: string;
     sender: string;
     origin_server_ts: number;
-    /** @deprecated - legacy field */
-    age?: number;
 }
 
 export interface IStateEvent extends IRoomEvent {
@@ -498,7 +496,7 @@ export class SyncAccumulator {
                 if (transformedEvent.unsigned !== undefined) {
                     transformedEvent.unsigned = Object.assign({}, transformedEvent.unsigned);
                 }
-                const age = e.unsigned ? e.unsigned.age : e.age;
+                const age = e.unsigned?.age;
                 if (age !== undefined) transformedEvent._localTs = Date.now() - age;
             } else {
                 transformedEvent = e;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -748,12 +748,7 @@ export function safeSet<O extends Record<any, any>, K extends keyof O>(obj: O, p
 }
 
 export function noUnsafeEventProps(event: Partial<IEvent>): boolean {
-    return !(
-        unsafeProp(event.room_id) ||
-        unsafeProp(event.sender) ||
-        unsafeProp(event.user_id) ||
-        unsafeProp(event.event_id)
-    );
+    return !(unsafeProp(event.room_id) || unsafeProp(event.sender) || unsafeProp(event.event_id));
 }
 
 export class MapWithDefault<K, V> extends Map<K, V> {


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/12555

+ Removes legacy overload of `EventTimelineSet::addLiveEvent`
+ Removes legacy overload of `EventTimeline::addEvent`
+ Removes legacy overload of `Room::addLiveEvents`
+ Removes backwards compatible export of `CryptoApi`, use `Crypto.CryptoApi` instead
+ Removes backwards compatible export of `DeviceVerificationStatus`, use `Crypto.DeviceVerificationStatus` instead
+ Removes `Autodiscovery.ERROR_HOMESERVER_TOO_OLD`, use `Autodiscovery.ERROR_UNSUPPORTED_HOMESERVER_SPEC_VERSION` instead
+ Removes registration request body fields `x_show_msisdn`, `bind_msisdn`, `bind_email`. These were unspecced and unsupported for a long time.
+ Removes long deprecated event fields `age`, `prev_content`, these now live in `unsigned`
+ Removes long deprecated event field `user_id`, this is now `sender`
+ Remove `Room::lastThread` in favour of `Room::getLastThread()`
+ Remove `Room::hasUnverifiedDevices`. Instead, call `Room::getEncryptionTargetMembers`, `CryptoApi::getUserDeviceInfo`, and `CryptoApi::getDeviceVerificationStatus`