### PR TITLE
set entrypoints to use ./lib rather than ./src

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,9 @@
         "matrix-org"
     ],
     "type": "module",
-    "main": "./src/index.ts",
-    "browser": "./src/browser-index.ts",
-    "matrix_src_main": "./src/index.ts",
-    "matrix_src_browser": "./src/browser-index.ts",
-    "matrix_lib_main": "./lib/index.js",
-    "matrix_lib_browser": "./lib/browser-index.js",
-    "matrix_lib_typings": "./lib/index.d.ts",
+    "main": "./lib/index.js",
+    "browser": "./lib/browser-index.js",
+    "typings": "./lib/index.d.ts",
     "author": "matrix.org",
     "license": "Apache-2.0",
     "files": [


### PR DESCRIPTION
Currently, we replace the entrypoints in package.json during the release cycle. I think, historically, this was done to make matrix-react-sdk and element-web development easier, but neither of those projects actually use these entrypoints (instead they import from `src`).

Accordingly, I think the switcheroo is unnecessary; furthermore it causes a whole bunch of confusion by making the development environment different from the release environment, and it complicates our CI and release process.

In short, the switcheroo has to die.

This change updates `package.json` to make the switcheroo a no-op, and removes the call to `scripts/switch_package_to_release.js` from the static analysis CI job. Unfortunately we'll need to update the react SDK before we can actually remove that script.

There is a second set of scripts, and GH workflows, that do the switcheroo at release time (the scripts are in `scripts/release`). These are pulled from *develop* during release, so we should keep them around until we are confident that we will not have to release from a branch that requires them.