### PR TITLE
Expose the event ID of a call membership

### DIFF
--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -128,6 +128,10 @@ export class CallMembership {
         return this.parentEvent.getSender();
     }
 
+    public get eventId(): string | undefined {
+        return this.parentEvent.getId();
+    }
+
     public get callId(): string {
         return this.membershipData.call_id;
     }


### PR DESCRIPTION
This is in line with the other information we're already exposing, such as the event's sender and timestamp. We want this in order to play around with [adding reactions](https://github.com/element-hq/element-call/pull/2542) to the membership event.