### PR TITLE
Resend MatrixRTC encryption keys if a membership has changed

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -640,9 +640,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
     };
 
-    private isMyMembership(m: CallMembership): boolean {
-        return m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
-    }
+    private isMyMembership = (m: CallMembership): boolean =>
+        m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
 
     /**
      * Examines the latest call memberships and handles any encryption key sending or rotation that is needed.

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -650,7 +650,6 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      */
     public onMembershipUpdate = (): void => {
         const oldMemberships = this.memberships;
-        const oldFingerprints = this.lastMembershipFingerprints;
         this.memberships = MatrixRTCSession.callMembershipsForRoom(this.room);
 
         this._callId = this._callId ?? this.memberships[0]?.callId;
@@ -677,6 +676,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             const anyLeft = Array.from(oldMembershipIds).some((x) => !newMembershipIds.has(x));
             const anyJoined = Array.from(newMembershipIds).some((x) => !oldMembershipIds.has(x));
 
+            const oldFingerprints = this.lastMembershipFingerprints;
             // always store the fingerprints of these latest memberships
             this.storeLastMembershipFingerprints();
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -644,6 +644,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         return m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
     }
 
+    /**
+     * Examines the latest call memberships and handles any encryption key sending or rotation that is needed.
+     *
+     * This function should be called when the room members or call memberships might have changed.
+     */
     public onMembershipUpdate = (): void => {
         const oldMemberships = this.memberships;
         this.memberships = MatrixRTCSession.callMembershipsForRoom(this.room);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -671,6 +671,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 this.memberships.filter((m) => !this.isMyMembership(m)).map(getParticipantIdFromMembership),
             );
 
+            // We can use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference
+            // for this once available
             const anyLeft = Array.from(oldMembershipIds).some((x) => !newMembershipIds.has(x));
             const anyJoined = Array.from(newMembershipIds).some((x) => !oldMembershipIds.has(x));
 
@@ -686,6 +688,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 this.storeLastMembershipFingerprints();
                 const newFingerprints = this.lastMembershipFingerprints;
 
+                // We can use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference
+                // for this once available
                 const candidateUpdates =
                     Array.from(oldFingerprints).some((x) => !newFingerprints.has(x)) ||
                     Array.from(newFingerprints).some((x) => !oldFingerprints.has(x));


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

This fixes https://github.com/element-hq/element-call/issues/2415 by having call participants proactively sending a  new `io.element.call.encryption_keys` room event with the same key if they detect that another participants has updated the `membershipID` or `created_ts` part of their call membership.

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
