### PR TITLE
Fix screen sharing in recent Chrome

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -25,7 +25,7 @@ import { v4 as uuidv4 } from "uuid";
 import { parse as parseSdp, write as writeSdp } from "sdp-transform";
 
 import { logger } from "../logger";
-import { checkObjectHasKeys, deepCompare, isNullOrUndefined, recursivelyAssign } from "../utils";
+import { checkObjectHasKeys, isNullOrUndefined, recursivelyAssign } from "../utils";
 import { MatrixEvent } from "../models/event";
 import { EventType, TimelineEvents, ToDeviceMessageId } from "../@types/event";
 import { RoomMember } from "../models/room-member";

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -25,7 +25,7 @@ import { v4 as uuidv4 } from "uuid";
 import { parse as parseSdp, write as writeSdp } from "sdp-transform";
 
 import { logger } from "../logger";
-import { checkObjectHasKeys, isNullOrUndefined, recursivelyAssign } from "../utils";
+import { checkObjectHasKeys, deepCompare, isNullOrUndefined, recursivelyAssign } from "../utils";
 import { MatrixEvent } from "../models/event";
 import { EventType, TimelineEvents, ToDeviceMessageId } from "../@types/event";
 import { RoomMember } from "../models/room-member";
@@ -2381,22 +2381,42 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         // RTCRtpReceiver.getCapabilities and RTCRtpSender.getCapabilities don't seem to be supported on FF before v113
         if (!RTCRtpReceiver.getCapabilities || !RTCRtpSender.getCapabilities) return;
 
-        const recvCodecs = RTCRtpReceiver.getCapabilities("video")!.codecs;
-        const sendCodecs = RTCRtpSender.getCapabilities("video")!.codecs;
-        const codecs = [...sendCodecs, ...recvCodecs];
-
-        for (const codec of codecs) {
-            if (codec.mimeType === "video/rtx") {
-                const rtxCodecIndex = codecs.indexOf(codec);
-                codecs.splice(rtxCodecIndex, 1);
-            }
-        }
-
         const screenshareVideoTransceiver = this.transceivers.get(
             getTransceiverKey(SDPStreamMetadataPurpose.Screenshare, "video"),
         );
+
         // setCodecPreferences isn't supported on FF (as of v113)
-        screenshareVideoTransceiver?.setCodecPreferences?.(codecs);
+        if (!screenshareVideoTransceiver || !screenshareVideoTransceiver.setCodecPreferences) return;
+
+        const recvCodecs = RTCRtpReceiver.getCapabilities("video")!.codecs;
+        const sendCodecs = RTCRtpSender.getCapabilities("video")!.codecs;
+        const codecs = [];
+
+        for (const codec of [...recvCodecs, ...sendCodecs]) {
+            if (codec.mimeType !== "video/rtx") {
+                codecs.push(codec);
+                try {
+                    screenshareVideoTransceiver.setCodecPreferences(codecs);
+                } catch (e) {
+                    // Specifically, Chrome around version 125 and Electron 30 (which is Chromium 124) return an H.264 codec in
+                    // the sender's capabilities but throw when you try to set it. Hence... this mess.
+                    // Specifically, that codec is:
+                    // {
+                    //   clockRate: 90000,
+                    //   mimeType: "video/H264",
+                    //   sdpFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640034",
+                    // }
+                    logger.info(
+                        "Working around buggy WebRTC impl: claimed to support codec but threw when setting codec preferences",
+                        codec,
+                        e,
+                    );
+                    codecs.pop();
+                }
+            }
+        }
+
+        //screenshareVideoTransceiver.setCodecPreferences(codecs);
     }
 
     private onNegotiationNeeded = async (): Promise<void> => {

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2415,8 +2415,6 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                 }
             }
         }
-
-        //screenshareVideoTransceiver.setCodecPreferences(codecs);
     }
 
     private onNegotiationNeeded = async (): Promise<void> => {


### PR DESCRIPTION
Dreadful hack to work around a bug in recent chrome/electron's WebRTC, as explained.

I'm not sure which is the least hideous out of this (ie. repeatedly calling setCodecPreferences and seeing if it crashes each time) or hardcoding the bad codec and skipping it. Opinions welcome. Edit: LiveKit work around this bug by using the receiver codecs (https://github.com/livekit/client-sdk-js/pull/1088) so that's also an option.

This will probably want backporting to the release.

Fixes https://github.com/element-hq/element-desktop/issues/1703

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
