### PR TITLE
Support Futures via widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "jwt-decode": "^4.0.0",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.6.0",
+        "matrix-widget-api": "^1.8.1",
         "oidc-client-ts": "^3.0.1",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",

--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -268,7 +268,8 @@ describe("MSC4108SignInWithQR", () => {
         it("should abort if device doesn't come up by timeout", async () => {
             jest.spyOn(global, "setTimeout").mockImplementation((fn) => {
                 (<Function>fn)();
-                return -1;
+                // TODO: mock timers properly
+                return -1 as any;
             });
             jest.spyOn(Date, "now").mockImplementation(() => {
                 return 12345678 + mocked(setTimeout).mock.calls.length * 1000;
@@ -320,7 +321,8 @@ describe("MSC4108SignInWithQR", () => {
         it("should not send secrets if user cancels", async () => {
             jest.spyOn(global, "setTimeout").mockImplementation((fn) => {
                 (<Function>fn)();
-                return -1;
+                // TODO: mock timers properly
+                return -1 as any;
             });
 
             await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);

--- a/src/client.ts
+++ b/src/client.ts
@@ -535,7 +535,7 @@ export const UNSTABLE_MSC2666_SHARED_ROOMS = "uk.half-shot.msc2666";
 export const UNSTABLE_MSC2666_MUTUAL_ROOMS = "uk.half-shot.msc2666.mutual_rooms";
 export const UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_mutual_rooms";
 
-const UNSTABLE_MSC4140_DELAYED_EVENTS = "org.matrix.msc4140";
+export const UNSTABLE_MSC4140_DELAYED_EVENTS = "org.matrix.msc4140";
 
 enum CrossSigningKeyType {
     MasterKey = "master_key",

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -26,8 +26,13 @@ import {
 } from "matrix-widget-api";
 
 import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event";
-import { ISendEventResponse, SendDelayedEventRequestOpts, SendDelayedEventResponse } from "./@types/requests";
-import { EventType } from "./@types/event";
+import {
+    ISendEventResponse,
+    SendDelayedEventRequestOpts,
+    SendDelayedEventResponse,
+    UpdateDelayedEventAction,
+} from "./@types/requests";
+import { EventType, StateEvents } from "./@types/event";
 import { logger } from "./logger";
 import {
     MatrixClient,
@@ -36,6 +41,7 @@ import {
     IStartClientOpts,
     SendToDeviceContentMap,
     IOpenIDToken,
+    UNSTABLE_MSC4140_DELAYED_EVENTS,
 } from "./client";
 import { SyncApi, SyncState } from "./sync";
 import { SlidingSyncSdk } from "./sliding-sync-sdk";
@@ -95,6 +101,20 @@ export interface ICapabilities {
      * @defaultValue false
      */
     turnServers?: boolean;
+
+    /**
+     * Whether this client needs to be able to send delayed events.
+     * @experimental Part of MSC4140 & MSC4157
+     * @defaultValue false
+     */
+    sendDelayedEvents?: boolean;
+
+    /**
+     * Whether this client needs to be able to update delayed events.
+     * @experimental Part of MSC4140 & MSC4157
+     * @defaultValue false
+     */
+    updateDelayedEvents?: boolean;
 }
 
 /**
@@ -162,6 +182,18 @@ export class RoomWidgetClient extends MatrixClient {
         );
         capabilities.sendToDevice?.forEach((eventType) => widgetApi.requestCapabilityToSendToDevice(eventType));
         capabilities.receiveToDevice?.forEach((eventType) => widgetApi.requestCapabilityToReceiveToDevice(eventType));
+        if (
+            capabilities.sendDelayedEvents &&
+            (capabilities.sendEvent?.length ||
+                capabilities.sendMessage === true ||
+                (Array.isArray(capabilities.sendMessage) && capabilities.sendMessage.length) ||
+                capabilities.sendState?.length)
+        ) {
+            widgetApi.requestCapability(MatrixCapabilities.MSC4157SendDelayedEvent);
+        }
+        if (capabilities.updateDelayedEvents) {
+            widgetApi.requestCapability(MatrixCapabilities.MSC4157UpdateDelayedEvent);
+        }
         if (capabilities.turnServers) {
             widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
         }
@@ -260,8 +292,17 @@ export class RoomWidgetClient extends MatrixClient {
         delayOpts?: SendDelayedEventRequestOpts,
     ): Promise<ISendEventResponse | SendDelayedEventResponse> {
         if (delayOpts) {
-            throw new Error("Delayed event sending via widgets is not implemented");
+            // TODO: updatePendingEvent for delayed events?
+            const response = await this.widgetApi.sendRoomEvent(
+                event.getType(),
+                event.getContent(),
+                room.roomId,
+                "delay" in delayOpts ? delayOpts.delay : undefined,
+                "parent_delay_id" in delayOpts ? delayOpts.parent_delay_id : undefined,
+            );
+            return this.validateSendDelayedEventResponse(response);
         }
+
         let response: ISendEventFromWidgetResponseData;
         try {
             response = await this.widgetApi.sendRoomEvent(event.getType(), event.getContent(), room.roomId);
@@ -270,6 +311,7 @@ export class RoomWidgetClient extends MatrixClient {
             throw e;
         }
 
+        // This also checks for an event id on the response
         room.updatePendingEvent(event, EventStatus.SENT, response.event_id);
         return { event_id: response.event_id! };
     }
@@ -280,7 +322,56 @@ export class RoomWidgetClient extends MatrixClient {
         content: any,
         stateKey = "",
     ): Promise<ISendEventResponse> {
-        return (await this.widgetApi.sendStateEvent(eventType, stateKey, content, roomId)) as ISendEventResponse;
+        const response = await this.widgetApi.sendStateEvent(eventType, stateKey, content, roomId);
+        if (response.event_id === undefined) {
+            throw new Error("'event_id' absent from response to an event request");
+        }
+        return { event_id: response.event_id };
+    }
+
+    /**
+     * @experimental This currently relies on an unstable MSC (MSC4140).
+     */
+    // eslint-disable-next-line
+    public async _unstable_sendDelayedStateEvent<K extends keyof StateEvents>(
+        roomId: string,
+        delayOpts: SendDelayedEventRequestOpts,
+        eventType: K,
+        content: StateEvents[K],
+        stateKey = "",
+    ): Promise<SendDelayedEventResponse> {
+        if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4140_DELAYED_EVENTS))) {
+            throw Error("Server does not support the delayed events API");
+        }
+
+        const response = await this.widgetApi.sendStateEvent(
+            eventType,
+            stateKey,
+            content,
+            roomId,
+            "delay" in delayOpts ? delayOpts.delay : undefined,
+            "parent_delay_id" in delayOpts ? delayOpts.parent_delay_id : undefined,
+        );
+        return this.validateSendDelayedEventResponse(response);
+    }
+
+    private validateSendDelayedEventResponse(response: ISendEventFromWidgetResponseData): SendDelayedEventResponse {
+        if (response.delay_id === undefined) {
+            throw new Error("'delay_id' absent from response to a delayed event request");
+        }
+        return { delay_id: response.delay_id };
+    }
+
+    /**
+     * @experimental This currently relies on an unstable MSC (MSC4140).
+     */
+    // eslint-disable-next-line
+    public async _unstable_updateDelayedEvent(delayId: string, action: UpdateDelayedEventAction): Promise<{}> {
+        if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4140_DELAYED_EVENTS))) {
+            throw Error("Server does not support the delayed events API");
+        }
+
+        return await this.widgetApi.updateDelayedEvent(delayId, action);
     }
 
     public async sendToDevice(eventType: string, contentMap: SendToDeviceContentMap): Promise<{}> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4722,10 +4722,10 @@ matrix-mock-request@^2.5.0:
   dependencies:
     expect "^28.1.0"
 
-matrix-widget-api@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.7.0.tgz#ae3b44380f11bb03519d0bf0373dfc3341634667"
-  integrity sha512-dzSnA5Va6CeIkyWs89xZty/uv38HLyfjOrHGbbEikCa2ZV0HTkUNtrBMKlrn4CRYyDJ6yoO/3ssRwiR0jJvOkQ==
+matrix-widget-api@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.8.1.tgz#90fe4814956a27d6c6cff55c2aa67da516722eb1"
+  integrity sha512-oISJ9rmkfxNonrrWKUB2HCwj0i+J0b7zNGqwNudOjXj9Jsv7r8UWqowE7AEWyAsPp4IwW/hEvNeLbNo2wUsXwg==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

Dependencies:
- https://github.com/matrix-org/matrix-js-sdk/pull/4294
- https://github.com/matrix-org/matrix-widget-api/pull/92

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
