### PR TITLE
Remove redundant `TextEncoder` shim

### DIFF
--- a/src/crypto/aes.ts
+++ b/src/crypto/aes.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { decodeBase64, encodeBase64 } from "../base64";
-import { subtleCrypto, crypto, TextEncoder } from "./crypto";
+import { subtleCrypto, crypto } from "./crypto";
 
 // salt for HKDF, with 8 bytes of zeros
 const zeroSalt = new Uint8Array(8);

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -18,7 +18,6 @@ import { logger } from "../logger";
 
 export let crypto = globalThis.crypto;
 export let subtleCrypto = crypto?.subtle ?? crypto?.webkitSubtle; // TODO: Stop using webkitSubtle fallback
-export let TextEncoder = globalThis.TextEncoder;
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 if (!crypto) {
@@ -31,20 +30,9 @@ if (!crypto) {
 if (!subtleCrypto) {
     subtleCrypto = crypto?.subtle;
 }
-if (!TextEncoder) {
-    try {
-        TextEncoder = require("util").TextEncoder;
-    } catch (e) {
-        logger.error("Failed to load TextEncoder util", e);
-    }
-}
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 export function setCrypto(_crypto: Crypto): void {
     crypto = _crypto;
     subtleCrypto = _crypto.subtle ?? _crypto.webkitSubtle;
-}
-
-export function setTextEncoder(_TextEncoder: typeof TextEncoder): void {
-    TextEncoder = _TextEncoder;
 }

--- a/src/crypto/key_passphrase.ts
+++ b/src/crypto/key_passphrase.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { randomString } from "../randomstring";
-import { subtleCrypto, TextEncoder } from "./crypto";
+import { subtleCrypto } from "./crypto";
 
 const DEFAULT_ITERATIONS = 500000;
 

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { IdTokenClaims, Log, OidcClient, SigninResponse, SigninState, WebStorageStateStore } from "oidc-client-ts";
 
-import { subtleCrypto, TextEncoder } from "../crypto/crypto";
+import { subtleCrypto } from "../crypto/crypto";
 import { logger } from "../logger";
 import { randomString } from "../randomstring";
 import { OidcError } from "./error";

--- a/src/rendezvous/channels/MSC3903ECDHv2RendezvousChannel.ts
+++ b/src/rendezvous/channels/MSC3903ECDHv2RendezvousChannel.ts
@@ -26,7 +26,7 @@ import {
     LegacyRendezvousFailureReason as RendezvousFailureReason,
 } from "..";
 import { encodeUnpaddedBase64, decodeBase64 } from "../../base64";
-import { crypto, subtleCrypto, TextEncoder } from "../../crypto/crypto";
+import { crypto, subtleCrypto } from "../../crypto/crypto";
 import { generateDecimalSas } from "../../crypto/verification/SASDecimal";
 import { UnstableValue } from "../../NamespacedValue";
 


### PR DESCRIPTION
I believe the only reason we had this was that, before Node v11.0, `TextEncoder` wasn't available in the global object. Nowadays it is (see https://nodejs.org/api/util.html#class-utiltextencoder), so let's get rid of it.