### PR TITLE
Include redundant members in most timeline filters

### DIFF
--- a/spec/integ/matrix-client-event-timeline.spec.ts
+++ b/spec/integ/matrix-client-event-timeline.spec.ts
@@ -747,7 +747,7 @@ describe("MatrixClient event timelines", function () {
                 };
             });
             req.check((request) => {
-                expect(request.queryParams?.filter).toEqual(JSON.stringify(Filter.LAZY_LOADING_MESSAGES_FILTER));
+                expect(request.queryParams?.filter).toEqual(JSON.stringify(Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER));
             });
 
             await Promise.all([
@@ -1781,6 +1781,7 @@ describe("MatrixClient event timelines", function () {
                 expect(request.queryParams?.filter).toEqual(
                     JSON.stringify({
                         lazy_load_members: true,
+                        include_redundant_members: true,
                     }),
                 );
             });

--- a/src/client.ts
+++ b/src/client.ts
@@ -5946,7 +5946,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         let params: Record<string, string | string[]> | undefined = undefined;
         if (this.clientOpts?.lazyLoadMembers) {
-            params = { filter: JSON.stringify(Filter.LAZY_LOADING_MESSAGES_FILTER) };
+            params = { filter: JSON.stringify(Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER) };
         }
 
         // TODO: we should implement a backoff (as per scrollback()) to deal more nicely with HTTP errors.
@@ -6024,7 +6024,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             limit: "0",
         };
         if (this.clientOpts?.lazyLoadMembers) {
-            params.filter = JSON.stringify(Filter.LAZY_LOADING_MESSAGES_FILTER);
+            params.filter = JSON.stringify(Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER);
         }
 
         // TODO: we should implement a backoff (as per scrollback()) to deal more nicely with HTTP errors.
@@ -6204,7 +6204,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 dir: "b",
             };
             if (this.clientOpts?.lazyLoadMembers) {
-                params.filter = JSON.stringify(Filter.LAZY_LOADING_MESSAGES_FILTER);
+                params.filter = JSON.stringify(Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER);
             }
 
             const res = await this.http.authedRequest<IMessagesResponse>(Method.Get, messagesPath, params);
@@ -6249,7 +6249,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (this.clientOpts?.lazyLoadMembers) {
             // create a shallow copy of LAZY_LOADING_MESSAGES_FILTER,
             // so the timelineFilter doesn't get written into it below
-            filter = Object.assign({}, Filter.LAZY_LOADING_MESSAGES_FILTER);
+            filter = Object.assign({}, Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER);
         }
         if (timelineFilter) {
             // XXX: it's horrific that /messages' filter parameter doesn't match
@@ -6295,10 +6295,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         let filter: IRoomEventFilter = {};
         if (this.clientOpts?.lazyLoadMembers) {
-            // create a shallow copy of LAZY_LOADING_MESSAGES_FILTER,
+            // create a shallow copy of LAZY_LOADING_MESSAGES_REDUNDANT_FILTER,
             // so the timelineFilter doesn't get written into it below
             filter = {
-                ...Filter.LAZY_LOADING_MESSAGES_FILTER,
+                ...Filter.LAZY_LOADING_MESSAGES_REDUNDANT_FILTER,
             };
         }
         if (timelineFilter) {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -74,6 +74,11 @@ export class Filter {
         lazy_load_members: true,
     };
 
+    public static LAZY_LOADING_MESSAGES_REDUNDANT_FILTER = {
+        lazy_load_members: true,
+        include_redundant_members: true
+    };
+
     /**
      * Create a filter from existing data.
      */

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -76,7 +76,7 @@ export class Filter {
 
     public static LAZY_LOADING_MESSAGES_REDUNDANT_FILTER = {
         lazy_load_members: true,
-        include_redundant_members: true
+        include_redundant_members: true,
     };
 
     /**


### PR DESCRIPTION
Synapse never tries to avoid redundant members anyway, so it's hard to ensure that it works correctly (https://github.com/element-hq/synapse/blob/568051c0f07393b786b9d813a1db53dd332c9fc2/synapse/handlers/pagination.py#L639) 
It also seems like it would be difficult when the "Show current profile picture and name for users in message history" option is turned off

Conduwuit and Dendrite do attempt to remove redundant members, and it seems to cause some problems, so this commit tells them to include redundant members

Similar to element-hq/element-web#7417, which is also why there might still be missing data in rare cases after this

element-web notes: Fix some cases where profiles would be missing when using conduwuit or dendrite

Signed-off-by: morguldir <morguldir@protonmail.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
