### PR TITLE
Handle when `aud` OIDC claim is an Array

### DIFF
--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -170,6 +170,14 @@ describe("validateIdToken()", () => {
         expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));
     });
 
+    it("should not throw for a list of trusted audiences", () => {
+        mocked(jwtDecode).mockReturnValue({
+            ...validDecodedIdToken,
+            aud: [clientId],
+        });
+        expect(() => validateIdToken(idToken, issuer, clientId, nonce)).not.toThrow();
+    });
+
     it("should throw when nonce does not match", () => {
         mocked(jwtDecode).mockReturnValue({
             ...validDecodedIdToken,

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -155,7 +155,7 @@ describe("validateIdToken()", () => {
     it("should throw when audience does not include clientId", () => {
         mocked(jwtDecode).mockReturnValue({
             ...validDecodedIdToken,
-            aud: "qwerty,uiop,asdf",
+            aud: "qwerty-uiop-asdf",
         });
         expect(() => validateIdToken(idToken, issuer, clientId, nonce)).toThrow(new Error(OidcError.InvalidIdToken));
         expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));
@@ -164,7 +164,7 @@ describe("validateIdToken()", () => {
     it("should throw when audience includes clientId and other audiences", () => {
         mocked(jwtDecode).mockReturnValue({
             ...validDecodedIdToken,
-            aud: `${clientId},uiop,asdf`,
+            aud: `${clientId}-uiop-asdf`,
         });
         expect(() => validateIdToken(idToken, issuer, clientId, nonce)).toThrow(new Error(OidcError.InvalidIdToken));
         expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));
@@ -181,7 +181,7 @@ describe("validateIdToken()", () => {
     it("should throw when audience is an array that does not include clientId", () => {
         mocked(jwtDecode).mockReturnValue({
             ...validDecodedIdToken,
-            aud: [`${clientId},uiop`, "asdf"],
+            aud: ["qwerty-uiop-asdf", "asdf"],
         });
         expect(() => validateIdToken(idToken, issuer, clientId, nonce)).toThrow(new Error(OidcError.InvalidIdToken));
         expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -170,12 +170,21 @@ describe("validateIdToken()", () => {
         expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));
     });
 
-    it("should not throw for a list of trusted audiences", () => {
+    it("should not throw when audience is an array that includes clientId", () => {
         mocked(jwtDecode).mockReturnValue({
             ...validDecodedIdToken,
             aud: [clientId],
         });
         expect(() => validateIdToken(idToken, issuer, clientId, nonce)).not.toThrow();
+    });
+
+    it("should throw when audience is an array that does not include clientId", () => {
+        mocked(jwtDecode).mockReturnValue({
+            ...validDecodedIdToken,
+            aud: [`${clientId},uiop`, "asdf"],
+        });
+        expect(() => validateIdToken(idToken, issuer, clientId, nonce)).toThrow(new Error(OidcError.InvalidIdToken));
+        expect(logger.error).toHaveBeenCalledWith("Invalid ID token", new Error("Invalid audience"));
     });
 
     it("should throw when nonce does not match", () => {

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -179,7 +179,7 @@ export const validateIdToken = (
          * The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
          * EW: Don't accept tokens with other untrusted audiences
          * */
-        if (claims.aud !== clientId) {
+        if (claims.aud !== clientId && !(Array.isArray(claims.aud) && claims.aud.includes(clientId))) {
             throw new Error("Invalid audience");
         }
 

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -179,7 +179,7 @@ export const validateIdToken = (
          * The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
          * EW: Don't accept tokens with other untrusted audiences
          * */
-        const sanitisedAuds = typeof claims.aud === 'string' ? [claims.aud] : claims.aud;
+        const sanitisedAuds = typeof claims.aud === "string" ? [claims.aud] : claims.aud;
         if (!sanitisedAuds.includes(clientId)) {
             throw new Error("Invalid audience");
         }

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -179,7 +179,8 @@ export const validateIdToken = (
          * The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
          * EW: Don't accept tokens with other untrusted audiences
          * */
-        if (claims.aud !== clientId && !(Array.isArray(claims.aud) && claims.aud.includes(clientId))) {
+        const sanitisedAuds = typeof claims.aud === 'string' ? [claims.aud] : claims.aud;
+        if (!sanitisedAuds.includes(clientId)) {
             throw new Error("Invalid audience");
         }
 


### PR DESCRIPTION
The `aud` claim of OIDC id_tokens [can be an array](https://github.com/authts/oidc-client-ts/blob/ce6d694639c58e6a1c80904efdac5eda82b82042/src/Claims.ts#L92) but the existing logic incorrectly assumes `aud` is always a string.

This PR adds the necessary check.


Signed-off-by: Liam Diprose <liam@liamdiprose.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
