### PR TITLE
Remove redundant type arguments in function call

### DIFF
--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -162,7 +162,7 @@ export class RoomWidgetClient extends MatrixClient {
             data: T,
         ): Promise<R> => {
             try {
-                return await transportSend<T, R>(action, data);
+                return await transportSend(action, data);
             } catch (error) {
                 processAndThrow(error);
             }
@@ -174,7 +174,7 @@ export class RoomWidgetClient extends MatrixClient {
             data: T,
         ): Promise<R> => {
             try {
-                return await transportSendComplete<T, R>(action, data);
+                return await transportSendComplete(action, data);
             } catch (error) {
                 processAndThrow(error);
             }


### PR DESCRIPTION
as the types can be deduced by the function arguments.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
