### PR TITLE
Fetch capabilities in the background

### DIFF
--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -796,7 +796,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
 
             const result = await aliceCrypto.checkKeyBackupAndEnable();
             expect(result).toBeTruthy();
-            jest.runAllTimers();
+            jest.advanceTimersByTime(10 * 60 * 1000);
             await failurePromise;
 
             // Fix the endpoint to do successful uploads
@@ -829,7 +829,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
             });
 
             // run the timers, which will make the backup loop redo the request
-            await jest.runAllTimersAsync();
+            await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
             await successPromise;
             await allKeysUploadedPromise;
         });

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1292,6 +1292,41 @@ describe("MatrixClient", function () {
         });
     });
 
+    describe("getCapabilities", () => {
+        it("should return cached capabilities if present", async () => {
+            const capsObject = {
+                "m.change_password": false,
+            };
+
+            httpBackend!.when("GET", "/versions").respond(200, {});
+            httpBackend!.when("GET", "/pushrules").respond(200, {});
+            httpBackend!.when("POST", "/filter").respond(200, { filter_id: "a filter id" });
+            httpBackend.when("GET", "/capabilities").respond(200, {
+                capabilities: capsObject,
+            });
+
+            client.startClient();
+            await httpBackend!.flushAllExpected();
+
+            expect(await client.getCapabilities()).toEqual(capsObject);
+        });
+
+        it("should fetch capabilities if cache not present", async () => {
+            const capsObject = {
+                "m.change_password": false,
+            };
+
+            httpBackend.when("GET", "/capabilities").respond(200, {
+                capabilities: capsObject,
+            });
+
+            const capsPromise = client.getCapabilities();
+            await httpBackend!.flushAllExpected();
+
+            expect(await capsPromise).toEqual(capsObject);
+        });
+    });
+
     describe("getCachedCapabilities", () => {
         it("should return cached capabilities or undefined", async () => {
             const capsObject = {

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -1292,19 +1292,75 @@ describe("MatrixClient", function () {
         });
     });
 
-    describe("getCapabilities", () => {
-        it("should cache by default", async () => {
+    describe("getCachedCapabilities", () => {
+        it("should return cached capabilities or undefined", async () => {
+            const capsObject = {
+                "m.change_password": false,
+            };
+
+            httpBackend!.when("GET", "/versions").respond(200, {});
+            httpBackend!.when("GET", "/pushrules").respond(200, {});
+            httpBackend!.when("POST", "/filter").respond(200, { filter_id: "a filter id" });
             httpBackend.when("GET", "/capabilities").respond(200, {
-                capabilities: {
-                    "m.change_password": false,
-                },
+                capabilities: capsObject,
             });
-            const prom = httpBackend.flushAllExpected();
-            const capabilities1 = await client.getCapabilities();
-            const capabilities2 = await client.getCapabilities();
+
+            expect(client.getCachedCapabilities()).toBeUndefined();
+
+            client.startClient();
+
+            await httpBackend!.flushAllExpected();
+
+            expect(client.getCachedCapabilities()).toEqual(capsObject);
+        });
+    });
+
+    describe("fetchCapabilities", () => {
+        const capsObject = {
+            "m.change_password": false,
+        };
+
+        beforeEach(() => {
+            httpBackend.when("GET", "/capabilities").respond(200, {
+                capabilities: capsObject,
+            });
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it("should always fetch capabilities and then cache", async () => {
+            const prom = client.fetchCapabilities();
+            await httpBackend.flushAllExpected();
+            const caps = await prom;
+
+            expect(caps).toEqual(capsObject);
+        });
+
+        it("should write-through the cache", async () => {
+            httpBackend!.when("GET", "/versions").respond(200, {});
+            httpBackend!.when("GET", "/pushrules").respond(200, {});
+            httpBackend!.when("POST", "/filter").respond(200, { filter_id: "a filter id" });
+
+            client.startClient();
+            await httpBackend!.flushAllExpected();
+
+            expect(client.getCachedCapabilities()).toEqual(capsObject);
+
+            const newCapsObject = {
+                "m.change_password": true,
+            };
+
+            httpBackend.when("GET", "/capabilities").respond(200, {
+                capabilities: newCapsObject,
+            });
+
+            const prom = client.fetchCapabilities();
+            await httpBackend.flushAllExpected();
             await prom;
 
-            expect(capabilities1).toStrictEqual(capabilities2);
+            expect(client.getCachedCapabilities()).toEqual(newCapsObject);
         });
     });
 

--- a/spec/integ/matrix-client-syncing-errors.spec.ts
+++ b/spec/integ/matrix-client-syncing-errors.spec.ts
@@ -105,13 +105,13 @@ describe("MatrixClient syncing errors", () => {
 
         await client!.startClient();
         expect(await syncEvents[0].promise).toBe(SyncState.Error);
-        jest.runAllTimers(); // this will skip forward to trigger the keepAlive/sync
+        jest.advanceTimersByTime(60 * 1000); // this will skip forward to trigger the keepAlive/sync
         expect(await syncEvents[1].promise).toBe(SyncState.Error);
-        jest.runAllTimers(); // this will skip forward to trigger the keepAlive/sync
+        jest.advanceTimersByTime(60 * 1000); // this will skip forward to trigger the keepAlive/sync
         expect(await syncEvents[2].promise).toBe(SyncState.Prepared);
-        jest.runAllTimers(); // this will skip forward to trigger the keepAlive/sync
+        jest.advanceTimersByTime(60 * 1000); // this will skip forward to trigger the keepAlive/sync
         expect(await syncEvents[3].promise).toBe(SyncState.Syncing);
-        jest.runAllTimers(); // this will skip forward to trigger the keepAlive/sync
+        jest.advanceTimersByTime(60 * 1000); // this will skip forward to trigger the keepAlive/sync
         expect(await syncEvents[4].promise).toBe(SyncState.Syncing);
     });
 
@@ -119,6 +119,7 @@ describe("MatrixClient syncing errors", () => {
         jest.useFakeTimers();
         fetchMock.config.overwriteRoutes = false;
         fetchMock
+            .get("end:capabilities", {})
             .getOnce("end:versions", {}) // first version check without credentials needs to succeed
             .get("end:versions", unknownTokenErrorData) // further version checks fails with 401
             .get("end:pushrules/", 401) // fails with 401 without an error. This does happen in practice e.g. with Synapse

--- a/spec/test-utils/client.ts
+++ b/spec/test-utils/client.ts
@@ -88,6 +88,6 @@ export const mockClientMethodsEvents = () => ({
 export const mockClientMethodsServer = (): Partial<Record<MethodLikeKeys<MatrixClient>, unknown>> => ({
     getIdentityServerUrl: jest.fn(),
     getHomeserverUrl: jest.fn(),
-    getCapabilities: jest.fn().mockReturnValue({}),
+    getCachedCapabilities: jest.fn().mockReturnValue({}),
     doesServerSupportUnstableFeature: jest.fn().mockResolvedValue(false),
 });

--- a/spec/unit/rendezvous/rendezvous.spec.ts
+++ b/spec/unit/rendezvous/rendezvous.spec.ts
@@ -116,7 +116,7 @@ function makeMockClient(opts: {
                     },
                 };
             },
-            getCapabilities() {
+            getCachedCapabilities() {
                 return opts.msc3882r0Only
                     ? {}
                     : {

--- a/src/client.ts
+++ b/src/client.ts
@@ -2065,13 +2065,25 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
+     * Gets the cached capabilities of the homeserver, returning cached ones if available.
+     * If there are no cached capabilities and none can be fetched, throw an exception.
+     *
+     * @returns Promise resolving with The capabilities of the homeserver
+     */
+    public async getCapabilities(): Promise<Capabilities> {
+        const caps = this.serverCapabilitiesService.getCachedCapabilities();
+        if (caps) return caps;
+        return this.serverCapabilitiesService.fetchCapabilities();
+    }
+
+    /**
      * Gets the cached capabilities of the homeserver. If none have been fetched yet,
      * return undefined.
      *
      * @returns The capabilities of the homeserver
      */
     public getCachedCapabilities(): Capabilities | undefined {
-        return this.serverCapabilitiesService.getCapabilities();
+        return this.serverCapabilitiesService.getCachedCapabilities();
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -226,6 +226,7 @@ import { getRelationsThreadFilter } from "./thread-utils";
 import { KnownMembership, Membership } from "./@types/membership";
 import { RoomMessageEventContent, StickerEventContent } from "./@types/events";
 import { ImageInfo } from "./@types/media";
+import { Capabilities, ServerCapabilities } from "./serverCapabilities";
 
 export type Store = IStore;
 
@@ -233,7 +234,6 @@ export type ResetTimelineCallback = (roomId: string) => boolean;
 
 const SCROLLBACK_DELAY_MS = 3000;
 export const CRYPTO_ENABLED: boolean = isCryptoAvailable();
-const CAPABILITIES_CACHE_MS = 21600000; // 6 hours - an arbitrary value
 const TURN_CHECK_INTERVAL = 10 * 60 * 1000; // poll for turn credentials every 10 minutes
 
 export const UNSTABLE_MSC3852_LAST_SEEN_UA = new UnstableValue(
@@ -518,26 +518,6 @@ export interface IStartClientOpts {
 
 export interface IStoredClientOpts extends IStartClientOpts {}
 
-export enum RoomVersionStability {
-    Stable = "stable",
-    Unstable = "unstable",
-}
-
-export interface IRoomVersionsCapability {
-    default: string;
-    available: Record<string, RoomVersionStability>;
-}
-
-export interface ICapability {
-    enabled: boolean;
-}
-
-export interface IChangePasswordCapability extends ICapability {}
-
-export interface IThreadsCapability extends ICapability {}
-
-export interface IGetLoginTokenCapability extends ICapability {}
-
 export const GET_LOGIN_TOKEN_CAPABILITY = new NamespacedValue(
     "m.get_login_token",
     "org.matrix.msc3882.get_login_token",
@@ -546,19 +526,6 @@ export const GET_LOGIN_TOKEN_CAPABILITY = new NamespacedValue(
 export const UNSTABLE_MSC2666_SHARED_ROOMS = "uk.half-shot.msc2666";
 export const UNSTABLE_MSC2666_MUTUAL_ROOMS = "uk.half-shot.msc2666.mutual_rooms";
 export const UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_mutual_rooms";
-
-/**
- * A representation of the capabilities advertised by a homeserver as defined by
- * [Capabilities negotiation](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv3capabilities).
- */
-export interface Capabilities {
-    [key: string]: any;
-    "m.change_password"?: IChangePasswordCapability;
-    "m.room_versions"?: IRoomVersionsCapability;
-    "io.element.thread"?: IThreadsCapability;
-    "m.get_login_token"?: IGetLoginTokenCapability;
-    "org.matrix.msc3882.get_login_token"?: IGetLoginTokenCapability;
-}
 
 enum CrossSigningKeyType {
     MasterKey = "master_key",
@@ -1293,10 +1260,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     // TODO: This should expire: https://github.com/matrix-org/matrix-js-sdk/issues/1020
     protected serverVersionsPromise?: Promise<IServerVersions>;
 
-    public cachedCapabilities?: {
-        capabilities: Capabilities;
-        expiration: number;
-    };
     protected clientWellKnown?: IClientWellKnown;
     protected clientWellKnownPromise?: Promise<IClientWellKnown>;
     protected turnServers: ITurnServer[] = [];
@@ -1324,6 +1287,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public readonly ignoredInvites: IgnoredInvites;
 
     public readonly matrixRTC: MatrixRTCSessionManager;
+
+    private serverCapabilitiesService: ServerCapabilities;
 
     public constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -1417,6 +1382,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // NB. We initialise MatrixRTC whether we have call support or not: this is just
         // the underlying session management and doesn't use any actual media capabilities
         this.matrixRTC = new MatrixRTCSessionManager(this);
+
+        this.serverCapabilitiesService = new ServerCapabilities(this.http);
 
         this.on(ClientEvent.Sync, this.fixupRoomNotifications);
 
@@ -1540,6 +1507,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         this.toDeviceMessageQueue.start();
+        this.serverCapabilitiesService.start();
     }
 
     /**
@@ -1593,6 +1561,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.toDeviceMessageQueue.stop();
 
         this.matrixRTC.stop();
+
+        this.serverCapabilitiesService.stop();
     }
 
     /**
@@ -2095,47 +2065,23 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Gets the capabilities of the homeserver. Always returns an object of
-     * capability keys and their options, which may be empty.
-     * @param fresh - True to ignore any cached values.
-     * @returns Promise which resolves to the capabilities of the homeserver
-     * @returns Rejects: with an error response.
+     * Gets the cached capabilities of the homeserver. If none have been fetched yet,
+     * return undefined.
+     *
+     * @returns The capabilities of the homeserver
      */
-    public getCapabilities(fresh = false): Promise<Capabilities> {
-        const now = new Date().getTime();
+    public getCachedCapabilities(): Capabilities | undefined {
+        return this.serverCapabilitiesService.getCapabilities();
+    }
 
-        if (this.cachedCapabilities && !fresh) {
-            if (now < this.cachedCapabilities.expiration) {
-                this.logger.debug("Returning cached capabilities");
-                return Promise.resolve(this.cachedCapabilities.capabilities);
-            }
-        }
-
-        type Response = {
-            capabilities?: Capabilities;
-        };
-        return this.http
-            .authedRequest<Response>(Method.Get, "/capabilities")
-            .catch((e: Error): Response => {
-                // We swallow errors because we need a default object anyhow
-                this.logger.error(e);
-                return {};
-            })
-            .then((r = {}) => {
-                const capabilities = r["capabilities"] || {};
-
-                // If the capabilities missed the cache, cache it for a shorter amount
-                // of time to try and refresh them later.
-                const cacheMs = Object.keys(capabilities).length ? CAPABILITIES_CACHE_MS : 60000 + Math.random() * 5000;
-
-                this.cachedCapabilities = {
-                    capabilities,
-                    expiration: now + cacheMs,
-                };
-
-                this.logger.debug("Caching capabilities: ", capabilities);
-                return capabilities;
-            });
+    /**
+     * Fetches the latest capabilities from the homeserver, ignoring any cached
+     * versions. The newly returned version is cached.
+     *
+     * @returns A promise which resolves to the capabilities of the homeserver
+     */
+    public fetchCapabilities(): Promise<Capabilities> {
+        return this.serverCapabilitiesService.fetchCapabilities();
     }
 
     /**

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -24,6 +24,7 @@ import { RoomWidgetClient, ICapabilities } from "./embedded";
 import { CryptoStore } from "./crypto/store/base";
 
 export * from "./client";
+export * from "./serverCapabilities";
 export * from "./embedded";
 export * from "./http-api";
 export * from "./autodiscovery";

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -640,8 +640,12 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                     "to be supporting a newer room version we don't know about.",
             );
 
-            const caps = await this.client.fetchCapabilities();
-            versionCap = caps["m.room_versions"];
+            try {
+                capabilities = await this.client.fetchCapabilities();
+            } catch (e) {
+                logger.warn("Failed to refresh room version capabilities", e);
+            }
+            versionCap = capabilities["m.room_versions"];
             if (!versionCap) {
                 logger.warn("No room version capability - assuming upgrade required.");
                 return result;

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -70,7 +70,7 @@ import { RoomReceipts } from "./room-receipts";
 import { compareEventOrdering } from "./compare-event-ordering";
 import * as utils from "../utils";
 import { KnownMembership, Membership } from "../@types/membership";
-import { IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities";
+import { Capabilities, IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -612,8 +612,11 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * Resolves to the version the room should be upgraded to.
      */
     public async getRecommendedVersion(): Promise<IRecommendedVersion> {
-        const capabilities = this.client.getCachedCapabilities();
-        let versionCap = (capabilities ?? {})["m.room_versions"];
+        let capabilities: Capabilities = {};
+        try {
+            capabilities = await this.client.getCapabilities();
+        } catch (e) {}
+        let versionCap = capabilities["m.room_versions"];
         if (!versionCap) {
             versionCap = {
                 default: KNOWN_SAFE_ROOM_VERSION,

--- a/src/rendezvous/MSC3906Rendezvous.ts
+++ b/src/rendezvous/MSC3906Rendezvous.ts
@@ -22,12 +22,12 @@ import {
     LegacyRendezvousFailureReason as RendezvousFailureReason,
     RendezvousIntent,
 } from ".";
-import { IGetLoginTokenCapability, MatrixClient, GET_LOGIN_TOKEN_CAPABILITY } from "../client";
+import { MatrixClient, GET_LOGIN_TOKEN_CAPABILITY } from "../client";
 import { buildFeatureSupportMap, Feature, ServerSupport } from "../feature";
 import { logger } from "../logger";
 import { sleep } from "../utils";
 import { CrossSigningKey } from "../crypto-api";
-import { Device } from "../matrix";
+import { Device, IGetLoginTokenCapability } from "../matrix";
 
 enum PayloadType {
     Start = "m.login.start",
@@ -109,7 +109,7 @@ export class MSC3906Rendezvous {
         logger.info(`Connected to secure channel with checksum: ${checksum} our intent is ${this.ourIntent}`);
 
         // in stable and unstable r1 the availability is exposed as a capability
-        const capabilities = await this.client.getCapabilities();
+        const capabilities = this.client.getCachedCapabilities();
         // in r0 of MSC3882 the availability is exposed as a feature flag
         const features = await buildFeatureSupportMap(await this.client.getVersions());
         const capability = GET_LOGIN_TOKEN_CAPABILITY.findIn<IGetLoginTokenCapability>(capabilities);

--- a/src/rendezvous/MSC3906Rendezvous.ts
+++ b/src/rendezvous/MSC3906Rendezvous.ts
@@ -27,7 +27,7 @@ import { buildFeatureSupportMap, Feature, ServerSupport } from "../feature";
 import { logger } from "../logger";
 import { sleep } from "../utils";
 import { CrossSigningKey } from "../crypto-api";
-import { Device, IGetLoginTokenCapability } from "../matrix";
+import { Capabilities, Device, IGetLoginTokenCapability } from "../matrix";
 
 enum PayloadType {
     Start = "m.login.start",
@@ -109,7 +109,10 @@ export class MSC3906Rendezvous {
         logger.info(`Connected to secure channel with checksum: ${checksum} our intent is ${this.ourIntent}`);
 
         // in stable and unstable r1 the availability is exposed as a capability
-        const capabilities = this.client.getCachedCapabilities();
+        let capabilities: Capabilities = {};
+        try {
+            capabilities = await this.client.getCapabilities();
+        } catch (e) {}
         // in r0 of MSC3882 the availability is exposed as a feature flag
         const features = await buildFeatureSupportMap(await this.client.getVersions());
         const capability = GET_LOGIN_TOKEN_CAPABILITY.findIn<IGetLoginTokenCapability>(capabilities);

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IHttpOpts, MatrixHttpApi, Method } from "./http-api";
+import { logger } from "./logger";
+
+// How often we update the server capabilities.
+// // 6 hours - an arbitrary value, but they should change very infrequently.
+const CAPABILITIES_CACHE_MS = 6 * 60 * 60 * 1000;
+
+// How long we want before rtetrying if we couldn't fetch
+const CAPABILITIES_RETRY_MS = 30 * 1000;
+
+export interface ICapability {
+    enabled: boolean;
+}
+
+export interface IChangePasswordCapability extends ICapability {}
+
+export interface IThreadsCapability extends ICapability {}
+
+export interface IGetLoginTokenCapability extends ICapability {}
+
+export interface ISetDisplayNameCapability extends ICapability {}
+
+export interface ISetAvatarUrlCapability extends ICapability {}
+
+export enum RoomVersionStability {
+    Stable = "stable",
+    Unstable = "unstable",
+}
+
+export interface IRoomVersionsCapability {
+    default: string;
+    available: Record<string, RoomVersionStability>;
+}
+
+/**
+ * A representation of the capabilities advertised by a homeserver as defined by
+ * [Capabilities negotiation](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv3capabilities).
+ */
+export interface Capabilities {
+    [key: string]: any;
+    "m.change_password"?: IChangePasswordCapability;
+    "m.room_versions"?: IRoomVersionsCapability;
+    "io.element.thread"?: IThreadsCapability;
+    "m.get_login_token"?: IGetLoginTokenCapability;
+    "org.matrix.msc3882.get_login_token"?: IGetLoginTokenCapability;
+    "m.set_displayname"?: ISetDisplayNameCapability;
+    "m.set_avatar_url"?: ISetAvatarUrlCapability;
+}
+
+type CapabilitiesResponse = {
+    capabilities: Capabilities;
+};
+
+/**
+ * Manages storing and periodically refreshing the server capabilities.
+ */
+export class ServerCapabilities {
+    private capabilities?: Capabilities;
+    private retryTimeout?: ReturnType<typeof setTimeout>;
+    private refreshTimeout?: ReturnType<typeof setInterval>;
+
+    public constructor(private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>) {}
+
+    /**
+     * Starts periodically fetching the server capabilities.
+     */
+    public start(): void {
+        this.poll().then();
+    }
+
+    /**
+     * Stops the service
+     */
+    public stop(): void {
+        this.clearTimeouts();
+    }
+
+    /**
+     * Returns the cached capabilities, or undefined if none are cached.
+     * @returns the current capabilities, if any.
+     */
+    public getCapabilities(): Capabilities | undefined {
+        return this.capabilities;
+    }
+
+    /**
+     * Fetches the latest server capabilities from the homeserver and returns them, or rejects
+     * on failure.
+     */
+    public fetchCapabilities = async (): Promise<Capabilities> => {
+        const resp = await this.http.authedRequest<CapabilitiesResponse>(Method.Get, "/capabilities");
+        this.capabilities = resp["capabilities"];
+        return this.capabilities;
+    };
+
+    private poll = async (): Promise<void> => {
+        try {
+            this.fetchCapabilities();
+            this.clearTimeouts();
+            this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
+            logger.debug("Fetched new server capabilities");
+        } catch (e) {
+            this.clearTimeouts();
+            const howLong = CAPABILITIES_RETRY_MS + Math.random() * 5000;
+            this.retryTimeout = setTimeout(this.poll, howLong);
+            logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
+        }
+    };
+
+    private clearTimeouts(): void {
+        if (this.refreshTimeout) {
+            clearInterval(this.refreshTimeout);
+            this.refreshTimeout = undefined;
+        }
+        if (this.retryTimeout) {
+            clearTimeout(this.retryTimeout);
+            this.retryTimeout = undefined;
+        }
+    }
+}

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -111,7 +111,7 @@ export class ServerCapabilities {
 
     private poll = async (): Promise<void> => {
         try {
-            this.fetchCapabilities();
+            await this.fetchCapabilities();
             this.clearTimeouts();
             this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
             logger.debug("Fetched new server capabilities");

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -117,7 +117,7 @@ export class ServerCapabilities {
             logger.debug("Fetched new server capabilities");
         } catch (e) {
             this.clearTimeouts();
-            const howLong = CAPABILITIES_RETRY_MS + Math.random() * 5000;
+            const howLong = Math.floor(CAPABILITIES_RETRY_MS + Math.random() * 5000);
             this.retryTimeout = setTimeout(this.poll, howLong);
             logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
         }

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -95,7 +95,7 @@ export class ServerCapabilities {
      * Returns the cached capabilities, or undefined if none are cached.
      * @returns the current capabilities, if any.
      */
-    public getCapabilities(): Capabilities | undefined {
+    public getCachedCapabilities(): Capabilities | undefined {
         return this.capabilities;
     }
 

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -21,7 +21,7 @@ import { logger } from "./logger";
 // 6 hours - an arbitrary value, but they should change very infrequently.
 const CAPABILITIES_CACHE_MS = 6 * 60 * 60 * 1000;
 
-// How long we want before rtetrying if we couldn't fetch
+// How long we want before retrying if we couldn't fetch
 const CAPABILITIES_RETRY_MS = 30 * 1000;
 
 export interface ICapability {

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -18,7 +18,7 @@ import { IHttpOpts, MatrixHttpApi, Method } from "./http-api";
 import { logger } from "./logger";
 
 // How often we update the server capabilities.
-// // 6 hours - an arbitrary value, but they should change very infrequently.
+// 6 hours - an arbitrary value, but they should change very infrequently.
 const CAPABILITIES_CACHE_MS = 6 * 60 * 60 * 1000;
 
 // How long we want before rtetrying if we couldn't fetch


### PR DESCRIPTION
& keep them up to date.

I've elected to change the interface here and split it into two functions rather than re-use the same one. That way, the cached one doesn't need to return a promise. This does make it a BREAKING CHANGE. I've given both functions different names so it's obvious that they're different. It's a trivial code update so I don't really think its worth having a backwards compat function?

It also splits some code out of client.ts(!)

Any of the tests that use `runAllTimers()` needed replacing with something that would just run the ones they need, since this works by continually setting a timer to keep the capabilities up to date. I don't think `runAllTimers()` is a sensible thing to use unless you're testing a small piece of code where you know all the timers it's setting.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
