### PR TITLE
Use stable endpoints for MSC3916

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Object.keys(client.store.rooms).forEach((roomId) => {
 
 ## Authenticated media
 
-Servers supporting [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/pull/3916) will require clients, like
+Servers supporting [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/pull/3916) (Matrix 1.11) will require clients, like
 yours, to include an `Authorization` header when `/download`ing or `/thumbnail`ing media. For NodeJS environments this
 may be as easy as the following code snippet, though web browsers may need to use [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
 to append the header when using the endpoints in `<img />` elements and similar.

--- a/spec/unit/content-repo.spec.ts
+++ b/spec/unit/content-repo.spec.ts
@@ -81,11 +81,11 @@ describe("ContentRepo", function () {
             const mxcUri = "mxc://server.name/resourceid";
             expect(getHttpUriForMxc(baseUrl, mxcUri, undefined, undefined, undefined, undefined, true, true)).toEqual(
                 baseUrl +
-                    "/_matrix/client/unstable/org.matrix.msc3916/media/download/server.name/resourceid?allow_redirect=true",
+                    "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
             );
             expect(getHttpUriForMxc(baseUrl, mxcUri, 64, 64, "scale", undefined, true, true)).toEqual(
                 baseUrl +
-                    "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/server.name/resourceid?width=64&height=64&method=scale&allow_redirect=true",
+                    "/_matrix/client/v1/media/thumbnail/server.name/resourceid?width=64&height=64&method=scale&allow_redirect=true",
             );
         });
 
@@ -93,11 +93,11 @@ describe("ContentRepo", function () {
             const mxcUri = "mxc://server.name/resourceid";
             expect(getHttpUriForMxc(baseUrl, mxcUri, undefined, undefined, undefined, undefined, false, true)).toEqual(
                 baseUrl +
-                    "/_matrix/client/unstable/org.matrix.msc3916/media/download/server.name/resourceid?allow_redirect=true",
+                    "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
             );
             expect(getHttpUriForMxc(baseUrl, mxcUri, 64, 64, "scale", undefined, false, true)).toEqual(
                 baseUrl +
-                    "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/server.name/resourceid?width=64&height=64&method=scale&allow_redirect=true",
+                    "/_matrix/client/v1/media/thumbnail/server.name/resourceid?width=64&height=64&method=scale&allow_redirect=true",
             );
         });
     });

--- a/spec/unit/content-repo.spec.ts
+++ b/spec/unit/content-repo.spec.ts
@@ -80,8 +80,7 @@ describe("ContentRepo", function () {
         it("should return an authenticated URL when requested", function () {
             const mxcUri = "mxc://server.name/resourceid";
             expect(getHttpUriForMxc(baseUrl, mxcUri, undefined, undefined, undefined, undefined, true, true)).toEqual(
-                baseUrl +
-                    "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
+                baseUrl + "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
             );
             expect(getHttpUriForMxc(baseUrl, mxcUri, 64, 64, "scale", undefined, true, true)).toEqual(
                 baseUrl +
@@ -92,8 +91,7 @@ describe("ContentRepo", function () {
         it("should force-enable allow_redirects when useAuthentication is set true", function () {
             const mxcUri = "mxc://server.name/resourceid";
             expect(getHttpUriForMxc(baseUrl, mxcUri, undefined, undefined, undefined, undefined, false, true)).toEqual(
-                baseUrl +
-                    "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
+                baseUrl + "/_matrix/client/v1/media/download/server.name/resourceid?allow_redirect=true",
             );
             expect(getHttpUriForMxc(baseUrl, mxcUri, 64, 64, "scale", undefined, false, true)).toEqual(
                 baseUrl +

--- a/src/content-repo.ts
+++ b/src/content-repo.ts
@@ -62,7 +62,7 @@ export function getHttpUriForMxc(
     if (useAuthentication) {
         allowRedirects = true; // per docs (MSC3916 always expects redirects)
 
-        // Dev note: MSC3916 (as of writing) removes `allow_redirect` entirely, but
+        // Dev note: MSC3916 removes `allow_redirect` entirely, but
         // for explicitness we set it here. This makes it slightly more obvious to
         // callers, hopefully.
     }
@@ -70,8 +70,7 @@ export function getHttpUriForMxc(
     let serverAndMediaId = mxc.slice(6); // strips mxc://
     let prefix: string;
     if (useAuthentication) {
-        // TODO: Use stable once available (requires FCP on MSC3916).
-        prefix = "/_matrix/client/unstable/org.matrix.msc3916/media/download/";
+        prefix = "/_matrix/client/v1/media/download/";
     } else {
         prefix = "/_matrix/media/v3/download/";
     }
@@ -90,8 +89,7 @@ export function getHttpUriForMxc(
         // these are thumbnailing params so they probably want the
         // thumbnailing API...
         if (useAuthentication) {
-            // TODO: Use stable once available (requires FCP on MSC3916).
-            prefix = "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/";
+            prefix = "/_matrix/client/v1/media/thumbnail/";
         } else {
             prefix = "/_matrix/media/v3/thumbnail/";
         }


### PR DESCRIPTION
The MSC has completed FCP, so stable endpoints can be used.

Seeing as limited servers have shipped with the unstable endpoints, we're not generally concerned with backwards compatibility to `unstable` here - none of the freezing for the unauthenticated endpoints has happened yet.

For the "Matrix 1.11" bits, I am extremely confident that 1.11 will ship with MSC3916 - it's a release blocker. See https://github.com/matrix-org/matrix-spec/issues/1857 for release coordination.