### PR TITLE
Fix comment for useAuthorizationHeader config.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -324,10 +324,13 @@ export interface ICreateClientOpts {
     localTimeoutMs?: number;
 
     /**
-     * Set to true to use
-     * Authorization header instead of query param to send the access token to the server.
+     * Set to false to send the access token to the server via a query parameter rather
+     * than the Authorization HTTP header.
      *
-     * Default false.
+     * Note that as of v1.11 of the Matrix spec, sending the access token via a query
+     * is deprecated.
+     *
+     * Default true.
      */
     useAuthorizationHeader?: boolean;
 


### PR DESCRIPTION
It looks like the default value for this config option was changed, but the comment wasn't updated.  The comment at https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/http-api/interface.ts#L56 was updated, and https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/http-api/fetch.ts#L48 is where the default value gets applied.

And while I'm here, added a note that using the query param is deprecated.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
