### PR TITLE
Add `restoreKeybackup` to `CryptoApi`.

### DIFF
--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -317,6 +317,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
 
         beforeEach(async () => {
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
+            fetchMock.get(
+                `path:/_matrix/client/v3/room_keys/version/${testData.SIGNED_BACKUP_DATA.version}`,
+                testData.SIGNED_BACKUP_DATA,
+            );
 
             aliceClient = await initTestClient();
             aliceCrypto = aliceClient.getCrypto()!;

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -660,8 +660,8 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
             ).rejects.toThrow();
         });
 
-        newBackendOnly("Should throw an error if the decryption key is found in cache", async () => {
-            await expect(aliceCrypto.restoreKeyBackup()).rejects.toThrow("No decryption key found in cache");
+        newBackendOnly("Should throw an error if the decryption key is not found in cache", async () => {
+            await expect(aliceCrypto.restoreKeyBackup()).rejects.toThrow("No decryption key found in crypto store");
         });
     });
 

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -23,6 +23,7 @@ import {
     createClient,
     Crypto,
     CryptoEvent,
+    encodeBase64,
     ICreateClientOpts,
     IEvent,
     IMegolmSessionData,
@@ -621,11 +622,10 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
                 };
                 fetchMock.get("express:/_matrix/client/v3/room_keys/keys", fullBackup);
 
-                const check = await aliceCrypto.checkKeyBackupAndEnable();
-                const recoveryKey = await aliceCrypto.getSecretStorageBackupPrivateKey();
-                expect(recoveryKey).not.toBeNull();
+                await aliceCrypto.loadSessionBackupPrivateKeyFromSecretStorage();
+                const decryptionKey = await aliceCrypto.getSessionBackupPrivateKey();
+                expect(encodeBase64(decryptionKey!)).toStrictEqual(testData.BACKUP_DECRYPTION_KEY_BASE64);
 
-                await aliceCrypto.storeSessionBackupPrivateKey(recoveryKey!, check!.backupInfo!.version!);
                 const result = await aliceCrypto.restoreKeyBackup();
                 expect(result.imported).toStrictEqual(1);
             },

--- a/src/client.ts
+++ b/src/client.ts
@@ -3706,6 +3706,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackupWithPassphrase | `CryptoApi.restoreKeyBackupWithPassphrase`}.
+     */
     public async restoreKeyBackupWithPassword(
         password: string,
         targetRoomId: string,
@@ -3713,6 +3716,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackupWithPassphrase | `CryptoApi.restoreKeyBackupWithPassphrase`}.
+     */
     public async restoreKeyBackupWithPassword(
         password: string,
         targetRoomId: string,
@@ -3720,6 +3726,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackupWithPassphrase | `CryptoApi.restoreKeyBackupWithPassphrase`}.
+     */
     public async restoreKeyBackupWithPassword(
         password: string,
         targetRoomId: string | undefined,
@@ -3792,6 +3801,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public restoreKeyBackupWithRecoveryKey(
         recoveryKey: string,
         targetRoomId: string,
@@ -3799,6 +3811,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public restoreKeyBackupWithRecoveryKey(
         recoveryKey: string,
         targetRoomId: string,
@@ -3806,6 +3821,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public restoreKeyBackupWithRecoveryKey(
         recoveryKey: string,
         targetRoomId: string | undefined,
@@ -3832,18 +3850,27 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public async restoreKeyBackupWithCache(
         targetRoomId: string,
         targetSessionId: undefined,
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public async restoreKeyBackupWithCache(
         targetRoomId: string,
         targetSessionId: string,
         backupInfo: IKeyBackupInfo,
         opts?: IKeyBackupRestoreOpts,
     ): Promise<IKeyBackupRestoreResult>;
+    /**
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public async restoreKeyBackupWithCache(
         targetRoomId: string | undefined,
         targetSessionId: string | undefined,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3696,6 +3696,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param opts - Optional params such as callbacks
      * @returns Status of restoration with `total` and `imported`
      * key counts.
+     *
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackupWithPassphrase | `CryptoApi.restoreKeyBackupWithPassphrase`}.
      */
     public async restoreKeyBackupWithPassword(
         password: string,
@@ -3741,6 +3743,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param opts - Optional params such as callbacks
      * @returns Status of restoration with `total` and `imported`
      * key counts.
+     *
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
      */
     public async restoreKeyBackupWithSecretStorage(
         backupInfo: IKeyBackupInfo,
@@ -3778,6 +3782,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
      * @returns Status of restoration with `total` and `imported`
      * key counts.
+     *
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
      */
     public restoreKeyBackupWithRecoveryKey(
         recoveryKey: string,
@@ -3811,6 +3817,15 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         return this.restoreKeyBackup(privKey, targetRoomId!, targetSessionId!, backupInfo, opts);
     }
 
+    /**
+     * Restore from an existing key backup via a private key stored locally
+     * @param targetRoomId
+     * @param targetSessionId
+     * @param backupInfo
+     * @param opts
+     *
+     * @deprecated Prefer {@link CryptoApi.restoreKeyBackup | `CryptoApi.restoreKeyBackup`}.
+     */
     public async restoreKeyBackupWithCache(
         targetRoomId: undefined,
         targetSessionId: undefined,

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -509,7 +509,7 @@ export interface CryptoApi {
      * if they match, stores the key in the crypto store by calling {@link storeSessionBackupPrivateKey},
      * which enables automatic restore of individual keys when an Unable-to-decrypt error is encountered.
      *
-     * if we are unable to fetch the key from secret storage, there is no backup on the server, or the key
+     * If we are unable to fetch the key from secret storage, there is no backup on the server, or the key
      * does not match, throws an exception.
      */
     loadSessionBackupPrivateKeyFromSecretStorage(): Promise<void>;

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -560,7 +560,7 @@ export interface CryptoApi {
      * @param phassphrase - The passphrase to use to restore the key backup.
      * @param opts
      *
-     * @deprecated Deriving a backup key from a passphrase is not part of the matrix spec. Instead, a random key is generated and stored/ shared via 4S.
+     * @deprecated Deriving a backup key from a passphrase is not part of the matrix spec. Instead, a random key is generated and stored/shared via 4S.
      */
     restoreKeyBackupWithPassphrase(phassphrase: string, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
 

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -471,6 +471,15 @@ export interface CryptoApi {
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
+     * Fetch the backup decryption key we have saved in our secret storage.
+     *
+     * This can be used for gossiping the key to other devices.
+     *
+     * @returns the key, if any, or null
+     */
+    getSecretStorageBackupPrivateKey(): Promise<Uint8Array | null>;
+
+    /**
      * Fetch the backup decryption key we have saved in our store.
      *
      * This can be used for gossiping the key to other devices.
@@ -546,14 +555,12 @@ export interface CryptoApi {
     deleteKeyBackupVersion(version: string): Promise<void>;
 
     /**
-     * Restores a key backup.
-     * If the recovery key is not provided, it will try to restore the key backup using the recovery key stored
-     * in the local cache or in the Secret Storage.
+     * Download the last key backup from the homeserver (endpoint GET /room_keys/keys/).
+     * The key backup is decrypted and imported by using the decryption key stored locally. The decryption key should be stored locally by using {@link CryptoApi#storeSessionBackupPrivateKey}.
      *
-     * @param recoveryKey - The recovery key to use to restore the key backup.
      * @param opts
      */
-    restoreKeyBackup(recoveryKey: string | undefined, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
+    restoreKeyBackup(opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
 
     /**
      * Restores a key backup using a passphrase.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -22,7 +22,13 @@ import { DeviceMap } from "../models/device.ts";
 import { UIAuthCallback } from "../interactive-auth.ts";
 import { PassphraseInfo, SecretStorageCallbacks, SecretStorageKeyDescription } from "../secret-storage.ts";
 import { VerificationRequest } from "./verification.ts";
-import { BackupTrustInfo, KeyBackupCheck, KeyBackupInfo } from "./keybackup.ts";
+import {
+    BackupTrustInfo,
+    KeyBackupCheck,
+    KeyBackupInfo,
+    KeyBackupRestoreOpts,
+    KeyBackupRestoreResult,
+} from "./keybackup.ts";
 import { ISignatures } from "../@types/signed.ts";
 import { MatrixEvent } from "../models/event.ts";
 
@@ -538,6 +544,25 @@ export interface CryptoApi {
      * @param version - The backup version to delete.
      */
     deleteKeyBackupVersion(version: string): Promise<void>;
+
+    /**
+     * Restores a key backup.
+     * If the recovery key is not provided, it will try to restore the key backup using the recovery key stored
+     * in the local cache or in the Secret Storage.
+     *
+     * @param recoveryKey - The recovery key to use to restore the key backup.
+     * @param opts
+     */
+    restoreKeyBackup(recoveryKey: string | undefined, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
+
+    /**
+     * Restores a key backup using a passphrase.
+     * @param phassphrase - The passphrase to use to restore the key backup.
+     * @param opts
+     *
+     * @deprecated Deriving a backup key from a passphrase is not part of the matrix spec. Instead, a random key is generated and stored/ shared via 4S.
+     */
+    restoreKeyBackupWithPassphrase(phassphrase: string, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -564,12 +564,12 @@ export interface CryptoApi {
 
     /**
      * Restores a key backup using a passphrase.
-     * @param phassphrase - The passphrase to use to restore the key backup.
+     * @param passphrase - The passphrase to use to restore the key backup.
      * @param opts
      *
      * @deprecated Deriving a backup key from a passphrase is not part of the matrix spec. Instead, a random key is generated and stored/shared via 4S.
      */
-    restoreKeyBackupWithPassphrase(phassphrase: string, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
+    restoreKeyBackupWithPassphrase(passphrase: string, opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -555,15 +555,18 @@ export interface CryptoApi {
     deleteKeyBackupVersion(version: string): Promise<void>;
 
     /**
-     * Download the last key backup from the homeserver (endpoint GET /room_keys/keys/).
+     * Download and restore the last key backup from the homeserver (endpoint GET /room_keys/keys/).
      * The key backup is decrypted and imported by using the decryption key stored locally. The decryption key should be stored locally by using {@link CryptoApi#storeSessionBackupPrivateKey}.
      *
+     * Warning: the full key backup may be quite large, so this operation may take several hours to complete.
+     * Use of {@link KeyBackupRestoreOpts.progressCallback} is recommended.
      * @param opts
      */
     restoreKeyBackup(opts?: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult>;
 
     /**
      * Restores a key backup using a passphrase.
+     * The decoded key (derivated from the passphrase) is store locally by calling {@link CryptoApi#storeSessionBackupPrivateKey}.
      * @param passphrase - The passphrase to use to restore the key backup.
      * @param opts
      *

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -471,15 +471,6 @@ export interface CryptoApi {
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Fetch the backup decryption key we have saved in our secret storage.
-     *
-     * This can be used for gossiping the key to other devices.
-     *
-     * @returns the key, if any, or null
-     */
-    getSecretStorageBackupPrivateKey(): Promise<Uint8Array | null>;
-
-    /**
      * Fetch the backup decryption key we have saved in our store.
      *
      * This can be used for gossiping the key to other devices.
@@ -510,6 +501,12 @@ export interface CryptoApi {
      * @param version - the backup version corresponding to this decryption key
      */
     storeSessionBackupPrivateKey(key: Uint8Array, version: string): Promise<void>;
+
+    /**
+     * Fetch the backup decryption key from the secret storage, fetch the backup info version.
+     * Store locally the key and the backup info version by calling {@link storeSessionBackupPrivateKey}.
+     */
+    loadSessionBackupPrivateKeyFromSecretStorage(): Promise<void>;
 
     /**
      * Get the current status of key backup.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -912,8 +912,8 @@ export class DeviceVerificationStatus {
 
 /**
  * Room key import progress report.
- * Used when calling {@link CryptoApi#importRoomKeys} or
- * {@link CryptoApi#importRoomKeysAsJson} as the parameter of
+ * Used when calling {@link CryptoApi#importRoomKeys},
+ * {@link CryptoApi#importRoomKeysAsJson} or {@link CryptoApi#restoreKeyBackup} as the parameter of
  * the progressCallback. Used to display feedback.
  */
 export interface ImportRoomKeyProgressData {

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -89,14 +89,6 @@ export interface KeyBackupRoomSessions {
     [sessionId: string]: KeyBackupSession;
 }
 
-export interface RoomKeysResponse {
-    sessions: KeyBackupRoomSessions;
-}
-
-export interface RoomsKeysResponse {
-    rooms: Record<string, RoomKeysResponse>;
-}
-
 export interface KeyBackupRestoreOpts {
     progressCallback?: (progress: ImportRoomKeyProgressData) => void;
 }

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { ISigned } from "../@types/signed.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { ImportRoomKeyProgressData } from "./index.ts";
 
 export interface Curve25519AuthData {
     public_key: string;
@@ -86,4 +87,21 @@ export interface KeyBackupSession<T = Curve25519SessionData | AESEncryptedSecret
 
 export interface KeyBackupRoomSessions {
     [sessionId: string]: KeyBackupSession;
+}
+
+export interface RoomKeysResponse {
+    sessions: KeyBackupRoomSessions;
+}
+
+export interface RoomsKeysResponse {
+    rooms: Record<string, RoomKeysResponse>;
+}
+
+export interface KeyBackupRestoreOpts {
+    progressCallback?: (progress: ImportRoomKeyProgressData) => void;
+}
+
+export interface KeyBackupRestoreResult {
+    total: number;
+    imported: number;
 }

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -94,7 +94,7 @@ export interface KeyBackupRoomSessions {
  */
 export interface KeyBackupRestoreOpts {
     /**
-     * Reports ongoing progress of the import process.
+     * A callback which, if defined, will be called periodically to report ongoing progress of the backup restore process.
      * @param progress
      */
     progressCallback?: (progress: ImportRoomKeyProgressData) => void;

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -89,11 +89,27 @@ export interface KeyBackupRoomSessions {
     [sessionId: string]: KeyBackupSession;
 }
 
+/**
+ * Extra parameters for {@link CryptoApi.restoreKeyBackup} and {@link CryptoApi.restoreKeyBackupWithPassphrase}.
+ */
 export interface KeyBackupRestoreOpts {
+    /**
+     * Reports ongoing progress of the import process.
+     * @param progress
+     */
     progressCallback?: (progress: ImportRoomKeyProgressData) => void;
 }
 
+/**
+ * The result of {@link CryptoApi.restoreKeyBackup}.
+ */
 export interface KeyBackupRestoreResult {
+    /**
+     * The total number of keys that were found in the backup.
+     */
     total: number;
+    /**
+     * The number of keys that were imported.
+     */
     imported: number;
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4322,7 +4322,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
-     * Stub function -- restoreBackupWithPassphrase is not implemented here, so throw error
+     * Stub function -- restoreKeyBackupWithPassphrase is not implemented here, so throw error
      */
     public restoreKeyBackupWithPassphrase(
         phassphrase: string,

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1309,6 +1309,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     }
 
     /**
+     * Implementation of {@link Crypto.loadSessionBackupPrivateKeyFromSecretStorage}.
+     */
+    public loadSessionBackupPrivateKeyFromSecretStorage(): Promise<void> {
+        throw new Error("Not implmeented");
+    }
+
+    /**
      * Get the current status of key backup.
      *
      * Implementation of {@link Crypto.CryptoApi.getActiveSessionBackupVersion}.
@@ -4325,13 +4332,6 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         passphrase: string,
         opts: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
-        throw new Error("Not implemented");
-    }
-
-    /**
-     * Stub function -- getSecretStorageBackupPrivateKey is not implemented here, so throw error
-     */
-    public getSecretStorageBackupPrivateKey(): Promise<Uint8Array | null> {
         throw new Error("Not implemented");
     }
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4314,10 +4314,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Stub function -- restoreKeyBackup is not implemented here, so throw error
      */
-    public restoreKeyBackup(
-        recoveryKey: string | undefined,
-        opts: KeyBackupRestoreOpts,
-    ): Promise<KeyBackupRestoreResult> {
+    public restoreKeyBackup(opts: KeyBackupRestoreOpts): Promise<KeyBackupRestoreResult> {
         throw new Error("Not implemented");
     }
 
@@ -4328,6 +4325,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
         phassphrase: string,
         opts: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Stub function -- getSecretStorageBackupPrivateKey is not implemented here, so throw error
+     */
+    public getSecretStorageBackupPrivateKey(): Promise<Uint8Array | null> {
         throw new Error("Not implemented");
     }
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4322,7 +4322,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * Stub function -- restoreKeyBackupWithPassphrase is not implemented here, so throw error
      */
     public restoreKeyBackupWithPassphrase(
-        phassphrase: string,
+        passphrase: string,
         opts: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
         throw new Error("Not implemented");

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -102,6 +102,8 @@ import {
     OwnDeviceKeys,
     CryptoEvent as CryptoApiCryptoEvent,
     CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
+    KeyBackupRestoreResult,
+    KeyBackupRestoreOpts,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -4306,6 +4308,26 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * Stub function -- dehydration is not implemented here, so throw error
      */
     public async startDehydration(createNewKey?: boolean): Promise<void> {
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Stub function -- restoreKeyBackup is not implemented here, so throw error
+     */
+    public restoreKeyBackup(
+        recoveryKey: string | undefined,
+        opts: KeyBackupRestoreOpts,
+    ): Promise<KeyBackupRestoreResult> {
+        throw new Error("Not implemented");
+    }
+
+    /**
+     * Stub function -- restoreBackupWithPassphrase is not implemented here, so throw error
+     */
+    public restoreKeyBackupWithPassphrase(
+        phassphrase: string,
+        opts: KeyBackupRestoreOpts,
+    ): Promise<KeyBackupRestoreResult> {
         throw new Error("Not implemented");
     }
 }

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -505,6 +505,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      * Get information about a key backup from the server
      * - If version is provided, get information about that backup version.
      * - If no version is provided, get information about the latest backup.
+     *
      * @param version - The version of the backup to get information about.
      * @returns Information object from API or null if there is no active backup.
      */
@@ -616,7 +617,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
     /**
      * Call `/room_keys/keys` to download the key backup (room keys) for the given backup version.
-     * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeys
+     * https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3room_keyskeys
      *
      * @param backupVersion
      * @returns The key backup response.
@@ -635,7 +636,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
     /**
      * Import the room keys from a `/room_keys/keys` call.
-     * Call the opts.progressCallback with the progress of the import.
+     * Calls the `opts.progressCallback` with the progress of the import.
      *
      * @param keyBackup - The response from the server containing the keys to import.
      * @param backupVersion - The version of the backup info.
@@ -802,10 +803,13 @@ export class RustBackupDecryptor implements BackupDecryptor {
 
 /**
  * Fetch a key backup info from the server.
- * - If `version` is provided call GET /room_keys/version/$version and get the backup info for that version.
- * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keysversionversion
- * - If not, call GET /room_keys/version and get the latest backup info.
- * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keysversion
+ *
+ * If `version` is provided, calls `GET /room_keys/version/$version` and gets the backup info for that version.
+ * See https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3room_keysversionversion.
+ *
+ * If not, calls `GET /room_keys/version` and get the latest backup info.
+ * See https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3room_keysversion
+ *
  * @param http
  * @param version - the specific version of the backup info to fetch
  * @returns The key backup info or null if there is no backup.
@@ -830,11 +834,12 @@ export async function requestKeyBackupVersion(
 
 /**
  * Checks if the provided decryption key matches the public key of the key backup info.
+ *
  * @param decryptionKey - The decryption key to check.
  * @param keyBackupInfo - The key backup info to check against.
  * @returns `true` if the decryption key matches the key backup info, `false` otherwise.
  */
-export function decryptionKeyMatchKeyBackupInfo(decryptionKey: Uint8Array, keyBackupInfo: KeyBackupInfo): boolean {
+export function decryptionKeyMatchesKeyBackupInfo(decryptionKey: Uint8Array, keyBackupInfo: KeyBackupInfo): boolean {
     const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(encodeBase64(decryptionKey));
     const authData = <Curve25519AuthData>keyBackupInfo.auth_data;
     return authData.public_key === backupDecryptionKey.megolmV1PublicKey.publicKeyBase64;

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -635,7 +635,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
     /**
      * Import the room keys from a `/room_keys/keys` call.
-     * Calls the `opts.progressCallback` with the progress of the import.
+     * Calls `opts.progressCallback` with the progress of the import.
      *
      * @param keyBackup - The response from the server containing the keys to import.
      * @param backupVersion - The version of the backup info.
@@ -806,7 +806,7 @@ export class RustBackupDecryptor implements BackupDecryptor {
  * If `version` is provided, calls `GET /room_keys/version/$version` and gets the backup info for that version.
  * See https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3room_keysversionversion.
  *
- * If not, calls `GET /room_keys/version` and get the latest backup info.
+ * If not, calls `GET /room_keys/version` and gets the latest backup info.
  * See https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3room_keysversion
  *
  * @param http

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -24,10 +24,9 @@ import {
     KeyBackupInfo,
     KeyBackupSession,
     Curve25519SessionData,
-    RoomKeysResponse,
-    RoomsKeysResponse,
     KeyBackupRestoreOpts,
     KeyBackupRestoreResult,
+    KeyBackupRoomSessions,
 } from "../crypto-api/keybackup.ts";
 import { logger } from "../logger.ts";
 import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
@@ -38,7 +37,7 @@ import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
-import { IKeyBackupInfo, IKeyBackupRoomSessions } from "../crypto/keybackup.ts";
+import { IKeyBackupInfo } from "../crypto/keybackup.ts";
 import { IKeyBackup } from "../crypto/backup.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 
@@ -783,9 +782,9 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         const { rooms } = res;
 
         let groupChunkCount = 0;
-        let chunkGroupByRoom: Map<string, IKeyBackupRoomSessions> = new Map();
+        let chunkGroupByRoom: Map<string, KeyBackupRoomSessions> = new Map();
 
-        const handleChunkCallback = async (roomChunks: Map<string, IKeyBackupRoomSessions>): Promise<void> => {
+        const handleChunkCallback = async (roomChunks: Map<string, KeyBackupRoomSessions>): Promise<void> => {
             const currentChunk: IMegolmSessionData[] = [];
             for (const roomId of roomChunks.keys()) {
                 const decryptedSessions = await backupDecryptor.decryptSessions(roomChunks.get(roomId)!);
@@ -917,3 +916,11 @@ export type RustBackupCryptoEventMap = {
     [CryptoEvent.KeyBackupFailed]: (errCode: string) => void;
     [CryptoEvent.KeyBackupDecryptionKeyCached]: (version: string) => void;
 };
+
+interface RoomKeysResponse {
+    sessions: KeyBackupRoomSessions;
+}
+
+interface RoomsKeysResponse {
+    rooms: Record<string, RoomKeysResponse>;
+}

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -593,36 +593,36 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
     /**
      * Restore a key backup.
      *
-     * @param backupInfoVersion - The version of the backup to restore.
+     * @param backupVersion - The version of the backup to restore.
      * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
      * @param opts - Options for the restore.
      * @returns The total number of keys and the total imported.
      */
     public async restoreKeyBackup(
-        backupInfoVersion: string,
+        backupVersion: string,
         backupDecryptor: BackupDecryptor,
         opts?: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
-        const keyBackup = await this.downloadKeyBackup(backupInfoVersion);
+        const keyBackup = await this.downloadKeyBackup(backupVersion);
         opts?.progressCallback?.({
             stage: "load_keys",
         });
 
-        return this.importKeyBackup(keyBackup, backupInfoVersion, backupDecryptor, opts);
+        return this.importKeyBackup(keyBackup, backupVersion, backupDecryptor, opts);
     }
 
     /**
      * Call `/room_keys/keys` to download the key backup (room keys) for the given backup version.
      * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeys
      *
-     * @param backupInfoVersion
+     * @param backupVersion
      * @returns The key backup response.
      */
-    private downloadKeyBackup(backupInfoVersion: string): Promise<KeyBackup> {
+    private downloadKeyBackup(backupVersion: string): Promise<KeyBackup> {
         return this.http.authedRequest<KeyBackup>(
             Method.Get,
             "/room_keys/keys",
-            { version: backupInfoVersion },
+            { version: backupVersion },
             undefined,
             {
                 prefix: ClientPrefix.V3,
@@ -635,7 +635,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      * Call the opts.progressCallback with the progress of the import.
      *
      * @param keyBackup - The response from the server containing the keys to import.
-     * @param backupInfoVersion - The version of the backup info.
+     * @param backupVersion - The version of the backup info.
      * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
      * @param opts - Options for the import.
      *
@@ -645,7 +645,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      */
     private async importKeyBackup(
         keyBackup: KeyBackup,
-        backupInfoVersion: string,
+        backupVersion: string,
         backupDecryptor: BackupDecryptor,
         opts?: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
@@ -677,7 +677,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
             // We have a chunk of decrypted keys: import them
             try {
-                await this.importBackedUpRoomKeys(currentChunk, backupInfoVersion);
+                await this.importBackedUpRoomKeys(currentChunk, backupVersion);
                 totalImported += currentChunk.length;
             } catch (e) {
                 totalFailures += currentChunk.length;

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -608,16 +608,12 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         backupDecryptor: BackupDecryptor,
         opts?: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
-        try {
-            const keyBackup = await this.downloadKeyBackup(backupInfoVersion);
-            opts?.progressCallback?.({
-                stage: "load_keys",
-            });
+        const keyBackup = await this.downloadKeyBackup(backupInfoVersion);
+        opts?.progressCallback?.({
+            stage: "load_keys",
+        });
 
-            return this.importKeyBackup(keyBackup, backupInfoVersion, backupDecryptor, opts);
-        } finally {
-            backupDecryptor.free();
-        }
+        return this.importKeyBackup(keyBackup, backupInfoVersion, backupDecryptor, opts);
     }
 
     /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -599,9 +599,10 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
     /**
      * Restore a key backup.
-     * @param backupInfoVersion
-     * @param backupDecryptor
-     * @param opts
+     * @param backupInfoVersion - The version of the backup info.
+     * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
+     * @param opts - Options for the restore.
+     * @returns The total number of keys and the total imported.
      */
     public async restoreKeyBackup(
         backupInfoVersion: string,
@@ -644,7 +645,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
      * @param opts - Options for the import.
      *
-     * @return The total number of keys and the total imported.
+     * @returns The total number of keys and the total imported.
      *
      * @private
      */

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -660,26 +660,31 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         const totalKeyCount = this.getTotalKeyCount(keyBackup);
         let totalImported = 0;
         let totalFailures = 0;
-        // Now decrypt and import the keys in chunks
-        await this.handleDecryptionOfAFullBackup(keyBackup, backupDecryptor, 200, async (chunk) => {
-            // We have a chunk of decrypted keys: import them
-            try {
-                await this.importBackedUpRoomKeys(chunk, backupInfoVersion);
-                totalImported += chunk.length;
-            } catch (e) {
-                totalFailures += chunk.length;
-                // We failed to import some keys, but we should still try to import the rest?
-                // Log the error and continue
-                logger.error("Error importing keys from backup", e);
-            }
 
-            opts?.progressCallback?.({
-                total: totalKeyCount,
-                successes: totalImported,
-                stage: "load_keys",
-                failures: totalFailures,
+        try {
+            // Now decrypt and import the keys in chunks
+            await this.handleDecryptionOfAFullBackup(keyBackup, backupDecryptor, 200, async (chunk) => {
+                // We have a chunk of decrypted keys: import them
+                try {
+                    await this.importBackedUpRoomKeys(chunk, backupInfoVersion);
+                    totalImported += chunk.length;
+                } catch (e) {
+                    totalFailures += chunk.length;
+                    // We failed to import some keys, but we should still try to import the rest?
+                    // Log the error and continue
+                    logger.error("Error importing keys from backup", e);
+                }
+
+                opts?.progressCallback?.({
+                    total: totalKeyCount,
+                    successes: totalImported,
+                    stage: "load_keys",
+                    failures: totalFailures,
+                });
             });
-        });
+        } finally {
+            backupDecryptor.free();
+        }
 
         return { total: totalKeyCount, imported: totalImported };
     }
@@ -710,7 +715,6 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
          */
         const handleChunkCallback = async (roomChunks: Map<string, KeyBackupRoomSessions>): Promise<void> => {
             const currentChunk: IMegolmSessionData[] = [];
-            // const decryptedSessions: IMegolmSessionData[] = [];
             for (const roomId of roomChunks.keys()) {
                 // Decrypt the sessions for the given room
                 const decryptedSessions = await backupDecryptor.decryptSessions(roomChunks.get(roomId)!);

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -38,7 +38,6 @@ import { sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
-import { encodeBase64 } from "../base64.ts";
 
 /** Authentification of the backup info, depends on algorithm */
 type AuthData = KeyBackupInfo["auth_data"];
@@ -839,10 +838,12 @@ export async function requestKeyBackupVersion(
  * @param keyBackupInfo - The key backup info to check against.
  * @returns `true` if the decryption key matches the key backup info, `false` otherwise.
  */
-export function decryptionKeyMatchesKeyBackupInfo(decryptionKey: Uint8Array, keyBackupInfo: KeyBackupInfo): boolean {
-    const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(encodeBase64(decryptionKey));
+export function decryptionKeyMatchesKeyBackupInfo(
+    decryptionKey: RustSdkCryptoJs.BackupDecryptionKey,
+    keyBackupInfo: KeyBackupInfo,
+): boolean {
     const authData = <Curve25519AuthData>keyBackupInfo.auth_data;
-    return authData.public_key === backupDecryptionKey.megolmV1PublicKey.publicKeyBase64;
+    return authData.public_key === decryptionKey.megolmV1PublicKey.publicKeyBase64;
 }
 
 /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -606,7 +606,8 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
     /**
      * Restore a key backup.
-     * @param backupInfoVersion - The version of the backup info.
+     *
+     * @param backupVersion - The backup version to restore.
      * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
      * @param opts - Options for the restore.
      * @returns The total number of keys and the total imported.

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -593,7 +593,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
     /**
      * Restore a key backup.
      *
-     * @param backupVersion - The backup version to restore.
+     * @param backupInfoVersion - The version of the backup to restore.
      * @param backupDecryptor - The backup decryptor to use to decrypt the keys.
      * @param opts - Options for the restore.
      * @returns The total number of keys and the total imported.

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -220,7 +220,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
     /**
      * Import a list of room keys previously exported by exportRoomKeysAsJson
      *
-     * @param keys - a JSON string encoding a list of session export objects,
+     * @param jsonKeys - a JSON string encoding a list of session export objects,
      *    each of which is an IMegolmSessionData
      * @param opts - options object
      * @returns a promise which resolves once the keys have been imported

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -498,7 +498,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      */
     private keysCountInBatch(batch: RustSdkCryptoJs.KeysBackupRequest): number {
         const parsedBody: KeyBackup = JSON.parse(batch.body);
-        return countKeystInBackup(parsedBody);
+        return countKeysInBackup(parsedBody);
     }
 
     /**
@@ -656,7 +656,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
         const CHUNK_SIZE = 200;
         // Get the total count as a first pass
-        const totalKeyCount = countKeystInBackup(keyBackup);
+        const totalKeyCount = countKeysInBackup(keyBackup);
         let totalImported = 0;
         let totalFailures = 0;
 
@@ -843,10 +843,9 @@ export function decryptionKeyMatchKeyBackupInfo(decryptionKey: Uint8Array, keyBa
 /**
  * Counts the total number of keys present in a key backup.
  * @param keyBackup - The key backup to count the keys from.
- *
  * @returns The total number of keys in the backup.
  */
-function countKeystInBackup(keyBackup: KeyBackup): number {
+function countKeysInBackup(keyBackup: KeyBackup): number {
     let count = 0;
     for (const { sessions } of Object.values(keyBackup.rooms)) {
         count += Object.keys(sessions).length;

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -656,30 +656,26 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         let totalImported = 0;
         let totalFailures = 0;
 
-        try {
-            // Now decrypt and import the keys in chunks
-            await this.handleDecryptionOfAFullBackup(keyBackup, backupDecryptor, 200, async (chunk) => {
-                // We have a chunk of decrypted keys: import them
-                try {
-                    await this.importBackedUpRoomKeys(chunk, backupInfoVersion);
-                    totalImported += chunk.length;
-                } catch (e) {
-                    totalFailures += chunk.length;
-                    // We failed to import some keys, but we should still try to import the rest?
-                    // Log the error and continue
-                    logger.error("Error importing keys from backup", e);
-                }
+        // Now decrypt and import the keys in chunks
+        await this.handleDecryptionOfAFullBackup(keyBackup, backupDecryptor, 200, async (chunk) => {
+            // We have a chunk of decrypted keys: import them
+            try {
+                await this.importBackedUpRoomKeys(chunk, backupInfoVersion);
+                totalImported += chunk.length;
+            } catch (e) {
+                totalFailures += chunk.length;
+                // We failed to import some keys, but we should still try to import the rest?
+                // Log the error and continue
+                logger.error("Error importing keys from backup", e);
+            }
 
-                opts?.progressCallback?.({
-                    total: totalKeyCount,
-                    successes: totalImported,
-                    stage: "load_keys",
-                    failures: totalFailures,
-                });
+            opts?.progressCallback?.({
+                total: totalKeyCount,
+                successes: totalImported,
+                stage: "load_keys",
+                failures: totalFailures,
             });
-        } finally {
-            backupDecryptor.free();
-        }
+        });
 
         return { total: totalKeyCount, imported: totalImported };
     }

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -38,6 +38,7 @@ import { sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { encodeBase64 } from "../base64.ts";
 
 /** Authentification of the backup info, depends on algorithm */
 type AuthData = KeyBackupInfo["auth_data"];
@@ -811,6 +812,18 @@ export async function requestKeyBackupVersion(
             throw e;
         }
     }
+}
+
+/**
+ * Checks if the provided decryption key matches the public key of the key backup info.
+ * @param decryptionKey - The decryption key to check.
+ * @param keyBackupInfo - The key backup info to check against.
+ * @returns `true` if the decryption key matches the key backup info, `false` otherwise.
+ */
+export function decryptionKeyMatchKeyBackupInfo(decryptionKey: Uint8Array, keyBackupInfo: KeyBackupInfo): boolean {
+    const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(encodeBase64(decryptionKey));
+    const authData = <Curve25519AuthData>keyBackupInfo.auth_data;
+    return authData.public_key === backupDecryptionKey.megolmV1PublicKey.publicKeyBase64;
 }
 
 /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -497,21 +497,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      */
     private keysCountInBatch(batch: RustSdkCryptoJs.KeysBackupRequest): number {
         const parsedBody: KeyBackup = JSON.parse(batch.body);
-        return this.getTotalKeyCount(parsedBody);
-    }
-
-    /**
-     * This method calculates the total number of keys present in a key backup
-     * @param keyBackup - The key backup to count the keys from.
-     *
-     * @returns The total number of keys in the backup.
-     */
-    private getTotalKeyCount(keyBackup: KeyBackup): number {
-        let count = 0;
-        for (const { sessions } of Object.values(keyBackup.rooms)) {
-            count += Object.keys(sessions).length;
-        }
-        return count;
+        return calculateKeyCountInKeyBackup(parsedBody);
     }
 
     /**
@@ -666,7 +652,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         // We have a full backup here, it can get quite big, so we need to decrypt and import it in chunks.
 
         // Get the total count as a first pass
-        const totalKeyCount = this.getTotalKeyCount(keyBackup);
+        const totalKeyCount = calculateKeyCountInKeyBackup(keyBackup);
         let totalImported = 0;
         let totalFailures = 0;
 
@@ -851,6 +837,20 @@ export async function requestKeyBackupVersion(
             throw e;
         }
     }
+}
+
+/**
+ * This method calculates the total number of keys present in a key backup
+ * @param keyBackup - The key backup to count the keys from.
+ *
+ * @returns The total number of keys in the backup.
+ */
+function calculateKeyCountInKeyBackup(keyBackup: KeyBackup): number {
+    let count = 0;
+    for (const { sessions } of Object.values(keyBackup.rooms)) {
+        count += Object.keys(sessions).length;
+    }
+    return count;
 }
 
 export type RustBackupCryptoEvents =

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -497,7 +497,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
      */
     private keysCountInBatch(batch: RustSdkCryptoJs.KeysBackupRequest): number {
         const parsedBody: KeyBackup = JSON.parse(batch.body);
-        return calculateKeyCountInKeyBackup(parsedBody);
+        return countKeystInBackup(parsedBody);
     }
 
     /**
@@ -653,7 +653,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
         const CHUNK_SIZE = 200;
         // Get the total count as a first pass
-        const totalKeyCount = calculateKeyCountInKeyBackup(keyBackup);
+        const totalKeyCount = countKeystInBackup(keyBackup);
         let totalImported = 0;
         let totalFailures = 0;
 
@@ -814,12 +814,12 @@ export async function requestKeyBackupVersion(
 }
 
 /**
- * This method calculates the total number of keys present in a key backup
+ * Counts the total number of keys present in a key backup.
  * @param keyBackup - The key backup to count the keys from.
  *
  * @returns The total number of keys in the backup.
  */
-function calculateKeyCountInKeyBackup(keyBackup: KeyBackup): number {
+function countKeystInBackup(keyBackup: KeyBackup): number {
     let count = 0;
     for (const { sessions } of Object.values(keyBackup.rooms)) {
         count += Object.keys(sessions).length;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -338,11 +338,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error(`getBackupDecryptor: Unsupported algorithm ${backupInfo.algorithm}`);
         }
 
-        if (!decryptionKeyMatchesKeyBackupInfo(privKey, backupInfo)) {
+        const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(encodeBase64(privKey));
+        if (!decryptionKeyMatchesKeyBackupInfo(backupDecryptionKey, backupInfo)) {
             throw new Error(`getBackupDecryptor: key backup on server does not match the decryption key`);
         }
 
-        const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(encodeBase64(privKey));
         return this.backupManager.createBackupDecryptor(backupDecryptionKey);
     }
 
@@ -1226,7 +1226,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: unable to get backup version");
         }
 
-        if (!decryptionKeyMatchesKeyBackupInfo(decodedKey, keyBackupInfo)) {
+        const backupDecryptionKey = RustSdkCryptoJs.BackupDecryptionKey.fromBase64(backupKey);
+        if (!decryptionKeyMatchesKeyBackupInfo(backupDecryptionKey, keyBackupInfo)) {
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: decryption key does not match backup info");
         }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -77,7 +77,7 @@ import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } 
 import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification.ts";
 import { EventType, MsgType } from "../@types/event.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { decryptionKeyMatchKeyBackupInfo, RustBackupManager } from "./backup.ts";
+import { decryptionKeyMatchesKeyBackupInfo, RustBackupManager } from "./backup.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { randomString } from "../randomstring.ts";
 import { ClientStoppedError } from "../errors.ts";
@@ -338,7 +338,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error(`getBackupDecryptor: Unsupported algorithm ${backupInfo.algorithm}`);
         }
 
-        if (!decryptionKeyMatchKeyBackupInfo(privKey, backupInfo)) {
+        if (!decryptionKeyMatchesKeyBackupInfo(privKey, backupInfo)) {
             throw new Error(`getBackupDecryptor: key backup on server does not match the decryption key`);
         }
 
@@ -1226,7 +1226,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: unable to get backup version");
         }
 
-        if (!decryptionKeyMatchKeyBackupInfo(decodedKey, keyBackupInfo)) {
+        if (!decryptionKeyMatchesKeyBackupInfo(decodedKey, keyBackupInfo)) {
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: decryption key does not match backup info");
         }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1211,9 +1211,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: missing decryption key in secret storage");
         }
 
-        const decodedKey = decodeBase64(backupKey);
         const keyBackupInfo = await this.backupManager.getServerBackupInfo();
-        if (!keyBackupInfo) {
+        if (!keyBackupInfo || !keyBackupInfo.version) {
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: unable to get backup version");
         }
 
@@ -1222,7 +1221,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("loadSessionBackupPrivateKeyFromSecretStorage: decryption key does not match backup info");
         }
 
-        await this.storeSessionBackupPrivateKey(decodedKey, keyBackupInfo.version);
+        await this.backupManager.saveBackupDecryptionKey(backupDecryptionKey, keyBackupInfo.version);
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1337,8 +1337,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
                 stage: "fetch",
             });
 
-            const result = await this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
-            return result;
+            return await this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
         } finally {
             // Free to avoid to keep in memory the decryption key stored in it. To avoid to exposing it to an attacker.
             backupDecryptor.free();

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1296,7 +1296,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * Implementation of {@link CryptoApi#restoreKeyBackupWithPassphrase}.
      */
     public async restoreKeyBackupWithPassphrase(
-        phassphrase: string,
+        passphrase: string,
         opts?: KeyBackupRestoreOpts,
     ): Promise<KeyBackupRestoreResult> {
         const backupInfo = await this.backupManager.getServerBackupInfo();
@@ -1304,7 +1304,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("No backup info available");
         }
 
-        const privateKey = await keyFromAuthData(backupInfo.auth_data, phassphrase);
+        const privateKey = await keyFromAuthData(backupInfo.auth_data, passphrase);
 
         // Cache the key
         await this.storeSessionBackupPrivateKey(privateKey, backupInfo.version);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1327,7 +1327,15 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             stage: "fetch",
         });
 
-        return this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
+        let result: KeyBackupRestoreResult;
+        try {
+            result = await this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
+        } finally {
+            // Free to avoid to keep in memory the decryption key stored in it. To avoid to exposing it to an attacker.
+            backupDecryptor.free();
+        }
+
+        return result;
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1348,11 +1348,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             stage: "fetch",
         });
 
-        try {
-            return this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
-        } finally {
-            backupDecryptor.free();
-        }
+        return this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1348,7 +1348,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             stage: "fetch",
         });
 
-        return this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
+        try {
+            return this.backupManager.restoreKeyBackup(backupInfo.version, backupDecryptor, opts);
+        } finally {
+            backupDecryptor.free();
+        }
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1323,10 +1323,10 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     }
 
     /**
-     *
-     * @param recoveryKey
-     * @param backupInfo
-     * @param opts
+     * Restore a key backup with the given key.
+     * @param recoveryKey - the key to use for decryption
+     * @param backupInfo - the backup info
+     * @param opts - additional options
      * @private
      */
     private async restoreKeyBackupWithKey(


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922

The goal is to simplify the `restoreKeyBackup` api and move it out of the `MatrixClient` to the `CryptoApi`. 

- Added two methods to `CryptoApi`
   - `restoreKeyBackup`
        - if a recovery key is provided, we use it otherwise we try to getting form our local cache or from the secret storage.
        - In [`RestoreKeyBackupDialog`](https://github.com/element-hq/element-web/blob/develop/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx) we never target a specific session or room when calling the `restoreKeyBackup*` consequently I get rid of the `targetRoomId` and `targetSessionId`. 
        - Also `IKeyBackupRestoreOpts.cacheCompleteCallback` is not used in `RestoreKeyBackupDialog`, I removed also this parameter.
        - Instead of having the `keyBackupInfo` as a parameter, we directly retrieve it internally.
   - `restoreKeyBackupWithPassphrase` which is deprecated because deriving a key backup from the passphrase is not in the spec.
   - Moved the key backup specific code into the `RustBackupManager.`
- Deprecate the `restoreKeyBackup*` in `MatrixClient`