### PR TITLE
Remove deprecated calls in `webrtc/call.ts`

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -2514,7 +2514,9 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                     return;
                 }
 
-                // Here we were calling `MatrixClient.encryptAndSendToDevices` which is not supported by the rust cryptography.
+                // TODO: Here we were sending the event to the opponent's device as a to-device message with MatrixClient.encryptAndSendToDevices.
+                // However due to the switch to Rust cryptography we need to migrate to the new encryptToDeviceMessages API.
+                throw new Error("Unimplemented");
             } else {
                 await this.client.sendToDevice(
                     eventType,

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -631,19 +631,17 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         if (!this.client.getUseE2eForGroupCall()) return;
         // It's possible to want E2EE and yet not have the means to manage E2EE
         // ourselves (for example if the client is a RoomWidgetClient)
-        if (!this.client.isCryptoEnabled()) {
+        if (!this.client.getCrypto()) {
             // All we know is the device ID
             this.opponentDeviceInfo = new DeviceInfo(this.opponentDeviceId);
             return;
         }
-        // if we've got to this point, we do want to init crypto, so throw if we can't
-        if (!this.client.crypto) throw new Error("Crypto is not initialised.");
-
         const userId = this.invitee || this.getOpponentMember()?.userId;
 
         if (!userId) throw new Error("Couldn't find opponent user ID to init crypto");
 
-        const deviceInfoMap = await this.client.crypto.deviceList.downloadKeys([userId], false);
+        // Here we were calling `MatrixClient.crypto.deviceList.downloadKeys` which is not supported by the rust cryptography.
+        const deviceInfoMap = new Map();
         this.opponentDeviceInfo = deviceInfoMap.get(userId)?.get(this.opponentDeviceId);
         if (this.opponentDeviceInfo === undefined) {
             throw new GroupCallUnknownDeviceError(userId);
@@ -2516,18 +2514,7 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
                     return;
                 }
 
-                await this.client.encryptAndSendToDevices(
-                    [
-                        {
-                            userId,
-                            deviceInfo: this.opponentDeviceInfo,
-                        },
-                    ],
-                    {
-                        type: eventType,
-                        content,
-                    },
-                );
+                // Here we were calling `MatrixClient.encryptAndSendToDevices` which is not supported by the rust cryptography.
             } else {
                 await this.client.sendToDevice(
                     eventType,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Require https://github.com/matrix-org/matrix-js-sdk/pull/4620
`webrtc/call.ts` uses deprecated and unsupported methods by the rust cryptography. I suppose it's somewhat broken since the usage of the rust cryptography.

I removed theses calls for https://github.com/element-hq/element-web/issues/26922
We wait for the js-sdk to drop the support of the legacy crypto (https://github.com/element-hq/element-web/issues/26922) to merge it in order to keep the feature when the legacy crypto is used.

