### PR TITLE
Don't retry on 4xx responses

### DIFF
--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -180,8 +180,8 @@ export function calculateRetryBackoff(err: any, attempts: number, retryConnectio
         return -1;
     }
 
-    if (err.httpStatus && Math.floor(err.httpStatus / 100) === 4) {
-        // client error; no amount of retrying will save you now.
+    if (err.httpStatus && Math.floor(err.httpStatus / 100) === 4 && err.httpStatus !== 429) {
+        // client error; no amount of retrying will save you now (except for rate limiting which is handled below)
         return -1;
     }
 

--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -180,7 +180,7 @@ export function calculateRetryBackoff(err: any, attempts: number, retryConnectio
         return -1;
     }
 
-    if (err.httpStatus && (err.httpStatus === 400 || err.httpStatus === 403 || err.httpStatus === 401)) {
+    if (err.httpStatus && Math.floor(err.httpStatus / 100) === 4) {
         // client error; no amount of retrying will save you now.
         return -1;
     }


### PR DESCRIPTION
I'm not sure why this was limited to a small set of 4xx responses. Nominally, no 4xx request should be retried (in fact the comment below says this, but then the code didn't quite match it).

This was causing key backup requests to be retried even when the server responded 404 because the backup in question had been deleted, meaning the client would retry uselessly and it would take longer for the client to prompt the user for action.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
