### PR TITLE
Avoid `<sender>|<session>` notation in log messages

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1537,7 +1537,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     private onRoomKeyUpdated(key: RustSdkCryptoJs.RoomKeyInfo): void {
         if (this.stopped) return;
         this.logger.debug(
-            `Got update for session ${key.senderKey.toBase64()}|${key.sessionId} in ${key.roomId.toString()}`,
+            `Got update for session ${key.sessionId} from sender ${key.senderKey.toBase64()} in ${key.roomId.toString()}`,
         );
         const pendingList = this.eventDecryptor.getEventsPendingRoomKey(key.roomId.toString(), key.sessionId);
         if (pendingList.length === 0) return;
@@ -1842,7 +1842,7 @@ class EventDecryptor {
         serverBackupInfo: KeyBackupInfo | null | undefined,
     ): never {
         const content = event.getWireContent();
-        const errorDetails = { session: content.sender_key + "|" + content.session_id };
+        const errorDetails = { sender_key: content.sender_key, session_id: content.session_id };
 
         // If the error looks like it might be recoverable from backup, queue up a request to try that.
         if (


### PR DESCRIPTION
We used to use the notation `<sender key>|<megolm session id>` fairly widely in log messages, but since the transition to rust crypto, it's unusual and now somewhat confusing. Make the log messages more explicit.
