### PR TITLE
Add crypto events to `crypto-api`

### DIFF
--- a/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
+++ b/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
@@ -26,7 +26,6 @@ import { RustBackupCryptoEventMap, RustBackupCryptoEvents, RustBackupManager } f
 import * as TestData from "../../test-utils/test-data";
 import {
     ConnectionError,
-    CryptoEvent,
     HttpApiEvent,
     HttpApiEventHandlerMap,
     IHttpOpts,
@@ -37,6 +36,7 @@ import {
 import * as testData from "../../test-utils/test-data";
 import { BackupDecryptor } from "../../../src/common-crypto/CryptoBackend";
 import { KeyBackupSession } from "../../../src/crypto-api/keybackup";
+import { CryptoEvent } from "../../../src/crypto-api/index.ts";
 
 describe("PerSessionKeyBackupDownloader", () => {
     /** The downloader under test */

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -2,7 +2,8 @@ import { Mocked } from "jest-mock";
 import fetchMock from "fetch-mock-jest";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { CryptoEvent, HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, TypedEventEmitter } from "../../../src";
+import { HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, TypedEventEmitter } from "../../../src";
+import { CryptoEvent } from "../../../src/crypto-api/index.ts";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import * as testData from "../../test-utils/test-data";
 import * as TestData from "../../test-utils/test-data";

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -71,6 +71,7 @@ import { Curve25519AuthData } from "../../../src/crypto-api/keybackup";
 import encryptAESSecretStorageItem from "../../../src/utils/encryptAESSecretStorageItem.ts";
 import { CryptoStore, SecretStorePrivateKeys } from "../../../src/crypto/store/base";
 import { CryptoEvent } from "../../../src/crypto-api/index.ts";
+import { CryptoEvent as LegacyCryptoEvent } from "../../../src/crypto/index.ts";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";
@@ -1264,7 +1265,7 @@ describe("RustCrypto", () => {
 
         const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), testData.TEST_USER_ID);
         const willUpdateCallback = jest.fn();
-        rustCrypto.on(CryptoEvent.WillUpdateDevices, willUpdateCallback);
+        rustCrypto.on(LegacyCryptoEvent.WillUpdateDevices, willUpdateCallback);
         const devicesUpdatedCallback = jest.fn();
         rustCrypto.on(CryptoEvent.DevicesUpdated, devicesUpdatedCallback);
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -30,7 +30,6 @@ import fetchMock from "fetch-mock-jest";
 import { RustCrypto } from "../../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../../src/rust-crypto";
 import {
-    CryptoEvent,
     Device,
     DeviceVerification,
     encodeBase64,
@@ -71,6 +70,7 @@ import { ClientEvent, ClientEventHandlerMap } from "../../../src/client";
 import { Curve25519AuthData } from "../../../src/crypto-api/keybackup";
 import encryptAESSecretStorageItem from "../../../src/utils/encryptAESSecretStorageItem.ts";
 import { CryptoStore, SecretStorePrivateKeys } from "../../../src/crypto/store/base";
+import { CryptoEvent } from "../../../src/crypto-api/index.ts";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -71,7 +71,6 @@ import { Curve25519AuthData } from "../../../src/crypto-api/keybackup";
 import encryptAESSecretStorageItem from "../../../src/utils/encryptAESSecretStorageItem.ts";
 import { CryptoStore, SecretStorePrivateKeys } from "../../../src/crypto/store/base";
 import { CryptoEvent } from "../../../src/crypto-api/index.ts";
-import { CryptoEvent as LegacyCryptoEvent } from "../../../src/crypto/index.ts";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";
@@ -1265,7 +1264,7 @@ describe("RustCrypto", () => {
 
         const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), testData.TEST_USER_ID);
         const willUpdateCallback = jest.fn();
-        rustCrypto.on(LegacyCryptoEvent.WillUpdateDevices, willUpdateCallback);
+        rustCrypto.on(CryptoEvent.WillUpdateDevices, willUpdateCallback);
         const devicesUpdatedCallback = jest.fn();
         rustCrypto.on(CryptoEvent.DevicesUpdated, devicesUpdatedCallback);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -228,7 +228,7 @@ import {
     decodeRecoveryKey,
     ImportRoomKeysOpts,
     CryptoEvent,
-    CryptoEvents as CryptoApiEvents,
+    CryptoEvents,
     CryptoEventHandlerMap,
 } from "./crypto-api/index.ts";
 import { DeviceInfoMap } from "./crypto/DeviceList.ts";
@@ -959,8 +959,6 @@ type LegacyCryptoEvents =
     | LegacyCryptoEvent.DevicesUpdated
     | LegacyCryptoEvent.WillUpdateDevices
     | LegacyCryptoEvent.LegacyCryptoStoreMigrationProgress;
-
-type CryptoEvents = CryptoApiEvents | LegacyCryptoEvent.WillUpdateDevices;
 
 type MatrixEventEvents = MatrixEventEvent.Decrypted | MatrixEventEvent.Replaced | MatrixEventEvent.VisibilityChange;
 
@@ -2303,7 +2301,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             CryptoEvent.KeyBackupDecryptionKeyCached,
             CryptoEvent.KeysChanged,
             CryptoEvent.DevicesUpdated,
-            LegacyCryptoEvent.WillUpdateDevices,
+            CryptoEvent.WillUpdateDevices,
         ]);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -227,6 +227,7 @@ import {
     CryptoApi,
     decodeRecoveryKey,
     ImportRoomKeysOpts,
+    CryptoEvent as RustCryptoEvent,
 } from "./crypto-api/index.ts";
 import { DeviceInfoMap } from "./crypto/DeviceList.ts";
 import {
@@ -244,6 +245,7 @@ import { ImageInfo } from "./@types/media.ts";
 import { Capabilities, ServerCapabilities } from "./serverCapabilities.ts";
 import { sha256 } from "./digest.ts";
 import { keyFromAuthData } from "./common-crypto/key-passphrase.ts";
+import { RustCryptoEventMap } from "./rust-crypto/rust-crypto.ts";
 
 export type Store = IStore;
 
@@ -957,6 +959,18 @@ type CryptoEvents =
     | CryptoEvent.WillUpdateDevices
     | CryptoEvent.LegacyCryptoStoreMigrationProgress;
 
+type RustCryptoEvents =
+    | RustCryptoEvent.KeyBackupStatus
+    | RustCryptoEvent.KeyBackupFailed
+    | RustCryptoEvent.KeyBackupSessionsRemaining
+    | RustCryptoEvent.KeyBackupDecryptionKeyCached
+    | RustCryptoEvent.VerificationRequestReceived
+    | RustCryptoEvent.UserTrustStatusChanged
+    | RustCryptoEvent.KeysChanged
+    | RustCryptoEvent.DevicesUpdated
+    | RustCryptoEvent.WillUpdateDevices
+    | RustCryptoEvent.LegacyCryptoStoreMigrationProgress;
+
 type MatrixEventEvents = MatrixEventEvent.Decrypted | MatrixEventEvent.Replaced | MatrixEventEvent.VisibilityChange;
 
 type RoomMemberEvents =
@@ -977,6 +991,7 @@ export type EmittedEvents =
     | RoomEvents
     | RoomStateEvents
     | CryptoEvents
+    | RustCryptoEvents
     | MatrixEventEvents
     | RoomMemberEvents
     | UserEvents
@@ -1188,6 +1203,7 @@ export type ClientEventHandlerMap = {
 } & RoomEventHandlerMap &
     RoomStateEventHandlerMap &
     CryptoEventHandlerMap &
+    RustCryptoEventMap &
     MatrixEventHandlerMap &
     RoomMemberEventHandlerMap &
     UserEventHandlerMap &
@@ -2288,15 +2304,15 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         // re-emit the events emitted by the crypto impl
         this.reEmitter.reEmit(rustCrypto, [
-            CryptoEvent.VerificationRequestReceived,
-            CryptoEvent.UserTrustStatusChanged,
-            CryptoEvent.KeyBackupStatus,
-            CryptoEvent.KeyBackupSessionsRemaining,
-            CryptoEvent.KeyBackupFailed,
-            CryptoEvent.KeyBackupDecryptionKeyCached,
-            CryptoEvent.KeysChanged,
-            CryptoEvent.DevicesUpdated,
-            CryptoEvent.WillUpdateDevices,
+            RustCryptoEvent.VerificationRequestReceived,
+            RustCryptoEvent.UserTrustStatusChanged,
+            RustCryptoEvent.KeyBackupStatus,
+            RustCryptoEvent.KeyBackupSessionsRemaining,
+            RustCryptoEvent.KeyBackupFailed,
+            RustCryptoEvent.KeyBackupDecryptionKeyCached,
+            RustCryptoEvent.KeysChanged,
+            RustCryptoEvent.DevicesUpdated,
+            RustCryptoEvent.WillUpdateDevices,
         ]);
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,8 +76,8 @@ import {
 } from "./http-api/index.ts";
 import {
     Crypto,
-    CryptoEvent,
-    CryptoEventHandlerMap,
+    CryptoEvent as LegacyCryptoEvent,
+    CryptoEventHandlerMap as LegacyCryptoEventHandlerMap,
     fixBackupKey,
     ICheckOwnCrossSigningTrustOpts,
     ICryptoCallbacks,
@@ -942,23 +942,23 @@ type RoomStateEvents =
     | RoomStateEvent.Update
     | RoomStateEvent.Marker;
 
-type CryptoEvents =
-    | CryptoEvent.KeySignatureUploadFailure
-    | CryptoEvent.KeyBackupStatus
-    | CryptoEvent.KeyBackupFailed
-    | CryptoEvent.KeyBackupSessionsRemaining
-    | CryptoEvent.KeyBackupDecryptionKeyCached
-    | CryptoEvent.RoomKeyRequest
-    | CryptoEvent.RoomKeyRequestCancellation
-    | CryptoEvent.VerificationRequest
-    | CryptoEvent.VerificationRequestReceived
-    | CryptoEvent.DeviceVerificationChanged
-    | CryptoEvent.UserTrustStatusChanged
-    | CryptoEvent.KeysChanged
-    | CryptoEvent.Warning
-    | CryptoEvent.DevicesUpdated
-    | CryptoEvent.WillUpdateDevices
-    | CryptoEvent.LegacyCryptoStoreMigrationProgress;
+type LegacyCryptoEvents =
+    | LegacyCryptoEvent.KeySignatureUploadFailure
+    | LegacyCryptoEvent.KeyBackupStatus
+    | LegacyCryptoEvent.KeyBackupFailed
+    | LegacyCryptoEvent.KeyBackupSessionsRemaining
+    | LegacyCryptoEvent.KeyBackupDecryptionKeyCached
+    | LegacyCryptoEvent.RoomKeyRequest
+    | LegacyCryptoEvent.RoomKeyRequestCancellation
+    | LegacyCryptoEvent.VerificationRequest
+    | LegacyCryptoEvent.VerificationRequestReceived
+    | LegacyCryptoEvent.DeviceVerificationChanged
+    | LegacyCryptoEvent.UserTrustStatusChanged
+    | LegacyCryptoEvent.KeysChanged
+    | LegacyCryptoEvent.Warning
+    | LegacyCryptoEvent.DevicesUpdated
+    | LegacyCryptoEvent.WillUpdateDevices
+    | LegacyCryptoEvent.LegacyCryptoStoreMigrationProgress;
 
 type RustCryptoEvents = CryptoApiEvents | LegacyCryptoEvent.WillUpdateDevices;
 
@@ -981,7 +981,7 @@ export type EmittedEvents =
     | ClientEvent
     | RoomEvents
     | RoomStateEvents
-    | CryptoEvents
+    | LegacyCryptoEvents
     | RustCryptoEvents
     | MatrixEventEvents
     | RoomMemberEvents
@@ -1193,7 +1193,7 @@ export type ClientEventHandlerMap = {
     [ClientEvent.TurnServersError]: (error: Error, fatal: boolean) => void;
 } & RoomEventHandlerMap &
     RoomStateEventHandlerMap &
-    CryptoEventHandlerMap &
+    LegacyCryptoEventHandlerMap &
     RustCryptoEventMap &
     MatrixEventHandlerMap &
     RoomMemberEventHandlerMap &
@@ -2183,16 +2183,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const crypto = new Crypto(this, userId, this.deviceId, this.store, this.cryptoStore, this.verificationMethods!);
 
         this.reEmitter.reEmit(crypto, [
-            CryptoEvent.KeyBackupFailed,
-            CryptoEvent.KeyBackupSessionsRemaining,
-            CryptoEvent.RoomKeyRequest,
-            CryptoEvent.RoomKeyRequestCancellation,
-            CryptoEvent.Warning,
-            CryptoEvent.DevicesUpdated,
-            CryptoEvent.WillUpdateDevices,
-            CryptoEvent.DeviceVerificationChanged,
-            CryptoEvent.UserTrustStatusChanged,
-            CryptoEvent.KeysChanged,
+            LegacyCryptoEvent.KeyBackupFailed,
+            LegacyCryptoEvent.KeyBackupSessionsRemaining,
+            LegacyCryptoEvent.RoomKeyRequest,
+            LegacyCryptoEvent.RoomKeyRequestCancellation,
+            LegacyCryptoEvent.Warning,
+            LegacyCryptoEvent.DevicesUpdated,
+            LegacyCryptoEvent.WillUpdateDevices,
+            LegacyCryptoEvent.DeviceVerificationChanged,
+            LegacyCryptoEvent.UserTrustStatusChanged,
+            LegacyCryptoEvent.KeysChanged,
         ]);
 
         this.logger.debug("Crypto: initialising crypto object...");
@@ -2279,7 +2279,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             legacyCryptoStore: this.cryptoStore,
             legacyPickleKey: this.pickleKey ?? "DEFAULT_KEY",
             legacyMigrationProgressListener: (progress: number, total: number): void => {
-                this.emit(CryptoEvent.LegacyCryptoStoreMigrationProgress, progress, total);
+                this.emit(LegacyCryptoEvent.LegacyCryptoStoreMigrationProgress, progress, total);
             },
         });
 
@@ -2303,7 +2303,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             RustCryptoEvent.KeyBackupDecryptionKeyCached,
             RustCryptoEvent.KeysChanged,
             RustCryptoEvent.DevicesUpdated,
-            CryptoEvent.WillUpdateDevices,
+            LegacyCryptoEvent.WillUpdateDevices,
         ]);
     }
 
@@ -2425,7 +2425,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns
      *
      * @remarks
-     * Fires {@link CryptoEvent#DeviceVerificationChanged}
+     * Fires {@link LegacyCryptoEvent#DeviceVerificationChanged}
      */
     public setDeviceVerified(userId: string, deviceId: string, verified = true): Promise<void> {
         const prom = this.setDeviceVerification(userId, deviceId, verified, null, null);
@@ -2452,7 +2452,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns
      *
      * @remarks
-     * Fires {@link CryptoEvent.DeviceVerificationChanged}
+     * Fires {@link LegacyCryptoEvent.DeviceVerificationChanged}
      *
      * @deprecated Not supported for Rust Cryptography.
      */

--- a/src/client.ts
+++ b/src/client.ts
@@ -228,7 +228,6 @@ import {
     decodeRecoveryKey,
     ImportRoomKeysOpts,
     CryptoEvent,
-    CryptoEvents,
     CryptoEventHandlerMap,
 } from "./crypto-api/index.ts";
 import { DeviceInfoMap } from "./crypto/DeviceList.ts";
@@ -959,6 +958,8 @@ type LegacyCryptoEvents =
     | LegacyCryptoEvent.DevicesUpdated
     | LegacyCryptoEvent.WillUpdateDevices
     | LegacyCryptoEvent.LegacyCryptoStoreMigrationProgress;
+
+type CryptoEvents = (typeof CryptoEvent)[keyof typeof CryptoEvent];
 
 type MatrixEventEvents = MatrixEventEvent.Decrypted | MatrixEventEvent.Replaced | MatrixEventEvent.VisibilityChange;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -228,6 +228,7 @@ import {
     decodeRecoveryKey,
     ImportRoomKeysOpts,
     CryptoEvent as RustCryptoEvent,
+    CryptoEvents as CryptoApiEvents,
 } from "./crypto-api/index.ts";
 import { DeviceInfoMap } from "./crypto/DeviceList.ts";
 import {
@@ -959,17 +960,7 @@ type CryptoEvents =
     | CryptoEvent.WillUpdateDevices
     | CryptoEvent.LegacyCryptoStoreMigrationProgress;
 
-type RustCryptoEvents =
-    | RustCryptoEvent.KeyBackupStatus
-    | RustCryptoEvent.KeyBackupFailed
-    | RustCryptoEvent.KeyBackupSessionsRemaining
-    | RustCryptoEvent.KeyBackupDecryptionKeyCached
-    | RustCryptoEvent.VerificationRequestReceived
-    | RustCryptoEvent.UserTrustStatusChanged
-    | RustCryptoEvent.KeysChanged
-    | RustCryptoEvent.DevicesUpdated
-    | CryptoEvent.WillUpdateDevices
-    | RustCryptoEvent.LegacyCryptoStoreMigrationProgress;
+type RustCryptoEvents = CryptoApiEvents | LegacyCryptoEvent.WillUpdateDevices;
 
 type MatrixEventEvents = MatrixEventEvent.Decrypted | MatrixEventEvent.Replaced | MatrixEventEvent.VisibilityChange;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -968,7 +968,7 @@ type RustCryptoEvents =
     | RustCryptoEvent.UserTrustStatusChanged
     | RustCryptoEvent.KeysChanged
     | RustCryptoEvent.DevicesUpdated
-    | RustCryptoEvent.WillUpdateDevices
+    | CryptoEvent.WillUpdateDevices
     | RustCryptoEvent.LegacyCryptoStoreMigrationProgress;
 
 type MatrixEventEvents = MatrixEventEvent.Decrypted | MatrixEventEvent.Replaced | MatrixEventEvent.VisibilityChange;
@@ -2312,7 +2312,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             RustCryptoEvent.KeyBackupDecryptionKeyCached,
             RustCryptoEvent.KeysChanged,
             RustCryptoEvent.DevicesUpdated,
-            RustCryptoEvent.WillUpdateDevices,
+            CryptoEvent.WillUpdateDevices,
         ]);
     }
 

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -14,28 +14,34 @@
  * limitations under the License.
  */
 
+/**
+ * Events emitted by the {@link CryptoApi}
+ */
 export enum CryptoEvent {
     /**
      * Fires when the trust status of a user changes.
-     * @param {string} userId - the user whose trust status changed
-     * @param {UserVerificationStatus} userTrustLevel - the new trust level
+     * The payload is a pair (userId, userTrustLevel).
      */
     UserTrustStatusChanged = "userTrustStatusChanged",
+
     /**
      * Fires when the key backup status changes.
-     * @param {boolean} status - true if the key backup is enabled, false otherwise.
+     * The payload is a boolean
      */
     KeyBackupStatus = "crypto.keyBackupStatus",
+
     /**
      * Fires when we failed to back up the keys
-     * @param {string} errorCode - the error code of the error that occurred
+     * The payload is an errorCode
      */
     KeyBackupFailed = "crypto.keyBackupFailed",
+
     /**
      * Fires when the number of sessions that can be backed up changes.
-     * @param {number} remaining - the remaining number of sessions that can be backed up.
+     * The payload is the remaining number of sessions that can be backed up.
      */
     KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
+
     /**
      * Fires when a new valid backup decryption key is in cache.
      * This will happen when a secret is received from another session, from secret storage,
@@ -46,19 +52,22 @@ export enum CryptoEvent {
      * This event is only fired by the rust crypto backend.
      */
     KeyBackupDecryptionKeyCached = "crypto.keyBackupDecryptionKeyCached",
+
     /**
      * Fires when a key verification request is received.
-     * @param {VerificationRequest} - the request that was received
+     * The payload is a VerificationRequest object.
      */
     VerificationRequestReceived = "crypto.verificationRequestReceived",
+
     /** @deprecated Use {@link DevicesUpdated} instead when using rust crypto */
     WillUpdateDevices = "crypto.willUpdateDevices",
+
     /**
      * Fires whenever the stored devices for a user have been updated
-     * @param {string[]} userIds - A list of user IDs that were updated
-     * @param {boolean} initialFetch - If true, the store was empty (apart from our own device) and has been seeded.
+     * The payload is a pair (userIds, initialFetch).
      */
     DevicesUpdated = "crypto.devicesUpdated",
+
     /**
      * Fires when the user's cross-signing keys have changed or cross-signing
      * has been enabled/disabled. The client can use getStoredCrossSigningForUser
@@ -82,5 +91,3 @@ export enum CryptoEvent {
      */
     LegacyCryptoStoreMigrationProgress = "crypto.legacyCryptoStoreMigrationProgress",
 }
-
-export type CryptoEvents = (typeof CryptoEvent)[keyof typeof CryptoEvent];

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -80,3 +80,5 @@ export enum CryptoEvent {
      */
     LegacyCryptoStoreMigrationProgress = "crypto.legacyCryptoStoreMigrationProgress",
 }
+
+export type CryptoEvents = (typeof CryptoEvent)[keyof typeof CryptoEvent];

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -20,19 +20,19 @@
 export enum CryptoEvent {
     /**
      * Fires when the trust status of a user changes.
-     * The payload is a pair (userId, userTrustLevel).
+     * The payload is a pair (userId, userTrustLevel). The trust level is one of the values from UserVerificationStatus.
      */
     UserTrustStatusChanged = "userTrustStatusChanged",
 
     /**
      * Fires when the key backup status changes.
-     * The payload is a boolean
+     * The payload is a boolean indicating whether the key backup is enabled.
      */
     KeyBackupStatus = "crypto.keyBackupStatus",
 
     /**
      * Fires when we failed to back up the keys
-     * The payload is an errorCode
+     * The payload is the error code of the error that occurred.
      */
     KeyBackupFailed = "crypto.keyBackupFailed",
 
@@ -55,7 +55,7 @@ export enum CryptoEvent {
 
     /**
      * Fires when a key verification request is received.
-     * The payload is a VerificationRequest object.
+     * The payload is a VerificationRequest object representing the request.
      */
     VerificationRequestReceived = "crypto.verificationRequestReceived",
 

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -51,6 +51,8 @@ export enum CryptoEvent {
      * @param {VerificationRequest} - the request that was received
      */
     VerificationRequestReceived = "crypto.verificationRequestReceived",
+    /** @deprecated Use {@link DevicesUpdated} instead when using rust crypto */
+    WillUpdateDevices = "crypto.willUpdateDevices",
     /**
      * Fires whenever the stored devices for a user have been updated
      * @param {string[]} userIds - A list of user IDs that were updated

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum CryptoEvent {
+    /**
+     * Fires when the trust status of a user changes.
+     * @param {string} userId - the user whose trust status changed
+     * @param {UserVerificationStatus} userTrustLevel - the new trust level
+     */
+    UserTrustStatusChanged = "userTrustStatusChanged",
+    /**
+     * Fires when the key backup status changes.
+     * @param {boolean} status - true if the key backup is enabled, false otherwise.
+     */
+    KeyBackupStatus = "crypto.keyBackupStatus",
+    /**
+     * Fires when we failed to back up the keys
+     * @param {string} errorCode - the error code of the error that occurred
+     */
+    KeyBackupFailed = "crypto.keyBackupFailed",
+    /**
+     * Fires when the number of sessions that can be backed up changes.
+     * @param {number} remaining - the remaining number of sessions that can be backed up.
+     */
+    KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
+    /**
+     * Fires when a new valid backup decryption key is in cache.
+     * This will happen when a secret is received from another session, from secret storage,
+     * or when a new backup is created from this session.
+     *
+     * The payload is the version of the backup for which we have the key for.
+     *
+     * This event is only fired by the rust crypto backend.
+     */
+    KeyBackupDecryptionKeyCached = "crypto.keyBackupDecryptionKeyCached",
+    /**
+     * Fires when a key verification request is received.
+     * @param {VerificationRequest} - the request that was received
+     */
+    VerificationRequestReceived = "crypto.verificationRequestReceived",
+    /**
+     * Fires whenever the stored devices for a user will be updated
+     * @deprecated Use {@link DevicesUpdated} instead
+     * @param {string[]} users - A list of user IDs that will be updated
+     * @param {boolean} initialFetch - If true, the store is empty (apart
+     *     from our own device) and is being seeded.
+     */
+    WillUpdateDevices = "crypto.willUpdateDevices",
+    /**
+     * Fires whenever the stored devices for a user have been updated
+     * @param {string[]} userIds - A list of user IDs that were updated
+     * @param {boolean} initialFetch - If true, the store was empty (apart from our own device) and has been seeded.
+     */
+    DevicesUpdated = "crypto.devicesUpdated",
+    /**
+     * Fires when the user's cross-signing keys have changed or cross-signing
+     * has been enabled/disabled. The client can use getStoredCrossSigningForUser
+     * with the user ID of the logged in user to check if cross-signing is
+     * enabled on the account. If enabled, it can test whether the current key
+     * is trusted using with checkUserTrust with the user ID of the logged
+     * in user. The checkOwnCrossSigningTrust function may be used to reconcile
+     * the trust in the account key.
+     *
+     * The cross-signing API is currently UNSTABLE and may change without notice.
+     * @experimental
+     */
+    KeysChanged = "crossSigning.keysChanged",
+
+    /**
+     * Fires when data is being migrated from legacy crypto to rust crypto.
+     *
+     * The payload is a pair `(progress, total)`, where `progress` is the number of steps completed so far, and
+     * `total` is the total number of steps. When migration is complete, a final instance of the event is emitted, with
+     * `progress === total === -1`.
+     */
+    LegacyCryptoStoreMigrationProgress = "crypto.legacyCryptoStoreMigrationProgress",
+}

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -52,14 +52,6 @@ export enum CryptoEvent {
      */
     VerificationRequestReceived = "crypto.verificationRequestReceived",
     /**
-     * Fires whenever the stored devices for a user will be updated
-     * @deprecated Use {@link DevicesUpdated} instead
-     * @param {string[]} users - A list of user IDs that will be updated
-     * @param {boolean} initialFetch - If true, the store is empty (apart
-     *     from our own device) and is being seeded.
-     */
-    WillUpdateDevices = "crypto.willUpdateDevices",
-    /**
      * Fires whenever the stored devices for a user have been updated
      * @param {string[]} userIds - A list of user IDs that were updated
      * @param {boolean} initialFetch - If true, the store was empty (apart from our own device) and has been seeded.

--- a/src/crypto-api/CryptoEventHandlerMap.ts
+++ b/src/crypto-api/CryptoEventHandlerMap.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CryptoEvent } from "./CryptoEvent.ts";
+import { CryptoEvent as LegacyCryptoEvent } from "../crypto/index.ts";
+import { VerificationRequest } from "./verification.ts";
+import { UserVerificationStatus } from "./index.ts";
+import { RustBackupCryptoEventMap } from "../rust-crypto/backup.ts";
+
+export type CryptoEventHandlerMap = {
+    /**
+     * Fires when a key verification request is received.
+     */
+    [CryptoEvent.VerificationRequestReceived]: (request: VerificationRequest) => void;
+
+    /**
+     * Fires when the trust status of a user changes.
+     */
+    [CryptoEvent.UserTrustStatusChanged]: (userId: string, userTrustLevel: UserVerificationStatus) => void;
+
+    [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
+    /**
+     * Fires when the user's cross-signing keys have changed or cross-signing
+     * has been enabled/disabled. The client can use getStoredCrossSigningForUser
+     * with the user ID of the logged in user to check if cross-signing is
+     * enabled on the account. If enabled, it can test whether the current key
+     * is trusted using with checkUserTrust with the user ID of the logged
+     * in user. The checkOwnCrossSigningTrust function may be used to reconcile
+     * the trust in the account key.
+     *
+     * The cross-signing API is currently UNSTABLE and may change without notice.
+     * @experimental
+     */
+    [CryptoEvent.KeysChanged]: (data: {}) => void;
+    /**
+     * Fires whenever the stored devices for a user will be updated
+     * @param users - A list of user IDs that will be updated
+     * @param initialFetch - If true, the store is empty (apart
+     *     from our own device) and is being seeded.
+     */
+    [LegacyCryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
+    /**
+     * Fires whenever the stored devices for a user have changed
+     * @param users - A list of user IDs that were updated
+     * @param initialFetch - If true, the store was empty (apart
+     *     from our own device) and has been seeded.
+     */
+    [CryptoEvent.DevicesUpdated]: (users: string[], initialFetch: boolean) => void;
+} & RustBackupCryptoEventMap;

--- a/src/crypto-api/CryptoEventHandlerMap.ts
+++ b/src/crypto-api/CryptoEventHandlerMap.ts
@@ -15,7 +15,6 @@
  */
 
 import { CryptoEvent } from "./CryptoEvent.ts";
-import { CryptoEvent as LegacyCryptoEvent } from "../crypto/index.ts";
 import { VerificationRequest } from "./verification.ts";
 import { UserVerificationStatus } from "./index.ts";
 import { RustBackupCryptoEventMap } from "../rust-crypto/backup.ts";
@@ -51,7 +50,7 @@ export type CryptoEventHandlerMap = {
      * @param initialFetch - If true, the store is empty (apart
      *     from our own device) and is being seeded.
      */
-    [LegacyCryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
+    [CryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
     /**
      * Fires whenever the stored devices for a user have changed
      * @param users - A list of user IDs that were updated

--- a/src/crypto-api/CryptoEventHandlerMap.ts
+++ b/src/crypto-api/CryptoEventHandlerMap.ts
@@ -19,43 +19,14 @@ import { VerificationRequest } from "./verification.ts";
 import { UserVerificationStatus } from "./index.ts";
 import { RustBackupCryptoEventMap } from "../rust-crypto/backup.ts";
 
+/**
+ * A map of the {@link CryptoEvent} fired by the {@link CryptoApi} and their payloads.
+ */
 export type CryptoEventHandlerMap = {
-    /**
-     * Fires when a key verification request is received.
-     */
     [CryptoEvent.VerificationRequestReceived]: (request: VerificationRequest) => void;
-
-    /**
-     * Fires when the trust status of a user changes.
-     */
     [CryptoEvent.UserTrustStatusChanged]: (userId: string, userTrustLevel: UserVerificationStatus) => void;
-
     [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
-    /**
-     * Fires when the user's cross-signing keys have changed or cross-signing
-     * has been enabled/disabled. The client can use getStoredCrossSigningForUser
-     * with the user ID of the logged in user to check if cross-signing is
-     * enabled on the account. If enabled, it can test whether the current key
-     * is trusted using with checkUserTrust with the user ID of the logged
-     * in user. The checkOwnCrossSigningTrust function may be used to reconcile
-     * the trust in the account key.
-     *
-     * The cross-signing API is currently UNSTABLE and may change without notice.
-     * @experimental
-     */
     [CryptoEvent.KeysChanged]: (data: {}) => void;
-    /**
-     * Fires whenever the stored devices for a user will be updated
-     * @param users - A list of user IDs that will be updated
-     * @param initialFetch - If true, the store is empty (apart
-     *     from our own device) and is being seeded.
-     */
     [CryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
-    /**
-     * Fires whenever the stored devices for a user have changed
-     * @param users - A list of user IDs that were updated
-     * @param initialFetch - If true, the store was empty (apart
-     *     from our own device) and has been seeded.
-     */
     [CryptoEvent.DevicesUpdated]: (users: string[], initialFetch: boolean) => void;
 } & RustBackupCryptoEventMap;

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -1084,3 +1084,4 @@ export * from "./keybackup.ts";
 export * from "./recovery-key.ts";
 export * from "./key-passphrase.ts";
 export * from "./CryptoEvent.ts";
+export * from "./CryptoEventHandlerMap.ts";

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -1074,3 +1074,4 @@ export * from "./verification.ts";
 export * from "./keybackup.ts";
 export * from "./recovery-key.ts";
 export * from "./key-passphrase.ts";
+export * from "./CryptoEvent.ts";

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -270,7 +270,7 @@ export enum CryptoEvent {
     /** @deprecated Event not fired by the rust crypto */
     Warning = "crypto.warning",
     /** @deprecated Use {@link DevicesUpdated} instead when using rust crypto */
-    WillUpdateDevices = "crypto.willUpdateDevices",
+    WillUpdateDevices = CryptoApiCryptoEvent.WillUpdateDevices,
     DevicesUpdated = CryptoApiCryptoEvent.DevicesUpdated,
     KeysChanged = CryptoApiCryptoEvent.KeysChanged,
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -101,6 +101,7 @@ import {
     KeyBackupInfo,
     OwnDeviceKeys,
     VerificationRequest as CryptoApiVerificationRequest,
+    CryptoEvent as CryptoApiCryptoEvent,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -232,16 +233,16 @@ export type IEncryptedContent = IOlmEncryptedContent | IMegolmEncryptedContent;
 export enum CryptoEvent {
     /** @deprecated Event not fired by the rust crypto */
     DeviceVerificationChanged = "deviceVerificationChanged",
-    UserTrustStatusChanged = "userTrustStatusChanged",
+    UserTrustStatusChanged = CryptoApiCryptoEvent.UserTrustStatusChanged,
     /** @deprecated Event not fired by the rust crypto */
     UserCrossSigningUpdated = "userCrossSigningUpdated",
     /** @deprecated Event not fired by the rust crypto */
     RoomKeyRequest = "crypto.roomKeyRequest",
     /** @deprecated Event not fired by the rust crypto */
     RoomKeyRequestCancellation = "crypto.roomKeyRequestCancellation",
-    KeyBackupStatus = "crypto.keyBackupStatus",
-    KeyBackupFailed = "crypto.keyBackupFailed",
-    KeyBackupSessionsRemaining = "crypto.keyBackupSessionsRemaining",
+    KeyBackupStatus = CryptoApiCryptoEvent.KeyBackupStatus,
+    KeyBackupFailed = CryptoApiCryptoEvent.KeyBackupFailed,
+    KeyBackupSessionsRemaining = CryptoApiCryptoEvent.KeyBackupSessionsRemaining,
 
     /**
      * Fires when a new valid backup decryption key is in cache.
@@ -252,7 +253,7 @@ export enum CryptoEvent {
      *
      * This event is only fired by the rust crypto backend.
      */
-    KeyBackupDecryptionKeyCached = "crypto.keyBackupDecryptionKeyCached",
+    KeyBackupDecryptionKeyCached = CryptoApiCryptoEvent.KeyBackupDecryptionKeyCached,
 
     /** @deprecated Event not fired by the rust crypto */
     KeySignatureUploadFailure = "crypto.keySignatureUploadFailure",
@@ -264,14 +265,14 @@ export enum CryptoEvent {
      *
      * The payload is a {@link Crypto.VerificationRequest}.
      */
-    VerificationRequestReceived = "crypto.verificationRequestReceived",
+    VerificationRequestReceived = CryptoApiCryptoEvent.VerificationRequestReceived,
 
     /** @deprecated Event not fired by the rust crypto */
     Warning = "crypto.warning",
     /** @deprecated Use {@link DevicesUpdated} instead when using rust crypto */
     WillUpdateDevices = "crypto.willUpdateDevices",
-    DevicesUpdated = "crypto.devicesUpdated",
-    KeysChanged = "crossSigning.keysChanged",
+    DevicesUpdated = CryptoApiCryptoEvent.DevicesUpdated,
+    KeysChanged = CryptoApiCryptoEvent.KeysChanged,
 
     /**
      * Fires when data is being migrated from legacy crypto to rust crypto.
@@ -280,7 +281,7 @@ export enum CryptoEvent {
      * `total` is the total number of steps. When migration is complete, a final instance of the event is emitted, with
      * `progress === total === -1`.
      */
-    LegacyCryptoStoreMigrationProgress = "crypto.legacyCryptoStoreMigrationProgress",
+    LegacyCryptoStoreMigrationProgress = CryptoApiCryptoEvent.LegacyCryptoStoreMigrationProgress,
 }
 
 export type CryptoEventHandlerMap = {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -100,8 +100,8 @@ import {
     KeyBackupCheck,
     KeyBackupInfo,
     OwnDeviceKeys,
-    VerificationRequest as CryptoApiVerificationRequest,
     CryptoEvent as CryptoApiCryptoEvent,
+    CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -284,7 +284,7 @@ export enum CryptoEvent {
     LegacyCryptoStoreMigrationProgress = CryptoApiCryptoEvent.LegacyCryptoStoreMigrationProgress,
 }
 
-export type CryptoEventHandlerMap = {
+export type CryptoEventHandlerMap = CryptoApiCryptoEventHandlerMap & {
     /**
      * Fires when a device is marked as verified/unverified/blocked/unblocked by
      * {@link MatrixClient#setDeviceVerified | MatrixClient.setDeviceVerified} or
@@ -296,18 +296,6 @@ export type CryptoEventHandlerMap = {
      */
     [CryptoEvent.DeviceVerificationChanged]: (userId: string, deviceId: string, deviceInfo: DeviceInfo) => void;
     /**
-     * Fires when the trust status of a user changes
-     * If userId is the userId of the logged-in user, this indicated a change
-     * in the trust status of the cross-signing data on the account.
-     *
-     * The cross-signing API is currently UNSTABLE and may change without notice.
-     * @experimental
-     *
-     * @param userId - the userId of the user in question
-     * @param trustLevel - The new trust level of the user
-     */
-    [CryptoEvent.UserTrustStatusChanged]: (userId: string, trustLevel: UserTrustLevel) => void;
-    /**
      * Fires when we receive a room key request
      *
      * @param request - request details
@@ -317,28 +305,6 @@ export type CryptoEventHandlerMap = {
      * Fires when we receive a room key request cancellation
      */
     [CryptoEvent.RoomKeyRequestCancellation]: (request: IncomingRoomKeyRequestCancellation) => void;
-    /**
-     * Fires whenever the status of e2e key backup changes, as returned by getKeyBackupEnabled()
-     * @param enabled - true if key backup has been enabled, otherwise false
-     * @example
-     * ```
-     * matrixClient.on("crypto.keyBackupStatus", function(enabled){
-     *   if (enabled) {
-     *     [...]
-     *   }
-     * });
-     * ```
-     */
-    [CryptoEvent.KeyBackupStatus]: (enabled: boolean) => void;
-    [CryptoEvent.KeyBackupFailed]: (errcode: string) => void;
-    [CryptoEvent.KeyBackupSessionsRemaining]: (remaining: number) => void;
-
-    /**
-     * Fires when the backup decryption key is received and cached.
-     *
-     * @param version - The version of the backup for which we have the key for.
-     */
-    [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
     [CryptoEvent.KeySignatureUploadFailure]: (
         failures: IUploadKeySignaturesResponse["failures"],
         source: "checkOwnCrossSigningTrust" | "afterCrossSigningLocalKeyChange" | "setDeviceVerification",
@@ -350,12 +316,6 @@ export type CryptoEventHandlerMap = {
      * Deprecated: use `CryptoEvent.VerificationRequestReceived`.
      */
     [CryptoEvent.VerificationRequest]: (request: VerificationRequest<any>) => void;
-
-    /**
-     * Fires when a key verification request is received.
-     */
-    [CryptoEvent.VerificationRequestReceived]: (request: CryptoApiVerificationRequest) => void;
-
     /**
      * Fires when the app may wish to warn the user about something related
      * the end-to-end crypto.
@@ -363,33 +323,6 @@ export type CryptoEventHandlerMap = {
      * @param type - One of the strings listed above
      */
     [CryptoEvent.Warning]: (type: string) => void;
-    /**
-     * Fires when the user's cross-signing keys have changed or cross-signing
-     * has been enabled/disabled. The client can use getStoredCrossSigningForUser
-     * with the user ID of the logged in user to check if cross-signing is
-     * enabled on the account. If enabled, it can test whether the current key
-     * is trusted using with checkUserTrust with the user ID of the logged
-     * in user. The checkOwnCrossSigningTrust function may be used to reconcile
-     * the trust in the account key.
-     *
-     * The cross-signing API is currently UNSTABLE and may change without notice.
-     * @experimental
-     */
-    [CryptoEvent.KeysChanged]: (data: {}) => void;
-    /**
-     * Fires whenever the stored devices for a user will be updated
-     * @param users - A list of user IDs that will be updated
-     * @param initialFetch - If true, the store is empty (apart
-     *     from our own device) and is being seeded.
-     */
-    [CryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
-    /**
-     * Fires whenever the stored devices for a user have changed
-     * @param users - A list of user IDs that were updated
-     * @param initialFetch - If true, the store was empty (apart
-     *     from our own device) and has been seeded.
-     */
-    [CryptoEvent.DevicesUpdated]: (users: string[], initialFetch: boolean) => void;
     [CryptoEvent.UserCrossSigningUpdated]: (userId: string) => void;
 
     [CryptoEvent.LegacyCryptoStoreMigrationProgress]: (progress: number, total: number) => void;

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -18,10 +18,10 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { Curve25519AuthData, KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.ts";
+import { CryptoEvent } from "../crypto-api/index.ts";
 import { Logger } from "../logger.ts";
 import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
 import { RustBackupManager } from "./backup.ts";
-import { CryptoEvent } from "../matrix.ts";
 import { encodeUri, sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -27,13 +27,13 @@ import {
 } from "../crypto-api/keybackup.ts";
 import { logger } from "../logger.ts";
 import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
-import { CryptoEvent, IMegolmSessionData } from "../crypto/index.ts";
+import { IMegolmSessionData } from "../crypto/index.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { encodeUri, logDuration } from "../utils.ts";
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
-import { ImportRoomKeyProgressData, ImportRoomKeysOpts } from "../crypto-api/index.ts";
+import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
 import { IKeyBackupInfo } from "../crypto/keybackup.ts";
 import { IKeyBackup } from "../crypto/backup.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -63,6 +63,7 @@ import {
     DeviceIsolationMode,
     AllDevicesIsolationMode,
     DeviceIsolationModeKind,
+    CryptoEvent,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
@@ -72,7 +73,6 @@ import { CrossSigningIdentity } from "./CrossSigningIdentity.ts";
 import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } from "./secret-storage.ts";
 import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification.ts";
 import { EventType, MsgType } from "../@types/event.ts";
-import { CryptoEvent } from "../crypto/index.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { RustBackupCryptoEventMap, RustBackupCryptoEvents, RustBackupManager } from "./backup.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
@@ -2085,7 +2085,7 @@ type RustCryptoEvents =
     | CryptoEvent.DevicesUpdated
     | RustBackupCryptoEvents;
 
-type RustCryptoEventMap = {
+export type RustCryptoEventMap = {
     /**
      * Fires when a key verification request is received.
      */

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -64,7 +64,6 @@ import {
     AllDevicesIsolationMode,
     DeviceIsolationModeKind,
     CryptoEvent,
-    CryptoEvents,
     CryptoEventHandlerMap,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
@@ -2079,4 +2078,5 @@ function rustEncryptionInfoToJsEncryptionInfo(
     return { shieldColour, shieldReason };
 }
 
+type CryptoEvents = (typeof CryptoEvent)[keyof typeof CryptoEvent];
 type RustCryptoEvents = Exclude<CryptoEvents, CryptoEvent.LegacyCryptoStoreMigrationProgress>;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -86,7 +86,6 @@ import { OutgoingRequestsManager } from "./OutgoingRequestsManager.ts";
 import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader.ts";
 import { DehydratedDeviceManager } from "./DehydratedDeviceManager.ts";
 import { VerificationMethod } from "../types.ts";
-import { CryptoEvent as LegacyCryptoEvent } from "../crypto/index.ts";
 
 const ALL_VERIFICATION_METHODS = [
     VerificationMethod.Sas,
@@ -1624,7 +1623,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * @param userIds - an array of user IDs of users whose devices have updated.
      */
     public async onDevicesUpdated(userIds: string[]): Promise<void> {
-        this.emit(LegacyCryptoEvent.WillUpdateDevices, userIds, false);
+        this.emit(CryptoEvent.WillUpdateDevices, userIds, false);
         this.emit(CryptoEvent.DevicesUpdated, userIds, false);
     }
 
@@ -2080,6 +2079,4 @@ function rustEncryptionInfoToJsEncryptionInfo(
     return { shieldColour, shieldReason };
 }
 
-type RustCryptoEvents =
-    | Exclude<CryptoEvents, CryptoEvent.LegacyCryptoStoreMigrationProgress>
-    | LegacyCryptoEvent.WillUpdateDevices;
+type RustCryptoEvents = Exclude<CryptoEvents, CryptoEvent.LegacyCryptoStoreMigrationProgress>;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -84,6 +84,7 @@ import { OutgoingRequestsManager } from "./OutgoingRequestsManager.ts";
 import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader.ts";
 import { DehydratedDeviceManager } from "./DehydratedDeviceManager.ts";
 import { VerificationMethod } from "../types.ts";
+import { CryptoEvent as LegacyCryptoEvent } from "../crypto/index.ts";
 
 const ALL_VERIFICATION_METHODS = [
     VerificationMethod.Sas,
@@ -1621,7 +1622,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, RustCryptoEv
      * @param userIds - an array of user IDs of users whose devices have updated.
      */
     public async onDevicesUpdated(userIds: string[]): Promise<void> {
-        this.emit(CryptoEvent.WillUpdateDevices, userIds, false);
+        this.emit(LegacyCryptoEvent.WillUpdateDevices, userIds, false);
         this.emit(CryptoEvent.DevicesUpdated, userIds, false);
     }
 
@@ -2081,7 +2082,7 @@ type RustCryptoEvents =
     | CryptoEvent.VerificationRequestReceived
     | CryptoEvent.UserTrustStatusChanged
     | CryptoEvent.KeysChanged
-    | CryptoEvent.WillUpdateDevices
+    | LegacyCryptoEvent.WillUpdateDevices
     | CryptoEvent.DevicesUpdated
     | RustBackupCryptoEvents;
 
@@ -2116,7 +2117,7 @@ export type RustCryptoEventMap = {
      * @param initialFetch - If true, the store is empty (apart
      *     from our own device) and is being seeded.
      */
-    [CryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
+    [LegacyCryptoEvent.WillUpdateDevices]: (users: string[], initialFetch: boolean) => void;
     /**
      * Fires whenever the stored devices for a user have changed
      * @param users - A list of user IDs that were updated


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922
- Add the crypto events used by the rust-crypto into the crypto api
- Use this new events for the rust-crypto

The old crypto events and the new ones are using the same string in the enums so there is no breaking change when listening for the events on the `MatrixClient`.