### PR TITLE
When state says you've left ongoing call, rejoin

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -777,8 +777,6 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 logger.warn("Missing own membership: force re-join");
                 // TODO: Should this be awaited? And is there anything to tell the focus?
                 this.triggerCallMembershipEventUpdate();
-                // TODO: Is this needed?
-                this.emit(MatrixRTCSessionEvent.JoinStateChanged, true);
             }
         }
 


### PR DESCRIPTION
When receiving a state change that says you are no longer a member of a RTC session that you are actually still participating in, send another state event to put yourself back in the session membership.

This can happen when an administrator overwrites your call membership event (which is allowed even with MSC3757's restrictions on state), or if your delayed disconnection event (via MSC4140) timed out before your client could send a heartbeat to delay it further.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
