### PR TITLE
Export `crypto-api/recovery-key.ts`

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -56,6 +56,7 @@ export * from "./crypto/store/memory-crypto-store.ts";
 export * from "./crypto/store/localStorage-crypto-store.ts";
 export * from "./crypto/store/indexeddb-crypto-store.ts";
 export type { OutgoingRoomKeyRequest } from "./crypto/store/base.ts";
+export * from "./crypto-api/recovery-key.ts";
 export * from "./content-repo.ts";
 export * from "./@types/common.ts";
 export * from "./@types/uia.ts";


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

In https://github.com/matrix-org/matrix-js-sdk/pull/4399, we deprecated [MatrixClient.keyBackupKeyFromRecoveryKey](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/client.ts#L3677) and [MatrixClient.isValidRecoveryKey](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/client.ts#L3643). We recommend to use [decodeRecoveryKey](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/crypto-api/recovery-key.ts#L47) directly however `decodeRecoveryKey` is not exported.
