### PR TITLE
Make doc clearer on getCrossSigningKeyId

### DIFF
--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -273,7 +273,8 @@ export interface CryptoApi {
     isCrossSigningReady(): Promise<boolean>;
 
     /**
-     * Get the ID of one of the user's cross-signing keys.
+     * Get the ID of one of the user's cross-signing keys, if the private is available.
+     * If the private key is not available, this will return null.
      *
      * @param type - The type of key to get the ID of.  One of `CrossSigningKey.Master`, `CrossSigningKey.SelfSigning`,
      *     or `CrossSigningKey.UserSigning`.  Defaults to `CrossSigningKey.Master`.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -273,8 +273,13 @@ export interface CryptoApi {
     isCrossSigningReady(): Promise<boolean>;
 
     /**
-     * Get the ID of one of the user's cross-signing keys, if the private is available.
-     * If the private key is not available, this will return null.
+     * Get the ID of one of the user's cross-signing keys, if both private and matching
+     * public parts of that key are available (ie. cached in the local crypto store).
+     *
+     * The public part may not be available if a /keys/query request has not yet been
+     * performed, or if the device that created the keys failed to publish them.
+     *
+     * If the keypair is not available, this will return null.
      *
      * @param type - The type of key to get the ID of.  One of `CrossSigningKey.Master`, `CrossSigningKey.SelfSigning`,
      *     or `CrossSigningKey.UserSigning`.  Defaults to `CrossSigningKey.Master`.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -276,10 +276,10 @@ export interface CryptoApi {
      * Get the ID of one of the user's cross-signing keys, if both private and matching
      * public parts of that key are available (ie. cached in the local crypto store).
      *
-     * The public part may not be available if a /keys/query request has not yet been
+     * The public part may not be available if a `/keys/query` request has not yet been
      * performed, or if the device that created the keys failed to publish them.
      *
-     * If the keypair is not available, this will return null.
+     * If either part of the keypair is not available, this will return `null`.
      *
      * @param type - The type of key to get the ID of.  One of `CrossSigningKey.Master`, `CrossSigningKey.SelfSigning`,
      *     or `CrossSigningKey.UserSigning`.  Defaults to `CrossSigningKey.Master`.


### PR DESCRIPTION
I was trying to work out why this was being used in a check. It turns out it only returns the key ID if the private part is stored locally, which seems very much non-obvious.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
