### PR TITLE
Remove redundant hack for using the old pickle key in rust crypto

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -66,26 +66,6 @@ describe("MatrixClient.initRustCrypto", () => {
         expect(databaseNames).toEqual(expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto"]));
     });
 
-    it("should create the meta db if given a pickleKey", async () => {
-        const matrixClient = createClient({
-            baseUrl: "http://test.server",
-            userId: "@alice:localhost",
-            deviceId: "aliceDevice",
-            pickleKey: "testKey",
-        });
-
-        // No databases.
-        expect(await indexedDB.databases()).toHaveLength(0);
-
-        await matrixClient.initRustCrypto();
-
-        // should have two indexed dbs now
-        const databaseNames = (await indexedDB.databases()).map((db) => db.name);
-        expect(databaseNames).toEqual(
-            expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto", "matrix-js-sdk::matrix-sdk-crypto-meta"]),
-        );
-    });
-
     it("should create the meta db if given a storageKey", async () => {
         const matrixClient = createClient({
             baseUrl: "http://test.server",
@@ -470,10 +450,9 @@ describe("MatrixClient.clearStores", () => {
             baseUrl: "http://test.server",
             userId: "@alice:localhost",
             deviceId: "aliceDevice",
-            pickleKey: "testKey",
         });
 
-        await matrixClient.initRustCrypto();
+        await matrixClient.initRustCrypto({ storagePassword: "testKey" });
         expect(await indexedDB.databases()).toHaveLength(2);
         await matrixClient.stopClient();
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2232,9 +2232,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             cryptoCallbacks: this.cryptoCallbacks,
             storePrefix: args.useIndexedDB === false ? null : RUST_SDK_STORE_PREFIX,
             storeKey: args.storageKey,
-
-            // temporary compatibility hack: if there is no storageKey nor storagePassword, fall back to the pickleKey
-            storePassphrase: args.storagePassword ?? this.pickleKey,
+            storePassphrase: args.storagePassword,
 
             legacyCryptoStore: this.cryptoStore,
             legacyPickleKey: this.pickleKey ?? "DEFAULT_KEY",


### PR DESCRIPTION
This was a temporary hack added in https://github.com/matrix-org/matrix-js-sdk/pull/4210 while clients were updated. This has now happened (https://github.com/matrix-org/matrix-react-sdk/pull/12543), so we can remove the hack and bring the behaviour in line with the documentation.

Notes: `MatrixClient.initRustCrypto` no longer uses the `pickleKey` as a passphrase for the rust crypto store. Populate `storagePassword` or `storageKey` to ensure the indexeddb store is encrypted.