### PR TITLE
Add option for MatrixClient.initRustCrypto() to disable tracing.

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -329,6 +329,46 @@ describe("initRustCrypto", () => {
             }
         }, 10000);
 
+        it("turns on tracing when tracingEnabled is true", async () => {
+            const mockStore = { free: jest.fn() } as unknown as StoreHandle;
+            jest.spyOn(StoreHandle, "open").mockResolvedValue(mockStore);
+            const tracingSpy = jest.spyOn(RustSdkCryptoJs.Tracing.prototype, 'turnOn').mockImplementation(() => {});
+    
+            await initRustCrypto({
+                logger,
+                http: {} as MatrixClient["http"],
+                userId: TEST_USER,
+                deviceId: TEST_DEVICE_ID,
+                secretStorage: {} as ServerSideSecretStorage,
+                cryptoCallbacks: {} as CryptoCallbacks,
+                storePrefix: "storePrefix",
+                tracingEnabled: true,  // Assuming you've added this parameter
+            });
+    
+            expect(tracingSpy).toHaveBeenCalled();
+            tracingSpy.mockRestore();  // Clean up the spy
+        });
+    
+        it("turns off tracing when tracingEnabled is false", async () => {
+            const mockStore = { free: jest.fn() } as unknown as StoreHandle;
+            jest.spyOn(StoreHandle, "open").mockResolvedValue(mockStore);
+            const tracingSpy = jest.spyOn(RustSdkCryptoJs.Tracing.prototype, 'turnOff').mockImplementation(() => {});
+    
+            await initRustCrypto({
+                logger,
+                http: {} as MatrixClient["http"],
+                userId: TEST_USER,
+                deviceId: TEST_DEVICE_ID,
+                secretStorage: {} as ServerSideSecretStorage,
+                cryptoCallbacks: {} as CryptoCallbacks,
+                storePrefix: "storePrefix",
+                tracingEnabled: false,  // Assuming you've added this parameter
+            });
+    
+            expect(tracingSpy).toHaveBeenCalled();
+            tracingSpy.mockRestore();  // Clean up the spy
+        });
+
         it("migrates data from a legacy crypto store when secret are not encrypted", async () => {
             const PICKLE_KEY = "pickle1234";
             const legacyStore = new MemoryCryptoStore();

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -84,22 +84,29 @@ export async function initRustCrypto(args: {
 
     /** The pickle key for `legacyCryptoStore` */
     legacyPickleKey?: string;
-
     /**
      * A callback which will receive progress updates on migration from `legacyCryptoStore`.
      *
      * Called with (-1, -1) to mark the end of migration.
      */
     legacyMigrationProgressListener?: (progress: number, total: number) => void;
+    /**
+     * Whether to enable tracing. Defaults to true.
+     */
+    tracingEnabled?: boolean;
 }): Promise<RustCrypto> {
-    const { logger } = args;
+    const { logger, tracingEnabled = true } = args;
 
     // initialise the rust matrix-sdk-crypto-wasm, if it hasn't already been done
     logger.debug("Initialising Rust crypto-sdk WASM artifact");
     await RustSdkCryptoJs.initAsync();
 
-    // enable tracing in the rust-sdk
-    new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
+    // Enable tracing in the rust-sdk based on the parameter
+    if (tracingEnabled) {
+        new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
+    } else {
+        new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Off).turnOn();
+    }
 
     logger.debug("Opening Rust CryptoStore");
     let storeHandle;

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -105,7 +105,7 @@ export async function initRustCrypto(args: {
     if (tracingEnabled) {
         new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
     } else {
-        new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Off).turnOn();
+        // Do not initialize tracing when disabled
     }
 
     logger.debug("Opening Rust CryptoStore");


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

## Fixes
fixes #4177 

## Description
This PR introduces an optional parameter, tracingEnabled, to the initRustCrypto function, allowing users to enable or disable tracing in the Rust crypto SDK.

Now, the tracing feature can be toggled:

Enabled: tracingEnabled: true - Tracing will capture debug-level logs.
Disabled: tracingEnabled: false - No tracing will occur, leading to cleaner log output and improved performance.

Signed-off-by: Srayash <srayashsingh995@gmail.com>