### PR TITLE
Refactor RTC key getter into generator function

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -443,7 +443,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     public *getEncryptionKeys(): IterableIterator<[string, Array<Uint8Array>]> {
         // the returned array doesn't contain the timestamps
         for (const [participantId, keys] of this.encryptionKeys.entries()) {
-            yield [participantId, keys.map(k => k.key)];
+            yield [participantId, keys.map((k) => k.key)];
         }
     }
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -440,11 +440,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      *
      * @deprecated This will be made private in a future release.
      */
-    public getEncryptionKeys(): IterableIterator<[string, Array<Uint8Array>]> {
+    public *getEncryptionKeys(): IterableIterator<[string, Array<Uint8Array>]> {
         // the returned array doesn't contain the timestamps
-        return Array.from(this.encryptionKeys.entries())
-            .map(([participantId, keys]): [string, Uint8Array[]] => [participantId, keys.map((k) => k.key)])
-            .values();
+        for (const [participantId, keys] of this.encryptionKeys.entries()) {
+            yield [participantId, keys.map(k => k.key)];
+        }
     }
 
     private getNewEncryptionKeyIndex(): number {


### PR DESCRIPTION
especially since it was already returning an IterableIterator

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
