### PR TITLE
Bump node.js requirement to 20.

### DIFF
--- a/.github/workflows/release-make.yml
+++ b/.github/workflows/release-make.yml
@@ -116,6 +116,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install dependencies
               run: "yarn install --frozen-lockfile"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,6 +25,7 @@ jobs:
               with:
                   cache: "yarn"
                   registry-url: "https://registry.npmjs.org"
+                  node-version-file: package.json
 
             - name: 🔨 Install dependencies
               run: "yarn install --frozen-lockfile"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: 🔨 Install dependencies
               run: "yarn install --frozen-lockfile"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -18,6 +18,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install Deps
               run: "yarn install"
@@ -44,6 +45,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install Deps
               run: "yarn install"
@@ -60,6 +62,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install Deps
               run: "yarn install --frozen-lockfile"
@@ -76,6 +79,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install Deps
               run: "yarn install"
@@ -100,6 +104,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   cache: "yarn"
+                  node-version-file: package.json
 
             - name: Install Deps
               run: "yarn install --frozen-lockfile"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 specs: [integ, unit]
-                node: [18, "lts/*", 21]
+                node: ["lts/*", 21, 22]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "33.1.0",
     "description": "Matrix Client-Server SDK for Javascript",
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "scripts": {
         "prepack": "yarn build",


### PR DESCRIPTION
According to https://github.com/matrix-org/matrix-js-sdk?tab=readme-ov-file#supported-platforms, we *only* support the latest LTS release (which is currently 20, per https://github.com/nodejs/release#release-schedule), so this should be safe.