### PR TITLE
Be specific about what is considered a MSC4143 call member event.

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -169,7 +169,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                     continue;
                 }
                 membershipContents = content["memberships"];
-            } else {
+            } else if ("focus_active" in content) {
                 // We have a MSC4143 event membership event
                 if (Object.keys(content).length !== 0) {
                     // We checked for empty content to not try to construct CallMembership's with {}.

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -160,6 +160,10 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         const callMemberships: CallMembership[] = [];
         for (const memberEvent of callMemberEvents) {
             const content = memberEvent.getContent();
+
+            // Dont even bother about empty events (saves us from costly type/"key in" checks in bigger rooms)
+            if (Object.keys(content).length === 0) continue;
+
             let membershipContents: any[] = [];
             // We first decide if its a MSC4143 event (per device state key)
             if ("memberships" in content) {
@@ -173,9 +177,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 // We have a MSC4143 event membership event
                 membershipContents.push(content);
             }
-            if (membershipContents.length === 0) {
-                continue;
-            }
+
+            if (membershipContents.length === 0) continue;
 
             for (const membershipData of membershipContents) {
                 try {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -165,17 +165,18 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             if (Object.keys(content).length === 0) continue;
 
             let membershipContents: any[] = [];
+
             // We first decide if its a MSC4143 event (per device state key)
-            if ("memberships" in content) {
+            if ("focus_active" in content) {
+                // We have a MSC4143 event membership event
+                membershipContents.push(content);
+            } else if ("memberships" in content) {
                 // we have a legacy (one event for all devices) event
                 if (!Array.isArray(content["memberships"])) {
                     logger.warn(`Malformed member event from ${memberEvent.getSender()}: memberships is not an array`);
                     continue;
                 }
                 membershipContents = content["memberships"];
-            } else if ("focus_active" in content) {
-                // We have a MSC4143 event membership event
-                membershipContents.push(content);
             }
 
             if (membershipContents.length === 0) continue;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -160,17 +160,17 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         const callMemberships: CallMembership[] = [];
         for (const memberEvent of callMemberEvents) {
             const content = memberEvent.getContent();
-
+            const eventKeysCount = Object.keys(content).length;
             // Dont even bother about empty events (saves us from costly type/"key in" checks in bigger rooms)
-            if (Object.keys(content).length === 0) continue;
+            if (eventKeysCount === 0) continue;
 
             let membershipContents: any[] = [];
 
             // We first decide if its a MSC4143 event (per device state key)
-            if ("focus_active" in content) {
+            if (eventKeysCount > 1 && "focus_active" in content) {
                 // We have a MSC4143 event membership event
                 membershipContents.push(content);
-            } else if ("memberships" in content) {
+            } else if (eventKeysCount === 1 && "memberships" in content) {
                 // we have a legacy (one event for all devices) event
                 if (!Array.isArray(content["memberships"])) {
                     logger.warn(`Malformed member event from ${memberEvent.getSender()}: memberships is not an array`);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -171,10 +171,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 membershipContents = content["memberships"];
             } else if ("focus_active" in content) {
                 // We have a MSC4143 event membership event
-                if (Object.keys(content).length !== 0) {
-                    // We checked for empty content to not try to construct CallMembership's with {}.
-                    membershipContents.push(content);
-                }
+                membershipContents.push(content);
             }
             if (membershipContents.length === 0) {
                 continue;


### PR DESCRIPTION
This is a solution (I am not sure it can be considered a actual fix. see below for additional thoughts on this) for EW exccessive logging for thirdroom rooms.

We do run checks on m.call.member events to check if the event can be considered a legacy event or a new session type event. This check does not consider that there is also a third content format created by thirdroom.

Hence we need to be more explicit to not consider third room call member events as session type events.


A more proper solution (that also was discussed is to rename the event type `org.matrix.msc3401.call.member`->`org.matrix.msc4143.call.member` comes to mind)
This is a much more breaking change however so we first go with this first reduce the logging step is a better first step.
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
