### PR TITLE
Throw clearer error if `createSecretStorageKey` misbehaves

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -763,6 +763,9 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
             // Create a new storage key and add it to secret storage
             this.logger.info("bootstrapSecretStorage: creating new secret storage key");
             const recoveryKey = await createSecretStorageKey();
+            if (!recoveryKey) {
+                throw new Error("createSecretStorageKey() callback did not return a secret storage key");
+            }
             await this.addSecretStorageKeyToSecretStorage(recoveryKey);
         }
 


### PR DESCRIPTION
https://github.com/element-hq/element-web/issues/27888 shows a slightly mysterious error message, but the problem is `createSecretStorageKey` returning the wrong thing.