### PR TITLE
Fix `RustBackupManager` remaining values after current backup removal

### DIFF
--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -583,6 +583,11 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         await this.http.authedRequest<void>(Method.Delete, path, undefined, undefined, {
             prefix: ClientPrefix.V3,
         });
+        // If the backup we are deleting is the active one, we need to disable the key backup and to have the local properties reset
+        if (this.activeBackupVersion === version) {
+            this.serverBackupInfo = null;
+            await this.disableKeyBackup();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Closes https://github.com/matrix-org/matrix-js-sdk/issues/4534
