### PR TITLE
Trigger call rejoin attempt only if you were in it

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -872,10 +872,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             this.emit(MatrixRTCSessionEvent.MembershipsChanged, oldMemberships, this.memberships);
 
             if (
-                this.isJoined() &&
-                oldMemberships.some(this.isMyMembership) &&
-                !this.memberships.some(this.isMyMembership)
+                this.isJoined() && // we mean to be joined
+                oldMemberships.some(this.isMyMembership) && // prior state says we were joined
+                !this.memberships.some(this.isMyMembership) // current says we are not joined
             ) {
+                // State says that we left, but we still mean to be joined
                 logger.warn("Missing own membership: force re-join");
                 // TODO: Should this be awaited? And is there anything to tell the focus?
                 this.triggerCallMembershipEventUpdate();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -871,7 +871,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             logger.info(`Memberships for call in room ${this.room.roomId} have changed: emitting`);
             this.emit(MatrixRTCSessionEvent.MembershipsChanged, oldMemberships, this.memberships);
 
-            if (this.isJoined() && !this.memberships.some(this.isMyMembership)) {
+            if (
+                this.isJoined() &&
+                oldMemberships.some(this.isMyMembership) &&
+                !this.memberships.some(this.isMyMembership)
+            ) {
                 logger.warn("Missing own membership: force re-join");
                 // TODO: Should this be awaited? And is there anything to tell the focus?
                 this.triggerCallMembershipEventUpdate();


### PR DESCRIPTION
Many membership events may get synced while your own join attempt is being processed, during which you will not be in the call membership list.  So, only try to rejoin if it seems that you have _left_ the call, not when you are not (yet) in the call.

Followup of https://github.com/matrix-org/matrix-js-sdk/pull/4342

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
