### PR TITLE
Prepare delayed call leave events more reliably

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -46,9 +46,6 @@ describe("MatrixRTCSession", () => {
         client = new MatrixClient({ baseUrl: "base_url" });
         client.getUserId = jest.fn().mockReturnValue("@alice:example.org");
         client.getDeviceId = jest.fn().mockReturnValue("AAAAAAA");
-        client.doesServerSupportUnstableFeature = jest.fn((feature) =>
-            Promise.resolve(feature === "org.matrix.msc4140"),
-        );
     });
 
     afterEach(() => {

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -414,6 +414,8 @@ describe("MatrixRTCSession", () => {
             client._unstable_sendDelayedStateEvent = sendDelayedStateMock;
             client.sendEvent = sendEventMock;
 
+            client._unstable_updateDelayedEvent = jest.fn();
+
             mockRoom = makeMockRoom([]);
             sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
         });
@@ -490,6 +492,13 @@ describe("MatrixRTCSession", () => {
                 );
                 await Promise.race([sentDelayedState, new Promise((resolve) => realSetTimeout(resolve, 500))]);
                 expect(client._unstable_sendDelayedStateEvent).toHaveBeenCalledTimes(1);
+
+                // should have tried updating the delayed leave to test that it wasn't replaced by own state
+                expect(client._unstable_updateDelayedEvent).toHaveBeenCalledTimes(1);
+                // should update delayed disconnect
+                jest.advanceTimersByTime(5000);
+                expect(client._unstable_updateDelayedEvent).toHaveBeenCalledTimes(2);
+
                 jest.useRealTimers();
             }
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -1111,7 +1111,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         this.memberEventTimeout = setTimeout(this.delayDisconnection, 5000);
     }
 
-    private delayDisconnection = async (): Promise<void> => {
+    private readonly delayDisconnection = async (): Promise<void> => {
         try {
             await this.client._unstable_updateDelayedEvent(this.disconnectDelayId!, UpdateDelayedEventAction.Restart);
             this.scheduleDelayDisconnection();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -140,6 +140,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     private encryptionKeys = new Map<string, Array<{ key: Uint8Array; timestamp: number }>>();
     private lastEncryptionKeyUpdateRequest?: number;
 
+    private disconnectDelayId: string | undefined;
+
     // We use this to store the last membership fingerprints we saw, so we can proactively re-send encryption keys
     // if it looks like a membership has been updated.
     private lastMembershipFingerprints: Set<string> | undefined;
@@ -1011,19 +1013,24 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             newContent = this.makeNewMembership(localDeviceId);
         }
 
-        const stateKey = legacy ? localUserId : this.makeMembershipStateKey(localUserId, localDeviceId);
         try {
-            await this.client.sendStateEvent(this.room.roomId, EventType.GroupCallMemberPrefix, newContent, stateKey);
-            logger.info(`Sent updated call member event.`);
-
-            // check periodically to see if we need to refresh our member event
-            if (this.isJoined()) {
-                if (legacy) {
+            if (legacy) {
+                await this.client.sendStateEvent(
+                    this.room.roomId,
+                    EventType.GroupCallMemberPrefix,
+                    newContent,
+                    localUserId,
+                );
+                if (this.isJoined()) {
+                    // check periodically to see if we need to refresh our member event
                     this.memberEventTimeout = setTimeout(
                         this.triggerCallMembershipEventUpdate,
                         MEMBER_EVENT_CHECK_PERIOD,
                     );
-                } else {
+                }
+            } else if (this.isJoined()) {
+                const stateKey = this.makeMembershipStateKey(localUserId, localDeviceId);
+                const prepareDelayedDisconnection = async (): Promise<void> => {
                     try {
                         // TODO: If delayed event times out, re-join!
                         const res = await this.client._unstable_sendDelayedStateEvent(
@@ -1035,12 +1042,65 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                             {}, // leave event
                             stateKey,
                         );
-                        this.scheduleDelayDisconnection(res.delay_id);
+                        this.disconnectDelayId = res.delay_id;
                     } catch (e) {
-                        logger.error("Failed to send delayed event:", e);
+                        // TODO: Retry if rate-limited
+                        logger.error("Failed to prepare delayed disconnection event:", e);
+                    }
+                };
+                await prepareDelayedDisconnection();
+                // Send join event _after_ preparing the delayed disconnection event
+                await this.client.sendStateEvent(
+                    this.room.roomId,
+                    EventType.GroupCallMemberPrefix,
+                    newContent,
+                    stateKey,
+                );
+                // If sending state cancels your own delayed state, prepare another delayed state
+                // TODO: Remove this once MSC4140 is stable & doesn't cancel own delayed state
+                if (this.disconnectDelayId !== undefined) {
+                    try {
+                        await this.client._unstable_updateDelayedEvent(
+                            this.disconnectDelayId,
+                            UpdateDelayedEventAction.Restart,
+                        );
+                    } catch (e) {
+                        // TODO: Retry if rate-limited
+                        if ((<MatrixError>e).errcode === "M_NOT_FOUND") {
+                            await prepareDelayedDisconnection();
+                        } else {
+                            this.disconnectDelayId = undefined;
+                        }
                     }
                 }
+                if (this.disconnectDelayId !== undefined) {
+                    this.scheduleDelayDisconnection();
+                }
+            } else {
+                let sentDelayedDisconnect = false;
+                if (this.disconnectDelayId !== undefined) {
+                    try {
+                        await this.client._unstable_updateDelayedEvent(
+                            this.disconnectDelayId,
+                            UpdateDelayedEventAction.Send,
+                        );
+                        sentDelayedDisconnect = true;
+                    } catch (e) {
+                        // TODO: Retry if rate-limited
+                        logger.error("Failed to send our delayed disconnection event:", e);
+                    }
+                    this.disconnectDelayId = undefined;
+                }
+                if (!sentDelayedDisconnect) {
+                    await this.client.sendStateEvent(
+                        this.room.roomId,
+                        EventType.GroupCallMemberPrefix,
+                        {},
+                        this.makeMembershipStateKey(localUserId, localDeviceId),
+                    );
+                }
             }
+            logger.info("Sent updated call member event.");
         } catch (e) {
             const resendDelay = CALL_MEMBER_EVENT_RETRY_DELAY_MIN + Math.random() * 2000;
             logger.warn(`Failed to send call member event (retrying in ${resendDelay}): ${e}`);
@@ -1049,18 +1109,19 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
     }
 
-    private scheduleDelayDisconnection(delayId: string): void {
-        this.memberEventTimeout = setTimeout(() => this.delayDisconnection(delayId), 5000);
+    private scheduleDelayDisconnection(): void {
+        this.memberEventTimeout = setTimeout(this.delayDisconnection, 5000);
     }
 
-    private async delayDisconnection(delayId: string): Promise<void> {
+    private delayDisconnection = async (): Promise<void> => {
         try {
-            await this.client._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart);
-            this.scheduleDelayDisconnection(delayId);
+            await this.client._unstable_updateDelayedEvent(this.disconnectDelayId!, UpdateDelayedEventAction.Restart);
+            this.scheduleDelayDisconnection();
         } catch (e) {
-            logger.error("Failed to delay our disconnection event", e);
+            // TODO: Retry if rate-limited
+            logger.error("Failed to delay our disconnection event:", e);
         }
-    }
+    };
 
     private stateEventsContainOngoingLegacySession(callMemberEvents: Map<string, MatrixEvent> | undefined): boolean {
         if (!callMemberEvents?.size) {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -1065,12 +1065,10 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                             UpdateDelayedEventAction.Restart,
                         );
                     } catch (e) {
-                        // TODO: Retry if rate-limited
-                        if ((<MatrixError>e).errcode === "M_NOT_FOUND") {
-                            await prepareDelayedDisconnection();
-                        } else {
-                            this.disconnectDelayId = undefined;
-                        }
+                        // TODO: Make embedded client include errcode, and retry only if not M_NOT_FOUND (or rate-limited)
+                        logger.warn("Failed to update delayed disconnection event, prepare it again:", e);
+                        this.disconnectDelayId = undefined;
+                        await prepareDelayedDisconnection();
                     }
                 }
                 if (this.disconnectDelayId !== undefined) {


### PR DESCRIPTION
- Try sending call join after preparing delayed leave
- On leave, send delayed leave instead of a new event

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
