### PR TITLE
RTCSession cleanup: deprecate getKeysForParticipant() and getEncryption(); add emitEncryptionKeys()

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -587,7 +587,7 @@ describe("MatrixRTCSession", () => {
             sess!.joinRoomSession([mockFocus], mockFocus, { manageMediaKeys: true });
             const encryptionKeyChangedListener = jest.fn();
             sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-            sess?.emitEncryptionKeys();
+            sess?.reemitEncryptionKeys();
             expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
             expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
                 expect.any(Uint8Array),
@@ -1202,7 +1202,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("this is the key", "utf-8"),
@@ -1234,7 +1234,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("this is the key", "utf-8"),
@@ -1266,7 +1266,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("this is the key", "utf-8"),
@@ -1293,7 +1293,7 @@ describe("MatrixRTCSession", () => {
         } as unknown as MatrixEvent);
 
         encryptionKeyChangedListener.mockClear();
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(2);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("this is the key", "utf-8"),
@@ -1346,7 +1346,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("newer key", "utf-8"),
@@ -1394,7 +1394,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(1);
         expect(encryptionKeyChangedListener).toHaveBeenCalledWith(
             Buffer.from("second key", "utf-8"),
@@ -1424,7 +1424,7 @@ describe("MatrixRTCSession", () => {
 
         const encryptionKeyChangedListener = jest.fn();
         sess!.on(MatrixRTCSessionEvent.EncryptionKeyChanged, encryptionKeyChangedListener);
-        sess!.emitEncryptionKeys();
+        sess!.reemitEncryptionKeys();
         expect(encryptionKeyChangedListener).toHaveBeenCalledTimes(0);
 
         expect(sess!.statistics.counters.roomEventEncryptionKeysReceived).toEqual(0);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -406,7 +406,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     }
 
     /**
-     * Re-emit EncryptionKeyChanged events for every tracked encryption keys. This can be used to export
+     * Re-emit an EncryptionKeyChanged event for each tracked encryption key. This can be used to export
      * the keys.
      */
     public reemitEncryptionKeys(): void {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -406,9 +406,10 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     }
 
     /**
-     * Emit an EncryptionKeyChanged event for every tracked encryption keys.
+     * Re-emit EncryptionKeyChanged events for every tracked encryption keys. This can be used to export
+     * the keys.
      */
-    public emitEncryptionKeys(): void {
+    public reemitEncryptionKeys(): void {
         this.encryptionKeys.forEach((keys, participantId) => {
             keys.forEach((key, index) => {
                 this.emit(MatrixRTCSessionEvent.EncryptionKeyChanged, key.key, index, participantId);
@@ -440,11 +441,6 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      * @deprecated This will be made private in a future release.
      */
     public getEncryptionKeys(): IterableIterator<[string, Array<Uint8Array>]> {
-        // the returned array doesn't contain the timestamps
-        return this.getEncryptionKeysInternal();
-    }
-
-    private getEncryptionKeysInternal(): IterableIterator<[string, Array<Uint8Array>]> {
         // the returned array doesn't contain the timestamps
         return Array.from(this.encryptionKeys.entries())
             .map(([participantId, keys]): [string, Uint8Array[]] => [participantId, keys.map((k) => k.key)])

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -406,7 +406,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     }
 
     /**
-     * Emit a EncryptionKeyChanged event for all known encryption keys.
+     * Emit an EncryptionKeyChanged event for every tracked encryption keys.
      */
     public emitEncryptionKeys(): void {
         this.encryptionKeys.forEach((keys, participantId) => {


### PR DESCRIPTION
This is an "alternative" to https://github.com/matrix-org/matrix-js-sdk/pull/4423 which cleans up the RTCSession API instead.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
