### PR TITLE
Avoid key prompts when resetting crypto

### DIFF
--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -328,7 +328,7 @@ export interface CryptoApi {
 
     /**
      * Bootstrap the secret storage by creating a new secret storage key, add it in the secret storage and
-     * store the cross signing keys in the secret storage.
+     * store the cross signing and room key backup key in the secret storage.
      *
      * - Generate a new key {@link GeneratedSecretStorageKey} with `createSecretStorageKey`.
      *   Only if `setupNewSecretStorage` is set or if there is no AES key in the secret storage

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -863,12 +863,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             return;
         }
 
-        const activeBackupVersion = await this.backupManager.getActiveBackupVersion();
-        if (!activeBackupVersion || activeBackupVersion !== keyBackupInfo.version) {
-            logger.info("Not saving backup key to secret storage: backup keys do not match active backup version");
-            return;
-        }
-
         const backupKeys: RustSdkCryptoJs.BackupKeys = await this.olmMachine.getBackupKeys();
         if (!backupKeys.decryptionKey) {
             logger.info("Not saving backup key to secret storage: no backup key");
@@ -880,14 +874,9 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             return;
         }
 
-        const backupKeyFromStorage = await this.secretStorage.get("m.megolm_backup.v1");
         const backupKeyBase64 = backupKeys.decryptionKey.toBase64();
 
-        // The backup version that the key corresponds to isn't saved in 4S so if it's different, we must assume
-        // it's stale and overwrite.
-        if (backupKeyFromStorage !== backupKeyBase64) {
-            await this.secretStorage.store("m.megolm_backup.v1", backupKeyBase64);
-        }
+        await this.secretStorage.store("m.megolm_backup.v1", backupKeyBase64);
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -854,7 +854,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
 
     /**
      * If we have a backup key for the current, trusted backup in cache,
-     * and we have secret storage active, save it to secret storage.
+     * save it to secret storage.
      */
     private async saveBackupKeyToStorage(): Promise<void> {
         const keyBackupInfo = await this.backupManager.getServerBackupInfo();


### PR DESCRIPTION
Attempting to get the backup key out of secret storage can cause the user to be prompted for their key, which is not helpful if this is being done as part of a reset. This check was redundant anyway and we can just overwrite the key with the same value.

Also fix docs and remove check for active backup.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
