### PR TITLE
Use shield status codes from Rust rather than string matching

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -991,23 +991,41 @@ describe("RustCrypto", () => {
         });
 
         it.each([
-            [undefined, null],
-            ["Encrypted by an unverified user.", EventShieldReason.UNVERIFIED_IDENTITY],
-            ["Encrypted by a device not verified by its owner.", EventShieldReason.UNSIGNED_DEVICE],
+            [undefined, undefined, null],
+            [
+                "Encrypted by an unverified user.",
+                RustSdkCryptoJs.ShieldStateCode.UnverifiedIdentity,
+                EventShieldReason.UNVERIFIED_IDENTITY,
+            ],
+            [
+                "Encrypted by a device not verified by its owner.",
+                RustSdkCryptoJs.ShieldStateCode.UnsignedDevice,
+                EventShieldReason.UNSIGNED_DEVICE,
+            ],
             [
                 "The authenticity of this encrypted message can't be guaranteed on this device.",
+                RustSdkCryptoJs.ShieldStateCode.AuthenticityNotGuaranteed,
                 EventShieldReason.AUTHENTICITY_NOT_GUARANTEED,
             ],
-            ["Encrypted by an unknown or deleted device.", EventShieldReason.UNKNOWN_DEVICE],
-            ["bloop", EventShieldReason.UNKNOWN],
-        ])("gets the right shield reason (%s)", async (rustReason, expectedReason) => {
+            [
+                "Encrypted by an unknown or deleted device.",
+                RustSdkCryptoJs.ShieldStateCode.UnknownDevice,
+                EventShieldReason.UNKNOWN_DEVICE,
+            ],
+            ["Not encrypted.", RustSdkCryptoJs.ShieldStateCode.SentInClear, EventShieldReason.SENT_IN_CLEAR],
+            [
+                "Encrypted by a previously-verified user who is no longer verified.",
+                RustSdkCryptoJs.ShieldStateCode.PreviouslyVerified,
+                EventShieldReason.VERIFICATION_VIOLATION,
+            ],
+        ])("gets the right shield reason (%s)", async (rustReason, rustCode, expectedReason) => {
             // suppress the warning from the unknown shield reason
             jest.spyOn(console, "warn").mockImplementation(() => {});
 
             const mockEncryptionInfo = {
                 shieldState: jest
                     .fn()
-                    .mockReturnValue({ color: RustSdkCryptoJs.ShieldColor.None, message: rustReason }),
+                    .mockReturnValue({ color: RustSdkCryptoJs.ShieldColor.None, code: rustCode, message: rustReason }),
             } as unknown as RustSdkCryptoJs.EncryptionInfo;
             olmMachine.getRoomEventEncryptionInfo.mockResolvedValue(mockEncryptionInfo);
 

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -1145,6 +1145,16 @@ export enum EventShieldReason {
      * decryption keys.
      */
     MISMATCHED_SENDER_KEY,
+
+    /**
+     * The event was sent unencrypted in an encrypted room.
+     */
+    SENT_IN_CLEAR,
+
+    /**
+     * The sender was previously verified but changed their identity.
+     */
+    VERIFICATION_VIOLATION,
 }
 
 /** The result of a call to {@link CryptoApi.getOwnDeviceKeys} */

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -2173,22 +2173,29 @@ function rustEncryptionInfoToJsEncryptionInfo(
     }
 
     let shieldReason: EventShieldReason | null;
-    if (shieldState.message === undefined) {
-        shieldReason = null;
-    } else if (shieldState.message === "Encrypted by an unverified user.") {
-        // this case isn't actually used with lax shield semantics.
-        shieldReason = EventShieldReason.UNVERIFIED_IDENTITY;
-    } else if (shieldState.message === "Encrypted by a device not verified by its owner.") {
-        shieldReason = EventShieldReason.UNSIGNED_DEVICE;
-    } else if (
-        shieldState.message === "The authenticity of this encrypted message can't be guaranteed on this device."
-    ) {
-        shieldReason = EventShieldReason.AUTHENTICITY_NOT_GUARANTEED;
-    } else if (shieldState.message === "Encrypted by an unknown or deleted device.") {
-        shieldReason = EventShieldReason.UNKNOWN_DEVICE;
-    } else {
-        logger.warn(`Unknown shield state message '${shieldState.message}'`);
-        shieldReason = EventShieldReason.UNKNOWN;
+    switch (shieldState.code) {
+        case undefined:
+        case null:
+            shieldReason = null;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.AuthenticityNotGuaranteed:
+            shieldReason = EventShieldReason.AUTHENTICITY_NOT_GUARANTEED;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.UnknownDevice:
+            shieldReason = EventShieldReason.UNKNOWN_DEVICE;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.UnsignedDevice:
+            shieldReason = EventShieldReason.UNSIGNED_DEVICE;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.UnverifiedIdentity:
+            shieldReason = EventShieldReason.UNVERIFIED_IDENTITY;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.SentInClear:
+            shieldReason = EventShieldReason.SENT_IN_CLEAR;
+            break;
+        case RustSdkCryptoJs.ShieldStateCode.PreviouslyVerified:
+            shieldReason = EventShieldReason.VERIFICATION_VIOLATION;
+            break;
     }
 
     return { shieldColour, shieldReason };


### PR DESCRIPTION
Also add EventShieldReasons to match.  Part of fixing https://github.com/element-hq/element-web/issues/28170

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
