### PR TITLE
Replace legacy keyBackup types

### DIFF
--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -3,13 +3,11 @@ import fetchMock from "fetch-mock-jest";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { HttpApiEvent, HttpApiEventHandlerMap, MatrixHttpApi, TypedEventEmitter } from "../../../src";
-import { CryptoEvent } from "../../../src/crypto-api/index.ts";
+import { CryptoEvent, KeyBackupSession } from "../../../src/crypto-api/index.ts";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import * as testData from "../../test-utils/test-data";
 import * as TestData from "../../test-utils/test-data";
-import { IKeyBackup } from "../../../src/crypto/backup";
-import { IKeyBackupSession } from "../../../src/crypto/keybackup";
-import { RustBackupManager } from "../../../src/rust-crypto/backup";
+import { RustBackupManager, KeyBackup } from "../../../src/rust-crypto/backup";
 
 describe("Upload keys to backup", () => {
     /** The backup manager under test */
@@ -27,7 +25,7 @@ describe("Upload keys to backup", () => {
 
     let idGenerator = 0;
     function mockBackupRequest(keyCount: number): RustSdkCryptoJs.KeysBackupRequest {
-        const requestBody: IKeyBackup = {
+        const requestBody: KeyBackup = {
             rooms: {
                 "!room1:server": {
                     sessions: {},
@@ -35,7 +33,7 @@ describe("Upload keys to backup", () => {
             },
         };
         for (let i = 0; i < keyCount; i++) {
-            requestBody.rooms["!room1:server"].sessions["session" + i] = {} as IKeyBackupSession;
+            requestBody.rooms["!room1:server"].sessions["session" + i] = {} as KeyBackupSession;
         }
         return {
             id: "id" + idGenerator++,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922
Getting rid of the legacy types used in `RustCrypto#RustBackupManager`