### PR TITLE
Use correct return type for RTCSession encryption keys

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -1274,6 +1274,9 @@ describe("MatrixRTCSession", () => {
 
         bobKeys = sess.getKeysForParticipant("@bob:example.org", "bobsphone")!;
         expect(bobKeys).toHaveLength(5);
+        expect(bobKeys[1]).toBeUndefined();
+        expect(bobKeys[2]).toBeUndefined();
+        expect(bobKeys[3]).toBeUndefined();
         expect(bobKeys[4]).toEqual(Buffer.from("this is the key", "utf-8"));
         expect(sess!.statistics.counters.roomEventEncryptionKeysReceived).toEqual(2);
     });


### PR DESCRIPTION
The functions have always possibly returned `undefined` where the key at a particular index was not known. This changes the return type to match this reality.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
