### PR TITLE
MatrixRTC: refactor MatrixRTCSession MemberManager API

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -561,7 +561,7 @@ describe("MatrixRTCSession", () => {
 
             const onMembershipsChanged = jest.fn();
             sess.on(MatrixRTCSessionEvent.MembershipsChanged, onMembershipsChanged);
-            sess.onMembershipUpdate();
+            sess.onMembershipsUpdate();
 
             expect(onMembershipsChanged).not.toHaveBeenCalled();
         });
@@ -574,7 +574,7 @@ describe("MatrixRTCSession", () => {
             sess.on(MatrixRTCSessionEvent.MembershipsChanged, onMembershipsChanged);
 
             mockRoom.getLiveTimeline().getState = jest.fn().mockReturnValue(makeMockRoomState([], mockRoom.roomId));
-            sess.onMembershipUpdate();
+            sess.onMembershipsUpdate();
 
             expect(onMembershipsChanged).toHaveBeenCalled();
         });
@@ -763,7 +763,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate], mockRoom.roomId));
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
 
                     // member2 re-joins which should trigger an immediate re-send
                     const keysSentPromise2 = new Promise<EncryptionKeysEventContent>((resolve) => {
@@ -772,7 +772,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
                     // but, that immediate resend is throttled so we need to wait a bit
                     jest.advanceTimersByTime(1000);
                     const { keys } = await keysSentPromise2;
@@ -825,7 +825,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
 
                     await keysSentPromise2;
 
@@ -879,7 +879,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockClear();
 
                     // these should be a no-op:
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
                     expect(sendEventMock).toHaveBeenCalledTimes(0);
                     expect(sess!.statistics.counters.roomEventEncryptionKeysSent).toEqual(1);
                 } finally {
@@ -933,7 +933,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockClear();
 
                     // this should be a no-op:
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
                     expect(sendEventMock).toHaveBeenCalledTimes(0);
 
                     // advance time to avoid key throttling
@@ -947,7 +947,7 @@ describe("MatrixRTCSession", () => {
                     });
 
                     // this should re-send the key
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
 
                     await keysSentPromise2;
 
@@ -1010,7 +1010,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate], mockRoom.roomId));
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
 
                     jest.advanceTimersByTime(10000);
 
@@ -1055,7 +1055,7 @@ describe("MatrixRTCSession", () => {
                                 );
                         }
 
-                        sess!.onMembershipUpdate();
+                        sess!.onMembershipsUpdate();
 
                         // advance time to avoid key throttling
                         jest.advanceTimersByTime(10000);
@@ -1096,7 +1096,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipUpdate();
+                    sess.onMembershipsUpdate();
 
                     await new Promise((resolve) => {
                         realSetTimeout(resolve);

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -555,7 +555,7 @@ describe("MatrixRTCSession", () => {
 
             const onMembershipsChanged = jest.fn();
             sess.on(MatrixRTCSessionEvent.MembershipsChanged, onMembershipsChanged);
-            sess.onMembershipsUpdate();
+            sess.onRTCSessionMemberUpdate();
 
             expect(onMembershipsChanged).not.toHaveBeenCalled();
         });
@@ -568,7 +568,7 @@ describe("MatrixRTCSession", () => {
             sess.on(MatrixRTCSessionEvent.MembershipsChanged, onMembershipsChanged);
 
             mockRoom.getLiveTimeline().getState = jest.fn().mockReturnValue(makeMockRoomState([], mockRoom.roomId));
-            sess.onMembershipsUpdate();
+            sess.onRTCSessionMemberUpdate();
 
             expect(onMembershipsChanged).toHaveBeenCalled();
         });
@@ -757,7 +757,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate], mockRoom.roomId));
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
 
                     // member2 re-joins which should trigger an immediate re-send
                     const keysSentPromise2 = new Promise<EncryptionKeysEventContent>((resolve) => {
@@ -766,7 +766,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
                     // but, that immediate resend is throttled so we need to wait a bit
                     jest.advanceTimersByTime(1000);
                     const { keys } = await keysSentPromise2;
@@ -819,7 +819,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
 
                     await keysSentPromise2;
 
@@ -873,7 +873,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockClear();
 
                     // these should be a no-op:
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
                     expect(sendEventMock).toHaveBeenCalledTimes(0);
                     expect(sess!.statistics.counters.roomEventEncryptionKeysSent).toEqual(1);
                 } finally {
@@ -927,7 +927,7 @@ describe("MatrixRTCSession", () => {
                     sendEventMock.mockClear();
 
                     // this should be a no-op:
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
                     expect(sendEventMock).toHaveBeenCalledTimes(0);
 
                     // advance time to avoid key throttling
@@ -941,7 +941,7 @@ describe("MatrixRTCSession", () => {
                     });
 
                     // this should re-send the key
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
 
                     await keysSentPromise2;
 
@@ -1004,7 +1004,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate], mockRoom.roomId));
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
 
                     jest.advanceTimersByTime(10000);
 
@@ -1049,7 +1049,7 @@ describe("MatrixRTCSession", () => {
                                 );
                         }
 
-                        sess!.onMembershipsUpdate();
+                        sess!.onRTCSessionMemberUpdate();
 
                         // advance time to avoid key throttling
                         jest.advanceTimersByTime(10000);
@@ -1090,7 +1090,7 @@ describe("MatrixRTCSession", () => {
                     mockRoom.getLiveTimeline().getState = jest
                         .fn()
                         .mockReturnValue(makeMockRoomState([membershipTemplate, member2], mockRoom.roomId));
-                    sess.onMembershipsUpdate();
+                    sess.onRTCSessionMemberUpdate();
 
                     await new Promise((resolve) => {
                         realSetTimeout(resolve);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -385,6 +385,11 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         return await leavePromise;
     }
 
+    /**
+     * Get the active focus from the current CallMemberState event
+     * @returns The focus that is currently in use to connect to this session. This is undefined
+     * if the client is not connected to this session.
+     */
     public getActiveFocus(): Focus | undefined {
         return this.membershipManager?.getActiveFocus();
     }
@@ -654,6 +659,13 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         return this.memberships[0];
     }
 
+    /**
+     * This method is used when the user is not yet connected to the Session but wants to know what focus
+     * the users in the session are using to make a decision how it wants/should connect.
+     *
+     * See also `getActiveFocus`
+     * @returns The focus which should be used when joining this session.
+     */
     public getFocusInUse(): Focus | undefined {
         const oldestMembership = this.getOldestMembership();
         if (oldestMembership?.getFocusSelection() === "oldest_membership") {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -283,7 +283,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         super();
         this._callId = memberships[0]?.callId;
         const roomState = this.room.getLiveTimeline().getState(EventTimeline.FORWARDS);
-        roomState?.on(RoomStateEvent.Members, this.onMembershipUpdate);
+        roomState?.on(RoomStateEvent.Members, this.onMembershipsUpdate);
         this.setExpiryTimer();
     }
 
@@ -305,7 +305,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             this.expiryTimeout = undefined;
         }
         const roomState = this.room.getLiveTimeline().getState(EventTimeline.FORWARDS);
-        roomState?.off(RoomStateEvent.Members, this.onMembershipUpdate);
+        roomState?.off(RoomStateEvent.Members, this.onMembershipsUpdate);
     }
 
     /**
@@ -646,7 +646,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         }
 
         if (soonestExpiry != undefined) {
-            this.expiryTimeout = setTimeout(this.onMembershipUpdate, soonestExpiry);
+            this.expiryTimeout = setTimeout(this.onMembershipsUpdate, soonestExpiry);
         }
     }
 
@@ -746,7 +746,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
      *
      * This function should be called when the room members or call memberships might have changed.
      */
-    public onMembershipUpdate = (): void => {
+    public onMembershipsUpdate = (): void => {
         const oldMemberships = this.memberships;
         this.memberships = MatrixRTCSession.callMembershipsForRoom(this.room);
 
@@ -763,7 +763,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             if (this.isJoined() && !this.memberships.some(this.isMyMembership)) {
                 logger.warn("Missing own membership: force re-join");
                 // TODO: Should this be awaited? And is there anything to tell the focus?
-                this.membershipManager?.triggerCallMembershipEventUpdate();
+                this.membershipManager?.onMembershipsUpdate();
             }
         }
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -29,7 +29,7 @@ import { decodeBase64, encodeUnpaddedBase64 } from "../base64.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { MatrixError, safeGetRetryAfterMs } from "../http-api/errors.ts";
 import { MatrixEvent } from "../models/event.ts";
-import { MembershipManager } from "./MembershipManager.ts";
+import { MembershipManager, MembershipManagerInterface } from "./MembershipManager.ts";
 
 const logger = rootLogger.getChild("MatrixRTCSession");
 
@@ -132,7 +132,7 @@ export type JoinSessionConfig = MembershipConfig & EncryptionConfig;
  * This class doesn't deal with media at all, just membership & properties of a session.
  */
 export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, MatrixRTCSessionEventHandlerMap> {
-    private membershipManager?: MembershipManager;
+    private membershipManager?: MembershipManagerInterface;
 
     // The session Id of the call, this is the call_id of the call Member event.
     private _callId: string | undefined;
@@ -283,6 +283,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         super();
         this._callId = memberships[0]?.callId;
         const roomState = this.room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+        // TODO: double check if this is actually needed. Should be covered by refreshRoom in MatrixRTCSessionManager
         roomState?.on(RoomStateEvent.Members, this.onMembershipsUpdate);
         this.setExpiryTimer();
     }
@@ -332,7 +333,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
                 this.getOldestMembership(),
             );
         }
-        this.membershipManager.join(fociPreferred, fociActive);
+        this.membershipManager!.join(fociPreferred, fociActive);
         this.manageMediaKeys = joinConfig?.manageMediaKeys ?? this.manageMediaKeys;
         if (joinConfig?.manageMediaKeys) {
             this.makeNewSenderKey();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -770,7 +770,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     };
 
     /**
-     * Call this when sth changed that impacts the current rtc members in this session.
+     * Call this when something changed that may impacts the current MatrixRTC members in this session.
      */
     public onRTCSessionMemberUpdate = (): void => {
         this.recalculateSessionMembers();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -781,11 +781,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
             logger.info(`Memberships for call in room ${this.room.roomId} have changed: emitting`);
             this.emit(MatrixRTCSessionEvent.MembershipsChanged, oldMemberships, this.memberships);
 
-            if (this.isJoined() && !this.memberships.some(this.isMyMembership)) {
-                logger.warn("Missing own membership: force re-join");
-                // TODO: Should this be awaited? And is there anything to tell the focus?
-                this.membershipManager?.onMembershipsUpdate();
-            }
+            this.membershipManager?.onMembershipsUpdate(this.memberships);
         }
 
         if (this.manageMediaKeys && this.isJoined()) {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -763,7 +763,7 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
     };
 
     /**
-     * Call this when the room members have changed.
+     * Call this when the Matrix room members have changed.
      */
     public onRoomMemberUpdate = (): void => {
         this.recalculateSessionMembers();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -755,6 +755,14 @@ export class MatrixRTCSession extends TypedEventEmitter<MatrixRTCSessionEvent, M
         m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
 
     /**
+     * @deprecated use onMembershipsUpdate instead. this should be called when any membership in the call is updated
+     * the old name might have implied to only need to call this when your own membership changes.
+     */
+    public onMembershipUpdate = (): void => {
+        this.onMembershipsUpdate();
+    };
+
+    /**
      * Examines the latest call memberships and handles any encryption key sending or rotation that is needed.
      *
      * This function should be called when the room members or call memberships might have changed.

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -153,7 +153,7 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
 
         const wasActiveAndKnown = sess.memberships.length > 0 && !isNewSession;
 
-        sess.onMembershipUpdate();
+        sess.onMembershipsUpdate();
 
         const nowActive = sess.memberships.length > 0;
 

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -153,7 +153,7 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
 
         const wasActiveAndKnown = sess.memberships.length > 0 && !isNewSession;
 
-        sess.onMembershipsUpdate();
+        sess.onRTCSessionMemberUpdate();
 
         const nowActive = sess.memberships.length > 0;
 

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -93,10 +93,10 @@ export class MembershipManager {
             return true;
         }
     }
-    public stop(): void {
-        if (this.memberEventTimeout) {
-            clearTimeout(this.memberEventTimeout);
-            this.memberEventTimeout = undefined;
+
+    public async onMembershipsUpdate(): Promise<void> {
+        return this.triggerCallMembershipEventUpdate();
+    }
         }
     }
     public triggerCallMembershipEventUpdate = async (): Promise<void> => {

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -10,7 +10,13 @@ import { CallMembership, DEFAULT_EXPIRE_DURATION, SessionMembershipData } from "
 import { Focus } from "./focus.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 import { MembershipConfig } from "./MatrixRTCSession.ts";
-
+/**
+ * This interface defines what a MembershipManager uses and exposes.
+ * This interface is what we use to write tests and allows to change the actual implementation
+ * Without breaking tests because of some internal method renaming.
+ *
+ * @internal
+ */
 export abstract class MembershipManagerInterface {
     public constructor(
         joinConfig: MembershipConfig | undefined,
@@ -48,7 +54,7 @@ export abstract class MembershipManagerInterface {
  *
  *  @internal
  */
-export class MembershipManager {
+export class MembershipManager implements MembershipManagerInterface {
     private relativeExpiry: number | undefined;
 
     private memberEventTimeout?: ReturnType<typeof setTimeout>;

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -17,25 +17,12 @@ import { MembershipConfig } from "./MatrixRTCSession.ts";
  *
  * @internal
  */
-export abstract class MembershipManagerInterface {
-    public constructor(
-        joinConfig: MembershipConfig | undefined,
-        room: Pick<Room, "getLiveTimeline">,
-        client: Pick<
-            MatrixClient,
-            | "getUserId"
-            | "getDeviceId"
-            | "sendStateEvent"
-            | "_unstable_sendDelayedEvent"
-            | "_unstable_sendDelayedStateEvent"
-        >,
-        getOldestMembership: () => CallMembership | undefined,
-    ) {}
-    public abstract isJoined(): boolean;
-    public abstract join(fociPreferred: Focus[], fociActive?: Focus): void;
-    public abstract leave(timeout: number | undefined): Promise<boolean>;
-    public abstract onMembershipsUpdate(): Promise<void>;
-    public abstract getActiveFocus(): Focus | undefined;
+export interface MembershipManagerInterface {
+    isJoined(): boolean;
+    join(fociPreferred: Focus[], fociActive?: Focus): void;
+    leave(timeout: number | undefined): Promise<boolean>;
+    onMembershipsUpdate(): Promise<void>;
+    getActiveFocus(): Focus | undefined;
 }
 
 /**
@@ -99,8 +86,16 @@ export class MembershipManager implements MembershipManagerInterface {
 
     public constructor(
         private joinConfig: MembershipConfig | undefined,
-        private room: Room,
-        private client: MatrixClient,
+        private room: Pick<Room, "getLiveTimeline" | "roomId" | "getVersion">,
+        private client: Pick<
+            MatrixClient,
+            | "getUserId"
+            | "getDeviceId"
+            | "sendStateEvent"
+            | "_unstable_sendDelayedEvent"
+            | "_unstable_sendDelayedStateEvent"
+            | "_unstable_updateDelayedEvent"
+        >,
         private getOldestMembership: () => CallMembership | undefined,
     ) {}
 

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -17,11 +17,14 @@ import { MembershipConfig } from "./MatrixRTCSession.ts";
  *
  * @internal
  */
-export interface MembershipManagerInterface {
+export interface IMembershipManager {
     isJoined(): boolean;
     join(fociPreferred: Focus[], fociActive?: Focus): void;
     leave(timeout: number | undefined): Promise<boolean>;
-    onMembershipsUpdate(memberships: CallMembership[]): Promise<void>;
+    /**
+     * call this if the MatrixRTC session members have changed
+     */
+    onRTCSessionMemberUpdate(memberships: CallMembership[]): Promise<void>;
     getActiveFocus(): Focus | undefined;
 }
 
@@ -41,7 +44,7 @@ export interface MembershipManagerInterface {
  *
  *  @internal
  */
-export class MembershipManager implements MembershipManagerInterface {
+export class LegacyMembershipManager implements IMembershipManager {
     private relativeExpiry: number | undefined;
 
     private memberEventTimeout?: ReturnType<typeof setTimeout>;
@@ -135,7 +138,7 @@ export class MembershipManager implements MembershipManagerInterface {
         }
     }
 
-    public async onMembershipsUpdate(memberships: CallMembership[]): Promise<void> {
+    public async onRTCSessionMemberUpdate(memberships: CallMembership[]): Promise<void> {
         const isMyMembership = (m: CallMembership): boolean =>
             m.sender === this.client.getUserId() && m.deviceId === this.client.getDeviceId();
 


### PR DESCRIPTION
Can be reviewed commit by commit.

This changes the api between the session and the `MembershipManager`.
It also makes sure that the tests are only using this api and nothing specific to the current `MembershipManager` implementation.

It is planned to do the same thing with the encryption logic of the session.
This allows to exchange the `MembershipManager` with a different implementation.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
