### PR TITLE
Deprecate unused callbacks in `CryptoCallbacks`

### DIFF
--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -936,8 +936,11 @@ export interface CrossSigningStatus {
  * Crypto callbacks provided by the application
  */
 export interface CryptoCallbacks extends SecretStorageCallbacks {
+    /** @deprecated: unused with the Rust crypto stack. */
     getCrossSigningKey?: (keyType: string, pubKey: string) => Promise<Uint8Array | null>;
+    /** @deprecated: unused with the Rust crypto stack. */
     saveCrossSigningKeys?: (keys: Record<string, Uint8Array>) => void;
+    /** @deprecated: unused with the Rust crypto stack. */
     shouldUpgradeDeviceVerifications?: (users: Record<string, any>) => Promise<string[]>;
     /**
      * Called by {@link CryptoApi#bootstrapSecretStorage}
@@ -962,6 +965,7 @@ export interface CryptoCallbacks extends SecretStorageCallbacks {
         checkFunc: (key: Uint8Array) => void,
     ) => Promise<Uint8Array>;
 
+    /** @deprecated: unused with the Rust crypto stack. */
     getBackupKey?: () => Promise<Uint8Array>;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922
Deprecate unused callbacks in `CryptoCallbacks` in the rust crypto stack.
