### PR TITLE
Handle M_MAX_DELAY_EXCEEDED errors

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -508,6 +508,20 @@ describe("MatrixRTCSession", () => {
 
                 jest.useFakeTimers();
 
+                // preparing the delayed disconnect should handle the delay being too long
+                const sendDelayedStateExceedAttempt = new Promise<void>((resolve) => {
+                    const error = new MatrixError({
+                        errcode: "M_UNKNOWN",
+                        "org.matrix.msc4140.errcode": "M_MAX_DELAY_EXCEEDED",
+                        "org.matrix.msc4140.max_delay": 7500,
+                    });
+                    sendDelayedStateMock.mockImplementationOnce(() => {
+                        resolve();
+                        return Promise.reject(error);
+                    });
+                });
+                expect(sess).toHaveProperty("membershipServerSideExpiryTimeoutOverride", undefined);
+
                 // preparing the delayed disconnect should handle ratelimiting
                 const sendDelayedStateAttempt = new Promise<void>((resolve) => {
                     const error = new MatrixError({ errcode: "M_LIMIT_EXCEEDED" });
@@ -542,6 +556,9 @@ describe("MatrixRTCSession", () => {
                 });
 
                 sess!.joinRoomSession([activeFocusConfig], activeFocus, { useLegacyMemberEvents: false });
+
+                await sendDelayedStateExceedAttempt.then(); // needed to resolve after the send attempt catches
+                expect(sess).toHaveProperty("membershipServerSideExpiryTimeoutOverride", 7500);
 
                 await sendDelayedStateAttempt;
                 jest.advanceTimersByTime(5000);

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -511,7 +511,7 @@ describe("MatrixRTCSession", () => {
                 // preparing the delayed disconnect should handle the delay being too long
                 const sendDelayedStateExceedAttempt = new Promise<void>((resolve) => {
                     const error = new MatrixError({
-                        errcode: "M_UNKNOWN",
+                        "errcode": "M_UNKNOWN",
                         "org.matrix.msc4140.errcode": "M_MAX_DELAY_EXCEEDED",
                         "org.matrix.msc4140.max_delay": 7500,
                     });

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -520,7 +520,6 @@ describe("MatrixRTCSession", () => {
                         return Promise.reject(error);
                     });
                 });
-                expect(sess).toHaveProperty("membershipServerSideExpiryTimeoutOverride", undefined);
 
                 // preparing the delayed disconnect should handle ratelimiting
                 const sendDelayedStateAttempt = new Promise<void>((resolve) => {
@@ -555,10 +554,14 @@ describe("MatrixRTCSession", () => {
                     });
                 });
 
-                sess!.joinRoomSession([activeFocusConfig], activeFocus, { useLegacyMemberEvents: false });
+                sess!.joinRoomSession([activeFocusConfig], activeFocus, {
+                    useLegacyMemberEvents: false,
+                    membershipServerSideExpiryTimeout: 9000,
+                });
 
+                expect(sess).toHaveProperty("membershipServerSideExpiryTimeout", 9000);
                 await sendDelayedStateExceedAttempt.then(); // needed to resolve after the send attempt catches
-                expect(sess).toHaveProperty("membershipServerSideExpiryTimeoutOverride", 7500);
+                expect(sess).toHaveProperty("membershipServerSideExpiryTimeout", 7500);
 
                 await sendDelayedStateAttempt;
                 jest.advanceTimersByTime(5000);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -184,8 +184,18 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         return this.joinConfig?.useKeyDelay ?? 5_000;
     }
 
+    /**
+     * If the server disallows the configured {@link membershipServerSideExpiryTimeout},
+     * this stores a delay that the server does allow.
+     */
+    private membershipServerSideExpiryTimeoutOverride?: number;
+
     private get membershipServerSideExpiryTimeout(): number {
-        return this.joinConfig?.membershipServerSideExpiryTimeout ?? 8_000;
+        return (
+            this.joinConfig?.membershipServerSideExpiryTimeout ??
+            this.membershipServerSideExpiryTimeoutOverride ??
+            8_000
+        );
     }
 
     private get membershipKeepAlivePeriod(): number {
@@ -1141,6 +1151,20 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                         );
                         this.disconnectDelayId = res.delay_id;
                     } catch (e) {
+                        if (
+                            e instanceof MatrixError &&
+                            e.errcode === "M_UNKNOWN" &&
+                            e.data["org.matrix.msc4140.errcode"] === "M_MAX_DELAY_EXCEEDED"
+                        ) {
+                            const maxDelayAllowed = e.data["org.matrix.msc4140.max_delay"];
+                            if (
+                                typeof maxDelayAllowed === "number" &&
+                                this.membershipServerSideExpiryTimeout > maxDelayAllowed
+                            ) {
+                                this.membershipServerSideExpiryTimeoutOverride = maxDelayAllowed;
+                                return prepareDelayedDisconnection();
+                            }
+                        }
                         logger.error("Failed to prepare delayed disconnection event:", e);
                     }
                 };

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -192,8 +192,8 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
 
     private get membershipServerSideExpiryTimeout(): number {
         return (
-            this.joinConfig?.membershipServerSideExpiryTimeout ??
             this.membershipServerSideExpiryTimeoutOverride ??
+            this.joinConfig?.membershipServerSideExpiryTimeout ??
             8_000
         );
     }


### PR DESCRIPTION
Use a lower delay time if the server rejects a delay as too long.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
