### PR TITLE
Fix DelayedEventInfo type

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -117,12 +117,14 @@ type DelayedPartialStateEvent = DelayedPartialTimelineEvent & {
 type DelayedPartialEvent = DelayedPartialTimelineEvent | DelayedPartialStateEvent;
 
 export type DelayedEventInfo = {
-    delayed_events: DelayedPartialEvent &
+    delayed_events: Array<
+        DelayedPartialEvent &
         SendDelayedEventResponse &
         SendDelayedEventRequestOpts &
         {
             running_since: number;
-        }[];
+        }
+    >;
     next_batch?: string;
 };
 

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -117,14 +117,11 @@ type DelayedPartialStateEvent = DelayedPartialTimelineEvent & {
 type DelayedPartialEvent = DelayedPartialTimelineEvent | DelayedPartialStateEvent;
 
 export type DelayedEventInfo = {
-    delayed_events: Array<
-        DelayedPartialEvent &
+    delayed_events: (DelayedPartialEvent &
         SendDelayedEventResponse &
-        SendDelayedEventRequestOpts &
-        {
+        SendDelayedEventRequestOpts & {
             running_since: number;
-        }
-    >;
+        })[];
     next_batch?: string;
 };
 

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -111,7 +111,6 @@ type DelayedPartialTimelineEvent = {
 
 type DelayedPartialStateEvent = DelayedPartialTimelineEvent & {
     state_key: string;
-    transaction_id: string;
 };
 
 type DelayedPartialEvent = DelayedPartialTimelineEvent | DelayedPartialStateEvent;


### PR DESCRIPTION
for MSC4140's GET `/delayed_events` (as of [`28970ec`](https://github.com/matrix-org/matrix-spec-proposals/blob/28970ec477f5d0ed051dbd9fa208a741207ae97e/proposals/4140-delayed-events-futures.md#getting-delayed-events))

Note that this does not match the response type of the MSC's new `/delayed_events/scheduled` and `delayed_events/finalized` endpoints; this only fixes a typing error in the original response type.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
