### PR TITLE
Set web team as codeowner for the scripts dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /.github/workflows/**     @matrix-org/element-web-team
 /package.json             @matrix-org/element-web-team
 /yarn.lock                @matrix-org/element-web-team
+/scripts/**               @matrix-org/element-web-team
 /src/webrtc               @matrix-org/element-call-reviewers
 /src/matrixrtc               @matrix-org/element-call-reviewers
 /spec/*/webrtc            @matrix-org/element-call-reviewers


### PR DESCRIPTION
The scripts in here are used in the release, and from the develop branch too (because it's the main branch and github actions does this) so it's critical for the release process.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
