### PR TITLE
Fix build for example script

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -3,12 +3,10 @@
     "version": "0.0.0",
     "description": "",
     "main": "app.js",
-    "scripts": {
-        "preinstall": "npm install ../.."
-    },
     "author": "",
     "license": "Apache 2.0",
     "dependencies": {
-        "cli-color": "^1.0.0"
+        "cli-color": "^1.0.0",
+        "matrix-js-sdk": "^32.0.0"
     }
 }


### PR DESCRIPTION
This example seems to have been broken by the switch to Typescript. We can't just symlink in `../..` because that gives us the typescript version of the source, which, obviously, doesn't work in node.

Instead, make sure we use a prebuilt version of the js-sdk.

It's actually even more broken as of js-sdk 33.0.0, thanks to the switch to ES modules (#4187), but we'll get to that later.