### PR TITLE
Don't run migration for Rust crypto if the legacy store is empty

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -309,8 +309,10 @@ describe("MatrixClient.initRustCrypto", () => {
             // See https://github.com/element-hq/element-web/issues/27447
 
             // Given we have an almost-empty legacy account in the database
-            fetchMock.get("path:/_matrix/client/v3/room_keys/version", EMPTY_ACCOUNT_DATASET.backupResponse);
-
+            fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                status: 404,
+                body: { errcode: "M_NOT_FOUND", error: "No backup found" },
+            });
             fetchMock.post("path:/_matrix/client/v3/keys/query", EMPTY_ACCOUNT_DATASET.keyQueryResponse);
 
             const testStoreName = "test-store";

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/README.md
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/README.md
@@ -1,0 +1,10 @@
+## Dump of an empty libolm indexeddb cryptostore to test skipping migration
+
+A dump of an account which is almost completely empty, and totally unsuitable
+for use as a real account.
+
+This dump was manually created by copying and editing full_account.
+
+Created to test
+["Unable to restore session" error due due to half-initialised legacy indexeddb crypto store #27447](https://github.com/element-hq/element-web/issues/27447).
+We should not launch the Rust migration code when we find a DB in this state.

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/dump.json
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/dump.json
@@ -1,0 +1,14 @@
+{
+    "account": [],
+    "device_data": [],
+    "inbound_group_sessions": [],
+    "inbound_group_sessions_withheld": [],
+    "notified_error_devices": [],
+    "outgoingRoomKeyRequests": [],
+    "parked_shared_history": [],
+    "rooms": [],
+    "session_problems": [],
+    "sessions": [],
+    "sessions_needing_backup": [],
+    "shared_history_inbound_group_sessions": []
+}

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { DumpDataSetInfo } from "../index";
 
 /**

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
@@ -1,0 +1,31 @@
+import { DumpDataSetInfo } from "../index";
+
+/**
+ * A key query response containing the current keys of the tested user.
+ * To be used during tests with fetchmock.
+ */
+const KEYS_QUERY_RESPONSE: any = {
+    device_keys: {},
+    master_keys: {},
+    self_signing_keys: {},
+    user_signing_keys: {},
+};
+
+/**
+ * A `/room_keys/version` response containing the current server-side backup info.
+ * To be used during tests with fetchmock.
+ */
+const BACKUP_RESPONSE: any = {};
+
+/**
+ * A dataset containing the information for the tested user.
+ * To be used during tests.
+ */
+export const EMPTY_ACCOUNT_DATASET: DumpDataSetInfo = {
+    userId: "@emptyuser:example.com",
+    deviceId: "EMPTYDEVIC",
+    pickleKey: "+/bcdefghijklmnopqrstu1/zyxvutsrqponmlkjih2",
+    backupResponse: BACKUP_RESPONSE,
+    keyQueryResponse: KEYS_QUERY_RESPONSE,
+    dumpPath: "spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/dump.json",
+};

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
@@ -28,12 +28,6 @@ const KEYS_QUERY_RESPONSE: any = {
 };
 
 /**
- * A `/room_keys/version` response containing the current server-side backup info.
- * To be used during tests with fetchmock.
- */
-const BACKUP_RESPONSE: any = {};
-
-/**
  * A dataset containing the information for the tested user.
  * To be used during tests.
  */
@@ -41,7 +35,6 @@ export const EMPTY_ACCOUNT_DATASET: DumpDataSetInfo = {
     userId: "@emptyuser:example.com",
     deviceId: "EMPTYDEVIC",
     pickleKey: "+/bcdefghijklmnopqrstu1/zyxvutsrqponmlkjih2",
-    backupResponse: BACKUP_RESPONSE,
     keyQueryResponse: KEYS_QUERY_RESPONSE,
     dumpPath: "spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/dump.json",
 };

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/empty_account/index.ts
@@ -20,12 +20,7 @@ import { DumpDataSetInfo } from "../index";
  * A key query response containing the current keys of the tested user.
  * To be used during tests with fetchmock.
  */
-const KEYS_QUERY_RESPONSE: any = {
-    device_keys: {},
-    master_keys: {},
-    self_signing_keys: {},
-    user_signing_keys: {},
-};
+const KEYS_QUERY_RESPONSE = { device_keys: { "@emptyuser:example.com": {} } };
 
 /**
  * A dataset containing the information for the tested user.

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/full_account/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/full_account/index.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { DumpDataSetInfo } from "../index";
 
 /**

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/no_cached_msk_dump/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/no_cached_msk_dump/index.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { KeyBackupInfo } from "../../../../src/crypto-api/keybackup";
 import { DumpDataSetInfo } from "../index";
 

--- a/spec/test-utils/test_indexeddb_cryptostore_dump/unverified/index.ts
+++ b/spec/test-utils/test_indexeddb_cryptostore_dump/unverified/index.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { DumpDataSetInfo } from "../index";
 
 /**

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -83,6 +83,19 @@ export async function migrateFromLegacyCrypto(args: {
     }
 
     await legacyStore.startup();
+
+    let account;
+    await legacyStore.doTxn("readonly", [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
+        legacyStore.getAccount(txn, (acct) => {
+            account = acct;
+        });
+    });
+    if (!account) {
+        // This store is not properly set up. Nothing to migrate.
+        logger.warn("Legacy crypto store is not set up (no account found). Not migrating.");
+        return;
+    }
+
     let migrationState = await legacyStore.getMigrationState();
 
     if (migrationState >= MigrationState.MEGOLM_SESSIONS_MIGRATED) {

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -92,7 +92,7 @@ export async function migrateFromLegacyCrypto(args: {
     });
     if (!accountPickle) {
         // This store is not properly set up. Nothing to migrate.
-        logger.warn("Legacy crypto store is not set up (no account found). Not migrating.");
+        logger.debug("Legacy crypto store is not set up (no account found). Not migrating.");
         return;
     }
 

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -84,13 +84,13 @@ export async function migrateFromLegacyCrypto(args: {
 
     await legacyStore.startup();
 
-    let account;
+    let accountPickle: string | null = null;
     await legacyStore.doTxn("readonly", [IndexedDBCryptoStore.STORE_ACCOUNT], (txn) => {
-        legacyStore.getAccount(txn, (acct) => {
-            account = acct;
+        legacyStore.getAccount(txn, (acctPickle) => {
+            accountPickle = acctPickle;
         });
     });
-    if (!account) {
+    if (!accountPickle) {
         // This store is not properly set up. Nothing to migrate.
         logger.warn("Legacy crypto store is not set up (no account found). Not migrating.");
         return;


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27447