### PR TITLE
Fix local echo in embedded mode

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -203,18 +203,22 @@ describe("RoomWidgetClient", () => {
             expect(widgetApi.requestCapabilityToReceiveEvent).toHaveBeenCalledWith("org.matrix.rageshake_request");
             // const sendSpy = jest.spyOn(widgetApi.transport, "send");
             const sendMock = jest.fn();
-            new Promise((resolve, _) => {
+            const sendPromise = new Promise<void>((resolve, _) => {
                 widgetApi.sendRoomEvent.mockImplementation(
-                    async (eType, content, roomId): Promise<ISendEventFromWidgetResponseData> => {},
+                    async (eType, content, roomId): Promise<ISendEventFromWidgetResponseData> => {
+                        await sendPromise;
+                        return { room_id: "!1:example.org", event_id: "event_id" };
+                    },
                 );
+                client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
+                expect(sendMock).toHaveBeenCalledWith("abc");
+                resolve();
             });
             // widgetApi.transport.o;
-            client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
-            expect(sendMock).toHaveBeenCalledWith("abc");
-            widgetApi.emit(
-                `action:${WidgetApiToWidgetAction.SendEvent}`,
-                new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, { detail: { data: event } }),
-            );
+            // widgetApi.emit(
+            //     `action:${WidgetApiToWidgetAction.SendEvent}`,
+            //     new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, { detail: { data: event } }),
+            // );
         });
 
         it("handles widget errors with generic error data", async () => {

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -30,6 +30,7 @@ import {
     ITurnServer,
     IRoomEvent,
     IOpenIDCredentials,
+    ISendEventFromWidgetResponseData,
 } from "matrix-widget-api";
 
 import { createRoomWidgetClient, MsgType, UpdateDelayedEventAction } from "../../src/matrix";
@@ -186,6 +187,28 @@ describe("RoomWidgetClient", () => {
                     .getEvents()
                     .map((e) => e.getEffectiveEvent()),
             ).toEqual([event]);
+        });
+        it("updates local echo", async () => {
+            await makeClient({
+                receiveEvent: ["org.matrix.rageshake_request"],
+                sendEvent: ["org.matrix.rageshake_request"],
+            });
+            expect(widgetApi.requestCapabilityForRoomTimeline).toHaveBeenCalledWith("!1:example.org");
+            expect(widgetApi.requestCapabilityToReceiveEvent).toHaveBeenCalledWith("org.matrix.rageshake_request");
+            // const sendSpy = jest.spyOn(widgetApi.transport, "send");
+            const sendMock = jest.fn();
+            new Promise((resolve, _) => {
+                widgetApi.sendRoomEvent.mockImplementation(
+                    async (eType, content, roomId): Promise<ISendEventFromWidgetResponseData> => {},
+                );
+            });
+            // widgetApi.transport.o;
+            client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
+            expect(sendMock).toHaveBeenCalledWith("abc");
+            widgetApi.emit(
+                `action:${WidgetApiToWidgetAction.SendEvent}`,
+                new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, { detail: { data: event } }),
+            );
         });
     });
 

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -41,6 +41,7 @@ import { ICapabilities, RoomWidgetClient } from "../../src/embedded";
 import { MatrixEvent } from "../../src/models/event";
 import { ToDeviceBatch } from "../../src/models/ToDeviceMessage";
 import { DeviceInfo } from "../../src/crypto/deviceinfo";
+import { sleep } from "../../src/utils";
 
 const testOIDCToken = {
     access_token: "12345678",
@@ -128,9 +129,16 @@ describe("RoomWidgetClient", () => {
     const makeClient = async (
         capabilities: ICapabilities,
         sendContentLoaded: boolean | undefined = undefined,
+        userId?: string,
     ): Promise<void> => {
         const baseUrl = "https://example.org";
-        client = createRoomWidgetClient(widgetApi, capabilities, "!1:example.org", { baseUrl }, sendContentLoaded);
+        client = createRoomWidgetClient(
+            widgetApi,
+            capabilities,
+            "!1:example.org",
+            { baseUrl, userId },
+            sendContentLoaded,
+        );
         expect(widgetApi.start).toHaveBeenCalled(); // needs to have been called early in order to not miss messages
         widgetApi.emit("ready");
         await client.startClient();
@@ -193,32 +201,141 @@ describe("RoomWidgetClient", () => {
                     .map((e) => e.getEffectiveEvent()),
             ).toEqual([event]);
         });
-
-        it("updates local echo", async () => {
-            await makeClient({
-                receiveEvent: ["org.matrix.rageshake_request"],
-                sendEvent: ["org.matrix.rageshake_request"],
-            });
-            expect(widgetApi.requestCapabilityForRoomTimeline).toHaveBeenCalledWith("!1:example.org");
-            expect(widgetApi.requestCapabilityToReceiveEvent).toHaveBeenCalledWith("org.matrix.rageshake_request");
-            // const sendSpy = jest.spyOn(widgetApi.transport, "send");
-            const sendMock = jest.fn();
-            const sendPromise = new Promise<void>((resolve, _) => {
+        describe("local echos", () => {
+            const setupRemoteEcho = () => {
+                makeClient(
+                    {
+                        receiveEvent: ["org.matrix.rageshake_request"],
+                        sendEvent: ["org.matrix.rageshake_request"],
+                    },
+                    undefined,
+                    "@me:example.org",
+                );
+                expect(widgetApi.requestCapabilityForRoomTimeline).toHaveBeenCalledWith("!1:example.org");
+                expect(widgetApi.requestCapabilityToReceiveEvent).toHaveBeenCalledWith("org.matrix.rageshake_request");
+                const injectSpy = jest.spyOn((client as any).syncApi, "injectRoomEvents");
+                const widgetSendEmitter = new EventEmitter();
+                const widgetSendPromise = new Promise<void>((resolve) =>
+                    widgetSendEmitter.once("send", () => resolve()),
+                );
+                const resolveWidgetSend = () => widgetSendEmitter.emit("send");
                 widgetApi.sendRoomEvent.mockImplementation(
                     async (eType, content, roomId): Promise<ISendEventFromWidgetResponseData> => {
-                        await sendPromise;
+                        await widgetSendPromise;
                         return { room_id: "!1:example.org", event_id: "event_id" };
                     },
                 );
-                client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
-                expect(sendMock).toHaveBeenCalledWith("abc");
-                resolve();
+                return { injectSpy, resolveWidgetSend };
+            };
+            const remoteEchoEvent = new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, {
+                detail: {
+                    data: {
+                        type: "org.matrix.rageshake_request",
+
+                        room_id: "!1:example.org",
+                        event_id: "event_id",
+                        sender: "@me:example.org",
+                        state_key: "bar",
+                        content: { hello: "world" },
+                        unsigned: { transaction_id: "1234" },
+                    },
+                },
+                cancelable: true,
             });
-            // widgetApi.transport.o;
-            // widgetApi.emit(
-            //     `action:${WidgetApiToWidgetAction.SendEvent}`,
-            //     new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, { detail: { data: event } }),
-            // );
+            it("get response then local echo", async () => {
+                await sleep(600);
+                const { injectSpy, resolveWidgetSend } = await setupRemoteEcho();
+
+                // Begin by sending an event:
+                client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
+                // we do not expect it to be send -- until we call `resolveWidgetSend`
+                expect(injectSpy).not.toHaveBeenCalled();
+
+                // We first get the response from the widget
+                resolveWidgetSend();
+                // We then get the remote echo from the widget
+                widgetApi.emit(`action:${WidgetApiToWidgetAction.SendEvent}`, remoteEchoEvent);
+
+                // gets emitted after the event got injected
+                await new Promise<void>((resolve) => client.once(ClientEvent.Event, () => resolve()));
+                expect(injectSpy).toHaveBeenCalled();
+
+                const call = injectSpy.mock.calls[0] as any;
+                const injectedEv = call[2][0];
+                expect(injectedEv.getType()).toBe("org.matrix.rageshake_request");
+                expect(injectedEv.getUnsigned().transaction_id).toBe("widgetTxId");
+            });
+
+            it("get local echo then response", async () => {
+                await sleep(600);
+                const { injectSpy, resolveWidgetSend } = await setupRemoteEcho();
+
+                // Begin by sending an event:
+                client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
+                // we do not expect it to be send -- until we call `resolveWidgetSend`
+                expect(injectSpy).not.toHaveBeenCalled();
+
+                // We first get the remote echo from the widget
+                widgetApi.emit(`action:${WidgetApiToWidgetAction.SendEvent}`, remoteEchoEvent);
+                expect(injectSpy).not.toHaveBeenCalled();
+
+                // We then get the response from the widget
+                resolveWidgetSend();
+
+                // Gets emitted after the event got injected
+                await new Promise<void>((resolve) => client.once(ClientEvent.Event, () => resolve()));
+                expect(injectSpy).toHaveBeenCalled();
+
+                const call = injectSpy.mock.calls[0] as any;
+                const injectedEv = call[2][0];
+                expect(injectedEv.getType()).toBe("org.matrix.rageshake_request");
+                expect(injectedEv.getUnsigned().transaction_id).toBe("widgetTxId");
+            });
+            it("__ local echo then response", async () => {
+                await sleep(600);
+                const { injectSpy, resolveWidgetSend } = await setupRemoteEcho();
+
+                // Begin by sending an event:
+                client.sendEvent("!1:example.org", "org.matrix.rageshake_request", { request_id: 12 }, "widgetTxId");
+                // we do not expect it to be send -- until we call `resolveWidgetSend`
+                expect(injectSpy).not.toHaveBeenCalled();
+
+                // We first get the remote echo from the widget
+                widgetApi.emit(`action:${WidgetApiToWidgetAction.SendEvent}`, remoteEchoEvent);
+                const otherRemoteEcho = new CustomEvent(`action:${WidgetApiToWidgetAction.SendEvent}`, {
+                    detail: { data: { ...remoteEchoEvent.detail.data } },
+                });
+                otherRemoteEcho.detail.data.unsigned.transaction_id = "4567";
+                otherRemoteEcho.detail.data.event_id = "other_id";
+                widgetApi.emit(`action:${WidgetApiToWidgetAction.SendEvent}`, otherRemoteEcho);
+
+                // Simulate the wait time while the widget is waiting for a response
+                // after we already received the remote echo
+                await sleep(20);
+                // even after the wait we do not want any event to be injected.
+                // we do not know their event_id and cannot know if they are the remote echo
+                // where we need to update the txId because they are send by this client
+                expect(injectSpy).not.toHaveBeenCalled();
+                // We then get the response from the widget
+                resolveWidgetSend();
+
+                // Gets emitted after the event got injected
+                await new Promise<void>((resolve) => client.once(ClientEvent.Event, () => resolve()));
+                // Now we want both events to be injected since we know the txId - event_id match
+                expect(injectSpy).toHaveBeenCalled();
+
+                // it has been called with the event sent by ourselves
+                const call = injectSpy.mock.calls[0] as any;
+                const injectedEv = call[2][0];
+                expect(injectedEv.getType()).toBe("org.matrix.rageshake_request");
+                expect(injectedEv.getUnsigned().transaction_id).toBe("widgetTxId");
+
+                // It has been called by the event we blocked because of our send right afterwards
+                const call2 = injectSpy.mock.calls[1] as any;
+                const injectedEv2 = call2[2][0];
+                expect(injectedEv2.getType()).toBe("org.matrix.rageshake_request");
+                expect(injectedEv2.getUnsigned().transaction_id).toBe("4567");
+            });
         });
 
         it("handles widget errors with generic error data", async () => {

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -46,11 +46,12 @@ import {
 import { SyncApi, SyncState } from "./sync.ts";
 import { SlidingSyncSdk } from "./sliding-sync-sdk.ts";
 import { User } from "./models/user.ts";
-import { Room, RoomEvent } from "./models/room.ts";
+import { Room } from "./models/room.ts";
 import { ToDeviceBatch, ToDevicePayload } from "./models/ToDeviceMessage.ts";
 import { DeviceInfo } from "./crypto/deviceinfo.ts";
 import { IOlmDevice } from "./crypto/algorithms/megolm.ts";
 import { MapWithDefault, recursiveMapToObject } from "./utils.ts";
+import { TypedEventEmitter } from "./matrix.ts";
 
 interface IStateEventRequest {
     eventType: string;
@@ -117,6 +118,10 @@ export interface ICapabilities {
     updateDelayedEvents?: boolean;
 }
 
+export enum PendingEvent {
+    PendingEventsChanged = "PendingEvent.pendingEventsChanged",
+}
+export type PendingEventHandlerMap = { [PendingEvent.PendingEventsChanged]: () => void };
 /**
  * A MatrixClient that routes its requests through the widget API instead of the
  * real CS API.
@@ -129,6 +134,7 @@ export class RoomWidgetClient extends MatrixClient {
     private syncState: SyncState | null = null;
 
     private pendingSendingEventsTxId: { type: string; id: string | undefined; txId: string }[] = [];
+    private pendingEventsEmitter = new TypedEventEmitter<PendingEvent.PendingEventsChanged, PendingEventHandlerMap>();
 
     /**
      *
@@ -324,17 +330,14 @@ export class RoomWidgetClient extends MatrixClient {
             this.updatePendingEventStatus(room, event, EventStatus.NOT_SENT);
             throw e;
         }
-
-        // Update the pending events list with the eventId
-        if (txId) {
-            this.pendingSendingEventsTxId.map((old) => {
-                if (old.txId === txId) old.id = response.event_id;
-                return old;
-            });
-        }
-
         // This also checks for an event id on the response
         room.updatePendingEvent(event, EventStatus.SENT, response.event_id);
+
+        // Update the pending events list with the eventId
+        this.pendingSendingEventsTxId.forEach((p) => {
+            if (p.txId === txId) p.id = response.event_id;
+        });
+        this.pendingEventsEmitter.emit(PendingEvent.PendingEventsChanged);
 
         return { event_id: response.event_id! };
     }
@@ -479,6 +482,48 @@ export class RoomWidgetClient extends MatrixClient {
         await this.widgetApi.transport.reply<IWidgetApiAcknowledgeResponseData>(ev.detail, {});
     }
 
+    private updateTxId = async (event: MatrixEvent): Promise<void> => {
+        // We update the txId for remote echos that originate from this client.
+        // This happens with the help of `pendingSendingEventsTxId` where we store all events that are currently sending
+        // with their widget txId and once ready the final evId.
+        if (
+            // This could theoretically be an event send by this device
+            // In that case we need to update the txId of the event because the embedded client/widget
+            // knows this event with a different transaction Id than what was used by the host client.
+            event.getSender() === this.getUserId() &&
+            // We optimize by not blocking events from types that we have not send
+            // with this client.
+            this.pendingSendingEventsTxId.some((p) => event.getType() === p.type)
+        ) {
+            // Compare by event Id if we have a matching pending event where we know the txId.
+            let matchingTxId = this.pendingSendingEventsTxId.find((p) => p.id === event.getId())?.txId;
+            // Block any further processing of this event until we have received the sending response.
+            // -> until we know the event id.
+            // -> until we have not pending events anymore.
+            while (!matchingTxId && this.pendingSendingEventsTxId.length > 0) {
+                // Recheck whenever the PendingEventsChanged
+                await new Promise<void>((resolve) =>
+                    this.pendingEventsEmitter.once(PendingEvent.PendingEventsChanged, () => resolve()),
+                );
+                matchingTxId = this.pendingSendingEventsTxId.find((p) => p.id === event.getId())?.txId;
+            }
+
+            // We found the correct txId: we update the event and delete the entry of the pending events.
+            if (matchingTxId) {
+                event.setTxnId(matchingTxId);
+                event.setUnsigned({ ...event.getUnsigned(), transaction_id: matchingTxId });
+            }
+            this.pendingSendingEventsTxId = this.pendingSendingEventsTxId.filter((p) => p.id !== event.getId());
+
+            // Emit once there are no pending events anymore to release all other events that got
+            // awaited in the `while (!matchingTxId && this.pendingSendingEventsTxId.length > 0)` loop
+            // but are not send by this client.
+            if (this.pendingSendingEventsTxId.length === 0) {
+                this.pendingEventsEmitter.emit(PendingEvent.PendingEventsChanged);
+            }
+        }
+    };
+
     private onEvent = async (ev: CustomEvent<ISendEventToWidgetActionRequest>): Promise<void> => {
         ev.preventDefault();
 
@@ -487,31 +532,8 @@ export class RoomWidgetClient extends MatrixClient {
         if (ev.detail.data.room_id === this.roomId) {
             const event = new MatrixEvent(ev.detail.data as Partial<IEvent>);
 
-            if (
-                // This could theoretically be an event send by this device
-                // In that case we need to update the txId of the event because the embedded client/widget
-                // knows this event with a different transaction Id than what was used by the host client.
-                event.getSender() === this.getUserId() &&
-                // this is an optimization so we do not block events from types that we have not send
-                // with this client
-                this.pendingSendingEventsTxId.some((p) => event.getType() === p.type)
-            ) {
-                // Compare by event Id if we have a matching pending event where we know the txId.
-                let matchingTxId = this.pendingSendingEventsTxId.find((p) => p.id === event.getId())?.txId;
-                // Block injection this event until we have received the sending response.
-                // -> until we know the event id.
-                while (!matchingTxId) {
-                    // Recheck whenever the LocalEchoUpdated
-                    await new Promise<void>((resolve) => this.room?.once(RoomEvent.LocalEchoUpdated, () => resolve()));
-                    matchingTxId = this.pendingSendingEventsTxId.find((p) => p.id === event.getId())?.txId;
-                }
-
-                // We found the correct txId: we update the event and delete the entry of the pending events.
-                event.setTxnId(matchingTxId);
-                event.setUnsigned({ ...event.getUnsigned(), transaction_id: matchingTxId });
-                this.pendingSendingEventsTxId.filter((p) => p.id !== event.getId());
-            }
-
+            // Only inject once we have update the txId
+            await this.updateTxId(event);
             await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
             this.emit(ClientEvent.Event, event);
             this.setSyncState(SyncState.Syncing);

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -56,7 +56,7 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
 
     public start(): void {
         // We shouldn't need to null-check here, but matrix-client.spec.ts mocks getRooms
-        // returing nothing, and breaks tests if you change it to return an empty array :'(
+        // returning nothing, and breaks tests if you change it to return an empty array :'(
         for (const room of this.client.getRooms() ?? []) {
             const session = MatrixRTCSession.roomSessionForRoom(this.client, room);
             if (session.memberships.length > 0) {


### PR DESCRIPTION
This fixes remote echos not appearing in the widget api. As a consequence, an event listener in a matroska widget will never receive events sent by itself with`isSending() === false`.

This is needed in the raise hand logic for element call. We send a raise hand and need to update the ui as soon as it is sent so that pressing the button again redacts the raise hand.

The issue is caused by the following:
 - An event gets a txId assigned by the embedded client (the widget)
 - This txId is tracked, so that the event can be matched once the remote echo is received. In that case the js-sdk "ignores" the remote event and instead updates the already existing local event to reflect it is send.
  - Using the widget api the event gets a txid twice. once in the widget (but that txid does **not** get forwarded to the client through the widget api) and once while it is sent by the client.
  - The event that then gets to the widget uses a different txid. The two events cannot be matched up because of the different txid's. since we do have the same evId however we still ignore the remote echo.
  - We end up with an ignored remote echo that did not update the local event to be sucessfully sent.
  
The fix works as following:
 - We track the txId of the local event.
 - We block all remote echos until we get a response from the send action.
 - Once we have the response form the send action we know the txId - evId relation
 - We take the remote echo and update the txId to not be the one created by the cleint but by the widget matching the local event of the widget.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
