### PR TITLE
Replace deprecate imports

### DIFF
--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -78,7 +78,7 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * Get information about the encryption of an event
      *
      * @param event - event to be checked
-     * @deprecated
+     * @deprecated Use {@link CryptoApi#getEncryptionInfoForEvent} instead
      */
     getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo;
 

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -78,6 +78,7 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * Get information about the encryption of an event
      *
      * @param event - event to be checked
+     * @deprecated
      */
     getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo;
 

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -30,7 +30,6 @@ import {
 } from "../crypto-api/keybackup.ts";
 import { logger } from "../logger.ts";
 import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
-import { IMegolmSessionData } from "../crypto/index.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { encodeUri, logDuration } from "../utils.ts";
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
@@ -38,6 +37,7 @@ import { sleep } from "../utils.ts";
 import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { IMegolmSessionData } from "../@types/crypto.ts";
 
 /** Authentification of the backup info, depends on algorithm */
 type AuthData = KeyBackupInfo["auth_data"];

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -21,7 +21,6 @@ import { CryptoStore, MigrationState, SecretStorePrivateKeys } from "../crypto/s
 import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.ts";
 import { IHttpOpts, MatrixHttpApi } from "../http-api/index.ts";
 import { requestKeyBackupVersion } from "./backup.ts";
-import { IRoomEncryption } from "../crypto/RoomList.ts";
 import { CrossSigningKeyInfo, Curve25519AuthData } from "../crypto-api/index.ts";
 import { RustCrypto } from "./rust-crypto.ts";
 import { KeyBackupInfo } from "../crypto-api/keybackup.ts";
@@ -29,6 +28,12 @@ import { sleep } from "../utils.ts";
 import { encodeBase64 } from "../base64.ts";
 import decryptAESSecretStorageItem from "../utils/decryptAESSecretStorageItem.ts";
 import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+
+interface LegacyRoomEncryption {
+    algorithm: string;
+    rotation_period_ms?: number;
+    rotation_period_msgs?: number;
+}
 
 /**
  * Determine if any data needs migrating from the legacy store, and do so.
@@ -375,7 +380,7 @@ export async function migrateRoomSettingsFromLegacyCrypto({
         return;
     }
 
-    let rooms: Record<string, IRoomEncryption> = {};
+    let rooms: Record<string, LegacyRoomEncryption> = {};
 
     await legacyStore.doTxn("readwrite", [IndexedDBCryptoStore.STORE_ROOMS], (txn) => {
         legacyStore.getEndToEndRooms(txn, (result) => {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -25,9 +25,8 @@ limitations under the License.
 import { IContent, IEvent, IUnsigned, MatrixEvent } from "./models/event.ts";
 import { RoomMember } from "./models/room-member.ts";
 import { EventType } from "./@types/event.ts";
-import { DecryptionError } from "./crypto/algorithms/index.ts";
 import { DecryptionFailureCode } from "./crypto-api/index.ts";
-import { EventDecryptionResult } from "./common-crypto/CryptoBackend.ts";
+import { DecryptionError, EventDecryptionResult } from "./common-crypto/CryptoBackend.ts";
 
 /**
  * Create a {@link MatrixEvent}.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922
- Replace some legacy crypto imports
- Deprecate `CryptoBackend.getEventEncryptionInfo`