### PR TITLE
Handle MatrixRTC encryption keys arriving out of order

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -438,16 +438,18 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
 
         const existingKeyAtIndex = participantKeys[encryptionKeyIndex];
 
-        if (existingKeyAtIndex && existingKeyAtIndex.timestamp > timestamp) {
-            logger.info(
-                `Ignoring new key at index ${encryptionKeyIndex} for ${participantId} as it is older than existing known key`,
-            );
-            return;
-        }
+        if (existingKeyAtIndex) {
+            if (existingKeyAtIndex.timestamp > timestamp) {
+                logger.info(
+                    `Ignoring new key at index ${encryptionKeyIndex} for ${participantId} as it is older than existing known key`,
+                );
+                return;
+            }
 
-        if (existingKeyAtIndex && keysEqual(existingKeyAtIndex.key, keyBin)) {
-            existingKeyAtIndex.timestamp = timestamp;
-            return;
+            if (keysEqual(existingKeyAtIndex.key, keyBin)) {
+                existingKeyAtIndex.timestamp = timestamp;
+                return;
+            }
         }
 
         participantKeys[encryptionKeyIndex] = {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -382,7 +382,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      * @returns The encryption keys for the given participant, or undefined if they are not known.
      */
     public getKeysForParticipant(userId: string, deviceId: string): Array<Uint8Array> | undefined {
-        return this.encryptionKeys.get(getParticipantId(userId, deviceId))?.map(({ key }) => key);
+        return this.encryptionKeys.get(getParticipantId(userId, deviceId))?.map((entry) => entry.key);
     }
 
     /**
@@ -392,7 +392,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     public getEncryptionKeys(): IterableIterator<[string, Array<Uint8Array>]> {
         // the returned array doesn't contain the timestamps
         return Array.from(this.encryptionKeys.entries())
-            .map(([participantId, keys]): [string, Uint8Array[]] => [participantId, keys.map((k): Uint8Array => k.key)])
+            .map(([participantId, keys]): [string, Uint8Array[]] => [participantId, keys.map((k) => k.key)])
             .values();
     }
 
@@ -446,12 +446,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
 
         if (existingKeyAtIndex && keysEqual(existingKeyAtIndex.key, keyBin)) {
-            // key values are the same
-
-            // update the timestamp if more recent that the one we received before
-            if (timestamp > existingKeyAtIndex.timestamp) {
-                existingKeyAtIndex.timestamp = timestamp;
-            }
+            existingKeyAtIndex.timestamp = timestamp;
             return;
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

This change ensures that if an older key is received after a newer one then it isn't allowed to overwrite the newer one. Resolves https://github.com/element-hq/element-call/issues/2549

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
