### PR TITLE
Remove useless log line

### DIFF
--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -105,10 +105,8 @@ export class RoomEncryptor {
             (member.membership == KnownMembership.Invite && this.room.shouldEncryptForInvitedMembers())
         ) {
             // make sure we are tracking the deviceList for this user
-            logDuration(this.prefixedLogger, "updateTrackedUsers", async () => {
-                this.olmMachine.updateTrackedUsers([new UserId(member.userId)]).catch((e) => {
-                    this.prefixedLogger.error("Unable to update tracked users", e);
-                });
+            this.olmMachine.updateTrackedUsers([new UserId(member.userId)]).catch((e) => {
+                this.prefixedLogger.error("Unable to update tracked users", e);
             });
         }
 


### PR DESCRIPTION
- it was spammy: https://github.com/element-hq/element-web/issues/27031
- it didn't actually log the duration, because the `block` function didn't `await` the inner promise.

This is impacting our ability to debug UTDs on Element-Web due to the spam cycling out useful logs.

Fixes https://github.com/element-hq/element-web/issues/27031
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
