### PR TITLE
Allow using sendEvent with a custom event type.

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -630,6 +630,45 @@ describe("MatrixClient", function () {
             await client.sendEvent(roomId, threadId, EventType.RoomMessage, { ...content }, txnId);
         });
 
+        it("overload with custom event type works", async () => {
+            const eventId = "$eventId:example.org";
+            const customEventType = "org.example.my.custom.type";
+            const txnId = client.makeTxnId();
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/${customEventType}/${txnId}`,
+                    data: { event_id: eventId },
+                    expectBody: content,
+                },
+            ];
+
+            await client.sendEvent(roomId, customEventType, { ...content }, txnId);
+        });
+
+        it("overload with custom event type and threadId works", async () => {
+            const eventId = "$eventId:example.org";
+            const customEventType = "org.example.my.custom.type";
+            const txnId = client.makeTxnId();
+            const threadId = "$threadId:server";
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/${customEventType}/${txnId}`,
+                    data: { event_id: eventId },
+                    expectBody: {
+                        ...content,
+                        "m.relates_to": {
+                            event_id: threadId,
+                            is_falling_back: true,
+                            rel_type: "m.thread",
+                        },
+                    },
+                },
+            ];
+            await client.sendEvent(roomId, threadId, customEventType, { ...content }, txnId);
+        });
+
         it("should add thread relation if threadId is passed and the relation is missing", async () => {
             const eventId = "$eventId:example.org";
             const threadId = "$threadId:server";

--- a/src/client.ts
+++ b/src/client.ts
@@ -4576,6 +4576,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         content: TimelineEvents[K],
         txnId?: string,
     ): Promise<ISendEventResponse>;
+    public sendEvent(roomId: string, eventType: string, content: IContent, txnId?: string): Promise<ISendEventResponse>;
+    public sendEvent(
+        roomId: string,
+        threadId: string | null,
+        eventType: string,
+        content: IContent,
+        txnId?: string,
+    ): Promise<ISendEventResponse>;
     public sendEvent(
         roomId: string,
         threadIdOrEventType: string | null,


### PR DESCRIPTION
This exposes the ability to send a custom event type outside of `TimelineEvents` for the purposes of sending events that are not part of the Matrix spec, but may be used for specific applications. This change simply exposes an overload for the existing function, and two tests to ensure the typings are valid.

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [N/A] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
