### PR TITLE
Remove the compare function from utils

### DIFF
--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1199,6 +1199,20 @@ describe("Room", function () {
 
                 expect(spy).toHaveBeenCalledWith(summary);
             });
+
+            it("recalculates in acceptable time without heroes", function () {
+                for (let i = 0; i < 10000; i++) {
+                    addMember(`@person${i}:bar`, KnownMembership.Join, { name: `Person ${i % 20} ${i % 10} ${i % 3}` });
+                }
+
+                // This isn't a real performance test and has plenty of headroom because github
+                // runners don't offer any kind of speed consistency guarantee, but this should at
+                // least assert that the perf doesn't suddenly become n^2.
+                const start = performance.now();
+                room.recalculate();
+                const duration = performance.now() - start;
+                expect(duration).toBeLessThan(50);
+            });
         });
 
         describe("Room.recalculate => Room Name", function () {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1396,7 +1396,7 @@ describe("Room", function () {
         });
 
         it("recalculates in acceptable time without heroes", function () {
-            for (let i = 0; i < 10000; i++) {
+            for (let i = 0; i < 5000; i++) {
                 addMember(`@person${i}:bar`, KnownMembership.Join, { name: `Person ${i % 20} ${i % 10} ${i % 3}` });
             }
 
@@ -1408,7 +1408,7 @@ describe("Room", function () {
                 room.recalculate();
             }
             const duration = performance.now() - start;
-            expect(duration).toBeLessThan(500);
+            expect(duration).toBeLessThan(200);
         });
     });
 

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -1199,20 +1199,6 @@ describe("Room", function () {
 
                 expect(spy).toHaveBeenCalledWith(summary);
             });
-
-            it("recalculates in acceptable time without heroes", function () {
-                for (let i = 0; i < 10000; i++) {
-                    addMember(`@person${i}:bar`, KnownMembership.Join, { name: `Person ${i % 20} ${i % 10} ${i % 3}` });
-                }
-
-                // This isn't a real performance test and has plenty of headroom because github
-                // runners don't offer any kind of speed consistency guarantee, but this should at
-                // least assert that the perf doesn't suddenly become n^2.
-                const start = performance.now();
-                room.recalculate();
-                const duration = performance.now() - start;
-                expect(duration).toBeLessThan(50);
-            });
         });
 
         describe("Room.recalculate => Room Name", function () {
@@ -1407,6 +1393,22 @@ describe("Room", function () {
                 const name = room.name;
                 expect(name).toEqual(userB);
             });
+        });
+
+        it("recalculates in acceptable time without heroes", function () {
+            for (let i = 0; i < 10000; i++) {
+                addMember(`@person${i}:bar`, KnownMembership.Join, { name: `Person ${i % 20} ${i % 10} ${i % 3}` });
+            }
+
+            // This isn't a real performance test and has plenty of headroom because github
+            // runners don't offer any kind of speed consistency guarantee, but this should at
+            // least assert that the perf doesn't suddenly become n^2.
+            const start = performance.now();
+            for (let i = 0; i < 50; i++) {
+                room.recalculate();
+            }
+            const duration = performance.now() - start;
+            expect(duration).toBeLessThan(500);
         });
     });
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -24,7 +24,7 @@ import {
 } from "./event-timeline-set";
 import { Direction, EventTimeline } from "./event-timeline";
 import { getHttpUriForMxc } from "../content-repo";
-import { compare, removeElement } from "../utils";
+import { removeElement } from "../utils";
 import { normalize, noUnsafeEventProps } from "../utils";
 import { IEvent, IThreadBundledRelationship, MatrixEvent, MatrixEventEvent, MatrixEventHandlerMap } from "./event";
 import { EventStatus } from "./event-status";
@@ -3451,7 +3451,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
                 return true;
             });
             // make sure members have stable order
-            otherMembers.sort((a, b) => compare(a.userId, b.userId));
+            const collator = new Intl.Collator();
+            otherMembers.sort((a, b) => collator.compare(a.userId, b.userId));
             // only 5 first members, immitate summaryHeroes
             otherMembers = otherMembers.slice(0, 5);
             otherNames = otherMembers.map((m) => m.name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -649,16 +649,6 @@ export function lexicographicCompare(a: string, b: string): number {
     }
 }
 
-const collator = new Intl.Collator();
-/**
- * Performant language-sensitive string comparison
- * @param a - the first string to compare
- * @param b - the second string to compare
- */
-export function compare(a: string, b: string): number {
-    return collator.compare(a, b);
-}
-
 /**
  * This function is similar to Object.assign() but it assigns recursively and
  * allows you to ignore nullish values from the source


### PR DESCRIPTION
and change the one use of it to just intantiate a collator and use it.

This was marked as internal module so this shouldn't be a breaking change. Of course, react-sdk was using it.

Requires: https://github.com/matrix-org/matrix-react-sdk/pull/12782

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
