### PR TITLE
Change imports for Node.js compatibility

### DIFF
--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { UnstableValue } from "../NamespacedValue";
-import { IClientWellKnown } from "../client";
+import { UnstableValue } from "../NamespacedValue.js";
+import { IClientWellKnown } from "../client.js";
 
 // disable lint because these are wire responses
 /* eslint-disable camelcase */

--- a/src/@types/beacon.ts
+++ b/src/@types/beacon.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RelatesToRelationship, REFERENCE_RELATION } from "./extensible_events";
-import { UnstableValue } from "../NamespacedValue";
-import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location";
+import { RelatesToRelationship, REFERENCE_RELATION } from "./extensible_events.js";
+import { UnstableValue } from "../NamespacedValue.js";
+import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location.js";
 
 /**
  * Beacon info and beacon event types as described in MSC3672

--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { ISignatures } from "./signed";
+import type { ISignatures } from "./signed.js";
 
 export type OlmGroupSessionExtraData = {
     untrusted?: boolean;
@@ -22,7 +22,7 @@ export type OlmGroupSessionExtraData = {
 };
 
 // Backwards compatible re-export
-export type { EventDecryptionResult as IEventDecryptionResult } from "../common-crypto/CryptoBackend";
+export type { EventDecryptionResult as IEventDecryptionResult } from "../common-crypto/CryptoBackend.js";
 
 interface Extensible {
     [key: string]: any;

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NamespacedValue, UnstableValue } from "../NamespacedValue";
+import { NamespacedValue, UnstableValue } from "../NamespacedValue.js";
 import {
     PolicyRuleEventContent,
     RoomAvatarEventContent,
@@ -34,16 +34,16 @@ import {
     RoomTopicEventContent,
     SpaceChildEventContent,
     SpaceParentEventContent,
-} from "./state_events";
+} from "./state_events.js";
 import {
     ExperimentalGroupCallRoomMemberState,
     IGroupCallRoomMemberState,
     IGroupCallRoomState,
-} from "../webrtc/groupCall";
-import { MSC3089EventContent } from "../models/MSC3089Branch";
-import { M_BEACON, M_BEACON_INFO, MBeaconEventContent, MBeaconInfoEventContent } from "./beacon";
-import { XOR } from "./common";
-import { ReactionEventContent, RoomMessageEventContent, StickerEventContent } from "./events";
+} from "../webrtc/groupCall.js";
+import { MSC3089EventContent } from "../models/MSC3089Branch.js";
+import { M_BEACON, M_BEACON_INFO, MBeaconEventContent, MBeaconInfoEventContent } from "./beacon.js";
+import { XOR } from "./common.js";
+import { ReactionEventContent, RoomMessageEventContent, StickerEventContent } from "./events.js";
 import {
     MCallAnswer,
     MCallBase,
@@ -54,10 +54,10 @@ import {
     MCallSelectAnswer,
     SDPStreamMetadata,
     SDPStreamMetadataKey,
-} from "../webrtc/callEventTypes";
-import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types";
-import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls";
-import { SessionMembershipData } from "../matrixrtc/CallMembership";
+} from "../webrtc/callEventTypes.js";
+import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types.js";
+import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls.js";
+import { SessionMembershipData } from "../matrixrtc/CallMembership.js";
 
 export enum EventType {
     // Room state events

--- a/src/@types/events.ts
+++ b/src/@types/events.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MsgType, RelationType } from "./event";
-import { FileInfo, ImageInfo, MediaEventContent } from "./media";
-import { XOR } from "./common";
+import { MsgType, RelationType } from "./event.js";
+import { FileInfo, ImageInfo, MediaEventContent } from "./media.js";
+import { XOR } from "./common.js";
 
 interface BaseTimelineEvent {
     "body": string;

--- a/src/@types/extensible_events.ts
+++ b/src/@types/extensible_events.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { EitherAnd, NamespacedValue, Optional, UnstableValue } from "matrix-events-sdk";
 
-import { isProvided } from "../extensible_events_v1/utilities";
+import { isProvided } from "../extensible_events_v1/utilities.js";
 
 // Types and utilities for MSC1767: Extensible events (version 1) in Matrix
 

--- a/src/@types/location.ts
+++ b/src/@types/location.ts
@@ -17,8 +17,8 @@ limitations under the License.
 // Types for MSC3488 - m.location: Extending events with location data
 import { EitherAnd } from "matrix-events-sdk";
 
-import { UnstableValue } from "../NamespacedValue";
-import { M_TEXT } from "./extensible_events";
+import { UnstableValue } from "../NamespacedValue.js";
+import { M_TEXT } from "./extensible_events.js";
 
 export enum LocationAssetType {
     Self = "m.self",

--- a/src/@types/media.ts
+++ b/src/@types/media.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MsgType } from "../@types/event";
+import { MsgType } from "../@types/event.js";
 
 /**
  * Information on encrypted media attachments.

--- a/src/@types/polls.ts
+++ b/src/@types/polls.ts
@@ -21,7 +21,7 @@ import {
     REFERENCE_RELATION,
     RelatesToRelationship,
     TSNamespace,
-} from "./extensible_events";
+} from "./extensible_events.js";
 
 /**
  * Identifier for a disclosed poll.

--- a/src/@types/registration.ts
+++ b/src/@types/registration.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AuthDict } from "../interactive-auth";
+import { AuthDict } from "../interactive-auth.js";
 
 /**
  * The request body of a call to `POST /_matrix/client/v3/register`.

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IContent, IEvent } from "../models/event";
-import { Preset, Visibility } from "./partials";
-import { IEventWithRoomId, SearchKey } from "./search";
-import { IRoomEventFilter } from "../filter";
-import { Direction } from "../models/event-timeline";
-import { PushRuleAction } from "./PushRules";
-import { IRoomEvent } from "../sync-accumulator";
-import { EventType, RelationType, RoomType } from "./event";
+import { IContent, IEvent } from "../models/event.js";
+import { Preset, Visibility } from "./partials.js";
+import { IEventWithRoomId, SearchKey } from "./search.js";
+import { IRoomEventFilter } from "../filter.js";
+import { Direction } from "../models/event-timeline.js";
+import { PushRuleAction } from "./PushRules.js";
+import { IRoomEvent } from "../sync-accumulator.js";
+import { EventType, RelationType, RoomType } from "./event.js";
 
 // allow camelcase as these are things that go onto the wire
 /* eslint-disable camelcase */

--- a/src/@types/search.ts
+++ b/src/@types/search.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Types relating to the /search API
 
-import { IRoomEvent, IStateEvent } from "../sync-accumulator";
-import { IRoomEventFilter } from "../filter";
-import { SearchResult } from "../models/search-result";
+import { IRoomEvent, IStateEvent } from "../sync-accumulator.js";
+import { IRoomEventFilter } from "../filter.js";
+import { SearchResult } from "../models/search-result.js";
 
 /* eslint-disable camelcase */
 export interface IEventWithRoomId extends IRoomEvent {

--- a/src/@types/spaces.ts
+++ b/src/@types/spaces.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IPublicRoomsChunkRoom } from "../client";
-import { RoomType } from "./event";
-import { IStrippedState } from "../sync-accumulator";
+import { IPublicRoomsChunkRoom } from "../client.js";
+import { RoomType } from "./event.js";
+import { IStrippedState } from "../sync-accumulator.js";
 
 // Types relating to Rooms of type `m.space` and related APIs
 

--- a/src/@types/state_events.ts
+++ b/src/@types/state_events.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RoomType } from "./event";
-import { GuestAccess, HistoryVisibility, JoinRule, RestrictedAllowType } from "./partials";
-import { ImageInfo } from "./media";
-import { PolicyRecommendation } from "../models/invites-ignorer";
+import { RoomType } from "./event.js";
+import { GuestAccess, HistoryVisibility, JoinRule, RestrictedAllowType } from "./partials.js";
+import { ImageInfo } from "./media.js";
+import { PolicyRecommendation } from "../models/invites-ignorer.js";
 
 export interface RoomCanonicalAliasEventContent {
     alias?: string;

--- a/src/@types/synapse.ts
+++ b/src/@types/synapse.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IdServerUnbindResult } from "./partials";
+import { IdServerUnbindResult } from "./partials.js";
 
 // Types relating to Synapse Admin APIs
 

--- a/src/@types/sync.ts
+++ b/src/@types/sync.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ServerControlledNamespacedValue } from "../NamespacedValue";
+import { ServerControlledNamespacedValue } from "../NamespacedValue.js";
 
 /**
  * https://github.com/matrix-org/matrix-doc/pull/3773

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import { EitherAnd } from "matrix-events-sdk";
 
-import { UnstableValue } from "../NamespacedValue";
-import { IMessageRendering } from "./extensible_events";
+import { UnstableValue } from "../NamespacedValue.js";
+import { IMessageRendering } from "./extensible_events.js";
 
 /**
  * Extensible topic event type based on MSC3765

--- a/src/@types/uia.ts
+++ b/src/@types/uia.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AuthDict, IAuthData } from "../interactive-auth";
+import { AuthDict, IAuthData } from "../interactive-auth.js";
 
 /**
  * Helper type to represent HTTP request body for a UIA enabled endpoint

--- a/src/ReEmitter.ts
+++ b/src/ReEmitter.ts
@@ -19,7 +19,7 @@ limitations under the License.
 // eslint-disable-next-line no-restricted-imports
 import { EventEmitter } from "events";
 
-import { ListenerMap, TypedEventEmitter } from "./models/typed-event-emitter";
+import { ListenerMap, TypedEventEmitter } from "./models/typed-event-emitter.js";
 
 export class ReEmitter {
     public constructor(private readonly target: EventEmitter) {}

--- a/src/ToDeviceMessageQueue.ts
+++ b/src/ToDeviceMessageQueue.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ToDeviceMessageId } from "./@types/event";
-import { logger } from "./logger";
-import { MatrixClient, ClientEvent } from "./client";
-import { MatrixError } from "./http-api";
-import { IndexedToDeviceBatch, ToDeviceBatch, ToDeviceBatchWithTxnId, ToDevicePayload } from "./models/ToDeviceMessage";
-import { MatrixScheduler } from "./scheduler";
-import { SyncState } from "./sync";
-import { MapWithDefault } from "./utils";
+import { ToDeviceMessageId } from "./@types/event.js";
+import { logger } from "./logger.js";
+import { MatrixClient, ClientEvent } from "./client.js";
+import { MatrixError } from "./http-api/index.js";
+import { IndexedToDeviceBatch, ToDeviceBatch, ToDeviceBatchWithTxnId, ToDevicePayload } from "./models/ToDeviceMessage.js";
+import { MatrixScheduler } from "./scheduler.js";
+import { SyncState } from "./sync.js";
+import { MapWithDefault } from "./utils.js";
 
 const MAX_BATCH_SIZE = 20;
 

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -15,10 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IClientWellKnown, IWellKnownConfig, IServerVersions } from "./client";
-import { logger } from "./logger";
-import { MatrixError, Method, timeoutSignal } from "./http-api";
-import { SUPPORTED_MATRIX_VERSIONS } from "./version-support";
+import { IClientWellKnown, IWellKnownConfig, IServerVersions } from "./client.js";
+import { logger } from "./logger.js";
+import { MatrixError, Method, timeoutSignal } from "./http-api/index.js";
+import { SUPPORTED_MATRIX_VERSIONS } from "./version-support.js";
 
 // Dev note: Auto discovery is part of the spec.
 // See: https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery

--- a/src/browser-index.ts
+++ b/src/browser-index.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as matrixcs from "./matrix";
+import * as matrixcs from "./matrix.js";
 
 type BrowserMatrix = typeof matrixcs;
 declare global {
@@ -40,5 +40,5 @@ if (indexedDB) {
     matrixcs.setCryptoStoreFactory(() => new matrixcs.IndexedDBCryptoStore(indexedDB!, "matrix-js-sdk:crypto"));
 }
 
-export * from "./matrix";
+export * from "./matrix.js";
 globalThis.matrixcs = matrixcs;

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,8 +20,8 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import type { IDeviceKeys, IMegolmSessionData, IOneTimeKey } from "./@types/crypto";
-import { ISyncStateData, SetPresence, SyncApi, SyncApiOptions, SyncState } from "./sync";
+import type { IDeviceKeys, IMegolmSessionData, IOneTimeKey } from "./@types/crypto.js";
+import { ISyncStateData, SetPresence, SyncApi, SyncApiOptions, SyncState } from "./sync.js";
 import {
     EventStatus,
     IContent,
@@ -31,29 +31,29 @@ import {
     MatrixEventEvent,
     MatrixEventHandlerMap,
     PushDetails,
-} from "./models/event";
-import { StubStore } from "./store/stub";
-import { CallEvent, CallEventHandlerMap, createNewMatrixCall, MatrixCall, supportsMatrixCall } from "./webrtc/call";
-import { Filter, IFilterDefinition, IRoomEventFilter } from "./filter";
-import { CallEventHandler, CallEventHandlerEvent, CallEventHandlerEventHandlerMap } from "./webrtc/callEventHandler";
+} from "./models/event.js";
+import { StubStore } from "./store/stub.js";
+import { CallEvent, CallEventHandlerMap, createNewMatrixCall, MatrixCall, supportsMatrixCall } from "./webrtc/call.js";
+import { Filter, IFilterDefinition, IRoomEventFilter } from "./filter.js";
+import { CallEventHandler, CallEventHandlerEvent, CallEventHandlerEventHandlerMap } from "./webrtc/callEventHandler.js";
 import {
     GroupCallEventHandler,
     GroupCallEventHandlerEvent,
     GroupCallEventHandlerEventHandlerMap,
-} from "./webrtc/groupCallEventHandler";
-import * as utils from "./utils";
-import { noUnsafeEventProps, QueryDict, replaceParam, safeSet, sleep } from "./utils";
-import { Direction, EventTimeline } from "./models/event-timeline";
-import { IActionsObject, PushProcessor } from "./pushprocessor";
-import { AutoDiscovery, AutoDiscoveryAction } from "./autodiscovery";
-import * as olmlib from "./crypto/olmlib";
-import { decodeBase64, encodeBase64, encodeUnpaddedBase64Url } from "./base64";
-import { IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice";
-import { IOlmDevice } from "./crypto/algorithms/megolm";
-import { TypedReEmitter } from "./ReEmitter";
-import { IRoomEncryption } from "./crypto/RoomList";
-import { logger, Logger } from "./logger";
-import { SERVICE_TYPES } from "./service-types";
+} from "./webrtc/groupCallEventHandler.js";
+import * as utils from "./utils.js";
+import { noUnsafeEventProps, QueryDict, replaceParam, safeSet, sleep } from "./utils.js";
+import { Direction, EventTimeline } from "./models/event-timeline.js";
+import { IActionsObject, PushProcessor } from "./pushprocessor.js";
+import { AutoDiscovery, AutoDiscoveryAction } from "./autodiscovery.js";
+import * as olmlib from "./crypto/olmlib.js";
+import { decodeBase64, encodeBase64, encodeUnpaddedBase64Url } from "./base64.js";
+import { IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice.js";
+import { IOlmDevice } from "./crypto/algorithms/megolm.js";
+import { TypedReEmitter } from "./ReEmitter.js";
+import { IRoomEncryption } from "./crypto/RoomList.js";
+import { logger, Logger } from "./logger.js";
+import { SERVICE_TYPES } from "./service-types.js";
 import {
     Body,
     ClientPrefix,
@@ -73,7 +73,7 @@ import {
     Upload,
     UploadOpts,
     UploadResponse,
-} from "./http-api";
+} from "./http-api/index.js";
 import {
     Crypto,
     CryptoEvent,
@@ -83,14 +83,14 @@ import {
     ICryptoCallbacks,
     IRoomKeyRequestBody,
     isCryptoAvailable,
-} from "./crypto";
-import { DeviceInfo } from "./crypto/deviceinfo";
-import { decodeRecoveryKey } from "./crypto/recoverykey";
-import { keyFromAuthData } from "./crypto/key_passphrase";
-import { User, UserEvent, UserEventHandlerMap } from "./models/user";
-import { getHttpUriForMxc } from "./content-repo";
-import { SearchResult } from "./models/search-result";
-import { DEHYDRATION_ALGORITHM, IDehydratedDevice, IDehydratedDeviceKeyInfo } from "./crypto/dehydration";
+} from "./crypto/index.js";
+import { DeviceInfo } from "./crypto/deviceinfo.js";
+import { decodeRecoveryKey } from "./crypto/recoverykey.js";
+import { keyFromAuthData } from "./crypto/key_passphrase.js";
+import { User, UserEvent, UserEventHandlerMap } from "./models/user.js";
+import { getHttpUriForMxc } from "./content-repo.js";
+import { SearchResult } from "./models/search-result.js";
+import { DEHYDRATION_ALGORITHM, IDehydratedDevice, IDehydratedDeviceKeyInfo } from "./crypto/dehydration.js";
 import {
     IKeyBackupInfo,
     IKeyBackupPrepareOpts,
@@ -98,21 +98,21 @@ import {
     IKeyBackupRestoreResult,
     IKeyBackupRoomSessions,
     IKeyBackupSession,
-} from "./crypto/keybackup";
-import { IIdentityServerProvider } from "./@types/IIdentityServerProvider";
-import { MatrixScheduler } from "./scheduler";
-import { BeaconEvent, BeaconEventHandlerMap } from "./models/beacon";
-import { AuthDict } from "./interactive-auth";
-import { IMinimalEvent, IRoomEvent, IStateEvent } from "./sync-accumulator";
-import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./crypto/api";
-import { EventTimelineSet } from "./models/event-timeline-set";
-import { VerificationRequest } from "./crypto/verification/request/VerificationRequest";
-import { VerificationBase as Verification } from "./crypto/verification/Base";
-import * as ContentHelpers from "./content-helpers";
-import { CrossSigningInfo, DeviceTrustLevel, ICacheCallbacks, UserTrustLevel } from "./crypto/CrossSigning";
-import { NotificationCountType, Room, RoomEvent, RoomEventHandlerMap, RoomNameState } from "./models/room";
-import { RoomMemberEvent, RoomMemberEventHandlerMap } from "./models/room-member";
-import { IPowerLevelsContent, RoomStateEvent, RoomStateEventHandlerMap } from "./models/room-state";
+} from "./crypto/keybackup.js";
+import { IIdentityServerProvider } from "./@types/IIdentityServerProvider.js";
+import { MatrixScheduler } from "./scheduler.js";
+import { BeaconEvent, BeaconEventHandlerMap } from "./models/beacon.js";
+import { AuthDict } from "./interactive-auth.js";
+import { IMinimalEvent, IRoomEvent, IStateEvent } from "./sync-accumulator.js";
+import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./crypto/api.js";
+import { EventTimelineSet } from "./models/event-timeline-set.js";
+import { VerificationRequest } from "./crypto/verification/request/VerificationRequest.js";
+import { VerificationBase as Verification } from "./crypto/verification/Base.js";
+import * as ContentHelpers from "./content-helpers.js";
+import { CrossSigningInfo, DeviceTrustLevel, ICacheCallbacks, UserTrustLevel } from "./crypto/CrossSigning.js";
+import { NotificationCountType, Room, RoomEvent, RoomEventHandlerMap, RoomNameState } from "./models/room.js";
+import { RoomMemberEvent, RoomMemberEventHandlerMap } from "./models/room-member.js";
+import { IPowerLevelsContent, RoomStateEvent, RoomStateEventHandlerMap } from "./models/room-state.js";
 import {
     DelayedEventInfo,
     IAddThreePidOnlyBody,
@@ -138,7 +138,7 @@ import {
     SendDelayedEventRequestOpts,
     SendDelayedEventResponse,
     UpdateDelayedEventAction,
-} from "./@types/requests";
+} from "./@types/requests.js";
 import {
     EventType,
     LOCAL_NOTIFICATION_SETTINGS_PREFIX,
@@ -153,15 +153,15 @@ import {
     UNSTABLE_MSC3088_ENABLED,
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
-} from "./@types/event";
-import { GuestAccess, HistoryVisibility, IdServerUnbindResult, JoinRule, Preset, Visibility } from "./@types/partials";
-import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper";
-import { randomString } from "./randomstring";
-import { BackupManager, IKeyBackup, IKeyBackupCheck, IPreparedKeyBackupVersion, TrustInfo } from "./crypto/backup";
-import { DEFAULT_TREE_POWER_LEVELS_TEMPLATE, MSC3089TreeSpace } from "./models/MSC3089TreeSpace";
-import { ISignatures } from "./@types/signed";
-import { IStore } from "./store";
-import { ISecretRequest } from "./crypto/SecretStorage";
+} from "./@types/event.js";
+import { GuestAccess, HistoryVisibility, IdServerUnbindResult, JoinRule, Preset, Visibility } from "./@types/partials.js";
+import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper.js";
+import { randomString } from "./randomstring.js";
+import { BackupManager, IKeyBackup, IKeyBackupCheck, IPreparedKeyBackupVersion, TrustInfo } from "./crypto/backup.js";
+import { DEFAULT_TREE_POWER_LEVELS_TEMPLATE, MSC3089TreeSpace } from "./models/MSC3089TreeSpace.js";
+import { ISignatures } from "./@types/signed.js";
+import { IStore } from "./store/index.js";
+import { ISecretRequest } from "./crypto/SecretStorage.js";
 import {
     IEventWithRoomId,
     ISearchRequestBody,
@@ -169,9 +169,9 @@ import {
     ISearchResults,
     IStateEventWithRoomId,
     SearchOrderBy,
-} from "./@types/search";
-import { ISynapseAdminDeactivateResponse, ISynapseAdminWhoisResponse } from "./@types/synapse";
-import { IHierarchyRoom } from "./@types/spaces";
+} from "./@types/search.js";
+import { ISynapseAdminDeactivateResponse, ISynapseAdminWhoisResponse } from "./@types/synapse.js";
+import { IHierarchyRoom } from "./@types/spaces.js";
 import {
     IPusher,
     IPusherRequest,
@@ -181,11 +181,11 @@ import {
     PushRuleActionName,
     PushRuleKind,
     RuleId,
-} from "./@types/PushRules";
-import { IThreepid } from "./@types/threepids";
-import { CryptoStore, OutgoingRoomKeyRequest } from "./crypto/store/base";
-import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./webrtc/groupCall";
-import { MediaHandler } from "./webrtc/mediaHandler";
+} from "./@types/PushRules.js";
+import { IThreepid } from "./@types/threepids.js";
+import { CryptoStore, OutgoingRoomKeyRequest } from "./crypto/store/base.js";
+import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./webrtc/groupCall.js";
+import { MediaHandler } from "./webrtc/mediaHandler.js";
 import {
     ILoginFlowsResponse,
     IRefreshTokenResponse,
@@ -193,11 +193,11 @@ import {
     LoginResponse,
     LoginTokenPostResponse,
     SSOAction,
-} from "./@types/auth";
-import { TypedEventEmitter } from "./models/typed-event-emitter";
-import { MAIN_ROOM_TIMELINE, ReceiptType } from "./@types/read_receipts";
-import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse, SlidingSync } from "./sliding-sync";
-import { SlidingSyncSdk } from "./sliding-sync-sdk";
+} from "./@types/auth.js";
+import { TypedEventEmitter } from "./models/typed-event-emitter.js";
+import { MAIN_ROOM_TIMELINE, ReceiptType } from "./@types/read_receipts.js";
+import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse, SlidingSync } from "./sliding-sync.js";
+import { SlidingSyncSdk } from "./sliding-sync-sdk.js";
 import {
     determineFeatureSupport,
     FeatureSupport,
@@ -205,33 +205,33 @@ import {
     THREAD_RELATION_TYPE,
     ThreadFilterType,
     threadFilterTypeToFilter,
-} from "./models/thread";
-import { M_BEACON_INFO, MBeaconInfoEventContent } from "./@types/beacon";
-import { NamespacedValue, UnstableValue } from "./NamespacedValue";
-import { ToDeviceMessageQueue } from "./ToDeviceMessageQueue";
-import { ToDeviceBatch } from "./models/ToDeviceMessage";
-import { IgnoredInvites } from "./models/invites-ignorer";
-import { UIARequest, UIAResponse } from "./@types/uia";
-import { LocalNotificationSettings } from "./@types/local_notifications";
-import { buildFeatureSupportMap, Feature, ServerSupport } from "./feature";
-import { BackupDecryptor, CryptoBackend } from "./common-crypto/CryptoBackend";
-import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants";
-import { BootstrapCrossSigningOpts, CrossSigningKeyInfo, CryptoApi, ImportRoomKeysOpts } from "./crypto-api";
-import { DeviceInfoMap } from "./crypto/DeviceList";
+} from "./models/thread.js";
+import { M_BEACON_INFO, MBeaconInfoEventContent } from "./@types/beacon.js";
+import { NamespacedValue, UnstableValue } from "./NamespacedValue.js";
+import { ToDeviceMessageQueue } from "./ToDeviceMessageQueue.js";
+import { ToDeviceBatch } from "./models/ToDeviceMessage.js";
+import { IgnoredInvites } from "./models/invites-ignorer.js";
+import { UIARequest, UIAResponse } from "./@types/uia.js";
+import { LocalNotificationSettings } from "./@types/local_notifications.js";
+import { buildFeatureSupportMap, Feature, ServerSupport } from "./feature.js";
+import { BackupDecryptor, CryptoBackend } from "./common-crypto/CryptoBackend.js";
+import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants.js";
+import { BootstrapCrossSigningOpts, CrossSigningKeyInfo, CryptoApi, ImportRoomKeysOpts } from "./crypto-api/index.js";
+import { DeviceInfoMap } from "./crypto/DeviceList.js";
 import {
     AddSecretStorageKeyOpts,
     SecretStorageKeyDescription,
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
-} from "./secret-storage";
-import { RegisterRequest, RegisterResponse } from "./@types/registration";
-import { MatrixRTCSessionManager } from "./matrixrtc/MatrixRTCSessionManager";
-import { getRelationsThreadFilter } from "./thread-utils";
-import { KnownMembership, Membership } from "./@types/membership";
-import { RoomMessageEventContent, StickerEventContent } from "./@types/events";
-import { ImageInfo } from "./@types/media";
-import { Capabilities, ServerCapabilities } from "./serverCapabilities";
-import { sha256 } from "./digest";
+} from "./secret-storage.js";
+import { RegisterRequest, RegisterResponse } from "./@types/registration.js";
+import { MatrixRTCSessionManager } from "./matrixrtc/MatrixRTCSessionManager.js";
+import { getRelationsThreadFilter } from "./thread-utils.js";
+import { KnownMembership, Membership } from "./@types/membership.js";
+import { RoomMessageEventContent, StickerEventContent } from "./@types/events.js";
+import { ImageInfo } from "./@types/media.js";
+import { Capabilities, ServerCapabilities } from "./serverCapabilities.js";
+import { sha256 } from "./digest.js";
 
 export type Store = IStore;
 

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
-import { IClearEvent, MatrixEvent } from "../models/event";
-import { Room } from "../models/room";
-import { CryptoApi, DecryptionFailureCode, ImportRoomKeysOpts } from "../crypto-api";
-import { CrossSigningInfo, UserTrustLevel } from "../crypto/CrossSigning";
-import { IEncryptedEventInfo } from "../crypto/api";
-import { KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup";
-import { IMegolmSessionData } from "../@types/crypto";
+import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.js";
+import { IClearEvent, MatrixEvent } from "../models/event.js";
+import { Room } from "../models/room.js";
+import { CryptoApi, DecryptionFailureCode, ImportRoomKeysOpts } from "../crypto-api/index.js";
+import { CrossSigningInfo, UserTrustLevel } from "../crypto/CrossSigning.js";
+import { IEncryptedEventInfo } from "../crypto/api.js";
+import { KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.js";
+import { IMegolmSessionData } from "../@types/crypto.js";
 
 /**
  * Common interface for the crypto implementations

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon";
-import { MsgType } from "./@types/event";
-import { M_TEXT, REFERENCE_RELATION } from "./@types/extensible_events";
-import { isProvided } from "./extensible_events_v1/utilities";
+import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon.js";
+import { MsgType } from "./@types/event.js";
+import { M_TEXT, REFERENCE_RELATION } from "./@types/extensible_events.js";
+import { isProvided } from "./extensible_events_v1/utilities.js";
 import {
     M_ASSET,
     LocationAssetType,
@@ -28,9 +28,9 @@ import {
     MLocationContent,
     MAssetContent,
     LegacyLocationEventContent,
-} from "./@types/location";
-import { MRoomTopicEventContent, MTopicContent, M_TOPIC } from "./@types/topic";
-import { RoomMessageEventContent } from "./@types/events";
+} from "./@types/location.js";
+import { MRoomTopicEventContent, MTopicContent, M_TOPIC } from "./@types/topic.js";
+import { RoomMessageEventContent } from "./@types/events.js";
 
 /**
  * Generates the content for a HTML Message event

--- a/src/content-repo.ts
+++ b/src/content-repo.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { encodeParams } from "./utils";
+import { encodeParams } from "./utils.js";
 
 /**
  * Get the HTTP URL for an MXC URI.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 import type { SecretsBundle } from "@matrix-org/matrix-sdk-crypto-wasm";
-import type { IMegolmSessionData } from "../@types/crypto";
-import { Room } from "../models/room";
-import { DeviceMap } from "../models/device";
-import { UIAuthCallback } from "../interactive-auth";
-import { PassphraseInfo, SecretStorageCallbacks, SecretStorageKeyDescription } from "../secret-storage";
-import { VerificationRequest } from "./verification";
-import { BackupTrustInfo, KeyBackupCheck, KeyBackupInfo } from "./keybackup";
-import { ISignatures } from "../@types/signed";
-import { MatrixEvent } from "../models/event";
+import type { IMegolmSessionData } from "../@types/crypto.js";
+import { Room } from "../models/room.js";
+import { DeviceMap } from "../models/device.js";
+import { UIAuthCallback } from "../interactive-auth.js";
+import { PassphraseInfo, SecretStorageCallbacks, SecretStorageKeyDescription } from "../secret-storage.js";
+import { VerificationRequest } from "./verification.js";
+import { BackupTrustInfo, KeyBackupCheck, KeyBackupInfo } from "./keybackup.js";
+import { ISignatures } from "../@types/signed.js";
+import { MatrixEvent } from "../models/event.js";
 
 /**
  * Public interface to the cryptography parts of the js-sdk
@@ -960,5 +960,5 @@ export interface OwnDeviceKeys {
     curve25519: string;
 }
 
-export * from "./verification";
-export * from "./keybackup";
+export * from "./verification.js";
+export * from "./keybackup.js";

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISigned } from "../@types/signed";
-import { IEncryptedPayload } from "../crypto/aes";
+import { ISigned } from "../@types/signed.js";
+import { IEncryptedPayload } from "../crypto/aes.js";
 
 export interface Curve25519AuthData {
     public_key: string;

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
+import { MatrixEvent } from "../models/event.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
 
 /**
  * An incoming, or outgoing, request to verify a user or a device via cross-signing.

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -19,19 +19,19 @@ limitations under the License.
  */
 
 import type { PkSigning } from "@matrix-org/olm";
-import { IObject, pkSign, pkVerify } from "./olmlib";
-import { logger } from "../logger";
-import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store";
-import { decryptAES, encryptAES } from "./aes";
-import { DeviceInfo } from "./deviceinfo";
-import { ISignedKey, MatrixClient } from "../client";
-import { OlmDevice } from "./OlmDevice";
-import { ICryptoCallbacks } from ".";
-import { ISignatures } from "../@types/signed";
-import { CryptoStore, SecretStorePrivateKeys } from "./store/base";
-import { ServerSideSecretStorage, SecretStorageKeyDescription } from "../secret-storage";
-import { CrossSigningKeyInfo, DeviceVerificationStatus, UserVerificationStatus as UserTrustLevel } from "../crypto-api";
-import { decodeBase64, encodeBase64 } from "../base64";
+import { IObject, pkSign, pkVerify } from "./olmlib.js";
+import { logger } from "../logger.js";
+import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.js";
+import { decryptAES, encryptAES } from "./aes.js";
+import { DeviceInfo } from "./deviceinfo.js";
+import { ISignedKey, MatrixClient } from "../client.js";
+import { OlmDevice } from "./OlmDevice.js";
+import { ICryptoCallbacks } from "./index.js";
+import { ISignatures } from "../@types/signed.js";
+import { CryptoStore, SecretStorePrivateKeys } from "./store/base.js";
+import { ServerSideSecretStorage, SecretStorageKeyDescription } from "../secret-storage.js";
+import { CrossSigningKeyInfo, DeviceVerificationStatus, UserVerificationStatus as UserTrustLevel } from "../crypto-api/index.js";
+import { decodeBase64, encodeBase64 } from "../base64.js";
 
 // backwards-compatibility re-exports
 export { UserTrustLevel };

--- a/src/crypto/DeviceList.ts
+++ b/src/crypto/DeviceList.ts
@@ -18,17 +18,17 @@ limitations under the License.
  * Manages the list of other users' devices
  */
 
-import { logger } from "../logger";
-import { DeviceInfo, IDevice } from "./deviceinfo";
-import { CrossSigningInfo, ICrossSigningInfo } from "./CrossSigning";
-import * as olmlib from "./olmlib";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
-import { chunkPromises, defer, IDeferred, sleep } from "../utils";
-import { DeviceKeys, IDownloadKeyResult, Keys, MatrixClient, SigningKeys } from "../client";
-import { OlmDevice } from "./OlmDevice";
-import { CryptoStore } from "./store/base";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { CryptoEvent, CryptoEventHandlerMap } from "./index";
+import { logger } from "../logger.js";
+import { DeviceInfo, IDevice } from "./deviceinfo.js";
+import { CrossSigningInfo, ICrossSigningInfo } from "./CrossSigning.js";
+import * as olmlib from "./olmlib.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
+import { chunkPromises, defer, IDeferred, sleep } from "../utils.js";
+import { DeviceKeys, IDownloadKeyResult, Keys, MatrixClient, SigningKeys } from "../client.js";
+import { OlmDevice } from "./OlmDevice.js";
+import { CryptoStore } from "./store/base.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { CryptoEvent, CryptoEventHandlerMap } from "./index.js";
 
 /* State transition diagram for DeviceList.deviceTrackingStatus
  *

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../logger";
-import { MatrixEvent } from "../models/event";
-import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
-import { Method, ClientPrefix } from "../http-api";
-import { Crypto, ICryptoCallbacks } from "./index";
-import { ClientEvent, ClientEventHandlerMap, CrossSigningKeys, ISignedKey, KeySignatures } from "../client";
-import { IKeyBackupInfo } from "./keybackup";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage";
-import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../crypto-api";
+import { logger } from "../logger.js";
+import { MatrixEvent } from "../models/event.js";
+import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
+import { Method, ClientPrefix } from "../http-api/index.js";
+import { Crypto, ICryptoCallbacks } from "./index.js";
+import { ClientEvent, ClientEventHandlerMap, CrossSigningKeys, ISignedKey, KeySignatures } from "../client.js";
+import { IKeyBackupInfo } from "./keybackup.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage.js";
+import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../crypto-api/index.js";
 
 interface ICrossSigningKeys {
     authUpload: BootstrapCrossSigningOpts["authUploadDeviceSigningKeys"];

--- a/src/crypto/OlmDevice.ts
+++ b/src/crypto/OlmDevice.ts
@@ -16,14 +16,14 @@ limitations under the License.
 
 import { Account, InboundGroupSession, OutboundGroupSession, Session, Utility } from "@matrix-org/olm";
 
-import { logger, Logger } from "../logger";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
-import { CryptoStore, IProblem, ISessionInfo, IWithheld } from "./store/base";
-import { IOlmDevice, IOutboundGroupSessionKey } from "./algorithms/megolm";
-import { IMegolmSessionData, OlmGroupSessionExtraData } from "../@types/crypto";
-import { IMessage } from "./algorithms/olm";
-import { DecryptionFailureCode } from "../crypto-api";
-import { DecryptionError } from "../common-crypto/CryptoBackend";
+import { logger, Logger } from "../logger.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
+import { CryptoStore, IProblem, ISessionInfo, IWithheld } from "./store/base.js";
+import { IOlmDevice, IOutboundGroupSessionKey } from "./algorithms/megolm.js";
+import { IMegolmSessionData, OlmGroupSessionExtraData } from "../@types/crypto.js";
+import { IMessage } from "./algorithms/olm.js";
+import { DecryptionFailureCode } from "../crypto-api/index.js";
+import { DecryptionError } from "../common-crypto/CryptoBackend.js";
 
 // The maximum size of an event is 65K, and we base64 the content, so this is a
 // reasonable approximation to the biggest plaintext we can encrypt.

--- a/src/crypto/OutgoingRoomKeyRequestManager.ts
+++ b/src/crypto/OutgoingRoomKeyRequestManager.ts
@@ -16,12 +16,12 @@ limitations under the License.
 
 import { v4 as uuidv4 } from "uuid";
 
-import { logger } from "../logger";
-import { MatrixClient } from "../client";
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "./index";
-import { CryptoStore, OutgoingRoomKeyRequest } from "./store/base";
-import { EventType, ToDeviceMessageId } from "../@types/event";
-import { MapWithDefault } from "../utils";
+import { logger } from "../logger.js";
+import { MatrixClient } from "../client.js";
+import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "./index.js";
+import { CryptoStore, OutgoingRoomKeyRequest } from "./store/base.js";
+import { EventType, ToDeviceMessageId } from "../@types/event.js";
+import { MapWithDefault } from "../utils.js";
 
 /**
  * Internal module. Management of outgoing room key requests.

--- a/src/crypto/RoomList.ts
+++ b/src/crypto/RoomList.ts
@@ -18,8 +18,8 @@ limitations under the License.
  * Manages the list of encrypted rooms
  */
 
-import { CryptoStore } from "./store/base";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
+import { CryptoStore } from "./store/base.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
 
 /* eslint-disable camelcase */
 export interface IRoomEncryption {

--- a/src/crypto/SecretSharing.ts
+++ b/src/crypto/SecretSharing.ts
@@ -15,13 +15,13 @@ limitations under the License.
 */
 import { v4 as uuidv4 } from "uuid";
 
-import { MatrixClient } from "../client";
-import { ICryptoCallbacks, IEncryptedContent } from "./index";
-import { defer, IDeferred } from "../utils";
-import { ToDeviceMessageId } from "../@types/event";
-import { logger } from "../logger";
-import { MatrixEvent } from "../models/event";
-import * as olmlib from "./olmlib";
+import { MatrixClient } from "../client.js";
+import { ICryptoCallbacks, IEncryptedContent } from "./index.js";
+import { defer, IDeferred } from "../utils.js";
+import { ToDeviceMessageId } from "../@types/event.js";
+import { logger } from "../logger.js";
+import { MatrixEvent } from "../models/event.js";
+import * as olmlib from "./olmlib.js";
 
 export interface ISecretRequest {
     requestId: string;

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ICryptoCallbacks } from ".";
-import { MatrixEvent } from "../models/event";
-import { MatrixClient } from "../client";
+import { ICryptoCallbacks } from "./index.js";
+import { MatrixEvent } from "../models/event.js";
+import { MatrixClient } from "../client.js";
 import {
     SecretStorageKeyDescription,
     SecretStorageKeyTuple,
@@ -25,8 +25,8 @@ import {
     AccountDataClient,
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
-} from "../secret-storage";
-import { ISecretRequest, SecretSharing } from "./SecretSharing";
+} from "../secret-storage.js";
+import { ISecretRequest, SecretSharing } from "./SecretSharing.js";
 
 /* re-exports for backwards compatibility */
 export type {
@@ -34,9 +34,9 @@ export type {
     SecretStorageKeyTuple,
     SecretStorageKeyObject,
     SECRET_STORAGE_ALGORITHM_V1_AES,
-} from "../secret-storage";
+} from "../secret-storage.js";
 
-export type { ISecretRequest } from "./SecretSharing";
+export type { ISecretRequest } from "./SecretSharing.js";
 
 /**
  * Implements Secure Secret Storage and Sharing (MSC1946)

--- a/src/crypto/aes.ts
+++ b/src/crypto/aes.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { decodeBase64, encodeBase64 } from "../base64";
+import { decodeBase64, encodeBase64 } from "../base64.js";
 
 // salt for HKDF, with 8 bytes of zeros
 const zeroSalt = new Uint8Array(8);

--- a/src/crypto/algorithms/base.ts
+++ b/src/crypto/algorithms/base.ts
@@ -18,15 +18,15 @@ limitations under the License.
  * Internal module. Defines the base classes of the encryption implementations
  */
 
-import type { IMegolmSessionData } from "../../@types/crypto";
-import { MatrixClient } from "../../client";
-import { Room } from "../../models/room";
-import { OlmDevice } from "../OlmDevice";
-import { IContent, MatrixEvent, RoomMember } from "../../matrix";
-import { Crypto, IEncryptedContent, IEventDecryptionResult, IncomingRoomKeyRequest } from "..";
-import { DeviceInfo } from "../deviceinfo";
-import { IRoomEncryption } from "../RoomList";
-import { DeviceInfoMap } from "../DeviceList";
+import type { IMegolmSessionData } from "../../@types/crypto.js";
+import { MatrixClient } from "../../client.js";
+import { Room } from "../../models/room.js";
+import { OlmDevice } from "../OlmDevice.js";
+import { IContent, MatrixEvent, RoomMember } from "../../matrix.js";
+import { Crypto, IEncryptedContent, IEventDecryptionResult, IncomingRoomKeyRequest } from "../index.js";
+import { DeviceInfo } from "../deviceinfo.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { DeviceInfoMap } from "../DeviceList.js";
 
 /**
  * Map of registered encryption algorithm classes. A map from string to {@link EncryptionAlgorithm} class
@@ -233,4 +233,4 @@ export function registerAlgorithm<P extends IParams = IParams>(
 }
 
 /* Re-export for backwards compatibility. Deprecated: this is an internal class. */
-export { DecryptionError } from "../../common-crypto/CryptoBackend";
+export { DecryptionError } from "../../common-crypto/CryptoBackend.js";

--- a/src/crypto/algorithms/index.ts
+++ b/src/crypto/algorithms/index.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import "./olm";
-import "./megolm";
+import "./olm.js";
+import "./megolm.js";
 
-export * from "./base";
+export * from "./base.js";

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -20,9 +20,9 @@ limitations under the License.
 
 import { v4 as uuidv4 } from "uuid";
 
-import type { IEventDecryptionResult, IMegolmSessionData } from "../../@types/crypto";
-import { logger, Logger } from "../../logger";
-import * as olmlib from "../olmlib";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../../@types/crypto.js";
+import { logger, Logger } from "../../logger.js";
+import * as olmlib from "../olmlib.js";
 import {
     DecryptionAlgorithm,
     DecryptionClassParams,
@@ -30,22 +30,22 @@ import {
     IParams,
     registerAlgorithm,
     UnknownDeviceError,
-} from "./base";
-import { IDecryptedGroupMessage, WITHHELD_MESSAGES } from "../OlmDevice";
-import { Room } from "../../models/room";
-import { DeviceInfo } from "../deviceinfo";
-import { IOlmSessionResult } from "../olmlib";
-import { DeviceInfoMap } from "../DeviceList";
-import { IContent, MatrixEvent } from "../../models/event";
-import { EventType, MsgType, ToDeviceMessageId } from "../../@types/event";
-import { IMegolmEncryptedContent, IncomingRoomKeyRequest, IEncryptedContent } from "../index";
-import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager";
-import { OlmGroupSessionExtraData } from "../../@types/crypto";
-import { MatrixError } from "../../http-api";
-import { immediate, MapWithDefault } from "../../utils";
-import { KnownMembership } from "../../@types/membership";
-import { DecryptionFailureCode } from "../../crypto-api";
-import { DecryptionError } from "../../common-crypto/CryptoBackend";
+} from "./base.js";
+import { IDecryptedGroupMessage, WITHHELD_MESSAGES } from "../OlmDevice.js";
+import { Room } from "../../models/room.js";
+import { DeviceInfo } from "../deviceinfo.js";
+import { IOlmSessionResult } from "../olmlib.js";
+import { DeviceInfoMap } from "../DeviceList.js";
+import { IContent, MatrixEvent } from "../../models/event.js";
+import { EventType, MsgType, ToDeviceMessageId } from "../../@types/event.js";
+import { IMegolmEncryptedContent, IncomingRoomKeyRequest, IEncryptedContent } from "../index.js";
+import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.js";
+import { OlmGroupSessionExtraData } from "../../@types/crypto.js";
+import { MatrixError } from "../../http-api/index.js";
+import { immediate, MapWithDefault } from "../../utils.js";
+import { KnownMembership } from "../../@types/membership.js";
+import { DecryptionFailureCode } from "../../crypto-api/index.js";
+import { DecryptionError } from "../../common-crypto/CryptoBackend.js";
 
 // determine whether the key can be shared with invitees
 export function isRoomSharedHistory(room: Room): boolean {

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -18,17 +18,17 @@ limitations under the License.
  * Defines m.olm encryption/decryption
  */
 
-import type { IEventDecryptionResult } from "../../@types/crypto";
-import { logger } from "../../logger";
-import * as olmlib from "../olmlib";
-import { DeviceInfo } from "../deviceinfo";
-import { DecryptionAlgorithm, EncryptionAlgorithm, registerAlgorithm } from "./base";
-import { Room } from "../../models/room";
-import { IContent, MatrixEvent } from "../../models/event";
-import { IEncryptedContent, IOlmEncryptedContent } from "../index";
-import { IInboundSession } from "../OlmDevice";
-import { DecryptionFailureCode } from "../../crypto-api";
-import { DecryptionError } from "../../common-crypto/CryptoBackend";
+import type { IEventDecryptionResult } from "../../@types/crypto.js";
+import { logger } from "../../logger.js";
+import * as olmlib from "../olmlib.js";
+import { DeviceInfo } from "../deviceinfo.js";
+import { DecryptionAlgorithm, EncryptionAlgorithm, registerAlgorithm } from "./base.js";
+import { Room } from "../../models/room.js";
+import { IContent, MatrixEvent } from "../../models/event.js";
+import { IEncryptedContent, IOlmEncryptedContent } from "../index.js";
+import { IInboundSession } from "../OlmDevice.js";
+import { DecryptionFailureCode } from "../../crypto-api/index.js";
+import { DecryptionError } from "../../common-crypto/CryptoBackend.js";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 

--- a/src/crypto/api.ts
+++ b/src/crypto/api.ts
@@ -14,26 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DeviceInfo } from "./deviceinfo";
+import { DeviceInfo } from "./deviceinfo.js";
 
 /* re-exports for backwards compatibility. */
 // CrossSigningKey is used as a value in `client.ts`, we can't export it as a type
-export { CrossSigningKey } from "../crypto-api";
+export { CrossSigningKey } from "../crypto-api/index.js";
 export type {
     GeneratedSecretStorageKey as IRecoveryKey,
     CreateSecretStorageOpts as ICreateSecretStorageOpts,
-} from "../crypto-api";
+} from "../crypto-api/index.js";
 
 export type {
     ImportRoomKeyProgressData as IImportOpts,
     ImportRoomKeysOpts as IImportRoomKeysOpts,
-} from "../crypto-api";
+} from "../crypto-api/index.js";
 
 export type {
     AddSecretStorageKeyOpts as IAddSecretStorageKeyOpts,
     PassphraseInfo as IPassphraseInfo,
     SecretStorageKeyDescription as ISecretStorageKeyInfo,
-} from "../secret-storage";
+} from "../secret-storage.js";
 
 // TODO: Merge this with crypto.js once converted
 

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -18,29 +18,29 @@ limitations under the License.
  * Classes for dealing with key backup.
  */
 
-import type { IMegolmSessionData } from "../@types/crypto";
-import { MatrixClient } from "../client";
-import { logger } from "../logger";
-import { MEGOLM_ALGORITHM, verifySignature } from "./olmlib";
-import { DeviceInfo } from "./deviceinfo";
-import { DeviceTrustLevel } from "./CrossSigning";
-import { keyFromPassphrase } from "./key_passphrase";
-import { encodeUri, safeSet, sleep } from "../utils";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
-import { encodeRecoveryKey } from "./recoverykey";
-import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes";
+import type { IMegolmSessionData } from "../@types/crypto.js";
+import { MatrixClient } from "../client.js";
+import { logger } from "../logger.js";
+import { MEGOLM_ALGORITHM, verifySignature } from "./olmlib.js";
+import { DeviceInfo } from "./deviceinfo.js";
+import { DeviceTrustLevel } from "./CrossSigning.js";
+import { keyFromPassphrase } from "./key_passphrase.js";
+import { encodeUri, safeSet, sleep } from "../utils.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
+import { encodeRecoveryKey } from "./recoverykey.js";
+import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes.js";
 import {
     Curve25519SessionData,
     IAes256AuthData,
     ICurve25519AuthData,
     IKeyBackupInfo,
     IKeyBackupSession,
-} from "./keybackup";
-import { UnstableValue } from "../NamespacedValue";
-import { CryptoEvent } from "./index";
-import { ClientPrefix, HTTPError, MatrixError, Method } from "../http-api";
-import { BackupTrustInfo } from "../crypto-api/keybackup";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend";
+} from "./keybackup.js";
+import { UnstableValue } from "../NamespacedValue.js";
+import { CryptoEvent } from "./index.js";
+import { ClientPrefix, HTTPError, MatrixError, Method } from "../http-api/index.js";
+import { BackupTrustInfo } from "../crypto-api/keybackup.js";
+import { BackupDecryptor } from "../common-crypto/CryptoBackend.js";
 
 const KEY_BACKUP_KEYS_PER_REQUEST = 200;
 const KEY_BACKUP_CHECK_RATE_LIMIT = 5000; // ms

--- a/src/crypto/dehydration.ts
+++ b/src/crypto/dehydration.ts
@@ -16,14 +16,14 @@ limitations under the License.
 
 import anotherjson from "another-json";
 
-import type { IDeviceKeys, IOneTimeKey } from "../@types/crypto";
-import { decodeBase64, encodeBase64 } from "../base64";
-import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store";
-import { decryptAES, encryptAES } from "./aes";
-import { logger } from "../logger";
-import { Crypto } from "./index";
-import { Method } from "../http-api";
-import { SecretStorageKeyDescription } from "../secret-storage";
+import type { IDeviceKeys, IOneTimeKey } from "../@types/crypto.js";
+import { decodeBase64, encodeBase64 } from "../base64.js";
+import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.js";
+import { decryptAES, encryptAES } from "./aes.js";
+import { logger } from "../logger.js";
+import { Crypto } from "./index.js";
+import { Method } from "../http-api/index.js";
+import { SecretStorageKeyDescription } from "../secret-storage.js";
 
 export interface IDehydratedDevice {
     device_id: string; // eslint-disable-line camelcase

--- a/src/crypto/device-converter.ts
+++ b/src/crypto/device-converter.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Device } from "../models/device";
-import { DeviceInfo } from "./deviceinfo";
+import { Device } from "../models/device.js";
+import { DeviceInfo } from "./deviceinfo.js";
 
 /**
  * Convert a {@link DeviceInfo} to a {@link Device}.

--- a/src/crypto/deviceinfo.ts
+++ b/src/crypto/deviceinfo.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISignatures } from "../@types/signed";
-import { DeviceVerification } from "../models/device";
+import { ISignatures } from "../@types/signed.js";
+import { DeviceVerification } from "../models/device.js";
 
 export interface IDevice {
     keys: Record<string, string>;

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -20,55 +20,55 @@ limitations under the License.
 import anotherjson from "another-json";
 import { v4 as uuidv4 } from "uuid";
 
-import type { IDeviceKeys, IEventDecryptionResult, IMegolmSessionData, IOneTimeKey } from "../@types/crypto";
+import type { IDeviceKeys, IEventDecryptionResult, IMegolmSessionData, IOneTimeKey } from "../@types/crypto.js";
 import type { PkDecryption, PkSigning } from "@matrix-org/olm";
-import { EventType, ToDeviceMessageId } from "../@types/event";
-import { TypedReEmitter } from "../ReEmitter";
-import { logger } from "../logger";
-import { IExportedDevice, OlmDevice } from "./OlmDevice";
-import { IOlmDevice } from "./algorithms/megolm";
-import * as olmlib from "./olmlib";
-import { DeviceInfoMap, DeviceList } from "./DeviceList";
-import { DeviceInfo, IDevice } from "./deviceinfo";
-import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms";
-import * as algorithms from "./algorithms";
-import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning";
-import { EncryptionSetupBuilder } from "./EncryptionSetup";
-import { SecretStorage as LegacySecretStorage } from "./SecretStorage";
-import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./api";
-import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager";
-import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store";
-import { VerificationBase } from "./verification/Base";
-import { ReciprocateQRCode, SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD } from "./verification/QRCode";
-import { SAS as SASVerification } from "./verification/SAS";
-import { keyFromPassphrase } from "./key_passphrase";
-import { decodeRecoveryKey, encodeRecoveryKey } from "./recoverykey";
-import { VerificationRequest } from "./verification/request/VerificationRequest";
-import { InRoomChannel, InRoomRequests } from "./verification/request/InRoomChannel";
-import { Request, ToDeviceChannel, ToDeviceRequests } from "./verification/request/ToDeviceChannel";
-import { IllegalMethod } from "./verification/IllegalMethod";
-import { KeySignatureUploadError } from "../errors";
-import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes";
-import { DehydrationManager } from "./dehydration";
-import { BackupManager, LibOlmBackupDecryptor, backupTrustInfoFromLegacyTrustInfo } from "./backup";
-import { IStore } from "../store";
-import { Room, RoomEvent } from "../models/room";
-import { RoomMember, RoomMemberEvent } from "../models/room-member";
-import { EventStatus, IContent, IEvent, MatrixEvent, MatrixEventEvent } from "../models/event";
-import { ToDeviceBatch } from "../models/ToDeviceMessage";
-import { ClientEvent, IKeysUploadResponse, ISignedKey, IUploadKeySignaturesResponse, MatrixClient } from "../client";
-import { IRoomEncryption, RoomList } from "./RoomList";
-import { IKeyBackupInfo } from "./keybackup";
-import { ISyncStateData } from "../sync";
-import { CryptoStore } from "./store/base";
-import { IVerificationChannel } from "./verification/request/Channel";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { IDeviceLists, ISyncResponse, IToDeviceEvent } from "../sync-accumulator";
-import { ISignatures } from "../@types/signed";
-import { IMessage } from "./algorithms/olm";
-import { BackupDecryptor, CryptoBackend, DecryptionError, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
-import { RoomState, RoomStateEvent } from "../models/room-state";
-import { MapWithDefault, recursiveMapToObject } from "../utils";
+import { EventType, ToDeviceMessageId } from "../@types/event.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { logger } from "../logger.js";
+import { IExportedDevice, OlmDevice } from "./OlmDevice.js";
+import { IOlmDevice } from "./algorithms/megolm.js";
+import * as olmlib from "./olmlib.js";
+import { DeviceInfoMap, DeviceList } from "./DeviceList.js";
+import { DeviceInfo, IDevice } from "./deviceinfo.js";
+import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms/index.js";
+import * as algorithms from "./algorithms/index.js";
+import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning.js";
+import { EncryptionSetupBuilder } from "./EncryptionSetup.js";
+import { SecretStorage as LegacySecretStorage } from "./SecretStorage.js";
+import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./api.js";
+import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager.js";
+import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.js";
+import { VerificationBase } from "./verification/Base.js";
+import { ReciprocateQRCode, SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD } from "./verification/QRCode.js";
+import { SAS as SASVerification } from "./verification/SAS.js";
+import { keyFromPassphrase } from "./key_passphrase.js";
+import { decodeRecoveryKey, encodeRecoveryKey } from "./recoverykey.js";
+import { VerificationRequest } from "./verification/request/VerificationRequest.js";
+import { InRoomChannel, InRoomRequests } from "./verification/request/InRoomChannel.js";
+import { Request, ToDeviceChannel, ToDeviceRequests } from "./verification/request/ToDeviceChannel.js";
+import { IllegalMethod } from "./verification/IllegalMethod.js";
+import { KeySignatureUploadError } from "../errors.js";
+import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./aes.js";
+import { DehydrationManager } from "./dehydration.js";
+import { BackupManager, LibOlmBackupDecryptor, backupTrustInfoFromLegacyTrustInfo } from "./backup.js";
+import { IStore } from "../store/index.js";
+import { Room, RoomEvent } from "../models/room.js";
+import { RoomMember, RoomMemberEvent } from "../models/room-member.js";
+import { EventStatus, IContent, IEvent, MatrixEvent, MatrixEventEvent } from "../models/event.js";
+import { ToDeviceBatch } from "../models/ToDeviceMessage.js";
+import { ClientEvent, IKeysUploadResponse, ISignedKey, IUploadKeySignaturesResponse, MatrixClient } from "../client.js";
+import { IRoomEncryption, RoomList } from "./RoomList.js";
+import { IKeyBackupInfo } from "./keybackup.js";
+import { ISyncStateData } from "../sync.js";
+import { CryptoStore } from "./store/base.js";
+import { IVerificationChannel } from "./verification/request/Channel.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { IDeviceLists, ISyncResponse, IToDeviceEvent } from "../sync-accumulator.js";
+import { ISignatures } from "../@types/signed.js";
+import { IMessage } from "./algorithms/olm.js";
+import { BackupDecryptor, CryptoBackend, DecryptionError, OnSyncCompletedData } from "../common-crypto/CryptoBackend.js";
+import { RoomState, RoomStateEvent } from "../models/room-state.js";
+import { MapWithDefault, recursiveMapToObject } from "../utils.js";
 import {
     AccountDataClient,
     AddSecretStorageKeyOpts,
@@ -77,8 +77,8 @@ import {
     SecretStorageKeyObject,
     SecretStorageKeyTuple,
     ServerSideSecretStorageImpl,
-} from "../secret-storage";
-import { ISecretRequest } from "./SecretSharing";
+} from "../secret-storage.js";
+import { ISecretRequest } from "./SecretSharing.js";
 import {
     BackupTrustInfo,
     BootstrapCrossSigningOpts,
@@ -94,18 +94,18 @@ import {
     KeyBackupInfo,
     OwnDeviceKeys,
     VerificationRequest as CryptoApiVerificationRequest,
-} from "../crypto-api";
-import { Device, DeviceMap } from "../models/device";
-import { deviceInfoToDevice } from "./device-converter";
-import { ClientPrefix, MatrixError, Method } from "../http-api";
-import { decodeBase64, encodeBase64 } from "../base64";
-import { KnownMembership } from "../@types/membership";
+} from "../crypto-api/index.js";
+import { Device, DeviceMap } from "../models/device.js";
+import { deviceInfoToDevice } from "./device-converter.js";
+import { ClientPrefix, MatrixError, Method } from "../http-api/index.js";
+import { decodeBase64, encodeBase64 } from "../base64.js";
+import { KnownMembership } from "../@types/membership.js";
 
 /* re-exports for backwards compatibility */
 export type {
     BootstrapCrossSigningOpts as IBootstrapCrossSigningOpts,
     CryptoCallbacks as ICryptoCallbacks,
-} from "../crypto-api";
+} from "../crypto-api/index.js";
 
 const DeviceVerification = DeviceInfo.DeviceVerification;
 
@@ -4374,4 +4374,4 @@ class IncomingRoomKeyRequestCancellation {
 }
 
 // a number of types are re-exported for backwards compatibility, in case any applications are referencing it.
-export type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
+export type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto.js";

--- a/src/crypto/key_passphrase.ts
+++ b/src/crypto/key_passphrase.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { randomString } from "../randomstring";
+import { randomString } from "../randomstring.js";
 
 const DEFAULT_ITERATIONS = 500000;
 

--- a/src/crypto/keybackup.ts
+++ b/src/crypto/keybackup.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Export for backward compatibility
-import { ImportRoomKeyProgressData } from "../crypto-api";
+import { ImportRoomKeyProgressData } from "../crypto-api/index.js";
 
 export type {
     Curve25519AuthData as ICurve25519AuthData,
@@ -24,7 +24,7 @@ export type {
     Curve25519SessionData,
     KeyBackupSession as IKeyBackupSession,
     KeyBackupRoomSessions as IKeyBackupRoomSessions,
-} from "../crypto-api/keybackup";
+} from "../crypto-api/keybackup.js";
 
 /* eslint-enable camelcase */
 

--- a/src/crypto/olmlib.ts
+++ b/src/crypto/olmlib.ts
@@ -21,16 +21,16 @@ limitations under the License.
 import anotherjson from "another-json";
 
 import type { PkSigning } from "@matrix-org/olm";
-import type { IOneTimeKey } from "../@types/crypto";
-import { OlmDevice } from "./OlmDevice";
-import { DeviceInfo } from "./deviceinfo";
-import { Logger, logger } from "../logger";
-import { IClaimOTKsResult, MatrixClient } from "../client";
-import { ISignatures } from "../@types/signed";
-import { MatrixEvent } from "../models/event";
-import { EventType } from "../@types/event";
-import { IMessage } from "./algorithms/olm";
-import { MapWithDefault } from "../utils";
+import type { IOneTimeKey } from "../@types/crypto.js";
+import { OlmDevice } from "./OlmDevice.js";
+import { DeviceInfo } from "./deviceinfo.js";
+import { Logger, logger } from "../logger.js";
+import { IClaimOTKsResult, MatrixClient } from "../client.js";
+import { ISignatures } from "../@types/signed.js";
+import { MatrixEvent } from "../models/event.js";
+import { EventType } from "../@types/event.js";
+import { IMessage } from "./algorithms/olm.js";
+import { MapWithDefault } from "../utils.js";
 
 enum Algorithm {
     Olm = "m.olm.v1.curve25519-aes-sha2",

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index";
-import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager";
-import { IOlmDevice } from "../algorithms/megolm";
-import { TrackingStatus } from "../DeviceList";
-import { IRoomEncryption } from "../RoomList";
-import { IDevice } from "../deviceinfo";
-import { ICrossSigningInfo } from "../CrossSigning";
-import { Logger } from "../../logger";
-import { InboundGroupSessionData } from "../OlmDevice";
-import { MatrixEvent } from "../../models/event";
-import { DehydrationManager } from "../dehydration";
-import { IEncryptedPayload } from "../aes";
-import { CrossSigningKeyInfo } from "../../crypto-api";
+import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.js";
+import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.js";
+import { IOlmDevice } from "../algorithms/megolm.js";
+import { TrackingStatus } from "../DeviceList.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { IDevice } from "../deviceinfo.js";
+import { ICrossSigningInfo } from "../CrossSigning.js";
+import { Logger } from "../../logger.js";
+import { InboundGroupSessionData } from "../OlmDevice.js";
+import { MatrixEvent } from "../../models/event.js";
+import { DehydrationManager } from "../dehydration.js";
+import { IEncryptedPayload } from "../aes.js";
+import { CrossSigningKeyInfo } from "../../crypto-api/index.js";
 
 /**
  * Internal module. Definitions for storage for the crypto module

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Logger, logger } from "../../logger";
-import { deepCompare } from "../../utils";
+import { Logger, logger } from "../../logger.js";
+import { deepCompare } from "../../utils.js";
 import {
     CryptoStore,
     IDeviceData,
@@ -31,13 +31,13 @@ import {
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
-} from "./base";
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index";
-import { IOlmDevice } from "../algorithms/megolm";
-import { IRoomEncryption } from "../RoomList";
-import { InboundGroupSessionData } from "../OlmDevice";
-import { IndexedDBCryptoStore } from "./indexeddb-crypto-store";
-import { CrossSigningKeyInfo } from "../../crypto-api";
+} from "./base.js";
+import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.js";
+import { IOlmDevice } from "../algorithms/megolm.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { InboundGroupSessionData } from "../OlmDevice.js";
+import { IndexedDBCryptoStore } from "./indexeddb-crypto-store.js";
+import { CrossSigningKeyInfo } from "../../crypto-api/index.js";
 
 const PROFILE_TRANSACTIONS = false;
 

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger, Logger } from "../../logger";
-import { LocalStorageCryptoStore } from "./localStorage-crypto-store";
-import { MemoryCryptoStore } from "./memory-crypto-store";
-import * as IndexedDBCryptoStoreBackend from "./indexeddb-crypto-store-backend";
-import { InvalidCryptoStoreError, InvalidCryptoStoreState } from "../../errors";
-import * as IndexedDBHelpers from "../../indexeddb-helpers";
+import { logger, Logger } from "../../logger.js";
+import { LocalStorageCryptoStore } from "./localStorage-crypto-store.js";
+import { MemoryCryptoStore } from "./memory-crypto-store.js";
+import * as IndexedDBCryptoStoreBackend from "./indexeddb-crypto-store-backend.js";
+import { InvalidCryptoStoreError, InvalidCryptoStoreState } from "../../errors.js";
+import * as IndexedDBHelpers from "../../indexeddb-helpers.js";
 import {
     CryptoStore,
     IDeviceData,
@@ -34,12 +34,12 @@ import {
     ParkedSharedHistory,
     SecretStorePrivateKeys,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
-} from "./base";
-import { IRoomKeyRequestBody } from "../index";
-import { IOlmDevice } from "../algorithms/megolm";
-import { IRoomEncryption } from "../RoomList";
-import { InboundGroupSessionData } from "../OlmDevice";
-import { CrossSigningKeyInfo } from "../../crypto-api";
+} from "./base.js";
+import { IRoomKeyRequestBody } from "../index.js";
+import { IOlmDevice } from "../algorithms/megolm.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { InboundGroupSessionData } from "../OlmDevice.js";
+import { CrossSigningKeyInfo } from "../../crypto-api/index.js";
 
 /*
  * Internal module. indexeddb storage for e2e.

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../../logger";
-import { MemoryCryptoStore } from "./memory-crypto-store";
+import { logger } from "../../logger.js";
+import { MemoryCryptoStore } from "./memory-crypto-store.js";
 import {
     CryptoStore,
     IDeviceData,
@@ -28,12 +28,12 @@ import {
     Mode,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
-} from "./base";
-import { IOlmDevice } from "../algorithms/megolm";
-import { IRoomEncryption } from "../RoomList";
-import { InboundGroupSessionData } from "../OlmDevice";
-import { safeSet } from "../../utils";
-import { CrossSigningKeyInfo } from "../../crypto-api";
+} from "./base.js";
+import { IOlmDevice } from "../algorithms/megolm.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { InboundGroupSessionData } from "../OlmDevice.js";
+import { safeSet } from "../../utils.js";
+import { CrossSigningKeyInfo } from "../../crypto-api/index.js";
 
 /**
  * Internal module. Partial localStorage backed storage for e2e.

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../../logger";
-import { deepCompare, promiseTry, safeSet } from "../../utils";
+import { logger } from "../../logger.js";
+import { deepCompare, promiseTry, safeSet } from "../../utils.js";
 import {
     CryptoStore,
     IDeviceData,
@@ -30,12 +30,12 @@ import {
     ParkedSharedHistory,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
-} from "./base";
-import { IRoomKeyRequestBody } from "../index";
-import { IOlmDevice } from "../algorithms/megolm";
-import { IRoomEncryption } from "../RoomList";
-import { InboundGroupSessionData } from "../OlmDevice";
-import { CrossSigningKeyInfo } from "../../crypto-api";
+} from "./base.js";
+import { IRoomKeyRequestBody } from "../index.js";
+import { IOlmDevice } from "../algorithms/megolm.js";
+import { IRoomEncryption } from "../RoomList.js";
+import { InboundGroupSessionData } from "../OlmDevice.js";
+import { CrossSigningKeyInfo } from "../../crypto-api/index.js";
 
 function encodeSessionKey(senderCurve25519Key: string, sessionId: string): string {
     return encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);

--- a/src/crypto/verification/Base.ts
+++ b/src/crypto/verification/Base.ts
@@ -19,23 +19,23 @@ limitations under the License.
  * Base class for verification methods.
  */
 
-import { MatrixEvent } from "../../models/event";
-import { EventType } from "../../@types/event";
-import { logger } from "../../logger";
-import { DeviceInfo } from "../deviceinfo";
-import { newTimeoutError } from "./Error";
-import { KeysDuringVerification, requestKeysDuringVerification } from "../CrossSigning";
-import { IVerificationChannel } from "./request/Channel";
-import { MatrixClient } from "../../client";
-import { VerificationRequest } from "./request/VerificationRequest";
-import { TypedEventEmitter } from "../../models/typed-event-emitter";
+import { MatrixEvent } from "../../models/event.js";
+import { EventType } from "../../@types/event.js";
+import { logger } from "../../logger.js";
+import { DeviceInfo } from "../deviceinfo.js";
+import { newTimeoutError } from "./Error.js";
+import { KeysDuringVerification, requestKeysDuringVerification } from "../CrossSigning.js";
+import { IVerificationChannel } from "./request/Channel.js";
+import { MatrixClient } from "../../client.js";
+import { VerificationRequest } from "./request/VerificationRequest.js";
+import { TypedEventEmitter } from "../../models/typed-event-emitter.js";
 import {
     ShowQrCodeCallbacks,
     ShowSasCallbacks,
     Verifier,
     VerifierEvent,
     VerifierEventHandlerMap,
-} from "../../crypto-api/verification";
+} from "../../crypto-api/verification.js";
 
 const timeoutException = new Error("Verification timed out");
 

--- a/src/crypto/verification/Error.ts
+++ b/src/crypto/verification/Error.ts
@@ -18,8 +18,8 @@ limitations under the License.
  * Error messages.
  */
 
-import { MatrixEvent } from "../../models/event";
-import { EventType } from "../../@types/event";
+import { MatrixEvent } from "../../models/event.js";
+import { EventType } from "../../@types/event.js";
 
 export function newVerificationError(code: string, reason: string, extraData?: Record<string, any>): MatrixEvent {
     const content = Object.assign({}, { code, reason }, extraData);

--- a/src/crypto/verification/IllegalMethod.ts
+++ b/src/crypto/verification/IllegalMethod.ts
@@ -19,11 +19,11 @@ limitations under the License.
  * do verification with this method).
  */
 
-import { VerificationBase as Base, VerificationEvent, VerificationEventHandlerMap } from "./Base";
-import { IVerificationChannel } from "./request/Channel";
-import { MatrixClient } from "../../client";
-import { MatrixEvent } from "../../models/event";
-import { VerificationRequest } from "./request/VerificationRequest";
+import { VerificationBase as Base, VerificationEvent, VerificationEventHandlerMap } from "./Base.js";
+import { IVerificationChannel } from "./request/Channel.js";
+import { MatrixClient } from "../../client.js";
+import { MatrixEvent } from "../../models/event.js";
+import { VerificationRequest } from "./request/VerificationRequest.js";
 
 export class IllegalMethod extends Base<VerificationEvent, VerificationEventHandlerMap> {
     public static factory(

--- a/src/crypto/verification/QRCode.ts
+++ b/src/crypto/verification/QRCode.ts
@@ -18,16 +18,16 @@ limitations under the License.
  * QR code key verification.
  */
 
-import { VerificationBase as Base } from "./Base";
-import { newKeyMismatchError, newUserCancelledError } from "./Error";
-import { decodeBase64, encodeUnpaddedBase64 } from "../../base64";
-import { logger } from "../../logger";
-import { VerificationRequest } from "./request/VerificationRequest";
-import { MatrixClient } from "../../client";
-import { IVerificationChannel } from "./request/Channel";
-import { MatrixEvent } from "../../models/event";
-import { ShowQrCodeCallbacks, VerifierEvent } from "../../crypto-api/verification";
-import { VerificationMethod } from "../../types";
+import { VerificationBase as Base } from "./Base.js";
+import { newKeyMismatchError, newUserCancelledError } from "./Error.js";
+import { decodeBase64, encodeUnpaddedBase64 } from "../../base64.js";
+import { logger } from "../../logger.js";
+import { VerificationRequest } from "./request/VerificationRequest.js";
+import { MatrixClient } from "../../client.js";
+import { IVerificationChannel } from "./request/Channel.js";
+import { MatrixEvent } from "../../models/event.js";
+import { ShowQrCodeCallbacks, VerifierEvent } from "../../crypto-api/verification.js";
+import { VerificationMethod } from "../../types.js";
 
 export const SHOW_QR_CODE_METHOD = VerificationMethod.ShowQrCode;
 export const SCAN_QR_CODE_METHOD = VerificationMethod.ScanQrCode;

--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -21,27 +21,27 @@ limitations under the License.
 import anotherjson from "another-json";
 import { Utility, SAS as OlmSAS } from "@matrix-org/olm";
 
-import { VerificationBase as Base, SwitchStartEventError } from "./Base";
+import { VerificationBase as Base, SwitchStartEventError } from "./Base.js";
 import {
     errorFactory,
     newInvalidMessageError,
     newKeyMismatchError,
     newUnknownMethodError,
     newUserCancelledError,
-} from "./Error";
-import { logger } from "../../logger";
-import { IContent, MatrixEvent } from "../../models/event";
-import { generateDecimalSas } from "./SASDecimal";
-import { EventType } from "../../@types/event";
-import { EmojiMapping, GeneratedSas, ShowSasCallbacks, VerifierEvent } from "../../crypto-api/verification";
-import { VerificationMethod } from "../../types";
+} from "./Error.js";
+import { logger } from "../../logger.js";
+import { IContent, MatrixEvent } from "../../models/event.js";
+import { generateDecimalSas } from "./SASDecimal.js";
+import { EventType } from "../../@types/event.js";
+import { EmojiMapping, GeneratedSas, ShowSasCallbacks, VerifierEvent } from "../../crypto-api/verification.js";
+import { VerificationMethod } from "../../types.js";
 
 // backwards-compatibility exports
 export type {
     ShowSasCallbacks as ISasEvent,
     GeneratedSas as IGeneratedSas,
     EmojiMapping,
-} from "../../crypto-api/verification";
+} from "../../crypto-api/verification.js";
 
 const START_TYPE = EventType.KeyVerificationStart;
 

--- a/src/crypto/verification/request/Channel.ts
+++ b/src/crypto/verification/request/Channel.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../../../models/event";
-import { VerificationRequest } from "./VerificationRequest";
+import { MatrixEvent } from "../../../models/event.js";
+import { VerificationRequest } from "./VerificationRequest.js";
 
 export interface IVerificationChannel {
     request?: VerificationRequest;

--- a/src/crypto/verification/request/InRoomChannel.ts
+++ b/src/crypto/verification/request/InRoomChannel.ts
@@ -15,13 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { VerificationRequest, REQUEST_TYPE, READY_TYPE, START_TYPE } from "./VerificationRequest";
-import { logger } from "../../../logger";
-import { IVerificationChannel } from "./Channel";
-import { EventType, TimelineEvents } from "../../../@types/event";
-import { MatrixClient } from "../../../client";
-import { MatrixEvent } from "../../../models/event";
-import { IRequestsMap } from "../..";
+import { VerificationRequest, REQUEST_TYPE, READY_TYPE, START_TYPE } from "./VerificationRequest.js";
+import { logger } from "../../../logger.js";
+import { IVerificationChannel } from "./Channel.js";
+import { EventType, TimelineEvents } from "../../../@types/event.js";
+import { MatrixClient } from "../../../client.js";
+import { MatrixEvent } from "../../../models/event.js";
+import { IRequestsMap } from "../../index.js";
 
 const MESSAGE_TYPE = EventType.RoomMessage;
 const M_REFERENCE = "m.reference";

--- a/src/crypto/verification/request/ToDeviceChannel.ts
+++ b/src/crypto/verification/request/ToDeviceChannel.ts
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { randomString } from "../../../randomstring";
-import { logger } from "../../../logger";
+import { randomString } from "../../../randomstring.js";
+import { logger } from "../../../logger.js";
 import {
     CANCEL_TYPE,
     PHASE_STARTED,
@@ -25,12 +25,12 @@ import {
     READY_TYPE,
     START_TYPE,
     VerificationRequest,
-} from "./VerificationRequest";
-import { errorFromEvent, newUnexpectedMessageError } from "../Error";
-import { MatrixEvent } from "../../../models/event";
-import { IVerificationChannel } from "./Channel";
-import { MatrixClient } from "../../../client";
-import { IRequestsMap } from "../..";
+} from "./VerificationRequest.js";
+import { errorFromEvent, newUnexpectedMessageError } from "../Error.js";
+import { MatrixEvent } from "../../../models/event.js";
+import { IVerificationChannel } from "./Channel.js";
+import { MatrixClient } from "../../../client.js";
+import { IRequestsMap } from "../../index.js";
 
 export type Request = VerificationRequest<ToDeviceChannel>;
 

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../../../logger";
-import { errorFactory, errorFromEvent, newUnexpectedMessageError, newUnknownMethodError } from "../Error";
-import { QRCodeData, SCAN_QR_CODE_METHOD } from "../QRCode";
-import { IVerificationChannel } from "./Channel";
-import { MatrixClient } from "../../../client";
-import { MatrixEvent } from "../../../models/event";
-import { EventType } from "../../../@types/event";
-import { VerificationBase } from "../Base";
-import { VerificationMethod } from "../../index";
-import { TypedEventEmitter } from "../../../models/typed-event-emitter";
+import { logger } from "../../../logger.js";
+import { errorFactory, errorFromEvent, newUnexpectedMessageError, newUnknownMethodError } from "../Error.js";
+import { QRCodeData, SCAN_QR_CODE_METHOD } from "../QRCode.js";
+import { IVerificationChannel } from "./Channel.js";
+import { MatrixClient } from "../../../client.js";
+import { MatrixEvent } from "../../../models/event.js";
+import { EventType } from "../../../@types/event.js";
+import { VerificationBase } from "../Base.js";
+import { VerificationMethod } from "../../index.js";
+import { TypedEventEmitter } from "../../../models/typed-event-emitter.js";
 import {
     canAcceptVerificationRequest,
     VerificationPhase as Phase,
@@ -31,10 +31,10 @@ import {
     VerificationRequestEvent,
     VerificationRequestEventHandlerMap,
     Verifier,
-} from "../../../crypto-api/verification";
+} from "../../../crypto-api/verification.js";
 
 // backwards-compatibility exports
-export { VerificationPhase as Phase, VerificationRequestEvent } from "../../../crypto-api/verification";
+export { VerificationPhase as Phase, VerificationRequestEvent } from "../../../crypto-api/verification.js";
 
 // How long after the event's timestamp that the request times out
 const TIMEOUT_FROM_EVENT_TS = 10 * 60 * 1000; // 10 minutes

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -25,15 +25,15 @@ import {
     ISendEventFromWidgetResponseData,
 } from "matrix-widget-api";
 
-import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event";
+import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event.js";
 import {
     ISendEventResponse,
     SendDelayedEventRequestOpts,
     SendDelayedEventResponse,
     UpdateDelayedEventAction,
-} from "./@types/requests";
-import { EventType, StateEvents } from "./@types/event";
-import { logger } from "./logger";
+} from "./@types/requests.js";
+import { EventType, StateEvents } from "./@types/event.js";
+import { logger } from "./logger.js";
 import {
     MatrixClient,
     ClientEvent,
@@ -42,15 +42,15 @@ import {
     SendToDeviceContentMap,
     IOpenIDToken,
     UNSTABLE_MSC4140_DELAYED_EVENTS,
-} from "./client";
-import { SyncApi, SyncState } from "./sync";
-import { SlidingSyncSdk } from "./sliding-sync-sdk";
-import { User } from "./models/user";
-import { Room } from "./models/room";
-import { ToDeviceBatch, ToDevicePayload } from "./models/ToDeviceMessage";
-import { DeviceInfo } from "./crypto/deviceinfo";
-import { IOlmDevice } from "./crypto/algorithms/megolm";
-import { MapWithDefault, recursiveMapToObject } from "./utils";
+} from "./client.js";
+import { SyncApi, SyncState } from "./sync.js";
+import { SlidingSyncSdk } from "./sliding-sync-sdk.js";
+import { User } from "./models/user.js";
+import { Room } from "./models/room.js";
+import { ToDeviceBatch, ToDevicePayload } from "./models/ToDeviceMessage.js";
+import { DeviceInfo } from "./crypto/deviceinfo.js";
+import { IOlmDevice } from "./crypto/algorithms/megolm.js";
+import { MapWithDefault, recursiveMapToObject } from "./utils.js";
 
 interface IStateEventRequest {
     eventType: string;

--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "./client";
-import { IEvent, MatrixEvent, MatrixEventEvent } from "./models/event";
-import { RelationType } from "./@types/event";
+import { MatrixClient } from "./client.js";
+import { IEvent, MatrixEvent, MatrixEventEvent } from "./models/event.js";
+import { RelationType } from "./@types/event.js";
 
 export type EventMapper = (obj: Partial<IEvent>) => MatrixEvent;
 

--- a/src/extensible_events_v1/ExtensibleEvent.ts
+++ b/src/extensible_events_v1/ExtensibleEvent.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ExtensibleEventType, IPartialEvent } from "../@types/extensible_events";
+import { ExtensibleEventType, IPartialEvent } from "../@types/extensible_events.js";
 
 /**
  * Represents an Extensible Event in Matrix.

--- a/src/extensible_events_v1/MessageEvent.ts
+++ b/src/extensible_events_v1/MessageEvent.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import { ExtensibleEvent } from "./ExtensibleEvent";
+import { ExtensibleEvent } from "./ExtensibleEvent.js";
 import {
     ExtensibleEventType,
     IMessageRendering,
@@ -26,9 +26,9 @@ import {
     M_MESSAGE,
     ExtensibleAnyMessageEventContent,
     M_TEXT,
-} from "../@types/extensible_events";
-import { isOptionalAString, isProvided } from "./utilities";
-import { InvalidEventError } from "./InvalidEventError";
+} from "../@types/extensible_events.js";
+import { isOptionalAString, isProvided } from "./utilities.js";
+import { InvalidEventError } from "./InvalidEventError.js";
 
 /**
  * Represents a message event. Message events are the simplest form of event with

--- a/src/extensible_events_v1/PollEndEvent.ts
+++ b/src/extensible_events_v1/PollEndEvent.ts
@@ -20,11 +20,11 @@ import {
     isEventTypeSame,
     M_TEXT,
     REFERENCE_RELATION,
-} from "../@types/extensible_events";
-import { M_POLL_END, PollEndEventContent } from "../@types/polls";
-import { ExtensibleEvent } from "./ExtensibleEvent";
-import { InvalidEventError } from "./InvalidEventError";
-import { MessageEvent } from "./MessageEvent";
+} from "../@types/extensible_events.js";
+import { M_POLL_END, PollEndEventContent } from "../@types/polls.js";
+import { ExtensibleEvent } from "./ExtensibleEvent.js";
+import { InvalidEventError } from "./InvalidEventError.js";
+import { MessageEvent } from "./MessageEvent.js";
 
 /**
  * Represents a poll end/closure event.

--- a/src/extensible_events_v1/PollResponseEvent.ts
+++ b/src/extensible_events_v1/PollResponseEvent.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ExtensibleEvent } from "./ExtensibleEvent";
-import { M_POLL_RESPONSE, PollResponseEventContent, PollResponseSubtype } from "../@types/polls";
-import { ExtensibleEventType, IPartialEvent, isEventTypeSame, REFERENCE_RELATION } from "../@types/extensible_events";
-import { InvalidEventError } from "./InvalidEventError";
-import { PollStartEvent } from "./PollStartEvent";
+import { ExtensibleEvent } from "./ExtensibleEvent.js";
+import { M_POLL_RESPONSE, PollResponseEventContent, PollResponseSubtype } from "../@types/polls.js";
+import { ExtensibleEventType, IPartialEvent, isEventTypeSame, REFERENCE_RELATION } from "../@types/extensible_events.js";
+import { InvalidEventError } from "./InvalidEventError.js";
+import { PollStartEvent } from "./PollStartEvent.js";
 
 /**
  * Represents a poll response event.

--- a/src/extensible_events_v1/PollStartEvent.ts
+++ b/src/extensible_events_v1/PollStartEvent.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import { NamespacedValue } from "matrix-events-sdk";
 
-import { MessageEvent } from "./MessageEvent";
-import { ExtensibleEventType, IPartialEvent, isEventTypeSame, M_TEXT } from "../@types/extensible_events";
+import { MessageEvent } from "./MessageEvent.js";
+import { ExtensibleEventType, IPartialEvent, isEventTypeSame, M_TEXT } from "../@types/extensible_events.js";
 import {
     KnownPollKind,
     M_POLL_KIND_DISCLOSED,
@@ -26,9 +26,9 @@ import {
     PollStartEventContent,
     PollStartSubtype,
     PollAnswer,
-} from "../@types/polls";
-import { InvalidEventError } from "./InvalidEventError";
-import { ExtensibleEvent } from "./ExtensibleEvent";
+} from "../@types/polls.js";
+import { InvalidEventError } from "./InvalidEventError.js";
+import { ExtensibleEvent } from "./ExtensibleEvent.js";
 
 /**
  * Represents a poll answer. Note that this is represented as a subtype and is

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IServerVersions } from "./client";
+import { IServerVersions } from "./client.js";
 
 export enum ServerSupport {
     Stable,

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RelationType } from "./@types/event";
-import { MatrixEvent } from "./models/event";
-import { FILTER_RELATED_BY_REL_TYPES, FILTER_RELATED_BY_SENDERS, THREAD_RELATION_TYPE } from "./models/thread";
+import { RelationType } from "./@types/event.js";
+import { MatrixEvent } from "./models/event.js";
+import { FILTER_RELATED_BY_REL_TYPES, FILTER_RELATED_BY_SENDERS, THREAD_RELATION_TYPE } from "./models/thread.js";
 
 /**
  * Checks if a value matches a given field value, which may be a * terminated

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType, RelationType } from "./@types/event";
-import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
-import { FilterComponent, IFilterComponent } from "./filter-component";
-import { MatrixEvent } from "./models/event";
+import { EventType, RelationType } from "./@types/event.js";
+import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.js";
+import { FilterComponent, IFilterComponent } from "./filter-component.js";
+import { MatrixEvent } from "./models/event.js";
 
 /**
  */

--- a/src/http-api/errors.ts
+++ b/src/http-api/errors.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IUsageLimit } from "../@types/partials";
-import { MatrixEvent } from "../models/event";
+import { IUsageLimit } from "../@types/partials.js";
+import { MatrixEvent } from "../models/event.js";
 
 interface IErrorJson extends Partial<IUsageLimit> {
     [key: string]: any; // extensible

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -18,13 +18,13 @@ limitations under the License.
  * This is an internal module. See {@link MatrixHttpApi} for the public class.
  */
 
-import { checkObjectHasKeys, encodeParams } from "../utils";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { Method } from "./method";
-import { ConnectionError, MatrixError } from "./errors";
-import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, IRequestOpts, Body } from "./interface";
-import { anySignal, parseErrorResponse, timeoutSignal } from "./utils";
-import { QueryDict } from "../utils";
+import { checkObjectHasKeys, encodeParams } from "../utils.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { Method } from "./method.js";
+import { ConnectionError, MatrixError } from "./errors.js";
+import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, IRequestOpts, Body } from "./interface.js";
+import { anySignal, parseErrorResponse, timeoutSignal } from "./utils.js";
+import { QueryDict } from "../utils.js";
 
 interface TypedResponse<T> extends Response {
     json(): Promise<T>;

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { FetchHttpApi } from "./fetch";
-import { FileType, IContentUri, IHttpOpts, Upload, UploadOpts, UploadResponse } from "./interface";
-import { MediaPrefix } from "./prefix";
-import { defer, QueryDict, removeElement } from "../utils";
-import * as callbacks from "../realtime-callbacks";
-import { Method } from "./method";
-import { ConnectionError } from "./errors";
-import { parseErrorResponse } from "./utils";
+import { FetchHttpApi } from "./fetch.js";
+import { FileType, IContentUri, IHttpOpts, Upload, UploadOpts, UploadResponse } from "./interface.js";
+import { MediaPrefix } from "./prefix.js";
+import { defer, QueryDict, removeElement } from "../utils.js";
+import * as callbacks from "../realtime-callbacks.js";
+import { Method } from "./method.js";
+import { ConnectionError } from "./errors.js";
+import { parseErrorResponse } from "./utils.js";
 
-export * from "./interface";
-export * from "./prefix";
-export * from "./errors";
-export * from "./method";
-export * from "./utils";
+export * from "./interface.js";
+export * from "./prefix.js";
+export * from "./errors.js";
+export * from "./method.js";
+export * from "./utils.js";
 
 export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
     private uploads: Upload[] = [];

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixError } from "./errors";
-import { Logger } from "../logger";
+import { MatrixError } from "./errors.js";
+import { Logger } from "../logger.js";
 
 export type Body = Record<string, any> | BodyInit;
 

--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 import { parse as parseContentType, ParsedMediaType } from "content-type";
 
-import { logger } from "../logger";
-import { sleep } from "../utils";
-import { ConnectionError, HTTPError, MatrixError } from "./errors";
+import { logger } from "../logger.js";
+import { sleep } from "../utils.js";
+import { ConnectionError, HTTPError, MatrixError } from "./errors.js";
 
 // Ponyfill for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout
 export function timeoutSignal(ms: number): AbortSignal {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as matrixcs from "./matrix";
+import * as matrixcs from "./matrix.js";
 
 if (global.__js_sdk_entrypoint) {
     throw new Error("Multiple matrix-js-sdk entrypoints detected!");
 }
 global.__js_sdk_entrypoint = true;
 
-export * from "./matrix";
+export * from "./matrix.js";
 export default matrixcs;

--- a/src/indexeddb-worker.ts
+++ b/src/indexeddb-worker.ts
@@ -21,4 +21,4 @@ limitations under the License.
  */
 
 /** The {@link IndexedDBStoreWorker} class. */
-export { IndexedDBStoreWorker } from "./store/indexeddb-store-worker";
+export { IndexedDBStoreWorker } from "./store/indexeddb-store-worker.js";

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -16,12 +16,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "./logger";
-import { MatrixClient } from "./client";
-import { defer, IDeferred } from "./utils";
-import { MatrixError } from "./http-api";
-import { UIAResponse } from "./@types/uia";
-import { UserIdentifier } from "./@types/auth";
+import { logger } from "./logger.js";
+import { MatrixClient } from "./client.js";
+import { defer, IDeferred } from "./utils.js";
+import { MatrixError } from "./http-api/index.js";
+import { UIAResponse } from "./@types/uia.js";
+import { UserIdentifier } from "./@types/auth.js";
 
 const EMAIL_STAGE_TYPE = "m.login.email.identity";
 const MSISDN_STAGE_TYPE = "m.login.msisdn";

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -16,74 +16,74 @@ limitations under the License.
 
 import { WidgetApi } from "matrix-widget-api";
 
-import { MemoryCryptoStore } from "./crypto/store/memory-crypto-store";
-import { MemoryStore } from "./store/memory";
-import { MatrixScheduler } from "./scheduler";
-import { MatrixClient, ICreateClientOpts } from "./client";
-import { RoomWidgetClient, ICapabilities } from "./embedded";
-import { CryptoStore } from "./crypto/store/base";
+import { MemoryCryptoStore } from "./crypto/store/memory-crypto-store.js";
+import { MemoryStore } from "./store/memory.js";
+import { MatrixScheduler } from "./scheduler.js";
+import { MatrixClient, ICreateClientOpts } from "./client.js";
+import { RoomWidgetClient, ICapabilities } from "./embedded.js";
+import { CryptoStore } from "./crypto/store/base.js";
 
-export * from "./client";
-export * from "./serverCapabilities";
-export * from "./embedded";
-export * from "./http-api";
-export * from "./autodiscovery";
-export * from "./sync-accumulator";
-export * from "./errors";
-export * from "./base64";
-export * from "./models/beacon";
-export * from "./models/event";
-export * from "./models/room";
-export * from "./models/event-timeline";
-export * from "./models/event-timeline-set";
-export * from "./models/poll";
-export * from "./models/room-member";
-export * from "./models/room-state";
-export * from "./models/thread";
-export * from "./models/typed-event-emitter";
-export * from "./models/user";
-export * from "./models/device";
-export * from "./models/search-result";
-export * from "./oidc";
-export * from "./scheduler";
-export * from "./filter";
-export * from "./timeline-window";
-export * from "./interactive-auth";
-export * from "./service-types";
-export * from "./store/memory";
-export * from "./store/indexeddb";
-export * from "./crypto/store/memory-crypto-store";
-export * from "./crypto/store/localStorage-crypto-store";
-export * from "./crypto/store/indexeddb-crypto-store";
-export type { OutgoingRoomKeyRequest } from "./crypto/store/base";
-export * from "./content-repo";
-export * from "./@types/common";
-export * from "./@types/uia";
-export * from "./@types/event";
-export * from "./@types/PushRules";
-export * from "./@types/partials";
-export * from "./@types/requests";
-export * from "./@types/search";
-export * from "./@types/beacon";
-export * from "./@types/topic";
-export * from "./@types/location";
-export * from "./@types/threepids";
-export * from "./@types/auth";
-export * from "./@types/polls";
-export * from "./@types/local_notifications";
-export * from "./@types/registration";
-export * from "./@types/read_receipts";
-export * from "./@types/crypto";
-export * from "./@types/extensible_events";
-export * from "./@types/IIdentityServerProvider";
-export * from "./models/room-summary";
-export * from "./models/event-status";
-export type { RoomSummary } from "./client";
-export * as ContentHelpers from "./content-helpers";
-export * as SecretStorage from "./secret-storage";
-export type { ICryptoCallbacks } from "./crypto"; // used to be located here
-export { createNewMatrixCall, CallEvent } from "./webrtc/call";
-export type { MatrixCall } from "./webrtc/call";
+export * from "./client.js";
+export * from "./serverCapabilities.js";
+export * from "./embedded.js";
+export * from "./http-api/index.js";
+export * from "./autodiscovery.js";
+export * from "./sync-accumulator.js";
+export * from "./errors.js";
+export * from "./base64.js";
+export * from "./models/beacon.js";
+export * from "./models/event.js";
+export * from "./models/room.js";
+export * from "./models/event-timeline.js";
+export * from "./models/event-timeline-set.js";
+export * from "./models/poll.js";
+export * from "./models/room-member.js";
+export * from "./models/room-state.js";
+export * from "./models/thread.js";
+export * from "./models/typed-event-emitter.js";
+export * from "./models/user.js";
+export * from "./models/device.js";
+export * from "./models/search-result.js";
+export * from "./oidc/index.js";
+export * from "./scheduler.js";
+export * from "./filter.js";
+export * from "./timeline-window.js";
+export * from "./interactive-auth.js";
+export * from "./service-types.js";
+export * from "./store/memory.js";
+export * from "./store/indexeddb.js";
+export * from "./crypto/store/memory-crypto-store.js";
+export * from "./crypto/store/localStorage-crypto-store.js";
+export * from "./crypto/store/indexeddb-crypto-store.js";
+export type { OutgoingRoomKeyRequest } from "./crypto/store/base.js";
+export * from "./content-repo.js";
+export * from "./@types/common.js";
+export * from "./@types/uia.js";
+export * from "./@types/event.js";
+export * from "./@types/PushRules.js";
+export * from "./@types/partials.js";
+export * from "./@types/requests.js";
+export * from "./@types/search.js";
+export * from "./@types/beacon.js";
+export * from "./@types/topic.js";
+export * from "./@types/location.js";
+export * from "./@types/threepids.js";
+export * from "./@types/auth.js";
+export * from "./@types/polls.js";
+export * from "./@types/local_notifications.js";
+export * from "./@types/registration.js";
+export * from "./@types/read_receipts.js";
+export * from "./@types/crypto.js";
+export * from "./@types/extensible_events.js";
+export * from "./@types/IIdentityServerProvider.js";
+export * from "./models/room-summary.js";
+export * from "./models/event-status.js";
+export type { RoomSummary } from "./client.js";
+export * as ContentHelpers from "./content-helpers.js";
+export * as SecretStorage from "./secret-storage.js";
+export type { ICryptoCallbacks } from "./crypto/index.js"; // used to be located here
+export { createNewMatrixCall, CallEvent } from "./webrtc/call.js";
+export type { MatrixCall } from "./webrtc/call.js";
 export {
     GroupCall,
     GroupCallEvent,
@@ -91,21 +91,21 @@ export {
     GroupCallState,
     GroupCallType,
     GroupCallStatsReportEvent,
-} from "./webrtc/groupCall";
-export { CryptoEvent } from "./crypto";
-export { SyncState, SetPresence } from "./sync";
-export type { ISyncStateData as SyncStateData } from "./sync";
-export { SlidingSyncEvent } from "./sliding-sync";
-export { MediaHandlerEvent } from "./webrtc/mediaHandler";
-export { CallFeedEvent } from "./webrtc/callFeed";
-export { StatsReport } from "./webrtc/stats/statsReport";
-export { Relations, RelationsEvent } from "./models/relations";
-export { TypedEventEmitter } from "./models/typed-event-emitter";
-export { LocalStorageErrors } from "./store/local-storage-events-emitter";
-export { IdentityProviderBrand, SSOAction } from "./@types/auth";
-export type { ISSOFlow as SSOFlow, LoginFlow } from "./@types/auth";
-export type { IHierarchyRelation as HierarchyRelation, IHierarchyRoom as HierarchyRoom } from "./@types/spaces";
-export { LocationAssetType } from "./@types/location";
+} from "./webrtc/groupCall.js";
+export { CryptoEvent } from "./crypto/index.js";
+export { SyncState, SetPresence } from "./sync.js";
+export type { ISyncStateData as SyncStateData } from "./sync.js";
+export { SlidingSyncEvent } from "./sliding-sync.js";
+export { MediaHandlerEvent } from "./webrtc/mediaHandler.js";
+export { CallFeedEvent } from "./webrtc/callFeed.js";
+export { StatsReport } from "./webrtc/stats/statsReport.js";
+export { Relations, RelationsEvent } from "./models/relations.js";
+export { TypedEventEmitter } from "./models/typed-event-emitter.js";
+export { LocalStorageErrors } from "./store/local-storage-events-emitter.js";
+export { IdentityProviderBrand, SSOAction } from "./@types/auth.js";
+export type { ISSOFlow as SSOFlow, LoginFlow } from "./@types/auth.js";
+export type { IHierarchyRelation as HierarchyRelation, IHierarchyRoom as HierarchyRoom } from "./@types/spaces.js";
+export { LocationAssetType } from "./@types/location.js";
 
 /**
  * Types supporting cryptography.
@@ -113,7 +113,7 @@ export { LocationAssetType } from "./@types/location";
  * The most important is {@link Crypto.CryptoApi}, an instance of which can be retrieved via
  * {@link MatrixClient.getCrypto}.
  */
-export * as Crypto from "./crypto-api";
+export * as Crypto from "./crypto-api/index.js";
 
 let cryptoStoreFactory = (): CryptoStore => new MemoryCryptoStore();
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -16,10 +16,10 @@ limitations under the License.
 
 import { EitherAnd } from "matrix-events-sdk/lib/types";
 
-import { MatrixEvent } from "../matrix";
-import { deepCompare } from "../utils";
-import { Focus } from "./focus";
-import { isLivekitFocusActive } from "./LivekitFocus";
+import { MatrixEvent } from "../matrix.js";
+import { deepCompare } from "../utils.js";
+import { Focus } from "./focus.js";
+import { isLivekitFocusActive } from "./LivekitFocus.js";
 
 type CallScope = "m.room" | "m.user";
 // Represents an entry in the memberships section of an m.call.member event as it is on the wire

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Focus } from "./focus";
+import { Focus } from "./focus.js";
 
 export interface LivekitFocusConfig extends Focus {
     type: "livekit";

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -14,30 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../logger";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { EventTimeline } from "../models/event-timeline";
-import { Room } from "../models/room";
-import { MatrixClient } from "../client";
-import { EventType } from "../@types/event";
-import { UpdateDelayedEventAction } from "../@types/requests";
+import { logger } from "../logger.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { EventTimeline } from "../models/event-timeline.js";
+import { Room } from "../models/room.js";
+import { MatrixClient } from "../client.js";
+import { EventType } from "../@types/event.js";
+import { UpdateDelayedEventAction } from "../@types/requests.js";
 import {
     CallMembership,
     CallMembershipData,
     CallMembershipDataLegacy,
     SessionMembershipData,
     isLegacyCallMembershipData,
-} from "./CallMembership";
-import { RoomStateEvent } from "../models/room-state";
-import { Focus } from "./focus";
-import { randomString, secureRandomBase64Url } from "../randomstring";
-import { EncryptionKeysEventContent } from "./types";
-import { decodeBase64, encodeUnpaddedBase64 } from "../base64";
-import { KnownMembership } from "../@types/membership";
-import { MatrixError } from "../http-api/errors";
-import { MatrixEvent } from "../models/event";
-import { isLivekitFocusActive } from "./LivekitFocus";
-import { ExperimentalGroupCallRoomMemberState } from "../webrtc/groupCall";
+} from "./CallMembership.js";
+import { RoomStateEvent } from "../models/room-state.js";
+import { Focus } from "./focus.js";
+import { randomString, secureRandomBase64Url } from "../randomstring.js";
+import { EncryptionKeysEventContent } from "./types.js";
+import { decodeBase64, encodeUnpaddedBase64 } from "../base64.js";
+import { KnownMembership } from "../@types/membership.js";
+import { MatrixError } from "../http-api/errors.js";
+import { MatrixEvent } from "../models/event.js";
+import { isLivekitFocusActive } from "./LivekitFocus.js";
+import { ExperimentalGroupCallRoomMemberState } from "../webrtc/groupCall.js";
 
 const MEMBERSHIP_EXPIRY_TIME = 60 * 60 * 1000;
 const MEMBER_EVENT_CHECK_PERIOD = 2 * 60 * 1000; // How often we check to see if we need to re-send our member event

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../logger";
-import { MatrixClient, ClientEvent } from "../client";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { Room, RoomEvent } from "../models/room";
-import { RoomState, RoomStateEvent } from "../models/room-state";
-import { MatrixEvent } from "../models/event";
-import { MatrixRTCSession } from "./MatrixRTCSession";
-import { EventType } from "../@types/event";
+import { logger } from "../logger.js";
+import { MatrixClient, ClientEvent } from "../client.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { Room, RoomEvent } from "../models/room.js";
+import { RoomState, RoomStateEvent } from "../models/room-state.js";
+import { MatrixEvent } from "../models/event.js";
+import { MatrixRTCSession } from "./MatrixRTCSession.js";
+import { EventType } from "../@types/event.js";
 
 export enum MatrixRTCSessionManagerEvents {
     // A member has joined the MatrixRTC session, creating an active session in a room where there wasn't previously

--- a/src/matrixrtc/index.ts
+++ b/src/matrixrtc/index.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export * from "./CallMembership";
-export * from "./focus";
-export * from "./LivekitFocus";
-export * from "./MatrixRTCSession";
-export * from "./MatrixRTCSessionManager";
-export * from "./types";
+export * from "./CallMembership.js";
+export * from "./focus.js";
+export * from "./LivekitFocus.js";
+export * from "./MatrixRTCSession.js";
+export * from "./MatrixRTCSessionManager.js";
+export * from "./types.js";

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { IMentions } from "../matrix";
+import { IMentions } from "../matrix.js";
 export interface EncryptionKeyEntry {
     index: number;
     key: string;

--- a/src/models/MSC3089Branch.ts
+++ b/src/models/MSC3089Branch.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../client";
-import { RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event";
-import { IContent, MatrixEvent } from "./event";
-import { MSC3089TreeSpace } from "./MSC3089TreeSpace";
-import { EventTimeline } from "./event-timeline";
-import { FileType } from "../http-api";
-import type { ISendEventResponse } from "../@types/requests";
-import { EncryptedFile } from "../@types/media";
+import { MatrixClient } from "../client.js";
+import { RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event.js";
+import { IContent, MatrixEvent } from "./event.js";
+import { MSC3089TreeSpace } from "./MSC3089TreeSpace.js";
+import { EventTimeline } from "./event-timeline.js";
+import { FileType } from "../http-api/index.js";
+import type { ISendEventResponse } from "../@types/requests.js";
+import { EncryptedFile } from "../@types/media.js";
 
 export interface MSC3089EventContent {
     active?: boolean;

--- a/src/models/MSC3089TreeSpace.ts
+++ b/src/models/MSC3089TreeSpace.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 import promiseRetry from "p-retry";
 
-import { MatrixClient } from "../client";
-import { EventType, MsgType, UNSTABLE_MSC3089_BRANCH, UNSTABLE_MSC3089_LEAF } from "../@types/event";
-import { Room } from "./room";
-import { logger } from "../logger";
-import { IContent, MatrixEvent } from "./event";
+import { MatrixClient } from "../client.js";
+import { EventType, MsgType, UNSTABLE_MSC3089_BRANCH, UNSTABLE_MSC3089_LEAF } from "../@types/event.js";
+import { Room } from "./room.js";
+import { logger } from "../logger.js";
+import { IContent, MatrixEvent } from "./event.js";
 import {
     averageBetweenStrings,
     DEFAULT_ALPHABET,
@@ -28,14 +28,14 @@ import {
     nextString,
     prevString,
     simpleRetryOperation,
-} from "../utils";
-import { MSC3089Branch } from "./MSC3089Branch";
-import { isRoomSharedHistory } from "../crypto/algorithms/megolm";
-import { ISendEventResponse } from "../@types/requests";
-import { FileType } from "../http-api";
-import { KnownMembership } from "../@types/membership";
-import { RoomPowerLevelsEventContent, SpaceChildEventContent } from "../@types/state_events";
-import type { EncryptedFile, FileContent } from "../@types/media";
+} from "../utils.js";
+import { MSC3089Branch } from "./MSC3089Branch.js";
+import { isRoomSharedHistory } from "../crypto/algorithms/megolm.js";
+import { ISendEventResponse } from "../@types/requests.js";
+import { FileType } from "../http-api/index.js";
+import { KnownMembership } from "../@types/membership.js";
+import { RoomPowerLevelsEventContent, SpaceChildEventContent } from "../@types/state_events.js";
+import type { EncryptedFile, FileContent } from "../@types/media.js";
 
 /**
  * The recommended defaults for a tree space's power levels. Note that this

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MBeaconEventContent } from "../@types/beacon";
-import { BeaconInfoState, BeaconLocationState, parseBeaconContent, parseBeaconInfoContent } from "../content-helpers";
-import { MatrixEvent } from "./event";
-import { sortEventsByLatestContentTimestamp } from "../utils";
-import { TypedEventEmitter } from "./typed-event-emitter";
+import { MBeaconEventContent } from "../@types/beacon.js";
+import { BeaconInfoState, BeaconLocationState, parseBeaconContent, parseBeaconInfoContent } from "../content-helpers.js";
+import { MatrixEvent } from "./event.js";
+import { sortEventsByLatestContentTimestamp } from "../utils.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
 
 export enum BeaconEvent {
     New = "Beacon.new",

--- a/src/models/compare-event-ordering.ts
+++ b/src/models/compare-event-ordering.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "./event";
-import { Room } from "./room";
-import { inMainTimelineForReceipt, threadIdForReceipt } from "../client";
+import { MatrixEvent } from "./event.js";
+import { Room } from "./room.js";
+import { inMainTimelineForReceipt, threadIdForReceipt } from "../client.js";
 
 /**
  * Determine the order of two events in a room.

--- a/src/models/event-context.ts
+++ b/src/models/event-context.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "./event";
-import { Direction } from "./event-timeline";
+import { MatrixEvent } from "./event.js";
+import { Direction } from "./event-timeline.js";
 
 export class EventContext {
     private timeline: MatrixEvent[];

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventTimeline, IAddEventOptions } from "./event-timeline";
-import { MatrixEvent } from "./event";
-import { logger } from "../logger";
-import { Room, RoomEvent } from "./room";
-import { Filter } from "../filter";
-import { RoomState } from "./room-state";
-import { TypedEventEmitter } from "./typed-event-emitter";
-import { RelationsContainer } from "./relations-container";
-import { MatrixClient } from "../client";
-import { Thread, ThreadFilterType } from "./thread";
+import { EventTimeline, IAddEventOptions } from "./event-timeline.js";
+import { MatrixEvent } from "./event.js";
+import { logger } from "../logger.js";
+import { Room, RoomEvent } from "./room.js";
+import { Filter } from "../filter.js";
+import { RoomState } from "./room-state.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
+import { RelationsContainer } from "./relations-container.js";
+import { MatrixClient } from "../client.js";
+import { Thread, ThreadFilterType } from "./thread.js";
 
 const DEBUG = true;
 

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMarkerFoundOptions, RoomState } from "./room-state";
-import { EventTimelineSet } from "./event-timeline-set";
-import { MatrixEvent } from "./event";
-import { Filter } from "../filter";
-import { EventType } from "../@types/event";
+import { IMarkerFoundOptions, RoomState } from "./room-state.js";
+import { EventTimelineSet } from "./event-timeline-set.js";
+import { MatrixEvent } from "./event.js";
+import { Filter } from "../filter.js";
+import { EventType } from "../@types/event.js";
 
 export interface IInitialiseStateOptions extends Pick<IMarkerFoundOptions, "timelineWasEmpty"> {
     // This is a separate interface without any extra stuff currently added on

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -21,9 +21,9 @@ limitations under the License.
 
 import { ExtensibleEvent, ExtensibleEvents, Optional } from "matrix-events-sdk";
 
-import type { IEventDecryptionResult } from "../@types/crypto";
-import { logger } from "../logger";
-import { VerificationRequest } from "../crypto/verification/request/VerificationRequest";
+import type { IEventDecryptionResult } from "../@types/crypto.js";
+import { logger } from "../logger.js";
+import { VerificationRequest } from "../crypto/verification/request/VerificationRequest.js";
 import {
     EVENT_VISIBILITY_CHANGE_TYPE,
     EventType,
@@ -32,24 +32,24 @@ import {
     ToDeviceMessageId,
     UNSIGNED_THREAD_ID_FIELD,
     UNSIGNED_MEMBERSHIP_FIELD,
-} from "../@types/event";
-import { Crypto } from "../crypto";
-import { deepSortedObjectEntries, internaliseString } from "../utils";
-import { RoomMember } from "./room-member";
-import { Thread, THREAD_RELATION_TYPE, ThreadEvent, ThreadEventHandlerMap } from "./thread";
-import { IActionsObject } from "../pushprocessor";
-import { TypedReEmitter } from "../ReEmitter";
-import { MatrixError } from "../http-api";
-import { TypedEventEmitter } from "./typed-event-emitter";
-import { EventStatus } from "./event-status";
-import { CryptoBackend, DecryptionError } from "../common-crypto/CryptoBackend";
-import { IAnnotatedPushRule } from "../@types/PushRules";
-import { Room } from "./room";
-import { EventTimeline } from "./event-timeline";
-import { Membership } from "../@types/membership";
-import { DecryptionFailureCode } from "../crypto-api";
+} from "../@types/event.js";
+import { Crypto } from "../crypto/index.js";
+import { deepSortedObjectEntries, internaliseString } from "../utils.js";
+import { RoomMember } from "./room-member.js";
+import { Thread, THREAD_RELATION_TYPE, ThreadEvent, ThreadEventHandlerMap } from "./thread.js";
+import { IActionsObject } from "../pushprocessor.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { MatrixError } from "../http-api/index.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
+import { EventStatus } from "./event-status.js";
+import { CryptoBackend, DecryptionError } from "../common-crypto/CryptoBackend.js";
+import { IAnnotatedPushRule } from "../@types/PushRules.js";
+import { Room } from "./room.js";
+import { EventTimeline } from "./event-timeline.js";
+import { Membership } from "../@types/membership.js";
+import { DecryptionFailureCode } from "../crypto-api/index.js";
 
-export { EventStatus } from "./event-status";
+export { EventStatus } from "./event-status.js";
 
 /* eslint-disable camelcase */
 export interface IContent {

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import { UnstableValue } from "matrix-events-sdk";
 
-import { MatrixClient } from "../client";
-import { IContent, MatrixEvent } from "./event";
-import { EventTimeline } from "./event-timeline";
-import { Preset } from "../@types/partials";
-import { globToRegexp } from "../utils";
-import { Room } from "./room";
-import { EventType, StateEvents } from "../@types/event";
+import { MatrixClient } from "../client.js";
+import { IContent, MatrixEvent } from "./event.js";
+import { EventTimeline } from "./event-timeline.js";
+import { Preset } from "../@types/partials.js";
+import { globToRegexp } from "../utils.js";
+import { Room } from "./room.js";
+import { EventType, StateEvents } from "../@types/event.js";
 
 /// The event type storing the user's individual policies.
 ///

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import { M_POLL_START } from "matrix-events-sdk";
 
-import { M_POLL_END, M_POLL_RESPONSE } from "../@types/polls";
-import { MatrixClient } from "../client";
-import { PollStartEvent } from "../extensible_events_v1/PollStartEvent";
-import { MatrixEvent } from "./event";
-import { Relations } from "./relations";
-import { Room } from "./room";
-import { TypedEventEmitter } from "./typed-event-emitter";
+import { M_POLL_END, M_POLL_RESPONSE } from "../@types/polls.js";
+import { MatrixClient } from "../client.js";
+import { PollStartEvent } from "../extensible_events_v1/PollStartEvent.js";
+import { MatrixEvent } from "./event.js";
+import { Relations } from "./relations.js";
+import { Room } from "./room.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
 
 export enum PollEvent {
     New = "Poll.new",

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -18,16 +18,16 @@ import {
     ReceiptCache,
     ReceiptType,
     WrappedReceipt,
-} from "../@types/read_receipts";
-import { ListenerMap, TypedEventEmitter } from "./typed-event-emitter";
-import { isSupportedReceiptType } from "../utils";
-import { MatrixEvent } from "./event";
-import { EventType } from "../@types/event";
-import { EventTimelineSet } from "./event-timeline-set";
-import { MapWithDefault } from "../utils";
-import { NotificationCountType } from "./room";
-import { logger } from "../logger";
-import { inMainTimelineForReceipt, threadIdForReceipt } from "../client";
+} from "../@types/read_receipts.js";
+import { ListenerMap, TypedEventEmitter } from "./typed-event-emitter.js";
+import { isSupportedReceiptType } from "../utils.js";
+import { MatrixEvent } from "./event.js";
+import { EventType } from "../@types/event.js";
+import { EventTimelineSet } from "./event-timeline-set.js";
+import { MapWithDefault } from "../utils.js";
+import { NotificationCountType } from "./room.js";
+import { logger } from "../logger.js";
+import { inMainTimelineForReceipt, threadIdForReceipt } from "../client.js";
 
 /**
  * Create a synthetic receipt for the given event

--- a/src/models/related-relations.ts
+++ b/src/models/related-relations.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Relations, RelationsEvent, EventHandlerMap } from "./relations";
-import { MatrixEvent } from "./event";
-import { Listener } from "./typed-event-emitter";
+import { Relations, RelationsEvent, EventHandlerMap } from "./relations.js";
+import { MatrixEvent } from "./event.js";
+import { Listener } from "./typed-event-emitter.js";
 
 export class RelatedRelations {
     private relations: Relations[];

--- a/src/models/relations-container.ts
+++ b/src/models/relations-container.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Relations } from "./relations";
-import { EventType, RelationType } from "../@types/event";
-import { EventStatus, MatrixEvent, MatrixEventEvent } from "./event";
-import { EventTimelineSet } from "./event-timeline-set";
-import { MatrixClient } from "../client";
-import { Room } from "./room";
+import { Relations } from "./relations.js";
+import { EventType, RelationType } from "../@types/event.js";
+import { EventStatus, MatrixEvent, MatrixEventEvent } from "./event.js";
+import { EventTimelineSet } from "./event-timeline-set.js";
+import { MatrixClient } from "../client.js";
+import { Room } from "./room.js";
 
 export class RelationsContainer {
     // A tree of objects to access a set of related children for an event, as in:

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventStatus, IAggregatedRelation, MatrixEvent, MatrixEventEvent } from "./event";
-import { logger } from "../logger";
-import { RelationType } from "../@types/event";
-import { TypedEventEmitter } from "./typed-event-emitter";
-import { MatrixClient } from "../client";
-import { Room } from "./room";
+import { EventStatus, IAggregatedRelation, MatrixEvent, MatrixEventEvent } from "./event.js";
+import { logger } from "../logger.js";
+import { RelationType } from "../@types/event.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
+import { MatrixClient } from "../client.js";
+import { Room } from "./room.js";
 
 export enum RelationsEvent {
     Add = "Relations.add",

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { getHttpUriForMxc } from "../content-repo";
-import { removeDirectionOverrideChars, removeHiddenChars } from "../utils";
-import { User } from "./user";
-import { MatrixEvent } from "./event";
-import { RoomState } from "./room-state";
-import { logger } from "../logger";
-import { TypedEventEmitter } from "./typed-event-emitter";
-import { EventType } from "../@types/event";
-import { KnownMembership, Membership } from "../@types/membership";
+import { getHttpUriForMxc } from "../content-repo.js";
+import { removeDirectionOverrideChars, removeHiddenChars } from "../utils.js";
+import { User } from "./user.js";
+import { MatrixEvent } from "./event.js";
+import { RoomState } from "./room-state.js";
+import { logger } from "../logger.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
+import { EventType } from "../@types/event.js";
+import { KnownMembership, Membership } from "../@types/membership.js";
 
 export enum RoomMemberEvent {
     Membership = "RoomMember.membership",

--- a/src/models/room-receipts.ts
+++ b/src/models/room-receipts.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MAIN_ROOM_TIMELINE, Receipt, ReceiptContent } from "../@types/read_receipts";
-import { threadIdForReceipt } from "../client";
-import { Room, RoomEvent } from "./room";
-import { MatrixEvent } from "./event";
-import { logger } from "../logger";
+import { MAIN_ROOM_TIMELINE, Receipt, ReceiptContent } from "../@types/read_receipts.js";
+import { threadIdForReceipt } from "../client.js";
+import { Room, RoomEvent } from "./room.js";
+import { MatrixEvent } from "./event.js";
+import { logger } from "../logger.js";
 
 /**
  * The latest receipts we have for a room.

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RoomMember } from "./room-member";
-import { logger } from "../logger";
-import { isNumber, removeHiddenChars } from "../utils";
-import { EventType, UNSTABLE_MSC2716_MARKER } from "../@types/event";
-import { IEvent, MatrixEvent, MatrixEventEvent } from "./event";
-import { MatrixClient } from "../client";
-import { GuestAccess, HistoryVisibility, JoinRule } from "../@types/partials";
-import { TypedEventEmitter } from "./typed-event-emitter";
-import { Beacon, BeaconEvent, BeaconEventHandlerMap, getBeaconInfoIdentifier, BeaconIdentifier } from "./beacon";
-import { TypedReEmitter } from "../ReEmitter";
-import { M_BEACON, M_BEACON_INFO } from "../@types/beacon";
-import { KnownMembership } from "../@types/membership";
-import { RoomJoinRulesEventContent } from "../@types/state_events";
+import { RoomMember } from "./room-member.js";
+import { logger } from "../logger.js";
+import { isNumber, removeHiddenChars } from "../utils.js";
+import { EventType, UNSTABLE_MSC2716_MARKER } from "../@types/event.js";
+import { IEvent, MatrixEvent, MatrixEventEvent } from "./event.js";
+import { MatrixClient } from "../client.js";
+import { GuestAccess, HistoryVisibility, JoinRule } from "../@types/partials.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
+import { Beacon, BeaconEvent, BeaconEventHandlerMap, getBeaconInfoIdentifier, BeaconIdentifier } from "./beacon.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { M_BEACON, M_BEACON_INFO } from "../@types/beacon.js";
+import { KnownMembership } from "../@types/membership.js";
+import { RoomJoinRulesEventContent } from "../@types/state_events.js";
 
 export interface IMarkerFoundOptions {
     /** Whether the timeline was empty before the marker event arrived in the

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -21,17 +21,17 @@ import {
     DuplicateStrategy,
     IAddLiveEventOptions,
     EventTimelineSetHandlerMap,
-} from "./event-timeline-set";
-import { Direction, EventTimeline } from "./event-timeline";
-import { getHttpUriForMxc } from "../content-repo";
-import { removeElement } from "../utils";
-import { normalize, noUnsafeEventProps } from "../utils";
-import { IEvent, IThreadBundledRelationship, MatrixEvent, MatrixEventEvent, MatrixEventHandlerMap } from "./event";
-import { EventStatus } from "./event-status";
-import { RoomMember } from "./room-member";
-import { IRoomSummary, RoomSummary } from "./room-summary";
-import { logger } from "../logger";
-import { TypedReEmitter } from "../ReEmitter";
+} from "./event-timeline-set.js";
+import { Direction, EventTimeline } from "./event-timeline.js";
+import { getHttpUriForMxc } from "../content-repo.js";
+import { removeElement } from "../utils.js";
+import { normalize, noUnsafeEventProps } from "../utils.js";
+import { IEvent, IThreadBundledRelationship, MatrixEvent, MatrixEventEvent, MatrixEventHandlerMap } from "./event.js";
+import { EventStatus } from "./event-status.js";
+import { RoomMember } from "./room-member.js";
+import { IRoomSummary, RoomSummary } from "./room-summary.js";
+import { logger } from "../logger.js";
+import { TypedReEmitter } from "../ReEmitter.js";
 import {
     EventType,
     RoomCreateTypeField,
@@ -40,12 +40,12 @@ import {
     EVENT_VISIBILITY_CHANGE_TYPE,
     RelationType,
     UNSIGNED_THREAD_ID_FIELD,
-} from "../@types/event";
-import { MatrixClient, PendingEventOrdering } from "../client";
-import { GuestAccess, HistoryVisibility, JoinRule, ResizeMethod } from "../@types/partials";
-import { Filter, IFilterDefinition } from "../filter";
-import { RoomState, RoomStateEvent, RoomStateEventHandlerMap } from "./room-state";
-import { BeaconEvent, BeaconEventHandlerMap } from "./beacon";
+} from "../@types/event.js";
+import { MatrixClient, PendingEventOrdering } from "../client.js";
+import { GuestAccess, HistoryVisibility, JoinRule, ResizeMethod } from "../@types/partials.js";
+import { Filter, IFilterDefinition } from "../filter.js";
+import { RoomState, RoomStateEvent, RoomStateEventHandlerMap } from "./room-state.js";
+import { BeaconEvent, BeaconEventHandlerMap } from "./beacon.js";
 import {
     Thread,
     ThreadEvent,
@@ -54,23 +54,23 @@ import {
     THREAD_RELATION_TYPE,
     FILTER_RELATED_BY_SENDERS,
     ThreadFilterType,
-} from "./thread";
+} from "./thread.js";
 import {
     CachedReceiptStructure,
     MAIN_ROOM_TIMELINE,
     Receipt,
     ReceiptContent,
     ReceiptType,
-} from "../@types/read_receipts";
-import { IStateEventWithRoomId } from "../@types/search";
-import { RelationsContainer } from "./relations-container";
-import { ReadReceipt, synthesizeReceipt } from "./read-receipt";
-import { isPollEvent, Poll, PollEvent } from "./poll";
-import { RoomReceipts } from "./room-receipts";
-import { compareEventOrdering } from "./compare-event-ordering";
-import * as utils from "../utils";
-import { KnownMembership, Membership } from "../@types/membership";
-import { Capabilities, IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities";
+} from "../@types/read_receipts.js";
+import { IStateEventWithRoomId } from "../@types/search.js";
+import { RelationsContainer } from "./relations-container.js";
+import { ReadReceipt, synthesizeReceipt } from "./read-receipt.js";
+import { isPollEvent, Poll, PollEvent } from "./poll.js";
+import { RoomReceipts } from "./room-receipts.js";
+import { compareEventOrdering } from "./compare-event-ordering.js";
+import * as utils from "../utils.js";
+import { KnownMembership, Membership } from "../@types/membership.js";
+import { Capabilities, IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities.js";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be

--- a/src/models/search-result.ts
+++ b/src/models/search-result.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventContext } from "./event-context";
-import { EventMapper } from "../event-mapper";
-import { IResultContext, ISearchResult } from "../@types/search";
+import { EventContext } from "./event-context.js";
+import { EventMapper } from "../event-mapper.js";
+import { IResultContext, ISearchResult } from "../@types/search.js";
 
 export class SearchResult {
     /**

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -16,19 +16,19 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import { MatrixClient, PendingEventOrdering } from "../client";
-import { TypedReEmitter } from "../ReEmitter";
-import { RelationType } from "../@types/event";
-import { IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event";
-import { Direction, EventTimeline } from "./event-timeline";
-import { EventTimelineSet, EventTimelineSetHandlerMap } from "./event-timeline-set";
-import { NotificationCountType, Room, RoomEvent } from "./room";
-import { RoomState } from "./room-state";
-import { ServerControlledNamespacedValue } from "../NamespacedValue";
-import { logger } from "../logger";
-import { ReadReceipt } from "./read-receipt";
-import { CachedReceiptStructure, Receipt, ReceiptType } from "../@types/read_receipts";
-import { Feature, ServerSupport } from "../feature";
+import { MatrixClient, PendingEventOrdering } from "../client.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { RelationType } from "../@types/event.js";
+import { IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event.js";
+import { Direction, EventTimeline } from "./event-timeline.js";
+import { EventTimelineSet, EventTimelineSetHandlerMap } from "./event-timeline-set.js";
+import { NotificationCountType, Room, RoomEvent } from "./room.js";
+import { RoomState } from "./room-state.js";
+import { ServerControlledNamespacedValue } from "../NamespacedValue.js";
+import { logger } from "../logger.js";
+import { ReadReceipt } from "./read-receipt.js";
+import { CachedReceiptStructure, Receipt, ReceiptType } from "../@types/read_receipts.js";
+import { Feature, ServerSupport } from "../feature.js";
 
 export enum ThreadEvent {
     New = "Thread.new",

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../matrix";
-import { MatrixEvent } from "./event";
-import { TypedEventEmitter } from "./typed-event-emitter";
+import { MatrixClient } from "../matrix.js";
+import { MatrixEvent } from "./event.js";
+import { TypedEventEmitter } from "./typed-event-emitter.js";
 
 export enum UserEvent {
     DisplayName = "User.displayName",

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 import { IdTokenClaims, Log, OidcClient, SigninResponse, SigninState, WebStorageStateStore } from "oidc-client-ts";
 
-import { logger } from "../logger";
-import { randomString } from "../randomstring";
-import { OidcError } from "./error";
+import { logger } from "../logger.js";
+import { randomString } from "../randomstring.js";
+import { OidcError } from "./error.js";
 import {
     BearerTokenResponse,
     UserState,
@@ -26,9 +26,9 @@ import {
     ValidatedIssuerMetadata,
     validateIdToken,
     validateStoredUserState,
-} from "./validate";
-import { sha256 } from "../digest";
-import { encodeUnpaddedBase64Url } from "../base64";
+} from "./validate.js";
+import { sha256 } from "../digest.js";
+import { encodeUnpaddedBase64Url } from "../base64.js";
 
 // reexport for backwards compatibility
 export type { BearerTokenResponse };

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 import { MetadataService, OidcClientSettingsStore } from "oidc-client-ts";
 
-import { isValidatedIssuerMetadata, validateOIDCIssuerWellKnown } from "./validate";
-import { Method, timeoutSignal } from "../http-api";
-import { OidcClientConfig } from "./index";
+import { isValidatedIssuerMetadata, validateOIDCIssuerWellKnown } from "./validate.js";
+import { Method, timeoutSignal } from "../http-api/index.js";
+import { OidcClientConfig } from "./index.js";
 
 /**
  * @experimental

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 import type { SigningKey } from "oidc-client-ts";
-import { ValidatedIssuerConfig, ValidatedIssuerMetadata } from "./validate";
+import { ValidatedIssuerConfig, ValidatedIssuerMetadata } from "./validate.js";
 
-export * from "./authorize";
-export * from "./discovery";
-export * from "./error";
-export * from "./register";
-export * from "./tokenRefresher";
-export * from "./validate";
+export * from "./authorize.js";
+export * from "./discovery.js";
+export * from "./error.js";
+export * from "./register.js";
+export * from "./tokenRefresher.js";
+export * from "./validate.js";
 
 /**
  * Validated config for native OIDC authentication, as returned by {@link discoverAndValidateOIDCIssuerWellKnown}.

--- a/src/oidc/register.ts
+++ b/src/oidc/register.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OidcClientConfig } from ".";
-import { OidcError } from "./error";
-import { Method } from "../http-api";
-import { logger } from "../logger";
-import { NonEmptyArray } from "../@types/common";
+import { OidcClientConfig } from "./index.js";
+import { OidcError } from "./error.js";
+import { Method } from "../http-api/index.js";
+import { logger } from "../logger.js";
+import { NonEmptyArray } from "../@types/common.js";
 
 /**
  * Client metadata passed to registration endpoint

--- a/src/oidc/tokenRefresher.ts
+++ b/src/oidc/tokenRefresher.ts
@@ -16,10 +16,10 @@ limitations under the License.
 
 import { IdTokenClaims, OidcClient, WebStorageStateStore } from "oidc-client-ts";
 
-import { AccessTokens } from "../http-api";
-import { generateScope } from "./authorize";
-import { discoverAndValidateOIDCIssuerWellKnown } from "./discovery";
-import { logger } from "../logger";
+import { AccessTokens } from "../http-api/index.js";
+import { generateScope } from "./authorize.js";
+import { discoverAndValidateOIDCIssuerWellKnown } from "./discovery.js";
+import { logger } from "../logger.js";
 
 /**
  * @experimental

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -17,8 +17,8 @@ limitations under the License.
 import { jwtDecode } from "jwt-decode";
 import { IdTokenClaims, OidcMetadata, SigninResponse } from "oidc-client-ts";
 
-import { logger } from "../logger";
-import { OidcError } from "./error";
+import { logger } from "../logger.js";
+import { OidcError } from "./error.js";
 
 export type ValidatedIssuerConfig = {
     authorizationEndpoint: string;

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { deepCompare, escapeRegExp, globToRegexp, isNullOrUndefined } from "./utils";
-import { logger } from "./logger";
-import { MatrixClient } from "./client";
-import { MatrixEvent } from "./models/event";
+import { deepCompare, escapeRegExp, globToRegexp, isNullOrUndefined } from "./utils.js";
+import { logger } from "./logger.js";
+import { MatrixClient } from "./client.js";
+import { MatrixEvent } from "./models/event.js";
 import {
     ConditionKind,
     IAnnotatedPushRule,
@@ -38,8 +38,8 @@ import {
     PushRuleSet,
     RuleId,
     TweakName,
-} from "./@types/PushRules";
-import { EventType } from "./@types/event";
+} from "./@types/PushRules.js";
+import { EventType } from "./@types/event.js";
 
 const RULEKINDS_IN_ORDER = [
     PushRuleKind.Override,

--- a/src/randomstring.ts
+++ b/src/randomstring.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { encodeUnpaddedBase64Url } from "./base64";
+import { encodeUnpaddedBase64Url } from "./base64.js";
 
 const LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
 const UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/src/realtime-callbacks.ts
+++ b/src/realtime-callbacks.ts
@@ -24,7 +24,7 @@ limitations under the License.
  * it will instead fire as soon as possible after resume.
  */
 
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 // we schedule a callback at least this often, to check if we've missed out on
 // some wall-clock time due to being suspended.

--- a/src/receipt-accumulator.ts
+++ b/src/receipt-accumulator.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMinimalEvent } from "./sync-accumulator";
-import { EventType } from "./@types/event";
-import { isSupportedReceiptType, MapWithDefault, recursiveMapToObject } from "./utils";
-import { IContent } from "./models/event";
-import { ReceiptContent, ReceiptType } from "./@types/read_receipts";
+import { IMinimalEvent } from "./sync-accumulator.js";
+import { EventType } from "./@types/event.js";
+import { isSupportedReceiptType, MapWithDefault, recursiveMapToObject } from "./utils.js";
+import { IContent } from "./models/event.js";
+import { ReceiptContent, ReceiptType } from "./@types/read_receipts.js";
 
 interface AccumulatedReceipt {
     data: IMinimalEvent;

--- a/src/rendezvous/MSC3906Rendezvous.ts
+++ b/src/rendezvous/MSC3906Rendezvous.ts
@@ -21,13 +21,13 @@ import {
     RendezvousFailureListener,
     LegacyRendezvousFailureReason as RendezvousFailureReason,
     RendezvousIntent,
-} from ".";
-import { MatrixClient, GET_LOGIN_TOKEN_CAPABILITY } from "../client";
-import { buildFeatureSupportMap, Feature, ServerSupport } from "../feature";
-import { logger } from "../logger";
-import { sleep } from "../utils";
-import { CrossSigningKey } from "../crypto-api";
-import { Capabilities, Device, IGetLoginTokenCapability } from "../matrix";
+} from "./index.js";
+import { MatrixClient, GET_LOGIN_TOKEN_CAPABILITY } from "../client.js";
+import { buildFeatureSupportMap, Feature, ServerSupport } from "../feature.js";
+import { logger } from "../logger.js";
+import { sleep } from "../utils.js";
+import { CrossSigningKey } from "../crypto-api/index.js";
+import { Capabilities, Device, IGetLoginTokenCapability } from "../matrix.js";
 
 enum PayloadType {
     Start = "m.login.start",

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -16,14 +16,14 @@ limitations under the License.
 
 import { QrCodeMode } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { ClientRendezvousFailureReason, MSC4108FailureReason, RendezvousError, RendezvousFailureListener } from ".";
-import { MatrixClient } from "../client";
-import { logger } from "../logger";
-import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel";
-import { MatrixError } from "../http-api";
-import { sleep } from "../utils";
-import { DEVICE_CODE_SCOPE, discoverAndValidateOIDCIssuerWellKnown, OidcClientConfig } from "../oidc";
-import { CryptoApi } from "../crypto-api";
+import { ClientRendezvousFailureReason, MSC4108FailureReason, RendezvousError, RendezvousFailureListener } from "./index.js";
+import { MatrixClient } from "../client.js";
+import { logger } from "../logger.js";
+import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.js";
+import { MatrixError } from "../http-api/index.js";
+import { sleep } from "../utils.js";
+import { DEVICE_CODE_SCOPE, discoverAndValidateOIDCIssuerWellKnown, OidcClientConfig } from "../oidc/index.js";
+import { CryptoApi } from "../crypto-api/index.js";
 
 /**
  * Enum representing the payload types transmissible over [MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108)

--- a/src/rendezvous/RendezvousChannel.ts
+++ b/src/rendezvous/RendezvousChannel.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousCode, RendezvousIntent, RendezvousFailureReason } from ".";
+import { RendezvousCode, RendezvousIntent, RendezvousFailureReason } from "./index.js";
 
 export interface RendezvousChannel<T> {
     /**

--- a/src/rendezvous/RendezvousCode.ts
+++ b/src/rendezvous/RendezvousCode.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousTransportDetails, RendezvousIntent } from ".";
+import { RendezvousTransportDetails, RendezvousIntent } from "./index.js";
 
 export interface RendezvousCode {
     intent: RendezvousIntent;

--- a/src/rendezvous/RendezvousError.ts
+++ b/src/rendezvous/RendezvousError.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousFailureReason } from ".";
+import { RendezvousFailureReason } from "./index.js";
 
 export class RendezvousError extends Error {
     public constructor(

--- a/src/rendezvous/RendezvousTransport.ts
+++ b/src/rendezvous/RendezvousTransport.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousFailureListener, RendezvousFailureReason } from ".";
+import { RendezvousFailureListener, RendezvousFailureReason } from "./index.js";
 
 export interface RendezvousTransportDetails {
     type: string;

--- a/src/rendezvous/channels/MSC3903ECDHv2RendezvousChannel.ts
+++ b/src/rendezvous/channels/MSC3903ECDHv2RendezvousChannel.ts
@@ -24,10 +24,10 @@ import {
     RendezvousIntent,
     RendezvousTransport,
     RendezvousTransportDetails,
-} from "..";
-import { decodeBase64, encodeUnpaddedBase64 } from "../../base64";
-import { generateDecimalSas } from "../../crypto/verification/SASDecimal";
-import { UnstableValue } from "../../NamespacedValue";
+} from "../index.js";
+import { decodeBase64, encodeUnpaddedBase64 } from "../../base64.js";
+import { generateDecimalSas } from "../../crypto/verification/SASDecimal.js";
+import { UnstableValue } from "../../NamespacedValue.js";
 
 const ECDH_V2 = new UnstableValue(
     "m.rendezvous.v2.curve25519-aes-sha256",

--- a/src/rendezvous/channels/MSC4108SecureChannel.ts
+++ b/src/rendezvous/channels/MSC4108SecureChannel.ts
@@ -28,9 +28,9 @@ import {
     MSC4108Payload,
     RendezvousError,
     RendezvousFailureListener,
-} from "..";
-import { MSC4108RendezvousSession } from "../transports/MSC4108RendezvousSession";
-import { logger } from "../../logger";
+} from "../index.js";
+import { MSC4108RendezvousSession } from "../transports/MSC4108RendezvousSession.js";
+import { logger } from "../../logger.js";
 
 /**
  * Prototype of the unstable [MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108)

--- a/src/rendezvous/channels/index.ts
+++ b/src/rendezvous/channels/index.ts
@@ -17,5 +17,5 @@ limitations under the License.
 /**
  * @deprecated in favour of MSC4108-based implementation
  */
-export * from "./MSC3903ECDHv2RendezvousChannel";
-export * from "./MSC4108SecureChannel";
+export * from "./MSC3903ECDHv2RendezvousChannel.js";
+export * from "./MSC4108SecureChannel.js";

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -17,13 +17,13 @@ limitations under the License.
 /**
  * @deprecated in favour of MSC4108-based implementation
  */
-export * from "./MSC3906Rendezvous";
-export * from "./MSC4108SignInWithQR";
-export * from "./RendezvousChannel";
-export * from "./RendezvousCode";
-export * from "./RendezvousError";
-export * from "./RendezvousFailureReason";
-export * from "./RendezvousIntent";
-export * from "./RendezvousTransport";
-export * from "./transports";
-export * from "./channels";
+export * from "./MSC3906Rendezvous.js";
+export * from "./MSC4108SignInWithQR.js";
+export * from "./RendezvousChannel.js";
+export * from "./RendezvousCode.js";
+export * from "./RendezvousError.js";
+export * from "./RendezvousFailureReason.js";
+export * from "./RendezvousIntent.js";
+export * from "./RendezvousTransport.js";
+export * from "./transports/index.js";
+export * from "./channels/index.js";

--- a/src/rendezvous/transports/MSC3886SimpleHttpRendezvousTransport.ts
+++ b/src/rendezvous/transports/MSC3886SimpleHttpRendezvousTransport.ts
@@ -16,16 +16,16 @@ limitations under the License.
 
 import { UnstableValue } from "matrix-events-sdk";
 
-import { logger } from "../../logger";
-import { sleep } from "../../utils";
+import { logger } from "../../logger.js";
+import { sleep } from "../../utils.js";
 import {
     RendezvousFailureListener,
     LegacyRendezvousFailureReason as RendezvousFailureReason,
     RendezvousTransport,
     RendezvousTransportDetails,
-} from "..";
-import { MatrixClient } from "../../matrix";
-import { ClientPrefix } from "../../http-api";
+} from "../index.js";
+import { MatrixClient } from "../../matrix.js";
+import { ClientPrefix } from "../../http-api/index.js";
 
 const TYPE = new UnstableValue("http.v1", "org.matrix.msc3886.http.v1");
 

--- a/src/rendezvous/transports/MSC4108RendezvousSession.ts
+++ b/src/rendezvous/transports/MSC4108RendezvousSession.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../../logger";
-import { sleep } from "../../utils";
-import { ClientRendezvousFailureReason, MSC4108FailureReason, RendezvousFailureListener } from "..";
-import { MatrixClient, Method } from "../../matrix";
-import { ClientPrefix } from "../../http-api";
+import { logger } from "../../logger.js";
+import { sleep } from "../../utils.js";
+import { ClientRendezvousFailureReason, MSC4108FailureReason, RendezvousFailureListener } from "../index.js";
+import { MatrixClient, Method } from "../../matrix.js";
+import { ClientPrefix } from "../../http-api/index.js";
 
 /**
  * Prototype of the unstable [MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108)

--- a/src/rendezvous/transports/index.ts
+++ b/src/rendezvous/transports/index.ts
@@ -17,5 +17,5 @@ limitations under the License.
 /**
  * @deprecated in favour of MSC4108-based implementation
  */
-export * from "./MSC3886SimpleHttpRendezvousTransport";
-export * from "./MSC4108RendezvousSession";
+export * from "./MSC3886SimpleHttpRendezvousTransport.js";
+export * from "./MSC4108RendezvousSession.js";

--- a/src/room-hierarchy.ts
+++ b/src/room-hierarchy.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Room } from "./models/room";
-import { IHierarchyRoom, IHierarchyRelation } from "./@types/spaces";
-import { MatrixClient } from "./client";
-import { EventType } from "./@types/event";
-import { MatrixError } from "./http-api";
+import { Room } from "./models/room.js";
+import { IHierarchyRoom, IHierarchyRelation } from "./@types/spaces.js";
+import { MatrixClient } from "./client.js";
+import { EventType } from "./@types/event.js";
+import { MatrixError } from "./http-api/index.js";
 
 export class RoomHierarchy {
     // Map from room id to list of servers which are listed as a via somewhere in the loaded hierarchy

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -17,11 +17,11 @@ limitations under the License.
 import { OlmMachine, CrossSigningStatus, CrossSigningBootstrapRequests } from "@matrix-org/matrix-sdk-crypto-wasm";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { BootstrapCrossSigningOpts } from "../crypto-api";
-import { logger } from "../logger";
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { UIAuthCallback } from "../interactive-auth";
-import { ServerSideSecretStorage } from "../secret-storage";
+import { BootstrapCrossSigningOpts } from "../crypto-api/index.js";
+import { logger } from "../logger.js";
+import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { UIAuthCallback } from "../interactive-auth.js";
+import { ServerSideSecretStorage } from "../secret-storage.js";
 
 /** Manages the cross-signing keys for our own user.
  *

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { encodeUri } from "../utils";
-import { IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api";
-import { IToDeviceEvent } from "../sync-accumulator";
-import { ServerSideSecretStorage } from "../secret-storage";
-import { decodeBase64, encodeUnpaddedBase64 } from "../base64";
-import { Logger } from "../logger";
+import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { encodeUri } from "../utils.js";
+import { IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.js";
+import { IToDeviceEvent } from "../sync-accumulator.js";
+import { ServerSideSecretStorage } from "../secret-storage.js";
+import { decodeBase64, encodeUnpaddedBase64 } from "../base64.js";
+import { Logger } from "../logger.js";
 
 /**
  * The response body of `GET /_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device`.

--- a/src/rust-crypto/KeyClaimManager.ts
+++ b/src/rust-crypto/KeyClaimManager.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import { OlmMachine, UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { LogSpan } from "../logger";
+import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { LogSpan } from "../logger.js";
 
 /**
  * KeyClaimManager: linearises calls to OlmMachine.getMissingSessions to avoid races

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -27,13 +27,13 @@ import {
     UploadSigningKeysRequest,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { logger } from "../logger";
-import { calculateRetryBackoff, IHttpOpts, MatrixHttpApi, Method } from "../http-api";
-import { logDuration, QueryDict, sleep } from "../utils";
-import { AuthDict, UIAuthCallback } from "../interactive-auth";
-import { UIAResponse } from "../@types/uia";
-import { ToDeviceMessageId } from "../@types/event";
-import { UnstablePrefix as DehydrationUnstablePrefix } from "./DehydratedDeviceManager";
+import { logger } from "../logger.js";
+import { calculateRetryBackoff, IHttpOpts, MatrixHttpApi, Method } from "../http-api/index.js";
+import { logDuration, QueryDict, sleep } from "../utils.js";
+import { AuthDict, UIAuthCallback } from "../interactive-auth.js";
+import { UIAResponse } from "../@types/uia.js";
+import { ToDeviceMessageId } from "../@types/event.js";
+import { UnstablePrefix as DehydrationUnstablePrefix } from "./DehydratedDeviceManager.js";
 
 /**
  * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.

--- a/src/rust-crypto/OutgoingRequestsManager.ts
+++ b/src/rust-crypto/OutgoingRequestsManager.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { Logger } from "../logger";
-import { defer, IDeferred, logDuration } from "../utils";
+import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { Logger } from "../logger.js";
+import { defer, IDeferred, logDuration } from "../utils.js";
 
 /**
  * OutgoingRequestsManager: responsible for processing outgoing requests from the OlmMachine.

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -17,13 +17,13 @@ limitations under the License.
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Curve25519AuthData, KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup";
-import { Logger } from "../logger";
-import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api";
-import { RustBackupManager } from "./backup";
-import { CryptoEvent } from "../matrix";
-import { encodeUri, sleep } from "../utils";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend";
+import { Curve25519AuthData, KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.js";
+import { Logger } from "../logger.js";
+import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.js";
+import { RustBackupManager } from "./backup.js";
+import { CryptoEvent } from "../matrix.js";
+import { encodeUri, sleep } from "../utils.js";
+import { BackupDecryptor } from "../common-crypto/CryptoBackend.js";
 
 // The minimum time to wait between two retries in case of errors. To avoid hammering the server.
 const KEY_BACKUP_BACKOFF = 5000; // ms

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -26,16 +26,16 @@ import {
     UserId,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { EventType } from "../@types/event";
-import { IContent, MatrixEvent } from "../models/event";
-import { Room } from "../models/room";
-import { Logger, logger, LogSpan } from "../logger";
-import { KeyClaimManager } from "./KeyClaimManager";
-import { RoomMember } from "../models/room-member";
-import { HistoryVisibility } from "../@types/partials";
-import { OutgoingRequestsManager } from "./OutgoingRequestsManager";
-import { logDuration } from "../utils";
-import { KnownMembership } from "../@types/membership";
+import { EventType } from "../@types/event.js";
+import { IContent, MatrixEvent } from "../models/event.js";
+import { Room } from "../models/room.js";
+import { Logger, logger, LogSpan } from "../logger.js";
+import { KeyClaimManager } from "./KeyClaimManager.js";
+import { RoomMember } from "../models/room-member.js";
+import { HistoryVisibility } from "../@types/partials.js";
+import { OutgoingRequestsManager } from "./OutgoingRequestsManager.js";
+import { logDuration } from "../utils.js";
+import { KnownMembership } from "../@types/membership.js";
 
 /**
  * RoomEncryptor: responsible for encrypting messages to a given room

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -24,19 +24,19 @@ import {
     KeyBackupInfo,
     KeyBackupSession,
     Curve25519SessionData,
-} from "../crypto-api/keybackup";
-import { logger } from "../logger";
-import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api";
-import { CryptoEvent, IMegolmSessionData } from "../crypto";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { encodeUri, logDuration } from "../utils";
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { sleep } from "../utils";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend";
-import { IEncryptedPayload } from "../crypto/aes";
-import { ImportRoomKeyProgressData, ImportRoomKeysOpts } from "../crypto-api";
-import { IKeyBackupInfo } from "../crypto/keybackup";
-import { IKeyBackup } from "../crypto/backup";
+} from "../crypto-api/keybackup.js";
+import { logger } from "../logger.js";
+import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.js";
+import { CryptoEvent, IMegolmSessionData } from "../crypto/index.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { encodeUri, logDuration } from "../utils.js";
+import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { sleep } from "../utils.js";
+import { BackupDecryptor } from "../common-crypto/CryptoBackend.js";
+import { IEncryptedPayload } from "../crypto/aes.js";
+import { ImportRoomKeyProgressData, ImportRoomKeysOpts } from "../crypto-api/index.js";
+import { IKeyBackupInfo } from "../crypto/keybackup.js";
+import { IKeyBackup } from "../crypto/backup.js";
 
 /** Authentification of the backup info, depends on algorithm */
 type AuthData = KeyBackupInfo["auth_data"];

--- a/src/rust-crypto/device-converter.ts
+++ b/src/rust-crypto/device-converter.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Device, DeviceVerification } from "../models/device";
-import { DeviceKeys } from "../client";
+import { Device, DeviceVerification } from "../models/device.js";
+import { DeviceKeys } from "../client.js";
 
 /**
  * Convert a {@link RustSdkCryptoJs.Device} to a {@link Device}

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -17,17 +17,17 @@ limitations under the License.
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { StoreHandle } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { RustCrypto } from "./rust-crypto";
-import { IHttpOpts, MatrixHttpApi } from "../http-api";
-import { ServerSideSecretStorage } from "../secret-storage";
-import { ICryptoCallbacks } from "../crypto";
-import { Logger } from "../logger";
-import { CryptoStore, MigrationState } from "../crypto/store/base";
+import { RustCrypto } from "./rust-crypto.js";
+import { IHttpOpts, MatrixHttpApi } from "../http-api/index.js";
+import { ServerSideSecretStorage } from "../secret-storage.js";
+import { ICryptoCallbacks } from "../crypto/index.js";
+import { Logger } from "../logger.js";
+import { CryptoStore, MigrationState } from "../crypto/store/base.js";
 import {
     migrateFromLegacyCrypto,
     migrateLegacyLocalTrustIfNeeded,
     migrateRoomSettingsFromLegacyCrypto,
-} from "./libolm_migration";
+} from "./libolm_migration.js";
 
 /**
  * Create a new `RustCrypto` implementation

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -16,18 +16,18 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Logger } from "../logger";
-import { CryptoStore, MigrationState, SecretStorePrivateKeys } from "../crypto/store/base";
-import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store";
-import { decryptAES, IEncryptedPayload } from "../crypto/aes";
-import { IHttpOpts, MatrixHttpApi } from "../http-api";
-import { requestKeyBackupVersion } from "./backup";
-import { IRoomEncryption } from "../crypto/RoomList";
-import { CrossSigningKeyInfo, Curve25519AuthData } from "../crypto-api";
-import { RustCrypto } from "./rust-crypto";
-import { KeyBackupInfo } from "../crypto-api/keybackup";
-import { sleep } from "../utils";
-import { encodeBase64 } from "../base64";
+import { Logger } from "../logger.js";
+import { CryptoStore, MigrationState, SecretStorePrivateKeys } from "../crypto/store/base.js";
+import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.js";
+import { decryptAES, IEncryptedPayload } from "../crypto/aes.js";
+import { IHttpOpts, MatrixHttpApi } from "../http-api/index.js";
+import { requestKeyBackupVersion } from "./backup.js";
+import { IRoomEncryption } from "../crypto/RoomList.js";
+import { CrossSigningKeyInfo, Curve25519AuthData } from "../crypto-api/index.js";
+import { RustCrypto } from "./rust-crypto.js";
+import { KeyBackupInfo } from "../crypto-api/keybackup.js";
+import { sleep } from "../utils.js";
+import { encodeBase64 } from "../base64.js";
 
 /**
  * Determine if any data needs migrating from the legacy store, and do so.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -17,20 +17,20 @@ limitations under the License.
 import anotherjson from "another-json";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto";
-import { KnownMembership } from "../@types/membership";
-import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator";
-import type { IEncryptedEventInfo } from "../crypto/api";
-import { MatrixEvent, MatrixEventEvent } from "../models/event";
-import { Room } from "../models/room";
-import { RoomMember } from "../models/room-member";
-import { BackupDecryptor, CryptoBackend, DecryptionError, OnSyncCompletedData } from "../common-crypto/CryptoBackend";
-import { logger, Logger } from "../logger";
-import { IHttpOpts, MatrixHttpApi, Method } from "../http-api";
-import { RoomEncryptor } from "./RoomEncryptor";
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { KeyClaimManager } from "./KeyClaimManager";
-import { logDuration, MapWithDefault } from "../utils";
+import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto.js";
+import { KnownMembership } from "../@types/membership.js";
+import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.js";
+import type { IEncryptedEventInfo } from "../crypto/api.js";
+import { MatrixEvent, MatrixEventEvent } from "../models/event.js";
+import { Room } from "../models/room.js";
+import { RoomMember } from "../models/room-member.js";
+import { BackupDecryptor, CryptoBackend, DecryptionError, OnSyncCompletedData } from "../common-crypto/CryptoBackend.js";
+import { logger, Logger } from "../logger.js";
+import { IHttpOpts, MatrixHttpApi, Method } from "../http-api/index.js";
+import { RoomEncryptor } from "./RoomEncryptor.js";
+import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { KeyClaimManager } from "./KeyClaimManager.js";
+import { logDuration, MapWithDefault } from "../utils.js";
 import {
     BackupTrustInfo,
     BootstrapCrossSigningOpts,
@@ -53,29 +53,29 @@ import {
     OwnDeviceKeys,
     UserVerificationStatus,
     VerificationRequest,
-} from "../crypto-api";
-import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter";
-import { IDownloadKeyResult, IQueryKeysRequest } from "../client";
-import { Device, DeviceMap } from "../models/device";
-import { SECRET_STORAGE_ALGORITHM_V1_AES, ServerSideSecretStorage } from "../secret-storage";
-import { CrossSigningIdentity } from "./CrossSigningIdentity";
-import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } from "./secret-storage";
-import { keyFromPassphrase } from "../crypto/key_passphrase";
-import { encodeRecoveryKey } from "../crypto/recoverykey";
-import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification";
-import { EventType, MsgType } from "../@types/event";
-import { CryptoEvent } from "../crypto";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { RustBackupCryptoEventMap, RustBackupCryptoEvents, RustBackupManager } from "./backup";
-import { TypedReEmitter } from "../ReEmitter";
-import { randomString } from "../randomstring";
-import { ClientStoppedError } from "../errors";
-import { ISignatures } from "../@types/signed";
-import { encodeBase64 } from "../base64";
-import { OutgoingRequestsManager } from "./OutgoingRequestsManager";
-import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader";
-import { DehydratedDeviceManager } from "./DehydratedDeviceManager";
-import { VerificationMethod } from "../types";
+} from "../crypto-api/index.js";
+import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.js";
+import { IDownloadKeyResult, IQueryKeysRequest } from "../client.js";
+import { Device, DeviceMap } from "../models/device.js";
+import { SECRET_STORAGE_ALGORITHM_V1_AES, ServerSideSecretStorage } from "../secret-storage.js";
+import { CrossSigningIdentity } from "./CrossSigningIdentity.js";
+import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } from "./secret-storage.js";
+import { keyFromPassphrase } from "../crypto/key_passphrase.js";
+import { encodeRecoveryKey } from "../crypto/recoverykey.js";
+import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification.js";
+import { EventType, MsgType } from "../@types/event.js";
+import { CryptoEvent } from "../crypto/index.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { RustBackupCryptoEventMap, RustBackupCryptoEvents, RustBackupManager } from "./backup.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { randomString } from "../randomstring.js";
+import { ClientStoppedError } from "../errors.js";
+import { ISignatures } from "../@types/signed.js";
+import { encodeBase64 } from "../base64.js";
+import { OutgoingRequestsManager } from "./OutgoingRequestsManager.js";
+import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader.js";
+import { DehydratedDeviceManager } from "./DehydratedDeviceManager.js";
+import { VerificationMethod } from "../types.js";
 
 const ALL_VERIFICATION_METHODS = [
     VerificationMethod.Sas,

--- a/src/rust-crypto/secret-storage.ts
+++ b/src/rust-crypto/secret-storage.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ServerSideSecretStorage } from "../secret-storage";
+import { ServerSideSecretStorage } from "../secret-storage.js";
 
 /**
  * Check that the private cross signing keys (master, self signing, user signing) are stored in the secret storage and encrypted with the default secret storage key.

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -28,14 +28,14 @@ import {
     Verifier,
     VerifierEvent,
     VerifierEventHandlerMap,
-} from "../crypto-api/verification";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor";
-import { TypedReEmitter } from "../ReEmitter";
-import { MatrixEvent } from "../models/event";
-import { EventType, MsgType } from "../@types/event";
-import { defer, IDeferred } from "../utils";
-import { VerificationMethod } from "../types";
+} from "../crypto-api/verification.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor.js";
+import { TypedReEmitter } from "../ReEmitter.js";
+import { MatrixEvent } from "../models/event.js";
+import { EventType, MsgType } from "../@types/event.js";
+import { defer, IDeferred } from "../utils.js";
+import { VerificationMethod } from "../types.js";
 
 /**
  * An incoming, or outgoing, request to verify a user or a device via cross-signing.

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -18,12 +18,12 @@ limitations under the License.
  * This is an internal module which manages queuing, scheduling and retrying
  * of requests.
  */
-import { logger } from "./logger";
-import { MatrixEvent } from "./models/event";
-import { EventType } from "./@types/event";
-import { defer, IDeferred, removeElement } from "./utils";
-import { calculateRetryBackoff, MatrixError } from "./http-api";
-import { ISendEventResponse } from "./@types/requests";
+import { logger } from "./logger.js";
+import { MatrixEvent } from "./models/event.js";
+import { EventType } from "./@types/event.js";
+import { defer, IDeferred, removeElement } from "./utils.js";
+import { calculateRetryBackoff, MatrixError } from "./http-api/index.js";
+import { ISendEventResponse } from "./@types/requests.js";
 
 const DEBUG = false; // set true to enable console logging.
 

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -20,12 +20,12 @@ limitations under the License.
  * @see https://spec.matrix.org/v1.6/client-server-api/#storage
  */
 
-import { TypedEventEmitter } from "./models/typed-event-emitter";
-import { ClientEvent, ClientEventHandlerMap } from "./client";
-import { MatrixEvent } from "./models/event";
-import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./crypto/aes";
-import { randomString } from "./randomstring";
-import { logger } from "./logger";
+import { TypedEventEmitter } from "./models/typed-event-emitter.js";
+import { ClientEvent, ClientEventHandlerMap } from "./client.js";
+import { MatrixEvent } from "./models/event.js";
+import { calculateKeyCheck, decryptAES, encryptAES, IEncryptedPayload } from "./crypto/aes.js";
+import { randomString } from "./randomstring.js";
+import { logger } from "./logger.js";
 
 export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
 

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IHttpOpts, MatrixHttpApi, Method } from "./http-api";
-import { logger } from "./logger";
+import { IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.js";
+import { logger } from "./logger.js";
 
 // How often we update the server capabilities.
 // 6 hours - an arbitrary value, but they should change very infrequently.

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend";
-import { NotificationCountType, Room, RoomEvent } from "./models/room";
-import { logger } from "./logger";
-import { promiseMapSeries } from "./utils";
-import { EventTimeline } from "./models/event-timeline";
-import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client";
+import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.js";
+import { NotificationCountType, Room, RoomEvent } from "./models/room.js";
+import { logger } from "./logger.js";
+import { promiseMapSeries } from "./utils.js";
+import { EventTimeline } from "./models/event-timeline.js";
+import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client.js";
 import {
     ISyncStateData,
     SyncState,
@@ -28,11 +28,11 @@ import {
     defaultClientOpts,
     defaultSyncApiOpts,
     SetPresence,
-} from "./sync";
-import { MatrixEvent } from "./models/event";
-import { Crypto } from "./crypto";
-import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator";
-import { MatrixError } from "./http-api";
+} from "./sync.js";
+import { MatrixEvent } from "./models/event.js";
+import { Crypto } from "./crypto/index.js";
+import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator.js";
+import { MatrixError } from "./http-api/index.js";
 import {
     Extension,
     ExtensionState,
@@ -41,12 +41,12 @@ import {
     SlidingSync,
     SlidingSyncEvent,
     SlidingSyncState,
-} from "./sliding-sync";
-import { EventType } from "./@types/event";
-import { IPushRules } from "./@types/PushRules";
-import { RoomStateEvent } from "./models/room-state";
-import { RoomMemberEvent } from "./models/room-member";
-import { KnownMembership } from "./@types/membership";
+} from "./sliding-sync.js";
+import { EventType } from "./@types/event.js";
+import { IPushRules } from "./@types/PushRules.js";
+import { RoomStateEvent } from "./models/room-state.js";
+import { RoomMemberEvent } from "./models/room-member.js";
+import { KnownMembership } from "./@types/membership.js";
 
 // Number of consecutive failed syncs that will lead to a syncState of ERROR as opposed
 // to RECONNECTING. This is needed to inform the client of server issues when the

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "./logger";
-import { MatrixClient } from "./client";
-import { IRoomEvent, IStateEvent } from "./sync-accumulator";
-import { TypedEventEmitter } from "./models/typed-event-emitter";
-import { sleep, IDeferred, defer } from "./utils";
-import { HTTPError } from "./http-api";
+import { logger } from "./logger.js";
+import { MatrixClient } from "./client.js";
+import { IRoomEvent, IStateEvent } from "./sync-accumulator.js";
+import { TypedEventEmitter } from "./models/typed-event-emitter.js";
+import { sleep, IDeferred, defer } from "./utils.js";
+import { HTTPError } from "./http-api/index.js";
 
 // /sync requests allow you to set a timeout= but the request may continue
 // beyond that and wedge forever, so we need to track how long we are willing

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType } from "../@types/event";
-import { Room } from "../models/room";
-import { User } from "../models/user";
-import { IEvent, MatrixEvent } from "../models/event";
-import { Filter } from "../filter";
-import { RoomSummary } from "../models/room-summary";
-import { IMinimalEvent, IRooms, ISyncResponse } from "../sync-accumulator";
-import { IStartClientOpts } from "../client";
-import { IStateEventWithRoomId } from "../@types/search";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
-import { EventEmitterEvents } from "../models/typed-event-emitter";
+import { EventType } from "../@types/event.js";
+import { Room } from "../models/room.js";
+import { User } from "../models/user.js";
+import { IEvent, MatrixEvent } from "../models/event.js";
+import { Filter } from "../filter.js";
+import { RoomSummary } from "../models/room-summary.js";
+import { IMinimalEvent, IRooms, ISyncResponse } from "../sync-accumulator.js";
+import { IStartClientOpts } from "../client.js";
+import { IStateEventWithRoomId } from "../@types/search.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
+import { EventEmitterEvents } from "../models/typed-event-emitter.js";
 
 export interface ISavedSync {
     nextBatch: string;

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISavedSync } from "./index";
-import { IEvent, IStateEventWithRoomId, IStoredClientOpts, ISyncResponse } from "../matrix";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
+import { ISavedSync } from "./index.js";
+import { IEvent, IStateEventWithRoomId, IStoredClientOpts, ISyncResponse } from "../matrix.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
 
 export interface IIndexedDBBackend {
     connect(onClose?: () => void): Promise<void>;

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMinimalEvent, ISyncData, ISyncResponse, SyncAccumulator } from "../sync-accumulator";
-import { deepCopy, promiseTry } from "../utils";
-import { exists as idbExists } from "../indexeddb-helpers";
-import { logger } from "../logger";
-import { IStateEventWithRoomId, IStoredClientOpts } from "../matrix";
-import { ISavedSync } from "./index";
-import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
+import { IMinimalEvent, ISyncData, ISyncResponse, SyncAccumulator } from "../sync-accumulator.js";
+import { deepCopy, promiseTry } from "../utils.js";
+import { exists as idbExists } from "../indexeddb-helpers.js";
+import { logger } from "../logger.js";
+import { IStateEventWithRoomId, IStoredClientOpts } from "../matrix.js";
+import { ISavedSync } from "./index.js";
+import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
 
 type DbMigration = (db: IDBDatabase) => void;
 const DB_MIGRATIONS: DbMigration[] = [

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../logger";
-import { defer, IDeferred } from "../utils";
-import { ISavedSync } from "./index";
-import { IStoredClientOpts } from "../client";
-import { IStateEventWithRoomId, ISyncResponse } from "../matrix";
-import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
+import { logger } from "../logger.js";
+import { defer, IDeferred } from "../utils.js";
+import { ISavedSync } from "./index.js";
+import { IStoredClientOpts } from "../client.js";
+import { IStateEventWithRoomId, ISyncResponse } from "../matrix.js";
+import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     private worker?: Worker;

--- a/src/store/indexeddb-store-worker.ts
+++ b/src/store/indexeddb-store-worker.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { LocalIndexedDBStoreBackend } from "./indexeddb-local-backend";
-import { logger } from "../logger";
+import { LocalIndexedDBStoreBackend } from "./indexeddb-local-backend.js";
+import { logger } from "../logger.js";
 
 interface ICmd {
     command: string;

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -16,18 +16,18 @@ limitations under the License.
 
 /* eslint-disable @babel/no-invalid-this */
 
-import { MemoryStore, IOpts as IBaseOpts } from "./memory";
-import { LocalIndexedDBStoreBackend } from "./indexeddb-local-backend";
-import { RemoteIndexedDBStoreBackend } from "./indexeddb-remote-backend";
-import { IEvent, MatrixEvent } from "../models/event";
-import { logger } from "../logger";
-import { ISavedSync } from "./index";
-import { IIndexedDBBackend } from "./indexeddb-backend";
-import { ISyncResponse } from "../sync-accumulator";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { IStateEventWithRoomId } from "../@types/search";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
-import { IStoredClientOpts } from "../client";
+import { MemoryStore, IOpts as IBaseOpts } from "./memory.js";
+import { LocalIndexedDBStoreBackend } from "./indexeddb-local-backend.js";
+import { RemoteIndexedDBStoreBackend } from "./indexeddb-remote-backend.js";
+import { IEvent, MatrixEvent } from "../models/event.js";
+import { logger } from "../logger.js";
+import { ISavedSync } from "./index.js";
+import { IIndexedDBBackend } from "./indexeddb-backend.js";
+import { ISyncResponse } from "../sync-accumulator.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { IStateEventWithRoomId } from "../@types/search.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
+import { IStoredClientOpts } from "../client.js";
 
 /**
  * This is an internal module. See {@link IndexedDBStore} for the public class.

--- a/src/store/local-storage-events-emitter.ts
+++ b/src/store/local-storage-events-emitter.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TypedEventEmitter } from "../models/typed-event-emitter";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
 
 export enum LocalStorageErrors {
     Global = "Global",

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -18,21 +18,21 @@ limitations under the License.
  * This is an internal module. See {@link MemoryStore} for the public class.
  */
 
-import { EventType } from "../@types/event";
-import { Room } from "../models/room";
-import { User } from "../models/user";
-import { IEvent, MatrixEvent } from "../models/event";
-import { RoomState, RoomStateEvent } from "../models/room-state";
-import { RoomMember } from "../models/room-member";
-import { Filter } from "../filter";
-import { ISavedSync, IStore, UserCreator } from "./index";
-import { RoomSummary } from "../models/room-summary";
-import { ISyncResponse } from "../sync-accumulator";
-import { IStateEventWithRoomId } from "../@types/search";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage";
-import { IStoredClientOpts } from "../client";
-import { MapWithDefault } from "../utils";
-import { KnownMembership } from "../@types/membership";
+import { EventType } from "../@types/event.js";
+import { Room } from "../models/room.js";
+import { User } from "../models/user.js";
+import { IEvent, MatrixEvent } from "../models/event.js";
+import { RoomState, RoomStateEvent } from "../models/room-state.js";
+import { RoomMember } from "../models/room-member.js";
+import { Filter } from "../filter.js";
+import { ISavedSync, IStore, UserCreator } from "./index.js";
+import { RoomSummary } from "../models/room-summary.js";
+import { ISyncResponse } from "../sync-accumulator.js";
+import { IStateEventWithRoomId } from "../@types/search.js";
+import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.js";
+import { IStoredClientOpts } from "../client.js";
+import { MapWithDefault } from "../utils.js";
+import { KnownMembership } from "../@types/membership.js";
 
 function isValidFilterId(filterId?: string | number | null): boolean {
     const isValidStr =

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -18,17 +18,17 @@ limitations under the License.
  * This is an internal module.
  */
 
-import { EventType } from "../@types/event";
-import { Room } from "../models/room";
-import { User } from "../models/user";
-import { IEvent, MatrixEvent } from "../models/event";
-import { Filter } from "../filter";
-import { ISavedSync, IStore, UserCreator } from "./index";
-import { RoomSummary } from "../models/room-summary";
-import { ISyncResponse } from "../sync-accumulator";
-import { IStateEventWithRoomId } from "../@types/search";
-import { IndexedToDeviceBatch, ToDeviceBatch } from "../models/ToDeviceMessage";
-import { IStoredClientOpts } from "../client";
+import { EventType } from "../@types/event.js";
+import { Room } from "../models/room.js";
+import { User } from "../models/user.js";
+import { IEvent, MatrixEvent } from "../models/event.js";
+import { Filter } from "../filter.js";
+import { ISavedSync, IStore, UserCreator } from "./index.js";
+import { RoomSummary } from "../models/room-summary.js";
+import { ISyncResponse } from "../sync-accumulator.js";
+import { IStateEventWithRoomId } from "../@types/search.js";
+import { IndexedToDeviceBatch, ToDeviceBatch } from "../models/ToDeviceMessage.js";
+import { IStoredClientOpts } from "../client.js";
 
 /**
  * Construct a stub store. This does no-ops on most store methods.

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -18,13 +18,13 @@ limitations under the License.
  * This is an internal module. See {@link SyncAccumulator} for the public class.
  */
 
-import { logger } from "./logger";
-import { deepCopy } from "./utils";
-import { IContent, IUnsigned } from "./models/event";
-import { IRoomSummary } from "./models/room-summary";
-import { EventType } from "./@types/event";
-import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
-import { ReceiptAccumulator } from "./receipt-accumulator";
+import { logger } from "./logger.js";
+import { deepCopy } from "./utils.js";
+import { IContent, IUnsigned } from "./models/event.js";
+import { IRoomSummary } from "./models/room-summary.js";
+import { EventType } from "./@types/event.js";
+import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.js";
+import { ReceiptAccumulator } from "./receipt-accumulator.js";
 
 interface IOpts {
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -25,14 +25,14 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend";
-import { User } from "./models/user";
-import { NotificationCountType, Room, RoomEvent } from "./models/room";
-import { deepCopy, defer, IDeferred, noUnsafeEventProps, promiseMapSeries, unsafeProp } from "./utils";
-import { Filter } from "./filter";
-import { EventTimeline } from "./models/event-timeline";
-import { logger } from "./logger";
-import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering, ResetTimelineCallback } from "./client";
+import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.js";
+import { User } from "./models/user.js";
+import { NotificationCountType, Room, RoomEvent } from "./models/room.js";
+import { deepCopy, defer, IDeferred, noUnsafeEventProps, promiseMapSeries, unsafeProp } from "./utils.js";
+import { Filter } from "./filter.js";
+import { EventTimeline } from "./models/event-timeline.js";
+import { logger } from "./logger.js";
+import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering, ResetTimelineCallback } from "./client.js";
 import {
     IEphemeral,
     IInvitedRoom,
@@ -47,20 +47,20 @@ import {
     ISyncResponse,
     ITimeline,
     IToDeviceEvent,
-} from "./sync-accumulator";
-import { MatrixEvent } from "./models/event";
-import { MatrixError, Method } from "./http-api";
-import { ISavedSync } from "./store";
-import { EventType } from "./@types/event";
-import { IPushRules } from "./@types/PushRules";
-import { RoomStateEvent, IMarkerFoundOptions } from "./models/room-state";
-import { RoomMemberEvent } from "./models/room-member";
-import { BeaconEvent } from "./models/beacon";
-import { IEventsResponse } from "./@types/requests";
-import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync";
-import { Feature, ServerSupport } from "./feature";
-import { Crypto } from "./crypto";
-import { KnownMembership } from "./@types/membership";
+} from "./sync-accumulator.js";
+import { MatrixEvent } from "./models/event.js";
+import { MatrixError, Method } from "./http-api/index.js";
+import { ISavedSync } from "./store/index.js";
+import { EventType } from "./@types/event.js";
+import { IPushRules } from "./@types/PushRules.js";
+import { RoomStateEvent, IMarkerFoundOptions } from "./models/room-state.js";
+import { RoomMemberEvent } from "./models/room-member.js";
+import { BeaconEvent } from "./models/beacon.js";
+import { IEventsResponse } from "./@types/requests.js";
+import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.js";
+import { Feature, ServerSupport } from "./feature.js";
+import { Crypto } from "./crypto/index.js";
+import { KnownMembership } from "./@types/membership.js";
 
 const DEBUG = true;
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -22,12 +22,12 @@ limitations under the License.
  * @packageDocumentation
  */
 
-import { IContent, IEvent, IUnsigned, MatrixEvent } from "./models/event";
-import { RoomMember } from "./models/room-member";
-import { EventType } from "./@types/event";
-import { DecryptionError } from "./crypto/algorithms";
-import { DecryptionFailureCode } from "./crypto-api";
-import { EventDecryptionResult } from "./common-crypto/CryptoBackend";
+import { IContent, IEvent, IUnsigned, MatrixEvent } from "./models/event.js";
+import { RoomMember } from "./models/room-member.js";
+import { EventType } from "./@types/event.js";
+import { DecryptionError } from "./crypto/algorithms/index.js";
+import { DecryptionFailureCode } from "./crypto-api/index.js";
+import { EventDecryptionResult } from "./common-crypto/CryptoBackend.js";
 
 /**
  * Create a {@link MatrixEvent}.

--- a/src/thread-utils.ts
+++ b/src/thread-utils.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { THREAD_RELATION_TYPE } from "./models/thread";
-import { IEvent } from "./models/event";
+import { THREAD_RELATION_TYPE } from "./models/thread.js";
+import { IEvent } from "./models/event.js";
 
 /**
  * Returns a filter function for the /relations endpoint to filter out relations directly

--- a/src/timeline-window.ts
+++ b/src/timeline-window.ts
@@ -16,12 +16,12 @@ limitations under the License.
 
 import { Optional } from "matrix-events-sdk";
 
-import { Direction, EventTimeline } from "./models/event-timeline";
-import { logger } from "./logger";
-import { MatrixClient } from "./client";
-import { EventTimelineSet } from "./models/event-timeline-set";
-import { MatrixEvent } from "./models/event";
-import { Room, RoomEvent } from "./models/room";
+import { Direction, EventTimeline } from "./models/event-timeline.js";
+import { logger } from "./logger.js";
+import { MatrixClient } from "./client.js";
+import { EventTimelineSet } from "./models/event-timeline-set.js";
+import { MatrixEvent } from "./models/event.js";
+import { Room, RoomEvent } from "./models/room.js";
 
 /**
  * @internal

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,11 +21,11 @@ limitations under the License.
  * Remember to only export *public* types from this file.
  */
 
-export type * from "./@types/media";
-export * from "./@types/membership";
-export type * from "./@types/event";
-export type * from "./@types/events";
-export type * from "./@types/state_events";
+export type * from "./@types/media.js";
+export * from "./@types/membership.js";
+export type * from "./@types/event.js";
+export type * from "./@types/events.js";
+export type * from "./@types/state_events.js";
 
 /** The different methods for device and user verification */
 export enum VerificationMethod {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,10 +22,10 @@ import unhomoglyph from "unhomoglyph";
 import promiseRetry from "p-retry";
 import { Optional } from "matrix-events-sdk";
 
-import { IEvent, MatrixEvent } from "./models/event";
-import { M_TIMESTAMP } from "./@types/location";
-import { ReceiptType } from "./@types/read_receipts";
-import { BaseLogger } from "./logger";
+import { IEvent, MatrixEvent } from "./models/event.js";
+import { M_TIMESTAMP } from "./@types/location.js";
+import { ReceiptType } from "./@types/read_receipts.js";
+import { BaseLogger } from "./logger.js";
 
 const interns = new Map<string, string>();
 

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -24,12 +24,12 @@ limitations under the License.
 import { v4 as uuidv4 } from "uuid";
 import { parse as parseSdp, write as writeSdp } from "sdp-transform";
 
-import { logger } from "../logger";
-import { checkObjectHasKeys, isNullOrUndefined, recursivelyAssign } from "../utils";
-import { MatrixEvent } from "../models/event";
-import { EventType, TimelineEvents, ToDeviceMessageId } from "../@types/event";
-import { RoomMember } from "../models/room-member";
-import { randomString } from "../randomstring";
+import { logger } from "../logger.js";
+import { checkObjectHasKeys, isNullOrUndefined, recursivelyAssign } from "../utils.js";
+import { MatrixEvent } from "../models/event.js";
+import { EventType, TimelineEvents, ToDeviceMessageId } from "../@types/event.js";
+import { RoomMember } from "../models/room-member.js";
+import { randomString } from "../randomstring.js";
 import {
     MCallReplacesEvent,
     MCallAnswer,
@@ -44,15 +44,15 @@ import {
     MCallCandidates,
     MCallBase,
     MCallHangupReject,
-} from "./callEventTypes";
-import { CallFeed } from "./callFeed";
-import { MatrixClient } from "../client";
-import { EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter";
-import { DeviceInfo } from "../crypto/deviceinfo";
-import { GroupCallUnknownDeviceError } from "./groupCall";
-import { IScreensharingOpts } from "./mediaHandler";
-import { MatrixError } from "../http-api";
-import { GroupCallStats } from "./stats/groupCallStats";
+} from "./callEventTypes.js";
+import { CallFeed } from "./callFeed.js";
+import { MatrixClient } from "../client.js";
+import { EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { DeviceInfo } from "../crypto/deviceinfo.js";
+import { GroupCallUnknownDeviceError } from "./groupCall.js";
+import { IScreensharingOpts } from "./mediaHandler.js";
+import { MatrixError } from "../http-api/index.js";
+import { GroupCallStats } from "./stats/groupCallStats.js";
 
 interface CallOpts {
     // The room ID for this call.

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event";
-import { logger } from "../logger";
-import { CallDirection, CallError, CallErrorCode, CallState, createNewMatrixCall, MatrixCall } from "./call";
-import { EventType } from "../@types/event";
-import { ClientEvent, MatrixClient } from "../client";
-import { MCallAnswer, MCallHangupReject } from "./callEventTypes";
-import { GroupCall, GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from "./groupCall";
-import { RoomEvent } from "../models/room";
+import { MatrixEvent } from "../models/event.js";
+import { logger } from "../logger.js";
+import { CallDirection, CallError, CallErrorCode, CallState, createNewMatrixCall, MatrixCall } from "./call.js";
+import { EventType } from "../@types/event.js";
+import { ClientEvent, MatrixClient } from "../client.js";
+import { MCallAnswer, MCallHangupReject } from "./callEventTypes.js";
+import { GroupCall, GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from "./groupCall.js";
+import { RoomEvent } from "../models/room.js";
 
 // Don't ring unless we'd be ringing for at least 3 seconds: the user needs some
 // time to press the 'accept' button

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -1,7 +1,7 @@
 // allow non-camelcase as these are events type that go onto the wire
 /* eslint-disable camelcase */
 
-import { CallErrorCode } from "./call";
+import { CallErrorCode } from "./call.js";
 
 // TODO: Change to "sdp_stream_metadata" when MSC3077 is merged
 export const SDPStreamMetadataKey = "org.matrix.msc3077.sdp_stream_metadata";

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { SDPStreamMetadataPurpose } from "./callEventTypes";
-import { acquireContext, releaseContext } from "./audioContext";
-import { MatrixClient } from "../client";
-import { RoomMember } from "../models/room-member";
-import { logger } from "../logger";
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { CallEvent, CallState, MatrixCall } from "./call";
+import { SDPStreamMetadataPurpose } from "./callEventTypes.js";
+import { acquireContext, releaseContext } from "./audioContext.js";
+import { MatrixClient } from "../client.js";
+import { RoomMember } from "../models/room-member.js";
+import { logger } from "../logger.js";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { CallEvent, CallState, MatrixCall } from "./call.js";
 
 const POLLING_INTERVAL = 200; // ms
 export const SPEAKING_THRESHOLD = -60; // dB

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -1,6 +1,6 @@
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { CallFeed, SPEAKING_THRESHOLD } from "./callFeed";
-import { MatrixClient, IMyDevice } from "../client";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { CallFeed, SPEAKING_THRESHOLD } from "./callFeed.js";
+import { MatrixClient, IMyDevice } from "../client.js";
 import {
     CallErrorCode,
     CallEvent,
@@ -11,31 +11,31 @@ import {
     setTracksEnabled,
     createNewMatrixCall,
     CallError,
-} from "./call";
-import { RoomMember } from "../models/room-member";
-import { Room } from "../models/room";
-import { RoomStateEvent } from "../models/room-state";
-import { logger } from "../logger";
-import { ReEmitter } from "../ReEmitter";
-import { SDPStreamMetadataPurpose } from "./callEventTypes";
-import { MatrixEvent } from "../models/event";
-import { EventType } from "../@types/event";
-import { CallEventHandlerEvent } from "./callEventHandler";
-import { GroupCallEventHandlerEvent } from "./groupCallEventHandler";
-import { IScreensharingOpts } from "./mediaHandler";
-import { mapsEqual } from "../utils";
-import { GroupCallStats } from "./stats/groupCallStats";
+} from "./call.js";
+import { RoomMember } from "../models/room-member.js";
+import { Room } from "../models/room.js";
+import { RoomStateEvent } from "../models/room-state.js";
+import { logger } from "../logger.js";
+import { ReEmitter } from "../ReEmitter.js";
+import { SDPStreamMetadataPurpose } from "./callEventTypes.js";
+import { MatrixEvent } from "../models/event.js";
+import { EventType } from "../@types/event.js";
+import { CallEventHandlerEvent } from "./callEventHandler.js";
+import { GroupCallEventHandlerEvent } from "./groupCallEventHandler.js";
+import { IScreensharingOpts } from "./mediaHandler.js";
+import { mapsEqual } from "../utils.js";
+import { GroupCallStats } from "./stats/groupCallStats.js";
 import {
     ByteSentStatsReport,
     CallFeedReport,
     ConnectionStatsReport,
     StatsReport,
     SummaryStatsReport,
-} from "./stats/statsReport";
-import { SummaryStatsReportGatherer } from "./stats/summaryStatsReportGatherer";
-import { CallFeedStatsReporter } from "./stats/callFeedStatsReporter";
-import { KnownMembership } from "../@types/membership";
-import { CallMembershipData } from "../matrixrtc/CallMembership";
+} from "./stats/statsReport.js";
+import { SummaryStatsReportGatherer } from "./stats/summaryStatsReportGatherer.js";
+import { CallFeedStatsReporter } from "./stats/callFeedStatsReporter.js";
+import { KnownMembership } from "../@types/membership.js";
+import { CallMembershipData } from "../matrixrtc/CallMembership.js";
 
 export enum GroupCallIntent {
     Ring = "m.ring",

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event";
-import { MatrixClient, ClientEvent } from "../client";
-import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./groupCall";
-import { Room } from "../models/room";
-import { RoomState, RoomStateEvent } from "../models/room-state";
-import { RoomMember } from "../models/room-member";
-import { logger } from "../logger";
-import { EventType } from "../@types/event";
-import { SyncState } from "../sync";
+import { MatrixEvent } from "../models/event.js";
+import { MatrixClient, ClientEvent } from "../client.js";
+import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./groupCall.js";
+import { Room } from "../models/room.js";
+import { RoomState, RoomStateEvent } from "../models/room-state.js";
+import { RoomMember } from "../models/room-member.js";
+import { logger } from "../logger.js";
+import { EventType } from "../@types/event.js";
+import { SyncState } from "../sync.js";
 
 export enum GroupCallEventHandlerEvent {
     Incoming = "GroupCall.incoming",

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -17,10 +17,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TypedEventEmitter } from "../models/typed-event-emitter";
-import { GroupCallType, GroupCallState } from "../webrtc/groupCall";
-import { logger } from "../logger";
-import { MatrixClient } from "../client";
+import { TypedEventEmitter } from "../models/typed-event-emitter.js";
+import { GroupCallType, GroupCallState } from "../webrtc/groupCall.js";
+import { logger } from "../logger.js";
+import { MatrixClient } from "../client.js";
 
 export enum MediaHandlerEvent {
     LocalStreamsChanged = "local_streams_changed",

--- a/src/webrtc/stats/callFeedStatsReporter.ts
+++ b/src/webrtc/stats/callFeedStatsReporter.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { CallFeedReport, CallFeedStats, TrackStats, TransceiverStats } from "./statsReport";
-import { CallFeed } from "../callFeed";
+import { CallFeedReport, CallFeedStats, TrackStats, TransceiverStats } from "./statsReport.js";
+import { CallFeed } from "../callFeed.js";
 
 export class CallFeedStatsReporter {
     public static buildCallFeedReport(callId: string, opponentMemberId: string, pc: RTCPeerConnection): CallFeedReport {

--- a/src/webrtc/stats/callStatsReportGatherer.ts
+++ b/src/webrtc/stats/callStatsReportGatherer.ts
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ConnectionStats } from "./connectionStats";
-import { StatsReportEmitter } from "./statsReportEmitter";
-import { ByteSend, ByteSentStatsReport, TrackID } from "./statsReport";
-import { ConnectionStatsBuilder } from "./connectionStatsBuilder";
-import { TransportStatsBuilder } from "./transportStatsBuilder";
-import { MediaSsrcHandler } from "./media/mediaSsrcHandler";
-import { MediaTrackHandler } from "./media/mediaTrackHandler";
-import { MediaTrackStatsHandler } from "./media/mediaTrackStatsHandler";
-import { TrackStatsBuilder } from "./trackStatsBuilder";
-import { ConnectionStatsReportBuilder } from "./connectionStatsReportBuilder";
-import { ValueFormatter } from "./valueFormatter";
-import { CallStatsReportSummary } from "./callStatsReportSummary";
-import { logger } from "../../logger";
-import { CallFeedStatsReporter } from "./callFeedStatsReporter";
+import { ConnectionStats } from "./connectionStats.js";
+import { StatsReportEmitter } from "./statsReportEmitter.js";
+import { ByteSend, ByteSentStatsReport, TrackID } from "./statsReport.js";
+import { ConnectionStatsBuilder } from "./connectionStatsBuilder.js";
+import { TransportStatsBuilder } from "./transportStatsBuilder.js";
+import { MediaSsrcHandler } from "./media/mediaSsrcHandler.js";
+import { MediaTrackHandler } from "./media/mediaTrackHandler.js";
+import { MediaTrackStatsHandler } from "./media/mediaTrackStatsHandler.js";
+import { TrackStatsBuilder } from "./trackStatsBuilder.js";
+import { ConnectionStatsReportBuilder } from "./connectionStatsReportBuilder.js";
+import { ValueFormatter } from "./valueFormatter.js";
+import { CallStatsReportSummary } from "./callStatsReportSummary.js";
+import { logger } from "../../logger.js";
+import { CallFeedStatsReporter } from "./callFeedStatsReporter.js";
 
 export class CallStatsReportGatherer {
     private isActive = true;

--- a/src/webrtc/stats/connectionStats.ts
+++ b/src/webrtc/stats/connectionStats.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TransportStats } from "./transportStats";
-import { Bitrate } from "./media/mediaTrackStats";
+import { TransportStats } from "./transportStats.js";
+import { Bitrate } from "./media/mediaTrackStats.js";
 
 export interface ConnectionStatsBandwidth {
     /**

--- a/src/webrtc/stats/connectionStatsBuilder.ts
+++ b/src/webrtc/stats/connectionStatsBuilder.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { Bitrate } from "./media/mediaTrackStats";
+import { Bitrate } from "./media/mediaTrackStats.js";
 
 export class ConnectionStatsBuilder {
     public static buildBandwidthReport(now: RTCIceCandidatePairStats): Bitrate {

--- a/src/webrtc/stats/connectionStatsReportBuilder.ts
+++ b/src/webrtc/stats/connectionStatsReportBuilder.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { AudioConcealment, CodecMap, ConnectionStatsReport, FramerateMap, ResolutionMap, TrackID } from "./statsReport";
-import { MediaTrackStats, Resolution } from "./media/mediaTrackStats";
+import { AudioConcealment, CodecMap, ConnectionStatsReport, FramerateMap, ResolutionMap, TrackID } from "./statsReport.js";
+import { MediaTrackStats, Resolution } from "./media/mediaTrackStats.js";
 
 export class ConnectionStatsReportBuilder {
     public static build(stats: Map<TrackID, MediaTrackStats>): ConnectionStatsReport {

--- a/src/webrtc/stats/groupCallStats.ts
+++ b/src/webrtc/stats/groupCallStats.ts
@@ -13,11 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { CallStatsReportGatherer } from "./callStatsReportGatherer";
-import { StatsReportEmitter } from "./statsReportEmitter";
-import { CallStatsReportSummary } from "./callStatsReportSummary";
-import { SummaryStatsReportGatherer } from "./summaryStatsReportGatherer";
-import { logger } from "../../logger";
+import { CallStatsReportGatherer } from "./callStatsReportGatherer.js";
+import { StatsReportEmitter } from "./statsReportEmitter.js";
+import { CallStatsReportSummary } from "./callStatsReportSummary.js";
+import { SummaryStatsReportGatherer } from "./summaryStatsReportGatherer.js";
+import { logger } from "../../logger.js";
 
 export class GroupCallStats {
     private timer: undefined | ReturnType<typeof setTimeout>;

--- a/src/webrtc/stats/media/mediaTrackStats.ts
+++ b/src/webrtc/stats/media/mediaTrackStats.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AudioConcealment } from "../statsReport";
-import { TrackId } from "./mediaTrackHandler";
+import { AudioConcealment } from "../statsReport.js";
+import { TrackId } from "./mediaTrackHandler.js";
 
 export interface PacketLoss {
     packetsTotal: number;

--- a/src/webrtc/stats/media/mediaTrackStatsHandler.ts
+++ b/src/webrtc/stats/media/mediaTrackStatsHandler.ts
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { TrackID } from "../statsReport";
-import { MediaTrackStats } from "./mediaTrackStats";
-import { MediaTrackHandler, TrackId } from "./mediaTrackHandler";
-import { MediaSsrcHandler } from "./mediaSsrcHandler";
+import { TrackID } from "../statsReport.js";
+import { MediaTrackStats } from "./mediaTrackStats.js";
+import { MediaTrackHandler, TrackId } from "./mediaTrackHandler.js";
+import { MediaSsrcHandler } from "./mediaSsrcHandler.js";
 
 export class MediaTrackStatsHandler {
     private readonly track2stats = new Map<TrackID, MediaTrackStats>();

--- a/src/webrtc/stats/statsReport.ts
+++ b/src/webrtc/stats/statsReport.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ConnectionStatsBandwidth, ConnectionStatsBitrate, PacketLoss } from "./connectionStats";
-import { TransportStats } from "./transportStats";
-import { Resolution } from "./media/mediaTrackStats";
+import { ConnectionStatsBandwidth, ConnectionStatsBitrate, PacketLoss } from "./connectionStats.js";
+import { TransportStats } from "./transportStats.js";
+import { Resolution } from "./media/mediaTrackStats.js";
 
 export enum StatsReport {
     CONNECTION_STATS = "StatsReport.connection_stats",

--- a/src/webrtc/stats/statsReportEmitter.ts
+++ b/src/webrtc/stats/statsReportEmitter.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TypedEventEmitter } from "../../models/typed-event-emitter";
+import { TypedEventEmitter } from "../../models/typed-event-emitter.js";
 import {
     ByteSentStatsReport,
     CallFeedReport,
     ConnectionStatsReport,
     StatsReport,
     SummaryStatsReport,
-} from "./statsReport";
+} from "./statsReport.js";
 
 export type StatsReportHandlerMap = {
     [StatsReport.BYTE_SENT_STATS]: (report: ByteSentStatsReport) => void;

--- a/src/webrtc/stats/summaryStatsReportGatherer.ts
+++ b/src/webrtc/stats/summaryStatsReportGatherer.ts
@@ -10,11 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { StatsReportEmitter } from "./statsReportEmitter";
-import { CallStatsReportSummary } from "./callStatsReportSummary";
-import { SummaryStatsReport } from "./statsReport";
-import { ParticipantState } from "../groupCall";
-import { RoomMember } from "../../matrix";
+import { StatsReportEmitter } from "./statsReportEmitter.js";
+import { CallStatsReportSummary } from "./callStatsReportSummary.js";
+import { SummaryStatsReport } from "./statsReport.js";
+import { ParticipantState } from "../groupCall.js";
+import { RoomMember } from "../../matrix.js";
 
 interface CallStatsReportSummaryCounter {
     receivedAudio: number;

--- a/src/webrtc/stats/trackStatsBuilder.ts
+++ b/src/webrtc/stats/trackStatsBuilder.ts
@@ -1,6 +1,6 @@
-import { MediaTrackStats } from "./media/mediaTrackStats";
-import { ValueFormatter } from "./valueFormatter";
-import { TrackSummary } from "./callStatsReportSummary";
+import { MediaTrackStats } from "./media/mediaTrackStats.js";
+import { ValueFormatter } from "./valueFormatter.js";
+import { TrackSummary } from "./callStatsReportSummary.js";
 
 export class TrackStatsBuilder {
     public static buildFramerateResolution(trackStats: MediaTrackStats, now: any): void {

--- a/src/webrtc/stats/transportStatsBuilder.ts
+++ b/src/webrtc/stats/transportStatsBuilder.ts
@@ -1,4 +1,4 @@
-import { TransportStats } from "./transportStats";
+import { TransportStats } from "./transportStats.js";
 
 export class TransportStatsBuilder {
     public static buildReport(


### PR DESCRIPTION
Fixes: #4287

This changes all imports to load `.js` files which seems to be the only way to make Node.js understand them.

This `yarn build`s and lets me run the Node.js example locally. However, tests are totally broken.

The replacements were done with the following shell script with folder imports scraped from #4373 (NB: this uses BSD `sed`):

```
while read -r file; do
    # Append .js to all imports
    sed -i '' -E 's/from "(\..*)"/from "\1.js"/' "$file"
    sed -i '' -E 's/import "(\..*)"/import "\1.js"/' "$file"

    # Fix folder imports to load index.js
    sed -i '' -E 's/\.\.js"/.\/index.js"/' "$file"
    sed -i '' -E 's/(\/algorithms)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/channels)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/crypto-api)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/crypto)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/http-api)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/oidc)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/store)\.js"/\1\/index.js"/' "$file"
    sed -i '' -E 's/(\/transports)\.js"/\1\/index.js"/' "$file"

    # Undo some of what we did above
    sed -i '' -E 's/(@types\/.*)\/index.js"/\1.js"/' "$file"
done < <(find src -name "*.ts")
```

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
