### PR TITLE
Deprecate `CreateSecretStorageOpts.keyBackupInfo` used in `CryptoApi.bootstrapSecretStorage.`

### DIFF
--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -957,6 +957,7 @@ export interface CreateSecretStorageOpts {
     /**
      * The current key backup object. If passed,
      * the passphrase and recovery key from this backup will be used.
+     * @deprecated Not used by the Rust crypto stack.
      */
     keyBackupInfo?: KeyBackupInfo;
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Deprecate `CreateSecretStorageOpts.keyBackupInfo` used in `CryptoApi.bootstrapSecretStorage.`
The parameter is not used in [`RustCrypto.bootstrapSecretStorage`](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/rust-crypto/rust-crypto.ts#L788)