### PR TITLE
Add ability to choose how many timeline events to sync when peeking

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -2281,7 +2281,7 @@ describe("MatrixClient syncing", () => {
             httpBackend!.expectedRequests = [];
         });
 
-        it("should return a room based on the room initialSync API", async () => {
+        it.each([undefined, 100])("should return a room based on the room initialSync API with limit %s", async (limit) => {
             httpBackend!.when("GET", `/rooms/${encodeURIComponent(roomOne)}/initialSync`).respond(200, {
                 room_id: roomOne,
                 membership: KnownMembership.Leave,
@@ -2328,7 +2328,7 @@ describe("MatrixClient syncing", () => {
             });
             httpBackend!.when("GET", "/events").respond(200, { chunk: [] });
 
-            const prom = client!.peekInRoom(roomOne);
+            const prom = client!.peekInRoom(roomOne, limit);
             await httpBackend!.flushAllExpected();
             const room = await prom;
 

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -2281,67 +2281,70 @@ describe("MatrixClient syncing", () => {
             httpBackend!.expectedRequests = [];
         });
 
-        it.each([undefined, 100])("should return a room based on the room initialSync API with limit %s", async (limit) => {
-            httpBackend!.when("GET", `/rooms/${encodeURIComponent(roomOne)}/initialSync`).respond(200, {
-                room_id: roomOne,
-                membership: KnownMembership.Leave,
-                messages: {
-                    start: "start",
-                    end: "end",
-                    chunk: [
+        it.each([undefined, 100])(
+            "should return a room based on the room initialSync API with limit %s",
+            async (limit) => {
+                httpBackend!.when("GET", `/rooms/${encodeURIComponent(roomOne)}/initialSync`).respond(200, {
+                    room_id: roomOne,
+                    membership: KnownMembership.Leave,
+                    messages: {
+                        start: "start",
+                        end: "end",
+                        chunk: [
+                            {
+                                content: { body: "Message 1" },
+                                type: "m.room.message",
+                                event_id: "$eventId1",
+                                sender: userA,
+                                origin_server_ts: 12313525,
+                                room_id: roomOne,
+                            },
+                            {
+                                content: { body: "Message 2" },
+                                type: "m.room.message",
+                                event_id: "$eventId2",
+                                sender: userB,
+                                origin_server_ts: 12315625,
+                                room_id: roomOne,
+                            },
+                        ],
+                    },
+                    state: [
                         {
-                            content: { body: "Message 1" },
-                            type: "m.room.message",
-                            event_id: "$eventId1",
+                            content: { name: "Room Name" },
+                            type: "m.room.name",
+                            event_id: "$eventId",
                             sender: userA,
-                            origin_server_ts: 12313525,
-                            room_id: roomOne,
-                        },
-                        {
-                            content: { body: "Message 2" },
-                            type: "m.room.message",
-                            event_id: "$eventId2",
-                            sender: userB,
-                            origin_server_ts: 12315625,
+                            origin_server_ts: 12314525,
+                            state_key: "",
                             room_id: roomOne,
                         },
                     ],
-                },
-                state: [
-                    {
-                        content: { name: "Room Name" },
-                        type: "m.room.name",
-                        event_id: "$eventId",
-                        sender: userA,
-                        origin_server_ts: 12314525,
-                        state_key: "",
-                        room_id: roomOne,
-                    },
-                ],
-                presence: [
-                    {
-                        content: {},
-                        type: "m.presence",
-                        sender: userA,
-                    },
-                ],
-            });
-            httpBackend!.when("GET", "/events").respond(200, { chunk: [] });
+                    presence: [
+                        {
+                            content: {},
+                            type: "m.presence",
+                            sender: userA,
+                        },
+                    ],
+                });
+                httpBackend!.when("GET", "/events").respond(200, { chunk: [] });
 
-            const prom = client!.peekInRoom(roomOne, limit);
-            await httpBackend!.flushAllExpected();
-            const room = await prom;
+                const prom = client!.peekInRoom(roomOne, limit);
+                await httpBackend!.flushAllExpected();
+                const room = await prom;
 
-            expect(room.roomId).toBe(roomOne);
-            expect(room.getMyMembership()).toBe(KnownMembership.Leave);
-            expect(room.name).toBe("Room Name");
-            expect(room.currentState.getStateEvents("m.room.name", "")?.getId()).toBe("$eventId");
-            expect(room.timeline[0].getContent().body).toBe("Message 1");
-            expect(room.timeline[1].getContent().body).toBe("Message 2");
-            client?.stopPeeking();
-            httpBackend!.when("GET", "/events").respond(200, { chunk: [] });
-            await httpBackend!.flushAllExpected();
-        });
+                expect(room.roomId).toBe(roomOne);
+                expect(room.getMyMembership()).toBe(KnownMembership.Leave);
+                expect(room.name).toBe("Room Name");
+                expect(room.currentState.getStateEvents("m.room.name", "")?.getId()).toBe("$eventId");
+                expect(room.timeline[0].getContent().body).toBe("Message 1");
+                expect(room.timeline[1].getContent().body).toBe("Message 2");
+                client?.stopPeeking();
+                httpBackend!.when("GET", "/events").respond(200, { chunk: [] });
+                await httpBackend!.flushAllExpected();
+            },
+        );
     });
 
     describe("user account data", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -6603,13 +6603,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * Peek into a room and receive updates about the room. This only works if the
      * history visibility for the room is world_readable.
      * @param roomId - The room to attempt to peek into.
+     * @param limit - The number of timeline events to initially retrieve.
      * @returns Promise which resolves: Room object
      * @returns Rejects: with an error response.
      */
-    public peekInRoom(roomId: string): Promise<Room> {
+    public peekInRoom(roomId: string, limit: number = 20): Promise<Room> {
         this.peekSync?.stopPeeking();
         this.peekSync = new SyncApi(this, this.clientOpts, this.buildSyncApiOptions());
-        return this.peekSync.peek(roomId);
+        return this.peekSync.peek(roomId, limit);
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -401,17 +401,18 @@ export class SyncApi {
      * Peek into a room. This will result in the room in question being synced so it
      * is accessible via getRooms(). Live updates for the room will be provided.
      * @param roomId - The room ID to peek into.
+     * @param limit - The number of timeline events to initially retrieve.
      * @returns A promise which resolves once the room has been added to the
      * store.
      */
-    public peek(roomId: string): Promise<Room> {
+    public peek(roomId: string, limit: number = 20): Promise<Room> {
         if (this._peekRoom?.roomId === roomId) {
             return Promise.resolve(this._peekRoom);
         }
 
         const client = this.client;
         this._peekRoom = this.createRoom(roomId);
-        return this.client.roomInitialSync(roomId, 20).then((response) => {
+        return this.client.roomInitialSync(roomId, limit).then((response) => {
             if (this._peekRoom?.roomId !== roomId) {
                 throw new Error("Peeking aborted");
             }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
If a user has left a room but wants to see a snapshot of what it looked like when they left, they would peek into the room.

In some use cases, it makes sense to sync many more than the hardcoded 20 timeline events.

Since it seems like something that all users could benefit from, I figured I would submit it as an upstream PR.

## Checklist

-   [x] Tests written for new code (and old code if feasible).
    - _Extended existing test suite to cover new parameter_
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Signed-off-by: Joel Garplind [joel.garplind+github@gmail.com](mailto:joel.garplind+github@gmail.com)
