### PR TITLE
Stabilise MSC4156

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4292,13 +4292,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             signPromise = this.http.requestOtherUrl<IThirdPartySigned>(Method.Post, url);
         }
 
-        let queryParams: QueryDict = {};
+        const queryParams: QueryDict = {};
         if (opts.viaServers) {
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
-            if (this.canSupport.get(Feature.MigrateServerNameToVia) === ServerSupport.Unstable) {
-                queryParams = replaceParam("via", "org.matrix.msc4156.via", queryParams);
-            }
         }
 
         const data: IJoinRequestBody = {};
@@ -4341,13 +4338,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const path = utils.encodeUri("/knock/$roomIdOrAlias", { $roomIdOrAlias: roomIdOrAlias });
 
-        let queryParams: QueryDict = {};
+        const queryParams: QueryDict = {};
         if (opts.viaServers) {
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
-            if (this.canSupport.get(Feature.MigrateServerNameToVia) === ServerSupport.Unstable) {
-                queryParams = replaceParam("via", "org.matrix.msc4156.via", queryParams);
-            }
         }
 
         const body: Record<string, string> = {};

--- a/src/client.ts
+++ b/src/client.ts
@@ -4294,6 +4294,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const queryParams: QueryDict = {};
         if (opts.viaServers) {
+            // server_name has been deprecated in favour of via with MSC4156
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
         }
@@ -4340,6 +4341,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const queryParams: QueryDict = {};
         if (opts.viaServers) {
+            // server_name has been deprecated in favour of via with MSC4156
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -4294,7 +4294,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const queryParams: QueryDict = {};
         if (opts.viaServers) {
-            // server_name has been deprecated in favour of via with MSC4156
+            // server_name has been deprecated in favour of via with Matrix >1.11 (MSC4156)
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
         }
@@ -4341,7 +4341,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const queryParams: QueryDict = {};
         if (opts.viaServers) {
-            // server_name has been deprecated in favour of via with MSC4156
+            // server_name has been deprecated in favour of via with Matrix >1.11 (MSC4156)
             queryParams.server_name = opts.viaServers;
             queryParams.via = opts.viaServers;
         }

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -33,7 +33,6 @@ export enum Feature {
     AccountDataDeletion = "AccountDataDeletion",
     RelationsRecursion = "RelationsRecursion",
     IntentionalMentions = "IntentionalMentions",
-    MigrateServerNameToVia = "MigrateServerNameToVia",
 }
 
 type FeatureSupportCondition = {
@@ -65,9 +64,6 @@ const featureSupportResolver: Record<string, FeatureSupportCondition> = {
     [Feature.IntentionalMentions]: {
         unstablePrefixes: ["org.matrix.msc3952_intentional_mentions"],
         matrixVersion: "v1.7",
-    },
-    [Feature.MigrateServerNameToVia]: {
-        unstablePrefixes: ["org.matrix.msc4156"],
     },
 };
 


### PR DESCRIPTION
[MSC4156](https://github.com/matrix-org/matrix-spec-proposals/pull/4156) has been merged so unstable prefixes are no longer required. To my knowledge, the only homeserver that implemented the unstable feature was Synapse. The unstable prefixes in Synapse are being removed with https://github.com/element-hq/synapse/pull/17650.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
