### PR TITLE
Add index.ts for matrixrtc module

### DIFF
--- a/src/matrixrtc/index.ts
+++ b/src/matrixrtc/index.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from "./CallMembership";
+export * from "./focus";
+export * from "./LivekitFocus";
+export * from "./MatrixRTCSession";
+export * from "./MatrixRTCSessionManager";
+export * from "./types";


### PR DESCRIPTION
This is required so we can (finally) remove the react-sdk import eslint exception comments.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
