### PR TITLE
Only re-prepare MatrixrRTC delayed disconnection event on 404 

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -1182,13 +1182,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 if (this.disconnectDelayId !== undefined) {
                     try {
                         const knownDisconnectDelayId = this.disconnectDelayId;
-                        await resendIfRateLimited(
-                            () =>
-                                this.client._unstable_updateDelayedEvent(
-                                    knownDisconnectDelayId,
-                                    UpdateDelayedEventAction.Restart,
-                                ),
-                            10,
+                        await resendIfRateLimited(() =>
+                            this.client._unstable_updateDelayedEvent(
+                                knownDisconnectDelayId,
+                                UpdateDelayedEventAction.Restart,
+                            ),
                         );
                     } catch (e) {
                         if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -1188,12 +1188,17 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                                     knownDisconnectDelayId,
                                     UpdateDelayedEventAction.Restart,
                                 ),
-                            1000,
+                            10,
                         );
                     } catch (e) {
-                        logger.warn("Failed to update delayed disconnection event, prepare it again:", e);
-                        this.disconnectDelayId = undefined;
-                        await prepareDelayedDisconnection();
+                        if (e instanceof MatrixError && e.errcode === "M_NOT_FOUND") {
+                            // If we get a M_NOT_FOUND we prepare a new delayed event.
+                            // In other error cases we do not want to prepare anything since we do not have the guarantee, that the
+                            // future is not still running.
+                            logger.warn("Failed to update delayed disconnection event, prepare it again:", e);
+                            this.disconnectDelayId = undefined;
+                            await prepareDelayedDisconnection();
+                        }
                     }
                 }
                 if (this.disconnectDelayId !== undefined) {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -1182,11 +1182,13 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 if (this.disconnectDelayId !== undefined) {
                     try {
                         const knownDisconnectDelayId = this.disconnectDelayId;
-                        await resendIfRateLimited(() =>
-                            this.client._unstable_updateDelayedEvent(
-                                knownDisconnectDelayId,
-                                UpdateDelayedEventAction.Restart,
-                            ),
+                        await resendIfRateLimited(
+                            () =>
+                                this.client._unstable_updateDelayedEvent(
+                                    knownDisconnectDelayId,
+                                    UpdateDelayedEventAction.Restart,
+                                ),
+                            1000,
                         );
                     } catch (e) {
                         logger.warn("Failed to update delayed disconnection event, prepare it again:", e);


### PR DESCRIPTION
n.b. The original scope of this PR has changed (reduced). It is not feasible to test this at the moment. We are planning a refactor of this class to make it easier to test.
 
With it being set to one the following issue could occur:

```
// If sending state cancels your own delayed state, prepare another delayed state
// TODO: Remove this once MSC4140 is stable & doesn't cancel own delayed state
if (this.disconnectDelayId !== undefined) {
    try {
        const knownDisconnectDelayId = this.disconnectDelayId;
        await resendIfRateLimited(
            () =>
                this.client._unstable_updateDelayedEvent(
                    knownDisconnectDelayId,
                    UpdateDelayedEventAction.Restart,
                ),
            1000,
        );
    } catch (e) {
        logger.warn("Failed to update delayed disconnection event, prepare it again:", e);
        this.disconnectDelayId = undefined;
        await prepareDelayedDisconnection();
    }
}
```
This code looks like the `catch(e)` could never be triggered with 429 (rate limit) because they would be caught by `await resendIfRateLimited`. EXCEPT that this is only happening once: `resendIfRateLimited<T>(func: () => Promise<T>, numRetriesAllowed: number = 1)`. So as soon as the server sends two rate limits in a row we get the following:
 - we get into the `catch(e)`  because of the rate limit
 - we forget about `this.disconnectDelayId = undefined`
 - we start a new delayed event `await prepareDelayedDisconnection();`
 - we do not anymore update the old delayed event which is still running!
 - the running delay event will make us disconnect from the call (call member becomes `{}`)
 - we get into our other error catching mechanism that resends the new state event
 - this cancels the newly created delay leave event (`await prepareDelayedDisconnection();`)
 - and create another delay leave event.
 - but if we are still rate limited (chances are really high due to the reconnect), this loop will REPEAT

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
