### PR TITLE
Add support for stable name for MSC4115

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -640,7 +640,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
 
                 const ev = await sendEventAndAwaitDecryption({
                     unsigned: {
-                        [UNSIGNED_MEMBERSHIP_FIELD.altName]: "leave",
+                        [UNSIGNED_MEMBERSHIP_FIELD.altName!]: "leave",
                     },
                 });
                 expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
@@ -687,7 +687,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
 
                     const ev = await sendEventAndAwaitDecryption({
                         unsigned: {
-                            [UNSIGNED_MEMBERSHIP_FIELD.altName]: "invite",
+                            [UNSIGNED_MEMBERSHIP_FIELD.altName!]: "invite",
                         },
                     });
                     expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);
@@ -733,7 +733,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
 
                     const ev = await sendEventAndAwaitDecryption({
                         unsigned: {
-                            [UNSIGNED_MEMBERSHIP_FIELD.altName]: "join",
+                            [UNSIGNED_MEMBERSHIP_FIELD.altName!]: "join",
                         },
                     });
                     expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -630,21 +630,26 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                 expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
             });
 
-            newBackendOnly("fails with NOT_JOINED if user is not member of room (MSC4115 unstable prefix)", async () => {
-                fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
-                    status: 404,
-                    body: { errcode: "M_NOT_FOUND", error: "No current backup version." },
-                });
-                expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
-                await startClientAndAwaitFirstSync();
+            newBackendOnly(
+                "fails with NOT_JOINED if user is not member of room (MSC4115 unstable prefix)",
+                async () => {
+                    fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                        status: 404,
+                        body: { errcode: "M_NOT_FOUND", error: "No current backup version." },
+                    });
+                    expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
+                    await startClientAndAwaitFirstSync();
 
-                const ev = await sendEventAndAwaitDecryption({
-                    unsigned: {
-                        [UNSIGNED_MEMBERSHIP_FIELD.altName!]: "leave",
-                    },
-                });
-                expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
-            });
+                    const ev = await sendEventAndAwaitDecryption({
+                        unsigned: {
+                            [UNSIGNED_MEMBERSHIP_FIELD.altName!]: "leave",
+                        },
+                    });
+                    expect(ev.decryptionFailureReason).toEqual(
+                        DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED,
+                    );
+                },
+            );
 
             newBackendOnly(
                 "fails with another error when the server reports user was a member of the room",

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -630,6 +630,22 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                 expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
             });
 
+            newBackendOnly("fails with NOT_JOINED if user is not member of room (MSC4115 unstable prefix)", async () => {
+                fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                    status: 404,
+                    body: { errcode: "M_NOT_FOUND", error: "No current backup version." },
+                });
+                expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
+                await startClientAndAwaitFirstSync();
+
+                const ev = await sendEventAndAwaitDecryption({
+                    unsigned: {
+                        [UNSIGNED_MEMBERSHIP_FIELD.altName]: "leave",
+                    },
+                });
+                expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
+            });
+
             newBackendOnly(
                 "fails with another error when the server reports user was a member of the room",
                 async () => {
@@ -655,6 +671,30 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
             );
 
             newBackendOnly(
+                "fails with another error when the server reports user was a member of the room (MSC4115 unstable prefix)",
+                async () => {
+                    // This tests that when the server reports that the user
+                    // was invited at the time the event was sent, then we
+                    // don't get a HISTORICAL_MESSAGE_USER_NOT_JOINED error,
+                    // and instead get some other error, since the user should
+                    // have gotten the key for the event.
+                    fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                        status: 404,
+                        body: { errcode: "M_NOT_FOUND", error: "No current backup version." },
+                    });
+                    expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
+                    await startClientAndAwaitFirstSync();
+
+                    const ev = await sendEventAndAwaitDecryption({
+                        unsigned: {
+                            [UNSIGNED_MEMBERSHIP_FIELD.altName]: "invite",
+                        },
+                    });
+                    expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);
+                },
+            );
+
+            newBackendOnly(
                 "fails with another error when the server reports user was a member of the room",
                 async () => {
                     // This tests that when the server reports the user's
@@ -671,6 +711,29 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                     const ev = await sendEventAndAwaitDecryption({
                         unsigned: {
                             [UNSIGNED_MEMBERSHIP_FIELD.name]: "join",
+                        },
+                    });
+                    expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);
+                },
+            );
+
+            newBackendOnly(
+                "fails with another error when the server reports user was a member of the room (MSC4115 unstable prefix)",
+                async () => {
+                    // This tests that when the server reports the user's
+                    // membership, and reports that the user was joined, then we
+                    // don't get a HISTORICAL_MESSAGE_USER_NOT_JOINED error, and
+                    // instead get some other error.
+                    fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                        status: 404,
+                        body: { errcode: "M_NOT_FOUND", error: "No current backup version." },
+                    });
+                    expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
+                    await startClientAndAwaitFirstSync();
+
+                    const ev = await sendEventAndAwaitDecryption({
+                        unsigned: {
+                            [UNSIGNED_MEMBERSHIP_FIELD.altName]: "join",
                         },
                     });
                     expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { UnstableValue } from "../NamespacedValue";
+import { NamespacedValue, UnstableValue } from "../NamespacedValue";
 import {
     PolicyRuleEventContent,
     RoomAvatarEventContent,
@@ -302,7 +302,7 @@ export const UNSIGNED_THREAD_ID_FIELD = new UnstableValue("thread_id", "org.matr
  *
  * @experimental
  */
-export const UNSIGNED_MEMBERSHIP_FIELD = new UnstableValue("membership", "io.element.msc4115.membership");
+export const UNSIGNED_MEMBERSHIP_FIELD = new NamespacedValue("membership", "io.element.msc4115.membership");
 
 /**
  * Mapped type from event type to content type for all specified non-state room events.

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -77,8 +77,6 @@ export interface IUnsigned {
     "invite_room_state"?: StrippedState[];
     "m.relations"?: Record<RelationType | string, any>; // No common pattern for aggregated relations
     [UNSIGNED_THREAD_ID_FIELD.name]?: string;
-    [UNSIGNED_MEMBERSHIP_FIELD.name]?: Membership | string;
-    [UNSIGNED_MEMBERSHIP_FIELD.altName]?: Membership | string;
 }
 
 export interface IThreadBundledRelationship {
@@ -715,19 +713,12 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * Get the user's room membership at the time the event was sent, as reported
      * by the server.  This uses MSC4115.
      *
-     * @returns The user's room membership, or `undefined` if the server does
+     * @returns The user's room membership, or `null` if the server does
      *   not report it.
      */
-    public getMembershipAtEvent(): Membership | string | undefined {
+    public getMembershipAtEvent(): Optional<Membership | string> {
         const unsigned = this.getUnsigned();
-        // check the stable name first, then check the unstable name
-        if (typeof unsigned[UNSIGNED_MEMBERSHIP_FIELD.name] === "string") {
-            return unsigned[UNSIGNED_MEMBERSHIP_FIELD.name];
-        } else if (typeof unsigned[UNSIGNED_MEMBERSHIP_FIELD.altName] === "string") {
-            return unsigned[UNSIGNED_MEMBERSHIP_FIELD.altName];
-        } else {
-            return undefined;
-        }
+        return UNSIGNED_MEMBERSHIP_FIELD.findIn<Membership | string>(unsigned);
     }
 
     /**

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -713,7 +713,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * Get the user's room membership at the time the event was sent, as reported
      * by the server.  This uses MSC4115.
      *
-     * @returns The user's room membership, or `null` if the server does
+     * @returns The user's room membership, or `undefined` if the server does
      *   not report it.
      */
     public getMembershipAtEvent(): Optional<Membership | string> {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -78,6 +78,7 @@ export interface IUnsigned {
     "m.relations"?: Record<RelationType | string, any>; // No common pattern for aggregated relations
     [UNSIGNED_THREAD_ID_FIELD.name]?: string;
     [UNSIGNED_MEMBERSHIP_FIELD.name]?: Membership | string;
+    [UNSIGNED_MEMBERSHIP_FIELD.altName]?: Membership | string;
 }
 
 export interface IThreadBundledRelationship {
@@ -719,8 +720,11 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     public getMembershipAtEvent(): Membership | string | undefined {
         const unsigned = this.getUnsigned();
+        // check the stable name first, then check the unstable name
         if (typeof unsigned[UNSIGNED_MEMBERSHIP_FIELD.name] === "string") {
             return unsigned[UNSIGNED_MEMBERSHIP_FIELD.name];
+        } else if (typeof unsigned[UNSIGNED_MEMBERSHIP_FIELD.altName] === "string") {
+            return unsigned[UNSIGNED_MEMBERSHIP_FIELD.altName];
         } else {
             return undefined;
         }


### PR DESCRIPTION
MSC4115 has been accepted, so enable checking the stable name.

fixes https://github.com/element-hq/element-web/issues/27515

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
