### PR TITLE
Ensure "type" = "module" ES declaration in pre-release.sh

### DIFF
--- a/scripts/release/pre-release.sh
+++ b/scripts/release/pre-release.sh
@@ -12,3 +12,6 @@ do
         jq ".$i = .matrix_lib_$i" package.json > package.json.new && mv package.json.new package.json && yarn prettier --write package.json
     fi
 done
+
+# Ensure that "type": "module" is present
+jq '.type = "module"' package.json > package.json.new && mv package.json.new package.json && yarn prettier --write package.json


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Attempts to fix the issue https://github.com/matrix-org/matrix-js-sdk/issues/4347. Added a line in `scripts/pre-release.sh` that should add `"type" = "module"` to  `package.json`. Analogous to https://github.com/matrix-org/matrix-js-sdk/pull/4285/commits/432aaa46d548728145a3af44245d9cc110ae180e.

Reasoning:
CI order goes [Release Process](https://github.com/matrix-org/matrix-js-sdk/blob/develop/.github/workflows/release.yml) > [Release Make](https://github.com/matrix-org/matrix-js-sdk/blob/develop/.github/workflows/release-make.yml) > `pre-release.sh`. It does not involve the other release script with the previous fix.

Unfortunately, I can't test or verify. The CI workflows are too complex.

Signed-off-by: Jonas Black blck-b@proton.me