### PR TITLE
Bump matrix-widget-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "jwt-decode": "^4.0.0",
         "loglevel": "^1.7.1",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.8.1",
+        "matrix-widget-api": "^1.8.2",
         "oidc-client-ts": "^3.0.1",
         "p-retry": "4",
         "sdp-transform": "^2.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4722,10 +4722,10 @@ matrix-mock-request@^2.5.0:
   dependencies:
     expect "^28.1.0"
 
-matrix-widget-api@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.8.1.tgz#90fe4814956a27d6c6cff55c2aa67da516722eb1"
-  integrity sha512-oISJ9rmkfxNonrrWKUB2HCwj0i+J0b7zNGqwNudOjXj9Jsv7r8UWqowE7AEWyAsPp4IwW/hEvNeLbNo2wUsXwg==
+matrix-widget-api@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.8.2.tgz#28d344502a85593740f560b0f8120e474a054505"
+  integrity sha512-kdmks3CvFNPIYN669Y4rO13KrazDvX8KHC7i6jOzJs8uZ8s54FNkuRVVyiQHeVCSZG5ixUqW9UuCj9lf03qxTQ==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
This is to get https://github.com/matrix-org/matrix-widget-api/pull/97.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
