### PR TITLE
Enable @typescript-eslint/consistent-type-imports lint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -139,6 +139,8 @@ module.exports = {
                     },
                 ],
                 "no-extra-boolean-cast": "error",
+                // to avoid unnecessary runtime dependencies between files
+                "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
             },
         },
         {

--- a/src/@types/auth.ts
+++ b/src/@types/auth.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { UnstableValue } from "../NamespacedValue.ts";
-import { IClientWellKnown } from "../client.ts";
+import { type IClientWellKnown } from "../client.ts";
 
 // disable lint because these are wire responses
 /* eslint-disable camelcase */

--- a/src/@types/beacon.ts
+++ b/src/@types/beacon.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RelatesToRelationship, REFERENCE_RELATION } from "./extensible_events.ts";
+import { type RelatesToRelationship, type REFERENCE_RELATION } from "./extensible_events.ts";
 import { UnstableValue } from "../NamespacedValue.ts";
-import { MAssetEvent, MLocationEvent, MTimestampEvent } from "./location.ts";
+import { type MAssetEvent, type MLocationEvent, type MTimestampEvent } from "./location.ts";
 
 /**
  * Beacon info and beacon event types as described in MSC3672

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -16,48 +16,48 @@ limitations under the License.
 
 import { NamespacedValue, UnstableValue } from "../NamespacedValue.ts";
 import {
-    PolicyRuleEventContent,
-    RoomAvatarEventContent,
-    RoomCanonicalAliasEventContent,
-    RoomCreateEventContent,
-    RoomEncryptionEventContent,
-    RoomGuestAccessEventContent,
-    RoomHistoryVisibilityEventContent,
-    RoomJoinRulesEventContent,
-    RoomMemberEventContent,
-    RoomNameEventContent,
-    RoomPinnedEventsEventContent,
-    RoomPowerLevelsEventContent,
-    RoomServerAclEventContent,
-    RoomThirdPartyInviteEventContent,
-    RoomTombstoneEventContent,
-    RoomTopicEventContent,
-    SpaceChildEventContent,
-    SpaceParentEventContent,
+    type PolicyRuleEventContent,
+    type RoomAvatarEventContent,
+    type RoomCanonicalAliasEventContent,
+    type RoomCreateEventContent,
+    type RoomEncryptionEventContent,
+    type RoomGuestAccessEventContent,
+    type RoomHistoryVisibilityEventContent,
+    type RoomJoinRulesEventContent,
+    type RoomMemberEventContent,
+    type RoomNameEventContent,
+    type RoomPinnedEventsEventContent,
+    type RoomPowerLevelsEventContent,
+    type RoomServerAclEventContent,
+    type RoomThirdPartyInviteEventContent,
+    type RoomTombstoneEventContent,
+    type RoomTopicEventContent,
+    type SpaceChildEventContent,
+    type SpaceParentEventContent,
 } from "./state_events.ts";
-import { IGroupCallRoomMemberState, IGroupCallRoomState } from "../webrtc/groupCall.ts";
-import { MSC3089EventContent } from "../models/MSC3089Branch.ts";
-import { M_BEACON, M_BEACON_INFO, MBeaconEventContent, MBeaconInfoEventContent } from "./beacon.ts";
-import { XOR } from "./common.ts";
-import { ReactionEventContent, RoomMessageEventContent, StickerEventContent } from "./events.ts";
+import { type IGroupCallRoomMemberState, type IGroupCallRoomState } from "../webrtc/groupCall.ts";
+import { type MSC3089EventContent } from "../models/MSC3089Branch.ts";
+import { type M_BEACON, type M_BEACON_INFO, type MBeaconEventContent, type MBeaconInfoEventContent } from "./beacon.ts";
+import { type XOR } from "./common.ts";
+import { type ReactionEventContent, type RoomMessageEventContent, type StickerEventContent } from "./events.ts";
 import {
-    MCallAnswer,
-    MCallBase,
-    MCallCandidates,
-    MCallHangupReject,
-    MCallInviteNegotiate,
-    MCallReplacesEvent,
-    MCallSelectAnswer,
-    SDPStreamMetadata,
-    SDPStreamMetadataKey,
+    type MCallAnswer,
+    type MCallBase,
+    type MCallCandidates,
+    type MCallHangupReject,
+    type MCallInviteNegotiate,
+    type MCallReplacesEvent,
+    type MCallSelectAnswer,
+    type SDPStreamMetadata,
+    type SDPStreamMetadataKey,
 } from "../webrtc/callEventTypes.ts";
-import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types.ts";
-import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls.ts";
-import { SessionMembershipData } from "../matrixrtc/CallMembership.ts";
-import { LocalNotificationSettings } from "./local_notifications.ts";
-import { IPushRules } from "./PushRules.ts";
-import { SecretInfo, SecretStorageKeyDescription } from "../secret-storage.ts";
-import { POLICIES_ACCOUNT_EVENT_TYPE } from "../models/invites-ignorer-types.ts";
+import { type EncryptionKeysEventContent, type ICallNotifyContent } from "../matrixrtc/types.ts";
+import { type M_POLL_END, type M_POLL_START, type PollEndEventContent, type PollStartEventContent } from "./polls.ts";
+import { type SessionMembershipData } from "../matrixrtc/CallMembership.ts";
+import { type LocalNotificationSettings } from "./local_notifications.ts";
+import { type IPushRules } from "./PushRules.ts";
+import { type SecretInfo, type SecretStorageKeyDescription } from "../secret-storage.ts";
+import { type POLICIES_ACCOUNT_EVENT_TYPE } from "../models/invites-ignorer-types.ts";
 
 export enum EventType {
     // Room state events

--- a/src/@types/events.ts
+++ b/src/@types/events.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MsgType, RelationType } from "./event.ts";
-import { FileInfo, ImageInfo, MediaEventContent } from "./media.ts";
-import { XOR } from "./common.ts";
+import { type MsgType, type RelationType } from "./event.ts";
+import { type FileInfo, type ImageInfo, type MediaEventContent } from "./media.ts";
+import { type XOR } from "./common.ts";
 
 interface BaseTimelineEvent {
     "body": string;

--- a/src/@types/extensible_events.ts
+++ b/src/@types/extensible_events.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd, NamespacedValue, Optional, UnstableValue } from "matrix-events-sdk";
+import { type EitherAnd, NamespacedValue, type Optional, UnstableValue } from "matrix-events-sdk";
 
 import { isProvided } from "../extensible_events_v1/utilities.ts";
 

--- a/src/@types/location.ts
+++ b/src/@types/location.ts
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 // Types for MSC3488 - m.location: Extending events with location data
-import { EitherAnd } from "matrix-events-sdk";
+import { type EitherAnd } from "matrix-events-sdk";
 
 import { UnstableValue } from "../NamespacedValue.ts";
-import { M_TEXT } from "./extensible_events.ts";
+import { type M_TEXT } from "./extensible_events.ts";
 
 export enum LocationAssetType {
     Self = "m.self",

--- a/src/@types/media.ts
+++ b/src/@types/media.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MsgType } from "../@types/event.ts";
+import { type MsgType } from "../@types/event.ts";
 
 /**
  * Information on encrypted media attachments.

--- a/src/@types/polls.ts
+++ b/src/@types/polls.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd, UnstableValue } from "matrix-events-sdk";
+import { type EitherAnd, UnstableValue } from "matrix-events-sdk";
 
 import {
-    ExtensibleAnyMessageEventContent,
-    REFERENCE_RELATION,
-    RelatesToRelationship,
-    TSNamespace,
+    type ExtensibleAnyMessageEventContent,
+    type REFERENCE_RELATION,
+    type RelatesToRelationship,
+    type TSNamespace,
 } from "./extensible_events.ts";
 
 /**

--- a/src/@types/registration.ts
+++ b/src/@types/registration.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AuthDict } from "../interactive-auth.ts";
+import { type AuthDict } from "../interactive-auth.ts";
 
 /**
  * The request body of a call to `POST /_matrix/client/v3/register`.

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IContent, IEvent } from "../models/event.ts";
-import { Preset, Visibility } from "./partials.ts";
-import { IEventWithRoomId, SearchKey } from "./search.ts";
-import { IRoomEventFilter } from "../filter.ts";
-import { Direction } from "../models/event-timeline.ts";
-import { PushRuleAction } from "./PushRules.ts";
-import { IRoomEvent } from "../sync-accumulator.ts";
-import { EventType, RelationType, RoomType } from "./event.ts";
+import { type IContent, type IEvent } from "../models/event.ts";
+import { type Preset, type Visibility } from "./partials.ts";
+import { type IEventWithRoomId, type SearchKey } from "./search.ts";
+import { type IRoomEventFilter } from "../filter.ts";
+import { type Direction } from "../models/event-timeline.ts";
+import { type PushRuleAction } from "./PushRules.ts";
+import { type IRoomEvent } from "../sync-accumulator.ts";
+import { type EventType, type RelationType, type RoomType } from "./event.ts";
 
 // allow camelcase as these are things that go onto the wire
 /* eslint-disable camelcase */

--- a/src/@types/search.ts
+++ b/src/@types/search.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Types relating to the /search API
 
-import { IRoomEvent, IStateEvent } from "../sync-accumulator.ts";
-import { IRoomEventFilter } from "../filter.ts";
-import { SearchResult } from "../models/search-result.ts";
+import { type IRoomEvent, type IStateEvent } from "../sync-accumulator.ts";
+import { type IRoomEventFilter } from "../filter.ts";
+import { type SearchResult } from "../models/search-result.ts";
 
 /* eslint-disable camelcase */
 export interface IEventWithRoomId extends IRoomEvent {

--- a/src/@types/spaces.ts
+++ b/src/@types/spaces.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IPublicRoomsChunkRoom } from "../client.ts";
-import { RoomType } from "./event.ts";
-import { IStrippedState } from "../sync-accumulator.ts";
+import { type IPublicRoomsChunkRoom } from "../client.ts";
+import { type RoomType } from "./event.ts";
+import { type IStrippedState } from "../sync-accumulator.ts";
 
 // Types relating to Rooms of type `m.space` and related APIs
 

--- a/src/@types/state_events.ts
+++ b/src/@types/state_events.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RoomType } from "./event.ts";
-import { GuestAccess, HistoryVisibility, JoinRule, RestrictedAllowType } from "./partials.ts";
-import { ImageInfo } from "./media.ts";
-import { PolicyRecommendation } from "../models/invites-ignorer.ts";
+import { type RoomType } from "./event.ts";
+import { type GuestAccess, type HistoryVisibility, type JoinRule, type RestrictedAllowType } from "./partials.ts";
+import { type ImageInfo } from "./media.ts";
+import { type PolicyRecommendation } from "../models/invites-ignorer.ts";
 
 export interface RoomCanonicalAliasEventContent {
     alias?: string;

--- a/src/@types/synapse.ts
+++ b/src/@types/synapse.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IdServerUnbindResult } from "./partials.ts";
+import { type IdServerUnbindResult } from "./partials.ts";
 
 // Types relating to Synapse Admin APIs
 

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd } from "matrix-events-sdk";
+import { type EitherAnd } from "matrix-events-sdk";
 
 import { UnstableValue } from "../NamespacedValue.ts";
-import { IMessageRendering } from "./extensible_events.ts";
+import { type IMessageRendering } from "./extensible_events.ts";
 
 /**
  * Extensible topic event type based on MSC3765

--- a/src/@types/uia.ts
+++ b/src/@types/uia.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AuthDict, IAuthData } from "../interactive-auth.ts";
+import { type AuthDict, type IAuthData } from "../interactive-auth.ts";
 
 /**
  * Helper type to represent HTTP request body for a UIA enabled endpoint

--- a/src/NamespacedValue.ts
+++ b/src/NamespacedValue.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk/lib/types";
+import { type Optional } from "matrix-events-sdk/lib/types";
 
 /**
  * Represents a simple Matrix namespaced value. This will assume that if a stable prefix

--- a/src/ReEmitter.ts
+++ b/src/ReEmitter.ts
@@ -17,9 +17,9 @@ limitations under the License.
 */
 
 // eslint-disable-next-line no-restricted-imports
-import { EventEmitter } from "events";
+import { type EventEmitter } from "events";
 
-import { ListenerMap, TypedEventEmitter } from "./models/typed-event-emitter.ts";
+import { type ListenerMap, type TypedEventEmitter } from "./models/typed-event-emitter.ts";
 
 export class ReEmitter {
     public constructor(private readonly target: EventEmitter) {}

--- a/src/ToDeviceMessageQueue.ts
+++ b/src/ToDeviceMessageQueue.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import { ToDeviceMessageId } from "./@types/event.ts";
 import { logger } from "./logger.ts";
-import { MatrixClient, ClientEvent } from "./client.ts";
-import { MatrixError } from "./http-api/index.ts";
+import { type MatrixClient, ClientEvent } from "./client.ts";
+import { type MatrixError } from "./http-api/index.ts";
 import {
-    IndexedToDeviceBatch,
-    ToDeviceBatch,
-    ToDeviceBatchWithTxnId,
-    ToDevicePayload,
+    type IndexedToDeviceBatch,
+    type ToDeviceBatch,
+    type ToDeviceBatchWithTxnId,
+    type ToDevicePayload,
 } from "./models/ToDeviceMessage.ts";
 import { MatrixScheduler } from "./scheduler.ts";
 import { SyncState } from "./sync.ts";

--- a/src/autodiscovery.ts
+++ b/src/autodiscovery.ts
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IClientWellKnown, IWellKnownConfig, IServerVersions } from "./client.ts";
+import { type IClientWellKnown, type IWellKnownConfig, type IServerVersions } from "./client.ts";
 import { logger } from "./logger.ts";
-import { MatrixError, Method, timeoutSignal } from "./http-api/index.ts";
+import { type MatrixError, Method, timeoutSignal } from "./http-api/index.ts";
 import { SUPPORTED_MATRIX_VERSIONS } from "./version-support.ts";
 
 // Dev note: Auto discovery is part of the spec.

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,125 +18,151 @@ limitations under the License.
  * This is an internal module. See {@link MatrixClient} for the public class.
  */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
 import type { IDeviceKeys, IMegolmSessionData, IOneTimeKey } from "./@types/crypto.ts";
-import { ISyncStateData, SetPresence, SyncApi, SyncApiOptions, SyncState } from "./sync.ts";
+import { type ISyncStateData, type SetPresence, SyncApi, type SyncApiOptions, SyncState } from "./sync.ts";
 import {
     EventStatus,
-    IContent,
-    IDecryptOptions,
-    IEvent,
+    type IContent,
+    type IDecryptOptions,
+    type IEvent,
     MatrixEvent,
     MatrixEventEvent,
-    MatrixEventHandlerMap,
-    PushDetails,
+    type MatrixEventHandlerMap,
+    type PushDetails,
 } from "./models/event.ts";
 import { StubStore } from "./store/stub.ts";
-import { CallEvent, CallEventHandlerMap, createNewMatrixCall, MatrixCall, supportsMatrixCall } from "./webrtc/call.ts";
-import { Filter, IFilterDefinition, IRoomEventFilter } from "./filter.ts";
-import { CallEventHandler, CallEventHandlerEvent, CallEventHandlerEventHandlerMap } from "./webrtc/callEventHandler.ts";
+import {
+    type CallEvent,
+    type CallEventHandlerMap,
+    createNewMatrixCall,
+    type MatrixCall,
+    supportsMatrixCall,
+} from "./webrtc/call.ts";
+import { Filter, type IFilterDefinition, type IRoomEventFilter } from "./filter.ts";
+import {
+    CallEventHandler,
+    type CallEventHandlerEvent,
+    type CallEventHandlerEventHandlerMap,
+} from "./webrtc/callEventHandler.ts";
 import {
     GroupCallEventHandler,
-    GroupCallEventHandlerEvent,
-    GroupCallEventHandlerEventHandlerMap,
+    type GroupCallEventHandlerEvent,
+    type GroupCallEventHandlerEventHandlerMap,
 } from "./webrtc/groupCallEventHandler.ts";
 import * as utils from "./utils.ts";
-import { noUnsafeEventProps, QueryDict, replaceParam, safeSet, sleep } from "./utils.ts";
+import { noUnsafeEventProps, type QueryDict, replaceParam, safeSet, sleep } from "./utils.ts";
 import { Direction, EventTimeline } from "./models/event-timeline.ts";
-import { IActionsObject, PushProcessor } from "./pushprocessor.ts";
-import { AutoDiscovery, AutoDiscoveryAction } from "./autodiscovery.ts";
+import { type IActionsObject, PushProcessor } from "./pushprocessor.ts";
+import { AutoDiscovery, type AutoDiscoveryAction } from "./autodiscovery.ts";
 import { decodeBase64, encodeBase64, encodeUnpaddedBase64Url } from "./base64.ts";
-import { IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice.ts";
-import { IOlmDevice } from "./crypto/algorithms/megolm.ts";
+import { type IExportedDevice as IExportedOlmDevice } from "./crypto/OlmDevice.ts";
+import { type IOlmDevice } from "./crypto/algorithms/megolm.ts";
 import { TypedReEmitter } from "./ReEmitter.ts";
-import { IRoomEncryption } from "./crypto/RoomList.ts";
-import { logger, Logger } from "./logger.ts";
+import { type IRoomEncryption } from "./crypto/RoomList.ts";
+import { logger, type Logger } from "./logger.ts";
 import { SERVICE_TYPES } from "./service-types.ts";
 import {
-    Body,
+    type Body,
     ClientPrefix,
-    FileType,
-    HttpApiEvent,
-    HttpApiEventHandlerMap,
-    HTTPError,
+    type FileType,
+    type HttpApiEvent,
+    type HttpApiEventHandlerMap,
+    type HTTPError,
     IdentityPrefix,
-    IHttpOpts,
-    IRequestOpts,
+    type IHttpOpts,
+    type IRequestOpts,
     MatrixError,
     MatrixHttpApi,
     MediaPrefix,
     Method,
     retryNetworkOperation,
-    TokenRefreshFunction,
-    Upload,
-    UploadOpts,
-    UploadResponse,
+    type TokenRefreshFunction,
+    type Upload,
+    type UploadOpts,
+    type UploadResponse,
 } from "./http-api/index.ts";
 import {
     Crypto,
     CryptoEvent as LegacyCryptoEvent,
-    CryptoEventHandlerMap as LegacyCryptoEventHandlerMap,
+    type CryptoEventHandlerMap as LegacyCryptoEventHandlerMap,
     fixBackupKey,
-    ICheckOwnCrossSigningTrustOpts,
-    IRoomKeyRequestBody,
+    type ICheckOwnCrossSigningTrustOpts,
+    type IRoomKeyRequestBody,
     isCryptoAvailable,
 } from "./crypto/index.ts";
-import { DeviceInfo } from "./crypto/deviceinfo.ts";
-import { User, UserEvent, UserEventHandlerMap } from "./models/user.ts";
+import { type DeviceInfo } from "./crypto/deviceinfo.ts";
+import { User, UserEvent, type UserEventHandlerMap } from "./models/user.ts";
 import { getHttpUriForMxc } from "./content-repo.ts";
 import { SearchResult } from "./models/search-result.ts";
-import { DEHYDRATION_ALGORITHM, IDehydratedDevice, IDehydratedDeviceKeyInfo } from "./crypto/dehydration.ts";
+import { DEHYDRATION_ALGORITHM, type IDehydratedDevice, type IDehydratedDeviceKeyInfo } from "./crypto/dehydration.ts";
 import {
-    IKeyBackupInfo,
-    IKeyBackupPrepareOpts,
-    IKeyBackupRestoreOpts,
-    IKeyBackupRestoreResult,
-    IKeyBackupRoomSessions,
-    IKeyBackupSession,
+    type IKeyBackupInfo,
+    type IKeyBackupPrepareOpts,
+    type IKeyBackupRestoreOpts,
+    type IKeyBackupRestoreResult,
+    type IKeyBackupRoomSessions,
+    type IKeyBackupSession,
 } from "./crypto/keybackup.ts";
-import { IIdentityServerProvider } from "./@types/IIdentityServerProvider.ts";
-import { MatrixScheduler } from "./scheduler.ts";
-import { BeaconEvent, BeaconEventHandlerMap } from "./models/beacon.ts";
-import { AuthDict } from "./interactive-auth.ts";
-import { IMinimalEvent, IRoomEvent, IStateEvent } from "./sync-accumulator.ts";
-import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./crypto/api.ts";
-import { EventTimelineSet } from "./models/event-timeline-set.ts";
-import { VerificationRequest } from "./crypto/verification/request/VerificationRequest.ts";
-import { VerificationBase as Verification } from "./crypto/verification/Base.ts";
-import * as ContentHelpers from "./content-helpers.ts";
-import { CrossSigningInfo, DeviceTrustLevel, ICacheCallbacks, UserTrustLevel } from "./crypto/CrossSigning.ts";
-import { NotificationCountType, Room, RoomEvent, RoomEventHandlerMap, RoomNameState } from "./models/room.ts";
-import { RoomMemberEvent, RoomMemberEventHandlerMap } from "./models/room-member.ts";
-import { IPowerLevelsContent, RoomStateEvent, RoomStateEventHandlerMap } from "./models/room-state.ts";
+import { type IIdentityServerProvider } from "./@types/IIdentityServerProvider.ts";
+import { type MatrixScheduler } from "./scheduler.ts";
+import { type BeaconEvent, type BeaconEventHandlerMap } from "./models/beacon.ts";
+import { type AuthDict } from "./interactive-auth.ts";
+import { type IMinimalEvent, type IRoomEvent, type IStateEvent } from "./sync-accumulator.ts";
 import {
-    DelayedEventInfo,
-    IAddThreePidOnlyBody,
-    IBindThreePidBody,
-    IContextResponse,
-    ICreateRoomOpts,
-    IEventSearchOpts,
-    IFilterResponse,
-    IGuestAccessOpts,
-    IJoinRoomOpts,
-    INotificationsResponse,
-    IPaginateOpts,
-    IPresenceOpts,
-    IRedactOpts,
-    IRelationsRequestOpts,
-    IRelationsResponse,
-    IRoomDirectoryOptions,
-    ISearchOpts,
-    ISendEventResponse,
-    IStatusResponse,
-    ITagsResponse,
-    KnockRoomOpts,
-    SendDelayedEventRequestOpts,
-    SendDelayedEventResponse,
-    UpdateDelayedEventAction,
+    CrossSigningKey,
+    type ICreateSecretStorageOpts,
+    type IEncryptedEventInfo,
+    type IRecoveryKey,
+} from "./crypto/api.ts";
+import { type EventTimelineSet } from "./models/event-timeline-set.ts";
+import { type VerificationRequest } from "./crypto/verification/request/VerificationRequest.ts";
+import { type VerificationBase as Verification } from "./crypto/verification/Base.ts";
+import * as ContentHelpers from "./content-helpers.ts";
+import {
+    type CrossSigningInfo,
+    type DeviceTrustLevel,
+    type ICacheCallbacks,
+    type UserTrustLevel,
+} from "./crypto/CrossSigning.ts";
+import {
+    NotificationCountType,
+    type Room,
+    type RoomEvent,
+    type RoomEventHandlerMap,
+    type RoomNameState,
+} from "./models/room.ts";
+import { RoomMemberEvent, type RoomMemberEventHandlerMap } from "./models/room-member.ts";
+import { type IPowerLevelsContent, type RoomStateEvent, type RoomStateEventHandlerMap } from "./models/room-state.ts";
+import {
+    type DelayedEventInfo,
+    type IAddThreePidOnlyBody,
+    type IBindThreePidBody,
+    type IContextResponse,
+    type ICreateRoomOpts,
+    type IEventSearchOpts,
+    type IFilterResponse,
+    type IGuestAccessOpts,
+    type IJoinRoomOpts,
+    type INotificationsResponse,
+    type IPaginateOpts,
+    type IPresenceOpts,
+    type IRedactOpts,
+    type IRelationsRequestOpts,
+    type IRelationsResponse,
+    type IRoomDirectoryOptions,
+    type ISearchOpts,
+    type ISendEventResponse,
+    type IStatusResponse,
+    type ITagsResponse,
+    type KnockRoomOpts,
+    type SendDelayedEventRequestOpts,
+    type SendDelayedEventResponse,
+    type UpdateDelayedEventAction,
 } from "./@types/requests.ts";
 import {
-    AccountDataEvents,
+    type AccountDataEvents,
     EventType,
     LOCAL_NOTIFICATION_SETTINGS_PREFIX,
     MSC3912_RELATION_BASED_REDACTIONS_PROP,
@@ -145,8 +171,8 @@ import {
     RelationType,
     RoomCreateTypeField,
     RoomType,
-    StateEvents,
-    TimelineEvents,
+    type StateEvents,
+    type TimelineEvents,
     UNSTABLE_MSC3088_ENABLED,
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
@@ -154,53 +180,64 @@ import {
 import {
     GuestAccess,
     HistoryVisibility,
-    IdServerUnbindResult,
-    JoinRule,
+    type IdServerUnbindResult,
+    type JoinRule,
     Preset,
-    Visibility,
+    type Visibility,
 } from "./@types/partials.ts";
-import { EventMapper, eventMapperFor, MapperOpts } from "./event-mapper.ts";
+import { type EventMapper, eventMapperFor, type MapperOpts } from "./event-mapper.ts";
 import { randomString } from "./randomstring.ts";
-import { BackupManager, IKeyBackup, IKeyBackupCheck, IPreparedKeyBackupVersion, TrustInfo } from "./crypto/backup.ts";
-import { DEFAULT_TREE_POWER_LEVELS_TEMPLATE, MSC3089TreeSpace } from "./models/MSC3089TreeSpace.ts";
-import { ISignatures } from "./@types/signed.ts";
-import { IStore } from "./store/index.ts";
-import { ISecretRequest } from "./crypto/SecretStorage.ts";
 import {
-    IEventWithRoomId,
-    ISearchRequestBody,
-    ISearchResponse,
-    ISearchResults,
-    IStateEventWithRoomId,
+    BackupManager,
+    type IKeyBackup,
+    type IKeyBackupCheck,
+    type IPreparedKeyBackupVersion,
+    type TrustInfo,
+} from "./crypto/backup.ts";
+import { DEFAULT_TREE_POWER_LEVELS_TEMPLATE, MSC3089TreeSpace } from "./models/MSC3089TreeSpace.ts";
+import { type ISignatures } from "./@types/signed.ts";
+import { type IStore } from "./store/index.ts";
+import { type ISecretRequest } from "./crypto/SecretStorage.ts";
+import {
+    type IEventWithRoomId,
+    type ISearchRequestBody,
+    type ISearchResponse,
+    type ISearchResults,
+    type IStateEventWithRoomId,
     SearchOrderBy,
 } from "./@types/search.ts";
-import { ISynapseAdminDeactivateResponse, ISynapseAdminWhoisResponse } from "./@types/synapse.ts";
-import { IHierarchyRoom } from "./@types/spaces.ts";
+import { type ISynapseAdminDeactivateResponse, type ISynapseAdminWhoisResponse } from "./@types/synapse.ts";
+import { type IHierarchyRoom } from "./@types/spaces.ts";
 import {
-    IPusher,
-    IPusherRequest,
-    IPushRule,
-    IPushRules,
-    PushRuleAction,
+    type IPusher,
+    type IPusherRequest,
+    type IPushRule,
+    type IPushRules,
+    type PushRuleAction,
     PushRuleActionName,
     PushRuleKind,
-    RuleId,
+    type RuleId,
 } from "./@types/PushRules.ts";
-import { IThreepid } from "./@types/threepids.ts";
-import { CryptoStore, OutgoingRoomKeyRequest } from "./crypto/store/base.ts";
-import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./webrtc/groupCall.ts";
+import { type IThreepid } from "./@types/threepids.ts";
+import { type CryptoStore, type OutgoingRoomKeyRequest } from "./crypto/store/base.ts";
+import {
+    GroupCall,
+    type GroupCallIntent,
+    type GroupCallType,
+    type IGroupCallDataChannelOptions,
+} from "./webrtc/groupCall.ts";
 import { MediaHandler } from "./webrtc/mediaHandler.ts";
 import {
-    ILoginFlowsResponse,
-    IRefreshTokenResponse,
-    LoginRequest,
-    LoginResponse,
-    LoginTokenPostResponse,
-    SSOAction,
+    type ILoginFlowsResponse,
+    type IRefreshTokenResponse,
+    type LoginRequest,
+    type LoginResponse,
+    type LoginTokenPostResponse,
+    type SSOAction,
 } from "./@types/auth.ts";
 import { TypedEventEmitter } from "./models/typed-event-emitter.ts";
 import { MAIN_ROOM_TIMELINE, ReceiptType } from "./@types/read_receipts.ts";
-import { MSC3575SlidingSyncRequest, MSC3575SlidingSyncResponse, SlidingSync } from "./sliding-sync.ts";
+import { type MSC3575SlidingSyncRequest, type MSC3575SlidingSyncResponse, type SlidingSync } from "./sliding-sync.ts";
 import { SlidingSyncSdk } from "./sliding-sync-sdk.ts";
 import {
     determineFeatureSupport,
@@ -210,41 +247,41 @@ import {
     ThreadFilterType,
     threadFilterTypeToFilter,
 } from "./models/thread.ts";
-import { M_BEACON_INFO, MBeaconInfoEventContent } from "./@types/beacon.ts";
+import { M_BEACON_INFO, type MBeaconInfoEventContent } from "./@types/beacon.ts";
 import { NamespacedValue, UnstableValue } from "./NamespacedValue.ts";
 import { ToDeviceMessageQueue } from "./ToDeviceMessageQueue.ts";
-import { ToDeviceBatch } from "./models/ToDeviceMessage.ts";
+import { type ToDeviceBatch } from "./models/ToDeviceMessage.ts";
 import { IgnoredInvites } from "./models/invites-ignorer.ts";
-import { UIARequest, UIAResponse } from "./@types/uia.ts";
-import { LocalNotificationSettings } from "./@types/local_notifications.ts";
+import { type UIARequest, type UIAResponse } from "./@types/uia.ts";
+import { type LocalNotificationSettings } from "./@types/local_notifications.ts";
 import { buildFeatureSupportMap, Feature, ServerSupport } from "./feature.ts";
-import { BackupDecryptor, CryptoBackend } from "./common-crypto/CryptoBackend.ts";
+import { type BackupDecryptor, type CryptoBackend } from "./common-crypto/CryptoBackend.ts";
 import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants.ts";
 import {
-    BootstrapCrossSigningOpts,
-    CrossSigningKeyInfo,
-    CryptoApi,
+    type BootstrapCrossSigningOpts,
+    type CrossSigningKeyInfo,
+    type CryptoApi,
     decodeRecoveryKey,
-    ImportRoomKeysOpts,
+    type ImportRoomKeysOpts,
     CryptoEvent,
-    CryptoEventHandlerMap,
-    CryptoCallbacks,
+    type CryptoEventHandlerMap,
+    type CryptoCallbacks,
 } from "./crypto-api/index.ts";
-import { DeviceInfoMap } from "./crypto/DeviceList.ts";
+import { type DeviceInfoMap } from "./crypto/DeviceList.ts";
 import {
-    AddSecretStorageKeyOpts,
-    SecretStorageKey,
-    SecretStorageKeyDescription,
-    ServerSideSecretStorage,
+    type AddSecretStorageKeyOpts,
+    type SecretStorageKey,
+    type SecretStorageKeyDescription,
+    type ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
 } from "./secret-storage.ts";
-import { RegisterRequest, RegisterResponse } from "./@types/registration.ts";
+import { type RegisterRequest, type RegisterResponse } from "./@types/registration.ts";
 import { MatrixRTCSessionManager } from "./matrixrtc/MatrixRTCSessionManager.ts";
 import { getRelationsThreadFilter } from "./thread-utils.ts";
-import { KnownMembership, Membership } from "./@types/membership.ts";
-import { RoomMessageEventContent, StickerEventContent } from "./@types/events.ts";
-import { ImageInfo } from "./@types/media.ts";
-import { Capabilities, ServerCapabilities } from "./serverCapabilities.ts";
+import { KnownMembership, type Membership } from "./@types/membership.ts";
+import { type RoomMessageEventContent, type StickerEventContent } from "./@types/events.ts";
+import { type ImageInfo } from "./@types/media.ts";
+import { type Capabilities, ServerCapabilities } from "./serverCapabilities.ts";
 import { sha256 } from "./digest.ts";
 import { keyFromAuthData } from "./common-crypto/key-passphrase.ts";
 

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -15,13 +15,13 @@ limitations under the License.
 */
 
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.ts";
-import { IClearEvent, MatrixEvent } from "../models/event.ts";
-import { Room } from "../models/room.ts";
-import { CryptoApi, DecryptionFailureCode, ImportRoomKeysOpts } from "../crypto-api/index.ts";
-import { CrossSigningInfo, UserTrustLevel } from "../crypto/CrossSigning.ts";
-import { IEncryptedEventInfo } from "../crypto/api.ts";
-import { KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.ts";
-import { IMegolmSessionData } from "../@types/crypto.ts";
+import { type IClearEvent, type MatrixEvent } from "../models/event.ts";
+import { type Room } from "../models/room.ts";
+import { type CryptoApi, type DecryptionFailureCode, type ImportRoomKeysOpts } from "../crypto-api/index.ts";
+import { type CrossSigningInfo, type UserTrustLevel } from "../crypto/CrossSigning.ts";
+import { type IEncryptedEventInfo } from "../crypto/api.ts";
+import { type KeyBackupInfo, type KeyBackupSession } from "../crypto-api/keybackup.ts";
+import { type IMegolmSessionData } from "../@types/crypto.ts";
 
 /**
  * Common interface for the crypto implementations

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon.ts";
+import { type MBeaconEventContent, type MBeaconInfoContent, type MBeaconInfoEventContent } from "./@types/beacon.ts";
 import { MsgType } from "./@types/event.ts";
 import { M_TEXT, REFERENCE_RELATION } from "./@types/extensible_events.ts";
 import { isProvided } from "./extensible_events_v1/utilities.ts";
@@ -23,14 +23,14 @@ import {
     LocationAssetType,
     M_LOCATION,
     M_TIMESTAMP,
-    LocationEventWireContent,
-    MLocationEventContent,
-    MLocationContent,
-    MAssetContent,
-    LegacyLocationEventContent,
+    type LocationEventWireContent,
+    type MLocationEventContent,
+    type MLocationContent,
+    type MAssetContent,
+    type LegacyLocationEventContent,
 } from "./@types/location.ts";
-import { MRoomTopicEventContent, MTopicContent, M_TOPIC } from "./@types/topic.ts";
-import { RoomMessageEventContent } from "./@types/events.ts";
+import { type MRoomTopicEventContent, type MTopicContent, M_TOPIC } from "./@types/topic.ts";
+import { type RoomMessageEventContent } from "./@types/events.ts";
 
 /**
  * Generates the content for a HTML Message event

--- a/src/crypto-api/CryptoEventHandlerMap.ts
+++ b/src/crypto-api/CryptoEventHandlerMap.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { CryptoEvent } from "./CryptoEvent.ts";
-import { VerificationRequest } from "./verification.ts";
-import { UserVerificationStatus } from "./index.ts";
-import { RustBackupCryptoEventMap } from "../rust-crypto/backup.ts";
+import { type CryptoEvent } from "./CryptoEvent.ts";
+import { type VerificationRequest } from "./verification.ts";
+import { type UserVerificationStatus } from "./index.ts";
+import { type RustBackupCryptoEventMap } from "../rust-crypto/backup.ts";
 
 /**
  * A map of the {@link CryptoEvent} fired by the {@link CryptoApi} and their payloads.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -17,20 +17,20 @@ limitations under the License.
 import type { SecretsBundle } from "@matrix-org/matrix-sdk-crypto-wasm";
 import type { IMegolmSessionData } from "../@types/crypto.ts";
 import type { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
-import { Room } from "../models/room.ts";
-import { DeviceMap } from "../models/device.ts";
-import { UIAuthCallback } from "../interactive-auth.ts";
-import { PassphraseInfo, SecretStorageKeyDescription } from "../secret-storage.ts";
-import { VerificationRequest } from "./verification.ts";
+import { type Room } from "../models/room.ts";
+import { type DeviceMap } from "../models/device.ts";
+import { type UIAuthCallback } from "../interactive-auth.ts";
+import { type PassphraseInfo, type SecretStorageKeyDescription } from "../secret-storage.ts";
+import { type VerificationRequest } from "./verification.ts";
 import {
-    BackupTrustInfo,
-    KeyBackupCheck,
-    KeyBackupInfo,
-    KeyBackupRestoreOpts,
-    KeyBackupRestoreResult,
+    type BackupTrustInfo,
+    type KeyBackupCheck,
+    type KeyBackupInfo,
+    type KeyBackupRestoreOpts,
+    type KeyBackupRestoreResult,
 } from "./keybackup.ts";
-import { ISignatures } from "../@types/signed.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type ISignatures } from "../@types/signed.ts";
+import { type MatrixEvent } from "../models/event.ts";
 
 /**
  * `matrix-js-sdk/lib/crypto-api`: End-to-end encryption support.

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISigned } from "../@types/signed.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
-import { ImportRoomKeyProgressData } from "./index.ts";
+import { type ISigned } from "../@types/signed.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type ImportRoomKeyProgressData } from "./index.ts";
 
 export interface Curve25519AuthData {
     public_key: string;

--- a/src/crypto-api/verification.ts
+++ b/src/crypto-api/verification.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event.ts";
-import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
+import { type MatrixEvent } from "../models/event.ts";
+import { type TypedEventEmitter } from "../models/typed-event-emitter.ts";
 
 /**
  * An incoming, or outgoing, request to verify a user or a device via cross-signing.

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -19,18 +19,18 @@ limitations under the License.
  */
 
 import type { PkSigning } from "@matrix-org/olm";
-import { IObject, pkSign, pkVerify } from "./olmlib.ts";
+import { type IObject, pkSign, pkVerify } from "./olmlib.ts";
 import { logger } from "../logger.ts";
 import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.ts";
-import { DeviceInfo } from "./deviceinfo.ts";
-import { ISignedKey, MatrixClient } from "../client.ts";
-import { OlmDevice } from "./OlmDevice.ts";
-import { ICryptoCallbacks } from "./index.ts";
-import { ISignatures } from "../@types/signed.ts";
-import { CryptoStore, SecretStorePrivateKeys } from "./store/base.ts";
-import { ServerSideSecretStorage, SecretStorageKeyDescription } from "../secret-storage.ts";
+import { type DeviceInfo } from "./deviceinfo.ts";
+import { type ISignedKey, type MatrixClient } from "../client.ts";
+import { type OlmDevice } from "./OlmDevice.ts";
+import { type ICryptoCallbacks } from "./index.ts";
+import { type ISignatures } from "../@types/signed.ts";
+import { type CryptoStore, type SecretStorePrivateKeys } from "./store/base.ts";
+import { type ServerSideSecretStorage, type SecretStorageKeyDescription } from "../secret-storage.ts";
 import {
-    CrossSigningKeyInfo,
+    type CrossSigningKeyInfo,
     DeviceVerificationStatus,
     UserVerificationStatus as UserTrustLevel,
 } from "../crypto-api/index.ts";

--- a/src/crypto/DeviceList.ts
+++ b/src/crypto/DeviceList.ts
@@ -19,16 +19,16 @@ limitations under the License.
  */
 
 import { logger } from "../logger.ts";
-import { DeviceInfo, IDevice } from "./deviceinfo.ts";
-import { CrossSigningInfo, ICrossSigningInfo } from "./CrossSigning.ts";
+import { DeviceInfo, type IDevice } from "./deviceinfo.ts";
+import { CrossSigningInfo, type ICrossSigningInfo } from "./CrossSigning.ts";
 import * as olmlib from "./olmlib.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
-import { chunkPromises, defer, IDeferred, sleep } from "../utils.ts";
-import { DeviceKeys, IDownloadKeyResult, Keys, MatrixClient, SigningKeys } from "../client.ts";
-import { OlmDevice } from "./OlmDevice.ts";
-import { CryptoStore } from "./store/base.ts";
+import { chunkPromises, defer, type IDeferred, sleep } from "../utils.ts";
+import { type DeviceKeys, type IDownloadKeyResult, type Keys, type MatrixClient, type SigningKeys } from "../client.ts";
+import { type OlmDevice } from "./OlmDevice.ts";
+import { type CryptoStore } from "./store/base.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { CryptoEvent, CryptoEventHandlerMap } from "./index.ts";
+import { CryptoEvent, type CryptoEventHandlerMap } from "./index.ts";
 
 /* State transition diagram for DeviceList.deviceTrackingStatus
  *

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -16,16 +16,22 @@ limitations under the License.
 
 import { logger } from "../logger.ts";
 import { MatrixEvent } from "../models/event.ts";
-import { createCryptoStoreCacheCallbacks, ICacheCallbacks } from "./CrossSigning.ts";
+import { createCryptoStoreCacheCallbacks, type ICacheCallbacks } from "./CrossSigning.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
 import { Method, ClientPrefix } from "../http-api/index.ts";
-import { Crypto, ICryptoCallbacks } from "./index.ts";
-import { ClientEvent, ClientEventHandlerMap, CrossSigningKeys, ISignedKey, KeySignatures } from "../client.ts";
-import { IKeyBackupInfo } from "./keybackup.ts";
+import { type Crypto, type ICryptoCallbacks } from "./index.ts";
+import {
+    ClientEvent,
+    type ClientEventHandlerMap,
+    type CrossSigningKeys,
+    type ISignedKey,
+    type KeySignatures,
+} from "../client.ts";
+import { type IKeyBackupInfo } from "./keybackup.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage.ts";
-import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../crypto-api/index.ts";
-import { AccountDataEvents } from "../@types/event.ts";
+import { type AccountDataClient, type SecretStorageKeyDescription } from "../secret-storage.ts";
+import { type BootstrapCrossSigningOpts, type CrossSigningKeyInfo } from "../crypto-api/index.ts";
+import { type AccountDataEvents } from "../@types/event.ts";
 
 interface ICrossSigningKeys {
     authUpload: BootstrapCrossSigningOpts["authUploadDeviceSigningKeys"];

--- a/src/crypto/OlmDevice.ts
+++ b/src/crypto/OlmDevice.ts
@@ -14,14 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Account, InboundGroupSession, OutboundGroupSession, Session, Utility } from "@matrix-org/olm";
+import {
+    type Account,
+    type InboundGroupSession,
+    type OutboundGroupSession,
+    type Session,
+    type Utility,
+} from "@matrix-org/olm";
 
-import { logger, Logger } from "../logger.ts";
+import { logger, type Logger } from "../logger.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
-import { CryptoStore, IProblem, ISessionInfo, IWithheld } from "./store/base.ts";
-import { IOlmDevice, IOutboundGroupSessionKey } from "./algorithms/megolm.ts";
-import { IMegolmSessionData, OlmGroupSessionExtraData } from "../@types/crypto.ts";
-import { IMessage } from "./algorithms/olm.ts";
+import { type CryptoStore, type IProblem, type ISessionInfo, type IWithheld } from "./store/base.ts";
+import { type IOlmDevice, type IOutboundGroupSessionKey } from "./algorithms/megolm.ts";
+import { type IMegolmSessionData, type OlmGroupSessionExtraData } from "../@types/crypto.ts";
+import { type IMessage } from "./algorithms/olm.ts";
 import { DecryptionFailureCode } from "../crypto-api/index.ts";
 import { DecryptionError } from "../common-crypto/CryptoBackend.ts";
 

--- a/src/crypto/OutgoingRoomKeyRequestManager.ts
+++ b/src/crypto/OutgoingRoomKeyRequestManager.ts
@@ -17,9 +17,9 @@ limitations under the License.
 import { v4 as uuidv4 } from "uuid";
 
 import { logger } from "../logger.ts";
-import { MatrixClient } from "../client.ts";
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "./index.ts";
-import { CryptoStore, OutgoingRoomKeyRequest } from "./store/base.ts";
+import { type MatrixClient } from "../client.ts";
+import { type IRoomKeyRequestBody, type IRoomKeyRequestRecipient } from "./index.ts";
+import { type CryptoStore, type OutgoingRoomKeyRequest } from "./store/base.ts";
 import { EventType, ToDeviceMessageId } from "../@types/event.ts";
 import { MapWithDefault } from "../utils.ts";
 

--- a/src/crypto/RoomList.ts
+++ b/src/crypto/RoomList.ts
@@ -18,7 +18,7 @@ limitations under the License.
  * Manages the list of encrypted rooms
  */
 
-import { CryptoStore } from "./store/base.ts";
+import { type CryptoStore } from "./store/base.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
 
 /* eslint-disable camelcase */

--- a/src/crypto/SecretSharing.ts
+++ b/src/crypto/SecretSharing.ts
@@ -15,12 +15,12 @@ limitations under the License.
 */
 import { v4 as uuidv4 } from "uuid";
 
-import { MatrixClient } from "../client.ts";
-import { ICryptoCallbacks, IEncryptedContent } from "./index.ts";
-import { defer, IDeferred } from "../utils.ts";
+import { type MatrixClient } from "../client.ts";
+import { type ICryptoCallbacks, type IEncryptedContent } from "./index.ts";
+import { defer, type IDeferred } from "../utils.ts";
 import { ToDeviceMessageId } from "../@types/event.ts";
 import { logger } from "../logger.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import * as olmlib from "./olmlib.ts";
 
 export interface ISecretRequest {

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ICryptoCallbacks } from "./index.ts";
-import { MatrixEvent } from "../models/event.ts";
-import { MatrixClient } from "../client.ts";
+import { type ICryptoCallbacks } from "./index.ts";
+import { type MatrixEvent } from "../models/event.ts";
+import { type MatrixClient } from "../client.ts";
 import {
-    SecretStorageKeyDescription,
-    SecretStorageKeyTuple,
-    SecretStorageKeyObject,
-    AddSecretStorageKeyOpts,
-    AccountDataClient,
-    ServerSideSecretStorage,
+    type SecretStorageKeyDescription,
+    type SecretStorageKeyTuple,
+    type SecretStorageKeyObject,
+    type AddSecretStorageKeyOpts,
+    type AccountDataClient,
+    type ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
-    SecretStorageKey,
+    type SecretStorageKey,
 } from "../secret-storage.ts";
-import { ISecretRequest, SecretSharing } from "./SecretSharing.ts";
+import { type ISecretRequest, SecretSharing } from "./SecretSharing.ts";
 
 /* re-exports for backwards compatibility */
 export type {

--- a/src/crypto/algorithms/base.ts
+++ b/src/crypto/algorithms/base.ts
@@ -19,14 +19,19 @@ limitations under the License.
  */
 
 import type { IMegolmSessionData } from "../../@types/crypto.ts";
-import { MatrixClient } from "../../client.ts";
-import { Room } from "../../models/room.ts";
-import { OlmDevice } from "../OlmDevice.ts";
-import { IContent, MatrixEvent, RoomMember } from "../../matrix.ts";
-import { Crypto, IEncryptedContent, IEventDecryptionResult, IncomingRoomKeyRequest } from "../index.ts";
-import { DeviceInfo } from "../deviceinfo.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { DeviceInfoMap } from "../DeviceList.ts";
+import { type MatrixClient } from "../../client.ts";
+import { type Room } from "../../models/room.ts";
+import { type OlmDevice } from "../OlmDevice.ts";
+import { type IContent, type MatrixEvent, type RoomMember } from "../../matrix.ts";
+import {
+    type Crypto,
+    type IEncryptedContent,
+    type IEventDecryptionResult,
+    type IncomingRoomKeyRequest,
+} from "../index.ts";
+import { type DeviceInfo } from "../deviceinfo.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type DeviceInfoMap } from "../DeviceList.ts";
 
 /**
  * Map of registered encryption algorithm classes. A map from string to {@link EncryptionAlgorithm} class

--- a/src/crypto/algorithms/megolm.ts
+++ b/src/crypto/algorithms/megolm.ts
@@ -21,27 +21,27 @@ limitations under the License.
 import { v4 as uuidv4 } from "uuid";
 
 import type { IEventDecryptionResult, IMegolmSessionData } from "../../@types/crypto.ts";
-import { logger, Logger } from "../../logger.ts";
+import { logger, type Logger } from "../../logger.ts";
 import * as olmlib from "../olmlib.ts";
 import {
     DecryptionAlgorithm,
-    DecryptionClassParams,
+    type DecryptionClassParams,
     EncryptionAlgorithm,
-    IParams,
+    type IParams,
     registerAlgorithm,
     UnknownDeviceError,
 } from "./base.ts";
-import { IDecryptedGroupMessage, WITHHELD_MESSAGES } from "../OlmDevice.ts";
-import { Room } from "../../models/room.ts";
-import { DeviceInfo } from "../deviceinfo.ts";
-import { IOlmSessionResult } from "../olmlib.ts";
-import { DeviceInfoMap } from "../DeviceList.ts";
-import { IContent, MatrixEvent } from "../../models/event.ts";
+import { type IDecryptedGroupMessage, WITHHELD_MESSAGES } from "../OlmDevice.ts";
+import { type Room } from "../../models/room.ts";
+import { type DeviceInfo } from "../deviceinfo.ts";
+import { type IOlmSessionResult } from "../olmlib.ts";
+import { type DeviceInfoMap } from "../DeviceList.ts";
+import { type IContent, type MatrixEvent } from "../../models/event.ts";
 import { EventType, MsgType, ToDeviceMessageId } from "../../@types/event.ts";
-import { IMegolmEncryptedContent, IncomingRoomKeyRequest, IEncryptedContent } from "../index.ts";
+import { type IMegolmEncryptedContent, type IncomingRoomKeyRequest, type IEncryptedContent } from "../index.ts";
 import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.ts";
-import { OlmGroupSessionExtraData } from "../../@types/crypto.ts";
-import { MatrixError } from "../../http-api/index.ts";
+import { type OlmGroupSessionExtraData } from "../../@types/crypto.ts";
+import { type MatrixError } from "../../http-api/index.ts";
 import { immediate, MapWithDefault } from "../../utils.ts";
 import { KnownMembership } from "../../@types/membership.ts";
 import { DecryptionFailureCode } from "../../crypto-api/index.ts";

--- a/src/crypto/algorithms/olm.ts
+++ b/src/crypto/algorithms/olm.ts
@@ -23,10 +23,10 @@ import { logger } from "../../logger.ts";
 import * as olmlib from "../olmlib.ts";
 import { DeviceInfo } from "../deviceinfo.ts";
 import { DecryptionAlgorithm, EncryptionAlgorithm, registerAlgorithm } from "./base.ts";
-import { Room } from "../../models/room.ts";
-import { IContent, MatrixEvent } from "../../models/event.ts";
-import { IEncryptedContent, IOlmEncryptedContent } from "../index.ts";
-import { IInboundSession } from "../OlmDevice.ts";
+import { type Room } from "../../models/room.ts";
+import { type IContent, type MatrixEvent } from "../../models/event.ts";
+import { type IEncryptedContent, type IOlmEncryptedContent } from "../index.ts";
+import { type IInboundSession } from "../OlmDevice.ts";
 import { DecryptionFailureCode } from "../../crypto-api/index.ts";
 import { DecryptionError } from "../../common-crypto/CryptoBackend.ts";
 

--- a/src/crypto/api.ts
+++ b/src/crypto/api.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DeviceInfo } from "./deviceinfo.ts";
+import { type DeviceInfo } from "./deviceinfo.ts";
 
 /* re-exports for backwards compatibility. */
 // CrossSigningKey is used as a value in `client.ts`, we can't export it as a type

--- a/src/crypto/backup.ts
+++ b/src/crypto/backup.ts
@@ -22,27 +22,27 @@ import type { IMegolmSessionData } from "../@types/crypto.ts";
 import { MatrixClient } from "../client.ts";
 import { logger } from "../logger.ts";
 import { MEGOLM_ALGORITHM, verifySignature } from "./olmlib.ts";
-import { DeviceInfo } from "./deviceinfo.ts";
-import { DeviceTrustLevel } from "./CrossSigning.ts";
+import { type DeviceInfo } from "./deviceinfo.ts";
+import { type DeviceTrustLevel } from "./CrossSigning.ts";
 import { keyFromPassphrase } from "./key_passphrase.ts";
 import { encodeUri, safeSet, sleep } from "../utils.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
 import {
-    Curve25519SessionData,
-    IAes256AuthData,
-    ICurve25519AuthData,
-    IKeyBackupInfo,
-    IKeyBackupSession,
+    type Curve25519SessionData,
+    type IAes256AuthData,
+    type ICurve25519AuthData,
+    type IKeyBackupInfo,
+    type IKeyBackupSession,
 } from "./keybackup.ts";
 import { UnstableValue } from "../NamespacedValue.ts";
 import { CryptoEvent } from "./index.ts";
-import { ClientPrefix, HTTPError, MatrixError, Method } from "../http-api/index.ts";
-import { BackupTrustInfo } from "../crypto-api/keybackup.ts";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
+import { ClientPrefix, type HTTPError, MatrixError, Method } from "../http-api/index.ts";
+import { type BackupTrustInfo } from "../crypto-api/keybackup.ts";
+import { type BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 import { encodeRecoveryKey } from "../crypto-api/index.ts";
 import decryptAESSecretStorageItem from "../utils/decryptAESSecretStorageItem.ts";
 import encryptAESSecretStorageItem from "../utils/encryptAESSecretStorageItem.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 import { calculateKeyCheck } from "../secret-storage.ts";
 
 const KEY_BACKUP_KEYS_PER_REQUEST = 200;

--- a/src/crypto/dehydration.ts
+++ b/src/crypto/dehydration.ts
@@ -20,9 +20,9 @@ import type { IDeviceKeys, IOneTimeKey } from "../@types/crypto.ts";
 import { decodeBase64, encodeBase64 } from "../base64.ts";
 import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.ts";
 import { logger } from "../logger.ts";
-import { Crypto } from "./index.ts";
+import { type Crypto } from "./index.ts";
 import { Method } from "../http-api/index.ts";
-import { SecretStorageKeyDescription } from "../secret-storage.ts";
+import { type SecretStorageKeyDescription } from "../secret-storage.ts";
 import decryptAESSecretStorageItem from "../utils/decryptAESSecretStorageItem.ts";
 import encryptAESSecretStorageItem from "../utils/encryptAESSecretStorageItem.ts";
 

--- a/src/crypto/device-converter.ts
+++ b/src/crypto/device-converter.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Device } from "../models/device.ts";
-import { DeviceInfo } from "./deviceinfo.ts";
+import { type DeviceInfo } from "./deviceinfo.ts";
 
 /**
  * Convert a {@link DeviceInfo} to a {@link Device}.

--- a/src/crypto/deviceinfo.ts
+++ b/src/crypto/deviceinfo.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISignatures } from "../@types/signed.ts";
+import { type ISignatures } from "../@types/signed.ts";
 import { DeviceVerification } from "../models/device.ts";
 
 export interface IDevice {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -25,95 +25,101 @@ import type { PkDecryption, PkSigning } from "@matrix-org/olm";
 import { EventType, ToDeviceMessageId } from "../@types/event.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { logger } from "../logger.ts";
-import { IExportedDevice, OlmDevice } from "./OlmDevice.ts";
-import { IOlmDevice } from "./algorithms/megolm.ts";
+import { type IExportedDevice, OlmDevice } from "./OlmDevice.ts";
+import { type IOlmDevice } from "./algorithms/megolm.ts";
 import * as olmlib from "./olmlib.ts";
-import { DeviceInfoMap, DeviceList } from "./DeviceList.ts";
-import { DeviceInfo, IDevice } from "./deviceinfo.ts";
+import { type DeviceInfoMap, DeviceList } from "./DeviceList.ts";
+import { DeviceInfo, type IDevice } from "./deviceinfo.ts";
 import type { DecryptionAlgorithm, EncryptionAlgorithm } from "./algorithms/index.ts";
 import * as algorithms from "./algorithms/index.ts";
 import { createCryptoStoreCacheCallbacks, CrossSigningInfo, DeviceTrustLevel, UserTrustLevel } from "./CrossSigning.ts";
 import { EncryptionSetupBuilder } from "./EncryptionSetup.ts";
 import { SecretStorage as LegacySecretStorage } from "./SecretStorage.ts";
-import { CrossSigningKey, ICreateSecretStorageOpts, IEncryptedEventInfo, IRecoveryKey } from "./api.ts";
+import { CrossSigningKey, type ICreateSecretStorageOpts, type IEncryptedEventInfo, type IRecoveryKey } from "./api.ts";
 import { OutgoingRoomKeyRequestManager } from "./OutgoingRoomKeyRequestManager.ts";
 import { IndexedDBCryptoStore } from "./store/indexeddb-crypto-store.ts";
-import { VerificationBase } from "./verification/Base.ts";
+import { type VerificationBase } from "./verification/Base.ts";
 import { ReciprocateQRCode, SCAN_QR_CODE_METHOD, SHOW_QR_CODE_METHOD } from "./verification/QRCode.ts";
 import { SAS as SASVerification } from "./verification/SAS.ts";
 import { keyFromPassphrase } from "./key_passphrase.ts";
 import { VerificationRequest } from "./verification/request/VerificationRequest.ts";
 import { InRoomChannel, InRoomRequests } from "./verification/request/InRoomChannel.ts";
-import { Request, ToDeviceChannel, ToDeviceRequests } from "./verification/request/ToDeviceChannel.ts";
+import { type Request, ToDeviceChannel, ToDeviceRequests } from "./verification/request/ToDeviceChannel.ts";
 import { IllegalMethod } from "./verification/IllegalMethod.ts";
 import { KeySignatureUploadError } from "../errors.ts";
 import { DehydrationManager } from "./dehydration.ts";
 import { BackupManager, LibOlmBackupDecryptor, backupTrustInfoFromLegacyTrustInfo } from "./backup.ts";
-import { IStore } from "../store/index.ts";
-import { Room, RoomEvent } from "../models/room.ts";
-import { RoomMember, RoomMemberEvent } from "../models/room-member.ts";
-import { EventStatus, IContent, IEvent, MatrixEvent, MatrixEventEvent } from "../models/event.ts";
-import { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
-import { ClientEvent, IKeysUploadResponse, ISignedKey, IUploadKeySignaturesResponse, MatrixClient } from "../client.ts";
-import { IRoomEncryption, RoomList } from "./RoomList.ts";
-import { IKeyBackupInfo } from "./keybackup.ts";
-import { ISyncStateData } from "../sync.ts";
-import { CryptoStore } from "./store/base.ts";
-import { IVerificationChannel } from "./verification/request/Channel.ts";
-import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { IDeviceLists, ISyncResponse, IToDeviceEvent } from "../sync-accumulator.ts";
-import { ISignatures } from "../@types/signed.ts";
-import { IMessage } from "./algorithms/olm.ts";
+import { type IStore } from "../store/index.ts";
+import { type Room, RoomEvent } from "../models/room.ts";
+import { type RoomMember, RoomMemberEvent } from "../models/room-member.ts";
+import { EventStatus, type IContent, type IEvent, MatrixEvent, MatrixEventEvent } from "../models/event.ts";
+import { type ToDeviceBatch, type ToDevicePayload } from "../models/ToDeviceMessage.ts";
 import {
-    BackupDecryptor,
-    CryptoBackend,
+    ClientEvent,
+    type IKeysUploadResponse,
+    type ISignedKey,
+    type IUploadKeySignaturesResponse,
+    MatrixClient,
+} from "../client.ts";
+import { type IRoomEncryption, RoomList } from "./RoomList.ts";
+import { type IKeyBackupInfo } from "./keybackup.ts";
+import { type ISyncStateData } from "../sync.ts";
+import { type CryptoStore } from "./store/base.ts";
+import { type IVerificationChannel } from "./verification/request/Channel.ts";
+import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
+import { type IDeviceLists, type ISyncResponse, type IToDeviceEvent } from "../sync-accumulator.ts";
+import { type ISignatures } from "../@types/signed.ts";
+import { type IMessage } from "./algorithms/olm.ts";
+import {
+    type BackupDecryptor,
+    type CryptoBackend,
     DecryptionError,
-    OnSyncCompletedData,
+    type OnSyncCompletedData,
 } from "../common-crypto/CryptoBackend.ts";
-import { RoomState, RoomStateEvent } from "../models/room-state.ts";
+import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
 import { MapWithDefault, recursiveMapToObject } from "../utils.ts";
 import {
-    AccountDataClient,
-    AddSecretStorageKeyOpts,
+    type AccountDataClient,
+    type AddSecretStorageKeyOpts,
     calculateKeyCheck,
     SECRET_STORAGE_ALGORITHM_V1_AES,
-    SecretStorageKey,
-    SecretStorageKeyDescription,
-    SecretStorageKeyObject,
-    SecretStorageKeyTuple,
+    type SecretStorageKey,
+    type SecretStorageKeyDescription,
+    type SecretStorageKeyObject,
+    type SecretStorageKeyTuple,
     ServerSideSecretStorageImpl,
 } from "../secret-storage.ts";
-import { ISecretRequest } from "./SecretSharing.ts";
+import { type ISecretRequest } from "./SecretSharing.ts";
 import {
-    BackupTrustInfo,
-    BootstrapCrossSigningOpts,
-    CrossSigningKeyInfo,
-    CrossSigningStatus,
+    type BackupTrustInfo,
+    type BootstrapCrossSigningOpts,
+    type CrossSigningKeyInfo,
+    type CrossSigningStatus,
     decodeRecoveryKey,
     DecryptionFailureCode,
-    DeviceIsolationMode,
-    DeviceVerificationStatus,
+    type DeviceIsolationMode,
+    type DeviceVerificationStatus,
     encodeRecoveryKey,
-    EventEncryptionInfo,
+    type EventEncryptionInfo,
     EventShieldColour,
     EventShieldReason,
-    ImportRoomKeysOpts,
-    KeyBackupCheck,
-    KeyBackupInfo,
-    OwnDeviceKeys,
+    type ImportRoomKeysOpts,
+    type KeyBackupCheck,
+    type KeyBackupInfo,
+    type OwnDeviceKeys,
     CryptoEvent as CryptoApiCryptoEvent,
-    CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
-    KeyBackupRestoreResult,
-    KeyBackupRestoreOpts,
+    type CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
+    type KeyBackupRestoreResult,
+    type KeyBackupRestoreOpts,
 } from "../crypto-api/index.ts";
-import { Device, DeviceMap } from "../models/device.ts";
+import { type Device, type DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
 import { ClientPrefix, MatrixError, Method } from "../http-api/index.ts";
 import { decodeBase64, encodeBase64 } from "../base64.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import decryptAESSecretStorageItem from "../utils/decryptAESSecretStorageItem.ts";
 import encryptAESSecretStorageItem from "../utils/encryptAESSecretStorageItem.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 
 /* re-exports for backwards compatibility */
 export type {

--- a/src/crypto/keybackup.ts
+++ b/src/crypto/keybackup.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Export for backward compatibility
-import { ImportRoomKeyProgressData } from "../crypto-api/index.ts";
+import { type ImportRoomKeyProgressData } from "../crypto-api/index.ts";
 
 export type {
     Curve25519AuthData as ICurve25519AuthData,

--- a/src/crypto/olmlib.ts
+++ b/src/crypto/olmlib.ts
@@ -22,14 +22,14 @@ import anotherjson from "another-json";
 
 import type { PkSigning } from "@matrix-org/olm";
 import type { IOneTimeKey } from "../@types/crypto.ts";
-import { OlmDevice } from "./OlmDevice.ts";
-import { DeviceInfo } from "./deviceinfo.ts";
-import { Logger, logger } from "../logger.ts";
-import { IClaimOTKsResult, MatrixClient } from "../client.ts";
-import { ISignatures } from "../@types/signed.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type OlmDevice } from "./OlmDevice.ts";
+import { type DeviceInfo } from "./deviceinfo.ts";
+import { type Logger, logger } from "../logger.ts";
+import { type IClaimOTKsResult, type MatrixClient } from "../client.ts";
+import { type ISignatures } from "../@types/signed.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { EventType } from "../@types/event.ts";
-import { IMessage } from "./algorithms/olm.ts";
+import { type IMessage } from "./algorithms/olm.ts";
 import { MapWithDefault } from "../utils.ts";
 
 enum Algorithm {

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.ts";
-import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
-import { TrackingStatus } from "../DeviceList.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { IDevice } from "../deviceinfo.ts";
-import { ICrossSigningInfo } from "../CrossSigning.ts";
-import { Logger } from "../../logger.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
-import { MatrixEvent } from "../../models/event.ts";
-import { DehydrationManager } from "../dehydration.ts";
-import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
-import { AESEncryptedSecretStoragePayload } from "../../@types/AESEncryptedSecretStoragePayload.ts";
+import { type IRoomKeyRequestBody, type IRoomKeyRequestRecipient } from "../index.ts";
+import { type RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.ts";
+import { type IOlmDevice } from "../algorithms/megolm.ts";
+import { type TrackingStatus } from "../DeviceList.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type IDevice } from "../deviceinfo.ts";
+import { type ICrossSigningInfo } from "../CrossSigning.ts";
+import { type Logger } from "../../logger.ts";
+import { type InboundGroupSessionData } from "../OlmDevice.ts";
+import { type MatrixEvent } from "../../models/event.ts";
+import { type DehydrationManager } from "../dehydration.ts";
+import { type CrossSigningKeyInfo } from "../../crypto-api/index.ts";
+import { type AESEncryptedSecretStoragePayload } from "../../@types/AESEncryptedSecretStoragePayload.ts";
 
 /**
  * Internal module. Definitions for storage for the crypto module

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -14,30 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Logger, logger } from "../../logger.ts";
+import { type Logger, logger } from "../../logger.ts";
 import { deepCompare } from "../../utils.ts";
 import {
-    CryptoStore,
-    IDeviceData,
-    IProblem,
-    ISession,
-    SessionExtended,
-    ISessionInfo,
-    IWithheld,
+    type CryptoStore,
+    type IDeviceData,
+    type IProblem,
+    type ISession,
+    type SessionExtended,
+    type ISessionInfo,
+    type IWithheld,
     MigrationState,
-    Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
-    SecretStorePrivateKeys,
+    type Mode,
+    type OutgoingRoomKeyRequest,
+    type ParkedSharedHistory,
+    type SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base.ts";
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
+import { type IRoomKeyRequestBody, type IRoomKeyRequestRecipient } from "../index.ts";
+import { type IOlmDevice } from "../algorithms/megolm.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type InboundGroupSessionData } from "../OlmDevice.ts";
 import { IndexedDBCryptoStore } from "./indexeddb-crypto-store.ts";
-import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
+import { type CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 const PROFILE_TRANSACTIONS = false;
 

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -14,32 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger, Logger } from "../../logger.ts";
+import { logger, type Logger } from "../../logger.ts";
 import { LocalStorageCryptoStore } from "./localStorage-crypto-store.ts";
 import { MemoryCryptoStore } from "./memory-crypto-store.ts";
 import * as IndexedDBCryptoStoreBackend from "./indexeddb-crypto-store-backend.ts";
 import { InvalidCryptoStoreError, InvalidCryptoStoreState } from "../../errors.ts";
 import * as IndexedDBHelpers from "../../indexeddb-helpers.ts";
 import {
-    CryptoStore,
-    IDeviceData,
-    IProblem,
-    ISession,
-    SessionExtended,
-    ISessionInfo,
-    IWithheld,
+    type CryptoStore,
+    type IDeviceData,
+    type IProblem,
+    type ISession,
+    type SessionExtended,
+    type ISessionInfo,
+    type IWithheld,
     MigrationState,
-    Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
-    SecretStorePrivateKeys,
+    type Mode,
+    type OutgoingRoomKeyRequest,
+    type ParkedSharedHistory,
+    type SecretStorePrivateKeys,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base.ts";
-import { IRoomKeyRequestBody } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
-import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
+import { type IRoomKeyRequestBody } from "../index.ts";
+import { type IOlmDevice } from "../algorithms/megolm.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type InboundGroupSessionData } from "../OlmDevice.ts";
+import { type CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 /*
  * Internal module. indexeddb storage for e2e.

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -17,23 +17,23 @@ limitations under the License.
 import { logger } from "../../logger.ts";
 import { MemoryCryptoStore } from "./memory-crypto-store.ts";
 import {
-    CryptoStore,
-    IDeviceData,
-    IProblem,
-    ISession,
-    SessionExtended,
-    ISessionInfo,
-    IWithheld,
+    type CryptoStore,
+    type IDeviceData,
+    type IProblem,
+    type ISession,
+    type SessionExtended,
+    type ISessionInfo,
+    type IWithheld,
     MigrationState,
-    Mode,
-    SecretStorePrivateKeys,
+    type Mode,
+    type SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
 } from "./base.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
+import { type IOlmDevice } from "../algorithms/megolm.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type InboundGroupSessionData } from "../OlmDevice.ts";
 import { safeSet } from "../../utils.ts";
-import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
+import { type CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 /**
  * Internal module. Partial localStorage backed storage for e2e.

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -17,25 +17,25 @@ limitations under the License.
 import { logger } from "../../logger.ts";
 import { deepCompare, promiseTry, safeSet } from "../../utils.ts";
 import {
-    CryptoStore,
-    IDeviceData,
-    IProblem,
-    ISession,
-    SessionExtended,
-    ISessionInfo,
-    IWithheld,
+    type CryptoStore,
+    type IDeviceData,
+    type IProblem,
+    type ISession,
+    type SessionExtended,
+    type ISessionInfo,
+    type IWithheld,
     MigrationState,
-    Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
-    SecretStorePrivateKeys,
+    type Mode,
+    type OutgoingRoomKeyRequest,
+    type ParkedSharedHistory,
+    type SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
 } from "./base.ts";
-import { IRoomKeyRequestBody } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
-import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
+import { type IRoomKeyRequestBody } from "../index.ts";
+import { type IOlmDevice } from "../algorithms/megolm.ts";
+import { type IRoomEncryption } from "../RoomList.ts";
+import { type InboundGroupSessionData } from "../OlmDevice.ts";
+import { type CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 function encodeSessionKey(senderCurve25519Key: string, sessionId: string): string {
     return encodeURIComponent(senderCurve25519Key) + "/" + encodeURIComponent(sessionId);

--- a/src/crypto/verification/Base.ts
+++ b/src/crypto/verification/Base.ts
@@ -24,17 +24,17 @@ import { EventType } from "../../@types/event.ts";
 import { logger } from "../../logger.ts";
 import { DeviceInfo } from "../deviceinfo.ts";
 import { newTimeoutError } from "./Error.ts";
-import { KeysDuringVerification, requestKeysDuringVerification } from "../CrossSigning.ts";
-import { IVerificationChannel } from "./request/Channel.ts";
-import { MatrixClient } from "../../client.ts";
-import { VerificationRequest } from "./request/VerificationRequest.ts";
+import { type KeysDuringVerification, requestKeysDuringVerification } from "../CrossSigning.ts";
+import { type IVerificationChannel } from "./request/Channel.ts";
+import { type MatrixClient } from "../../client.ts";
+import { type VerificationRequest } from "./request/VerificationRequest.ts";
 import { TypedEventEmitter } from "../../models/typed-event-emitter.ts";
 import {
-    ShowQrCodeCallbacks,
-    ShowSasCallbacks,
-    Verifier,
+    type ShowQrCodeCallbacks,
+    type ShowSasCallbacks,
+    type Verifier,
     VerifierEvent,
-    VerifierEventHandlerMap,
+    type VerifierEventHandlerMap,
 } from "../../crypto-api/verification.ts";
 
 const timeoutException = new Error("Verification timed out");

--- a/src/crypto/verification/IllegalMethod.ts
+++ b/src/crypto/verification/IllegalMethod.ts
@@ -19,11 +19,11 @@ limitations under the License.
  * do verification with this method).
  */
 
-import { VerificationBase as Base, VerificationEvent, VerificationEventHandlerMap } from "./Base.ts";
-import { IVerificationChannel } from "./request/Channel.ts";
-import { MatrixClient } from "../../client.ts";
-import { MatrixEvent } from "../../models/event.ts";
-import { VerificationRequest } from "./request/VerificationRequest.ts";
+import { VerificationBase as Base, type VerificationEvent, type VerificationEventHandlerMap } from "./Base.ts";
+import { type IVerificationChannel } from "./request/Channel.ts";
+import { type MatrixClient } from "../../client.ts";
+import { type MatrixEvent } from "../../models/event.ts";
+import { type VerificationRequest } from "./request/VerificationRequest.ts";
 
 export class IllegalMethod extends Base<VerificationEvent, VerificationEventHandlerMap> {
     public static factory(

--- a/src/crypto/verification/QRCode.ts
+++ b/src/crypto/verification/QRCode.ts
@@ -22,11 +22,11 @@ import { VerificationBase as Base } from "./Base.ts";
 import { newKeyMismatchError, newUserCancelledError } from "./Error.ts";
 import { decodeBase64, encodeUnpaddedBase64 } from "../../base64.ts";
 import { logger } from "../../logger.ts";
-import { VerificationRequest } from "./request/VerificationRequest.ts";
-import { MatrixClient } from "../../client.ts";
-import { IVerificationChannel } from "./request/Channel.ts";
-import { MatrixEvent } from "../../models/event.ts";
-import { ShowQrCodeCallbacks, VerifierEvent } from "../../crypto-api/verification.ts";
+import { type VerificationRequest } from "./request/VerificationRequest.ts";
+import { type MatrixClient } from "../../client.ts";
+import { type IVerificationChannel } from "./request/Channel.ts";
+import { type MatrixEvent } from "../../models/event.ts";
+import { type ShowQrCodeCallbacks, VerifierEvent } from "../../crypto-api/verification.ts";
 import { VerificationMethod } from "../../types.ts";
 
 export const SHOW_QR_CODE_METHOD = VerificationMethod.ShowQrCode;

--- a/src/crypto/verification/SAS.ts
+++ b/src/crypto/verification/SAS.ts
@@ -19,7 +19,7 @@ limitations under the License.
  */
 
 import anotherjson from "another-json";
-import { Utility, SAS as OlmSAS } from "@matrix-org/olm";
+import { type Utility, type SAS as OlmSAS } from "@matrix-org/olm";
 
 import { VerificationBase as Base, SwitchStartEventError } from "./Base.ts";
 import {
@@ -30,10 +30,15 @@ import {
     newUserCancelledError,
 } from "./Error.ts";
 import { logger } from "../../logger.ts";
-import { IContent, MatrixEvent } from "../../models/event.ts";
+import { type IContent, type MatrixEvent } from "../../models/event.ts";
 import { generateDecimalSas } from "./SASDecimal.ts";
 import { EventType } from "../../@types/event.ts";
-import { EmojiMapping, GeneratedSas, ShowSasCallbacks, VerifierEvent } from "../../crypto-api/verification.ts";
+import {
+    type EmojiMapping,
+    type GeneratedSas,
+    type ShowSasCallbacks,
+    VerifierEvent,
+} from "../../crypto-api/verification.ts";
 import { VerificationMethod } from "../../types.ts";
 
 // backwards-compatibility exports

--- a/src/crypto/verification/request/Channel.ts
+++ b/src/crypto/verification/request/Channel.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../../../models/event.ts";
-import { VerificationRequest } from "./VerificationRequest.ts";
+import { type MatrixEvent } from "../../../models/event.ts";
+import { type VerificationRequest } from "./VerificationRequest.ts";
 
 export interface IVerificationChannel {
     request?: VerificationRequest;

--- a/src/crypto/verification/request/InRoomChannel.ts
+++ b/src/crypto/verification/request/InRoomChannel.ts
@@ -17,11 +17,11 @@ limitations under the License.
 
 import { VerificationRequest, REQUEST_TYPE, READY_TYPE, START_TYPE } from "./VerificationRequest.ts";
 import { logger } from "../../../logger.ts";
-import { IVerificationChannel } from "./Channel.ts";
-import { EventType, TimelineEvents } from "../../../@types/event.ts";
-import { MatrixClient } from "../../../client.ts";
-import { MatrixEvent } from "../../../models/event.ts";
-import { IRequestsMap } from "../../index.ts";
+import { type IVerificationChannel } from "./Channel.ts";
+import { EventType, type TimelineEvents } from "../../../@types/event.ts";
+import { type MatrixClient } from "../../../client.ts";
+import { type MatrixEvent } from "../../../models/event.ts";
+import { type IRequestsMap } from "../../index.ts";
 
 const MESSAGE_TYPE = EventType.RoomMessage;
 const M_REFERENCE = "m.reference";

--- a/src/crypto/verification/request/ToDeviceChannel.ts
+++ b/src/crypto/verification/request/ToDeviceChannel.ts
@@ -28,9 +28,9 @@ import {
 } from "./VerificationRequest.ts";
 import { errorFromEvent, newUnexpectedMessageError } from "../Error.ts";
 import { MatrixEvent } from "../../../models/event.ts";
-import { IVerificationChannel } from "./Channel.ts";
-import { MatrixClient } from "../../../client.ts";
-import { IRequestsMap } from "../../index.ts";
+import { type IVerificationChannel } from "./Channel.ts";
+import { type MatrixClient } from "../../../client.ts";
+import { type IRequestsMap } from "../../index.ts";
 
 export type Request = VerificationRequest<ToDeviceChannel>;
 

--- a/src/crypto/verification/request/VerificationRequest.ts
+++ b/src/crypto/verification/request/VerificationRequest.ts
@@ -17,20 +17,20 @@ limitations under the License.
 import { logger } from "../../../logger.ts";
 import { errorFactory, errorFromEvent, newUnexpectedMessageError, newUnknownMethodError } from "../Error.ts";
 import { QRCodeData, SCAN_QR_CODE_METHOD } from "../QRCode.ts";
-import { IVerificationChannel } from "./Channel.ts";
-import { MatrixClient } from "../../../client.ts";
-import { MatrixEvent } from "../../../models/event.ts";
+import { type IVerificationChannel } from "./Channel.ts";
+import { type MatrixClient } from "../../../client.ts";
+import { type MatrixEvent } from "../../../models/event.ts";
 import { EventType } from "../../../@types/event.ts";
-import { VerificationBase } from "../Base.ts";
-import { VerificationMethod } from "../../index.ts";
+import { type VerificationBase } from "../Base.ts";
+import { type VerificationMethod } from "../../index.ts";
 import { TypedEventEmitter } from "../../../models/typed-event-emitter.ts";
 import {
     canAcceptVerificationRequest,
     VerificationPhase as Phase,
-    VerificationRequest as IVerificationRequest,
+    type VerificationRequest as IVerificationRequest,
     VerificationRequestEvent,
-    VerificationRequestEventHandlerMap,
-    Verifier,
+    type VerificationRequestEventHandlerMap,
+    type Verifier,
 } from "../../../crypto-api/verification.ts";
 
 // backwards-compatibility exports

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -15,47 +15,47 @@ limitations under the License.
 */
 
 import {
-    WidgetApi,
+    type WidgetApi,
     WidgetApiToWidgetAction,
     WidgetApiResponseError,
     MatrixCapabilities,
-    IWidgetApiRequest,
-    IWidgetApiAcknowledgeResponseData,
-    ISendEventToWidgetActionRequest,
-    ISendToDeviceToWidgetActionRequest,
-    ISendEventFromWidgetResponseData,
-    IWidgetApiRequestData,
-    WidgetApiAction,
-    IWidgetApiResponse,
-    IWidgetApiResponseData,
+    type IWidgetApiRequest,
+    type IWidgetApiAcknowledgeResponseData,
+    type ISendEventToWidgetActionRequest,
+    type ISendToDeviceToWidgetActionRequest,
+    type ISendEventFromWidgetResponseData,
+    type IWidgetApiRequestData,
+    type WidgetApiAction,
+    type IWidgetApiResponse,
+    type IWidgetApiResponseData,
 } from "matrix-widget-api";
 
-import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event.ts";
+import { MatrixEvent, type IEvent, type IContent, EventStatus } from "./models/event.ts";
 import {
-    ISendEventResponse,
-    SendDelayedEventRequestOpts,
-    SendDelayedEventResponse,
-    UpdateDelayedEventAction,
+    type ISendEventResponse,
+    type SendDelayedEventRequestOpts,
+    type SendDelayedEventResponse,
+    type UpdateDelayedEventAction,
 } from "./@types/requests.ts";
-import { EventType, StateEvents } from "./@types/event.ts";
+import { EventType, type StateEvents } from "./@types/event.ts";
 import { logger } from "./logger.ts";
 import {
     MatrixClient,
     ClientEvent,
-    IMatrixClientCreateOpts,
-    IStartClientOpts,
-    SendToDeviceContentMap,
-    IOpenIDToken,
+    type IMatrixClientCreateOpts,
+    type IStartClientOpts,
+    type SendToDeviceContentMap,
+    type IOpenIDToken,
     UNSTABLE_MSC4140_DELAYED_EVENTS,
 } from "./client.ts";
 import { SyncApi, SyncState } from "./sync.ts";
 import { SlidingSyncSdk } from "./sliding-sync-sdk.ts";
 import { MatrixError } from "./http-api/errors.ts";
 import { User } from "./models/user.ts";
-import { Room } from "./models/room.ts";
-import { ToDeviceBatch, ToDevicePayload } from "./models/ToDeviceMessage.ts";
-import { DeviceInfo } from "./crypto/deviceinfo.ts";
-import { IOlmDevice } from "./crypto/algorithms/megolm.ts";
+import { type Room } from "./models/room.ts";
+import { type ToDeviceBatch, type ToDevicePayload } from "./models/ToDeviceMessage.ts";
+import { type DeviceInfo } from "./crypto/deviceinfo.ts";
+import { type IOlmDevice } from "./crypto/algorithms/megolm.ts";
 import { MapWithDefault, recursiveMapToObject } from "./utils.ts";
 import { TypedEventEmitter } from "./matrix.ts";
 

--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "./client.ts";
-import { IEvent, MatrixEvent, MatrixEventEvent } from "./models/event.ts";
+import { type MatrixClient } from "./client.ts";
+import { type IEvent, MatrixEvent, MatrixEventEvent } from "./models/event.ts";
 import { RelationType } from "./@types/event.ts";
 
 export type EventMapper = (obj: Partial<IEvent>) => MatrixEvent;

--- a/src/extensible_events_v1/ExtensibleEvent.ts
+++ b/src/extensible_events_v1/ExtensibleEvent.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ExtensibleEventType, IPartialEvent } from "../@types/extensible_events.ts";
+import { type ExtensibleEventType, type IPartialEvent } from "../@types/extensible_events.ts";
 
 /**
  * Represents an Extensible Event in Matrix.

--- a/src/extensible_events_v1/MessageEvent.ts
+++ b/src/extensible_events_v1/MessageEvent.ts
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
 import { ExtensibleEvent } from "./ExtensibleEvent.ts";
 import {
-    ExtensibleEventType,
-    IMessageRendering,
-    IPartialEvent,
+    type ExtensibleEventType,
+    type IMessageRendering,
+    type IPartialEvent,
     isEventTypeSame,
     M_HTML,
     M_MESSAGE,
-    ExtensibleAnyMessageEventContent,
+    type ExtensibleAnyMessageEventContent,
     M_TEXT,
 } from "../@types/extensible_events.ts";
 import { isOptionalAString, isProvided } from "./utilities.ts";

--- a/src/extensible_events_v1/PollEndEvent.ts
+++ b/src/extensible_events_v1/PollEndEvent.ts
@@ -15,13 +15,13 @@ limitations under the License.
 */
 
 import {
-    ExtensibleEventType,
-    IPartialEvent,
+    type ExtensibleEventType,
+    type IPartialEvent,
     isEventTypeSame,
     M_TEXT,
     REFERENCE_RELATION,
 } from "../@types/extensible_events.ts";
-import { M_POLL_END, PollEndEventContent } from "../@types/polls.ts";
+import { M_POLL_END, type PollEndEventContent } from "../@types/polls.ts";
 import { ExtensibleEvent } from "./ExtensibleEvent.ts";
 import { InvalidEventError } from "./InvalidEventError.ts";
 import { MessageEvent } from "./MessageEvent.ts";

--- a/src/extensible_events_v1/PollResponseEvent.ts
+++ b/src/extensible_events_v1/PollResponseEvent.ts
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 import { ExtensibleEvent } from "./ExtensibleEvent.ts";
-import { M_POLL_RESPONSE, PollResponseEventContent, PollResponseSubtype } from "../@types/polls.ts";
+import { M_POLL_RESPONSE, type PollResponseEventContent, type PollResponseSubtype } from "../@types/polls.ts";
 import {
-    ExtensibleEventType,
-    IPartialEvent,
+    type ExtensibleEventType,
+    type IPartialEvent,
     isEventTypeSame,
     REFERENCE_RELATION,
 } from "../@types/extensible_events.ts";
 import { InvalidEventError } from "./InvalidEventError.ts";
-import { PollStartEvent } from "./PollStartEvent.ts";
+import { type PollStartEvent } from "./PollStartEvent.ts";
 
 /**
  * Represents a poll response event.

--- a/src/extensible_events_v1/PollStartEvent.ts
+++ b/src/extensible_events_v1/PollStartEvent.ts
@@ -17,15 +17,15 @@ limitations under the License.
 import { NamespacedValue } from "matrix-events-sdk";
 
 import { MessageEvent } from "./MessageEvent.ts";
-import { ExtensibleEventType, IPartialEvent, isEventTypeSame, M_TEXT } from "../@types/extensible_events.ts";
+import { type ExtensibleEventType, type IPartialEvent, isEventTypeSame, M_TEXT } from "../@types/extensible_events.ts";
 import {
-    KnownPollKind,
+    type KnownPollKind,
     M_POLL_KIND_DISCLOSED,
     M_POLL_KIND_UNDISCLOSED,
     M_POLL_START,
-    PollStartEventContent,
-    PollStartSubtype,
-    PollAnswer,
+    type PollStartEventContent,
+    type PollStartSubtype,
+    type PollAnswer,
 } from "../@types/polls.ts";
 import { InvalidEventError } from "./InvalidEventError.ts";
 import { ExtensibleEvent } from "./ExtensibleEvent.ts";

--- a/src/extensible_events_v1/utilities.ts
+++ b/src/extensible_events_v1/utilities.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
 /**
  * Determines if the given optional was provided a value.

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IServerVersions } from "./client.ts";
+import { type IServerVersions } from "./client.ts";
 
 export enum ServerSupport {
     Stable,

--- a/src/filter-component.ts
+++ b/src/filter-component.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RelationType } from "./@types/event.ts";
-import { MatrixEvent } from "./models/event.ts";
+import { type RelationType } from "./@types/event.ts";
+import { type MatrixEvent } from "./models/event.ts";
 import { FILTER_RELATED_BY_REL_TYPES, FILTER_RELATED_BY_SENDERS, THREAD_RELATION_TYPE } from "./models/thread.ts";
 
 /**

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType, RelationType } from "./@types/event.ts";
+import { type EventType, type RelationType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
-import { FilterComponent, IFilterComponent } from "./filter-component.ts";
-import { MatrixEvent } from "./models/event.ts";
+import { FilterComponent, type IFilterComponent } from "./filter-component.ts";
+import { type MatrixEvent } from "./models/event.ts";
 
 /**
  */

--- a/src/http-api/errors.ts
+++ b/src/http-api/errors.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMatrixApiError as IWidgetMatrixError } from "matrix-widget-api";
+import { type IMatrixApiError as IWidgetMatrixError } from "matrix-widget-api";
 
-import { IUsageLimit } from "../@types/partials.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type IUsageLimit } from "../@types/partials.ts";
+import { type MatrixEvent } from "../models/event.ts";
 
 interface IErrorJson extends Partial<IUsageLimit> {
     [key: string]: any; // extensible

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -19,12 +19,18 @@ limitations under the License.
  */
 
 import { checkObjectHasKeys, encodeParams } from "../utils.ts";
-import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
+import { type TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { Method } from "./method.ts";
-import { ConnectionError, MatrixError } from "./errors.ts";
-import { HttpApiEvent, HttpApiEventHandlerMap, IHttpOpts, IRequestOpts, Body } from "./interface.ts";
+import { ConnectionError, type MatrixError } from "./errors.ts";
+import {
+    HttpApiEvent,
+    type HttpApiEventHandlerMap,
+    type IHttpOpts,
+    type IRequestOpts,
+    type Body,
+} from "./interface.ts";
 import { anySignal, parseErrorResponse, timeoutSignal } from "./utils.ts";
-import { QueryDict } from "../utils.ts";
+import { type QueryDict } from "../utils.ts";
 
 interface TypedResponse<T> extends Response {
     json(): Promise<T>;

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -15,9 +15,16 @@ limitations under the License.
 */
 
 import { FetchHttpApi } from "./fetch.ts";
-import { FileType, IContentUri, IHttpOpts, Upload, UploadOpts, UploadResponse } from "./interface.ts";
+import {
+    type FileType,
+    type IContentUri,
+    type IHttpOpts,
+    type Upload,
+    type UploadOpts,
+    type UploadResponse,
+} from "./interface.ts";
 import { MediaPrefix } from "./prefix.ts";
-import { defer, QueryDict, removeElement } from "../utils.ts";
+import { defer, type QueryDict, removeElement } from "../utils.ts";
 import * as callbacks from "../realtime-callbacks.ts";
 import { Method } from "./method.ts";
 import { ConnectionError } from "./errors.ts";

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixError } from "./errors.ts";
-import { Logger } from "../logger.ts";
+import { type MatrixError } from "./errors.ts";
+import { type Logger } from "../logger.ts";
 
 export type Body = Record<string, any> | BodyInit;
 

--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { parse as parseContentType, ParsedMediaType } from "content-type";
+import { parse as parseContentType, type ParsedMediaType } from "content-type";
 
 import { logger } from "../logger.ts";
 import { sleep } from "../utils.ts";

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -17,11 +17,11 @@ limitations under the License.
 */
 
 import { logger } from "./logger.ts";
-import { MatrixClient } from "./client.ts";
-import { defer, IDeferred } from "./utils.ts";
+import { type MatrixClient } from "./client.ts";
+import { defer, type IDeferred } from "./utils.ts";
 import { MatrixError } from "./http-api/index.ts";
-import { UIAResponse } from "./@types/uia.ts";
-import { UserIdentifier } from "./@types/auth.ts";
+import { type UIAResponse } from "./@types/uia.ts";
+import { type UserIdentifier } from "./@types/auth.ts";
 
 const EMAIL_STAGE_TYPE = "m.login.email.identity";
 const MSISDN_STAGE_TYPE = "m.login.msisdn";

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { WidgetApi } from "matrix-widget-api";
+import { type WidgetApi } from "matrix-widget-api";
 
 import { MemoryCryptoStore } from "./crypto/store/memory-crypto-store.ts";
 import { MemoryStore } from "./store/memory.ts";
 import { MatrixScheduler } from "./scheduler.ts";
-import { MatrixClient, ICreateClientOpts } from "./client.ts";
-import { RoomWidgetClient, ICapabilities } from "./embedded.ts";
-import { CryptoStore } from "./crypto/store/base.ts";
+import { MatrixClient, type ICreateClientOpts } from "./client.ts";
+import { RoomWidgetClient, type ICapabilities } from "./embedded.ts";
+import { type CryptoStore } from "./crypto/store/base.ts";
 
 export * from "./client.ts";
 export * from "./serverCapabilities.ts";

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../matrix.ts";
+import { type MatrixEvent } from "../matrix.ts";
 import { deepCompare } from "../utils.ts";
-import { Focus } from "./focus.ts";
+import { type Focus } from "./focus.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 
 /**

--- a/src/matrixrtc/LivekitFocus.ts
+++ b/src/matrixrtc/LivekitFocus.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Focus } from "./focus.ts";
+import { type Focus } from "./focus.ts";
 
 export interface LivekitFocusConfig extends Focus {
     type: "livekit";

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -17,19 +17,19 @@ limitations under the License.
 import { logger as rootLogger } from "../logger.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { EventTimeline } from "../models/event-timeline.ts";
-import { Room } from "../models/room.ts";
-import { MatrixClient } from "../client.ts";
+import { type Room } from "../models/room.ts";
+import { type MatrixClient } from "../client.ts";
 import { EventType } from "../@types/event.ts";
 import { UpdateDelayedEventAction } from "../@types/requests.ts";
-import { CallMembership, DEFAULT_EXPIRE_DURATION, SessionMembershipData } from "./CallMembership.ts";
+import { CallMembership, DEFAULT_EXPIRE_DURATION, type SessionMembershipData } from "./CallMembership.ts";
 import { RoomStateEvent } from "../models/room-state.ts";
-import { Focus } from "./focus.ts";
+import { type Focus } from "./focus.ts";
 import { secureRandomBase64Url } from "../randomstring.ts";
-import { EncryptionKeysEventContent } from "./types.ts";
+import { type EncryptionKeysEventContent } from "./types.ts";
 import { decodeBase64, encodeUnpaddedBase64 } from "../base64.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { HTTPError, MatrixError, safeGetRetryAfterMs } from "../http-api/errors.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 import { sleep } from "../utils.ts";
 

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 import { logger as rootLogger } from "../logger.ts";
-import { MatrixClient, ClientEvent } from "../client.ts";
+import { type MatrixClient, ClientEvent } from "../client.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { Room, RoomEvent } from "../models/room.ts";
-import { RoomState, RoomStateEvent } from "../models/room-state.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type Room, RoomEvent } from "../models/room.ts";
+import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { MatrixRTCSession } from "./MatrixRTCSession.ts";
 import { EventType } from "../@types/event.ts";
 

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { IMentions } from "../matrix.ts";
+import { type IMentions } from "../matrix.ts";
 export interface EncryptionKeyEntry {
     index: number;
     key: string;

--- a/src/models/MSC3089Branch.ts
+++ b/src/models/MSC3089Branch.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 import { RelationType, UNSTABLE_MSC3089_BRANCH } from "../@types/event.ts";
-import { IContent, MatrixEvent } from "./event.ts";
-import { MSC3089TreeSpace } from "./MSC3089TreeSpace.ts";
+import { type IContent, type MatrixEvent } from "./event.ts";
+import { type MSC3089TreeSpace } from "./MSC3089TreeSpace.ts";
 import { EventTimeline } from "./event-timeline.ts";
-import { FileType } from "../http-api/index.ts";
+import { type FileType } from "../http-api/index.ts";
 import type { ISendEventResponse } from "../@types/requests.ts";
-import { EncryptedFile } from "../@types/media.ts";
+import { type EncryptedFile } from "../@types/media.ts";
 
 export interface MSC3089EventContent {
     active?: boolean;

--- a/src/models/MSC3089TreeSpace.ts
+++ b/src/models/MSC3089TreeSpace.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 import promiseRetry from "p-retry";
 
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 import { EventType, MsgType, UNSTABLE_MSC3089_BRANCH, UNSTABLE_MSC3089_LEAF } from "../@types/event.ts";
-import { Room } from "./room.ts";
+import { type Room } from "./room.ts";
 import { logger } from "../logger.ts";
-import { IContent, MatrixEvent } from "./event.ts";
+import { type IContent, type MatrixEvent } from "./event.ts";
 import {
     averageBetweenStrings,
     DEFAULT_ALPHABET,
@@ -30,10 +30,10 @@ import {
     simpleRetryOperation,
 } from "../utils.ts";
 import { MSC3089Branch } from "./MSC3089Branch.ts";
-import { ISendEventResponse } from "../@types/requests.ts";
-import { FileType } from "../http-api/index.ts";
+import { type ISendEventResponse } from "../@types/requests.ts";
+import { type FileType } from "../http-api/index.ts";
 import { KnownMembership } from "../@types/membership.ts";
-import { RoomPowerLevelsEventContent, SpaceChildEventContent } from "../@types/state_events.ts";
+import { type RoomPowerLevelsEventContent, type SpaceChildEventContent } from "../@types/state_events.ts";
 import type { EncryptedFile, FileContent } from "../@types/media.ts";
 
 /**

--- a/src/models/beacon.ts
+++ b/src/models/beacon.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MBeaconEventContent } from "../@types/beacon.ts";
+import { type MBeaconEventContent } from "../@types/beacon.ts";
 import {
-    BeaconInfoState,
-    BeaconLocationState,
+    type BeaconInfoState,
+    type BeaconLocationState,
     parseBeaconContent,
     parseBeaconInfoContent,
 } from "../content-helpers.ts";
-import { MatrixEvent } from "./event.ts";
+import { type MatrixEvent } from "./event.ts";
 import { sortEventsByLatestContentTimestamp } from "../utils.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 

--- a/src/models/compare-event-ordering.ts
+++ b/src/models/compare-event-ordering.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "./event.ts";
-import { Room } from "./room.ts";
+import { type MatrixEvent } from "./event.ts";
+import { type Room } from "./room.ts";
 import { inMainTimelineForReceipt, threadIdForReceipt } from "../client.ts";
 
 /**

--- a/src/models/event-context.ts
+++ b/src/models/event-context.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "./event.ts";
+import { type MatrixEvent } from "./event.ts";
 import { Direction } from "./event-timeline.ts";
 
 export class EventContext {

--- a/src/models/event-timeline-set.ts
+++ b/src/models/event-timeline-set.ts
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventTimeline, IAddEventOptions } from "./event-timeline.ts";
-import { MatrixEvent } from "./event.ts";
+import { EventTimeline, type IAddEventOptions } from "./event-timeline.ts";
+import { type MatrixEvent } from "./event.ts";
 import { logger } from "../logger.ts";
-import { Room, RoomEvent } from "./room.ts";
-import { Filter } from "../filter.ts";
-import { RoomState } from "./room-state.ts";
+import { type Room, RoomEvent } from "./room.ts";
+import { type Filter } from "../filter.ts";
+import { type RoomState } from "./room-state.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 import { RelationsContainer } from "./relations-container.ts";
-import { MatrixClient } from "../client.ts";
-import { Thread, ThreadFilterType } from "./thread.ts";
+import { type MatrixClient } from "../client.ts";
+import { type Thread, type ThreadFilterType } from "./thread.ts";
 
 const DEBUG = true;
 

--- a/src/models/event-timeline.ts
+++ b/src/models/event-timeline.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMarkerFoundOptions, RoomState } from "./room-state.ts";
-import { EventTimelineSet } from "./event-timeline-set.ts";
-import { MatrixEvent } from "./event.ts";
-import { Filter } from "../filter.ts";
+import { type IMarkerFoundOptions, RoomState } from "./room-state.ts";
+import { type EventTimelineSet } from "./event-timeline-set.ts";
+import { type MatrixEvent } from "./event.ts";
+import { type Filter } from "../filter.ts";
 import { EventType } from "../@types/event.ts";
 
 export interface IInitialiseStateOptions extends Pick<IMarkerFoundOptions, "timelineWasEmpty"> {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -19,34 +19,34 @@ limitations under the License.
  * the public classes.
  */
 
-import { ExtensibleEvent, ExtensibleEvents, Optional } from "matrix-events-sdk";
+import { type ExtensibleEvent, ExtensibleEvents, type Optional } from "matrix-events-sdk";
 
 import type { IEventDecryptionResult } from "../@types/crypto.ts";
 import { logger } from "../logger.ts";
-import { VerificationRequest } from "../crypto/verification/request/VerificationRequest.ts";
+import { type VerificationRequest } from "../crypto/verification/request/VerificationRequest.ts";
 import {
     EVENT_VISIBILITY_CHANGE_TYPE,
     EventType,
-    MsgType,
+    type MsgType,
     RelationType,
     ToDeviceMessageId,
     UNSIGNED_THREAD_ID_FIELD,
     UNSIGNED_MEMBERSHIP_FIELD,
 } from "../@types/event.ts";
-import { Crypto } from "../crypto/index.ts";
+import { type Crypto } from "../crypto/index.ts";
 import { deepSortedObjectEntries, internaliseString } from "../utils.ts";
-import { RoomMember } from "./room-member.ts";
-import { Thread, THREAD_RELATION_TYPE, ThreadEvent, ThreadEventHandlerMap } from "./thread.ts";
-import { IActionsObject } from "../pushprocessor.ts";
+import { type RoomMember } from "./room-member.ts";
+import { type Thread, THREAD_RELATION_TYPE, ThreadEvent, type ThreadEventHandlerMap } from "./thread.ts";
+import { type IActionsObject } from "../pushprocessor.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
-import { MatrixError } from "../http-api/index.ts";
+import { type MatrixError } from "../http-api/index.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
-import { EventStatus } from "./event-status.ts";
-import { CryptoBackend, DecryptionError } from "../common-crypto/CryptoBackend.ts";
-import { IAnnotatedPushRule } from "../@types/PushRules.ts";
-import { Room } from "./room.ts";
+import { type EventStatus } from "./event-status.ts";
+import { type CryptoBackend, DecryptionError } from "../common-crypto/CryptoBackend.ts";
+import { type IAnnotatedPushRule } from "../@types/PushRules.ts";
+import { type Room } from "./room.ts";
 import { EventTimeline } from "./event-timeline.ts";
-import { Membership } from "../@types/membership.ts";
+import { type Membership } from "../@types/membership.ts";
 import { DecryptionFailureCode } from "../crypto-api/index.ts";
 
 export { EventStatus } from "./event-status.ts";

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../client.ts";
-import { IContent, MatrixEvent } from "./event.ts";
+import { type MatrixClient } from "../client.ts";
+import { type IContent, type MatrixEvent } from "./event.ts";
 import { EventTimeline } from "./event-timeline.ts";
 import { Preset } from "../@types/partials.ts";
 import { globToRegexp } from "../utils.ts";
-import { Room } from "./room.ts";
-import { EventType, StateEvents } from "../@types/event.ts";
+import { type Room } from "./room.ts";
+import { EventType, type StateEvents } from "../@types/event.ts";
 import {
     IGNORE_INVITES_ACCOUNT_EVENT_KEY,
     POLICIES_ACCOUNT_EVENT_TYPE,

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -17,11 +17,11 @@ limitations under the License.
 import { M_POLL_START } from "matrix-events-sdk";
 
 import { M_POLL_END, M_POLL_RESPONSE } from "../@types/polls.ts";
-import { MatrixClient } from "../client.ts";
-import { PollStartEvent } from "../extensible_events_v1/PollStartEvent.ts";
-import { MatrixEvent } from "./event.ts";
+import { type MatrixClient } from "../client.ts";
+import { type PollStartEvent } from "../extensible_events_v1/PollStartEvent.ts";
+import { type MatrixEvent } from "./event.ts";
 import { Relations } from "./relations.ts";
-import { Room } from "./room.ts";
+import { type Room } from "./room.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 
 export enum PollEvent {

--- a/src/models/read-receipt.ts
+++ b/src/models/read-receipt.ts
@@ -12,18 +12,18 @@ limitations under the License.
 */
 
 import {
-    CachedReceipt,
+    type CachedReceipt,
     MAIN_ROOM_TIMELINE,
-    Receipt,
-    ReceiptCache,
+    type Receipt,
+    type ReceiptCache,
     ReceiptType,
-    WrappedReceipt,
+    type WrappedReceipt,
 } from "../@types/read_receipts.ts";
-import { ListenerMap, TypedEventEmitter } from "./typed-event-emitter.ts";
+import { type ListenerMap, TypedEventEmitter } from "./typed-event-emitter.ts";
 import { isSupportedReceiptType } from "../utils.ts";
 import { MatrixEvent } from "./event.ts";
 import { EventType } from "../@types/event.ts";
-import { EventTimelineSet } from "./event-timeline-set.ts";
+import { type EventTimelineSet } from "./event-timeline-set.ts";
 import { MapWithDefault } from "../utils.ts";
 import { NotificationCountType } from "./room.ts";
 import { logger } from "../logger.ts";

--- a/src/models/related-relations.ts
+++ b/src/models/related-relations.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Relations, RelationsEvent, EventHandlerMap } from "./relations.ts";
-import { MatrixEvent } from "./event.ts";
-import { Listener } from "./typed-event-emitter.ts";
+import { type Relations, type RelationsEvent, type EventHandlerMap } from "./relations.ts";
+import { type MatrixEvent } from "./event.ts";
+import { type Listener } from "./typed-event-emitter.ts";
 
 export class RelatedRelations {
     private relations: Relations[];

--- a/src/models/relations-container.ts
+++ b/src/models/relations-container.ts
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 import { Relations } from "./relations.ts";
-import { EventType, RelationType } from "../@types/event.ts";
-import { EventStatus, MatrixEvent, MatrixEventEvent } from "./event.ts";
-import { EventTimelineSet } from "./event-timeline-set.ts";
-import { MatrixClient } from "../client.ts";
-import { Room } from "./room.ts";
+import { type EventType, type RelationType } from "../@types/event.ts";
+import { EventStatus, type MatrixEvent, MatrixEventEvent } from "./event.ts";
+import { type EventTimelineSet } from "./event-timeline-set.ts";
+import { type MatrixClient } from "../client.ts";
+import { type Room } from "./room.ts";
 
 export class RelationsContainer {
     // A tree of objects to access a set of related children for an event, as in:

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventStatus, IAggregatedRelation, MatrixEvent, MatrixEventEvent } from "./event.ts";
+import { EventStatus, type IAggregatedRelation, type MatrixEvent, MatrixEventEvent } from "./event.ts";
 import { logger } from "../logger.ts";
 import { RelationType } from "../@types/event.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 import { Room } from "./room.ts";
-import { CryptoBackend } from "../common-crypto/CryptoBackend.ts";
+import { type CryptoBackend } from "../common-crypto/CryptoBackend.ts";
 
 export enum RelationsEvent {
     Add = "Relations.add",

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import { getHttpUriForMxc } from "../content-repo.ts";
 import { removeDirectionOverrideChars, removeHiddenChars } from "../utils.ts";
-import { User } from "./user.ts";
-import { MatrixEvent } from "./event.ts";
-import { RoomState } from "./room-state.ts";
+import { type User } from "./user.ts";
+import { type MatrixEvent } from "./event.ts";
+import { type RoomState } from "./room-state.ts";
 import { logger } from "../logger.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 import { EventType } from "../@types/event.ts";
-import { KnownMembership, Membership } from "../@types/membership.ts";
+import { KnownMembership, type Membership } from "../@types/membership.ts";
 
 export enum RoomMemberEvent {
     Membership = "RoomMember.membership",

--- a/src/models/room-receipts.ts
+++ b/src/models/room-receipts.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MAIN_ROOM_TIMELINE, Receipt, ReceiptContent } from "../@types/read_receipts.ts";
+import { MAIN_ROOM_TIMELINE, type Receipt, type ReceiptContent } from "../@types/read_receipts.ts";
 import { threadIdForReceipt } from "../client.ts";
-import { Room, RoomEvent } from "./room.ts";
-import { MatrixEvent } from "./event.ts";
+import { type Room, RoomEvent } from "./room.ts";
+import { type MatrixEvent } from "./event.ts";
 import { logger } from "../logger.ts";
 
 /**

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -18,15 +18,21 @@ import { RoomMember } from "./room-member.ts";
 import { logger } from "../logger.ts";
 import { isNumber, removeHiddenChars } from "../utils.ts";
 import { EventType, UNSTABLE_MSC2716_MARKER } from "../@types/event.ts";
-import { IEvent, MatrixEvent, MatrixEventEvent } from "./event.ts";
-import { MatrixClient } from "../client.ts";
+import { type IEvent, type MatrixEvent, MatrixEventEvent } from "./event.ts";
+import { type MatrixClient } from "../client.ts";
 import { GuestAccess, HistoryVisibility, JoinRule } from "../@types/partials.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
-import { Beacon, BeaconEvent, BeaconEventHandlerMap, getBeaconInfoIdentifier, BeaconIdentifier } from "./beacon.ts";
+import {
+    Beacon,
+    BeaconEvent,
+    type BeaconEventHandlerMap,
+    getBeaconInfoIdentifier,
+    type BeaconIdentifier,
+} from "./beacon.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { M_BEACON, M_BEACON_INFO } from "../@types/beacon.ts";
 import { KnownMembership } from "../@types/membership.ts";
-import { RoomJoinRulesEventContent } from "../@types/state_events.ts";
+import { type RoomJoinRulesEventContent } from "../@types/state_events.ts";
 
 export interface IMarkerFoundOptions {
     /** Whether the timeline was empty before the marker event arrived in the

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -14,22 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { M_POLL_START, Optional } from "matrix-events-sdk";
+import { M_POLL_START, type Optional } from "matrix-events-sdk";
 
 import {
     EventTimelineSet,
     DuplicateStrategy,
-    IAddLiveEventOptions,
-    EventTimelineSetHandlerMap,
+    type IAddLiveEventOptions,
+    type EventTimelineSetHandlerMap,
 } from "./event-timeline-set.ts";
 import { Direction, EventTimeline } from "./event-timeline.ts";
 import { getHttpUriForMxc } from "../content-repo.ts";
 import { removeElement } from "../utils.ts";
 import { normalize, noUnsafeEventProps } from "../utils.ts";
-import { IEvent, IThreadBundledRelationship, MatrixEvent, MatrixEventEvent, MatrixEventHandlerMap } from "./event.ts";
+import {
+    type IEvent,
+    type IThreadBundledRelationship,
+    MatrixEvent,
+    MatrixEventEvent,
+    type MatrixEventHandlerMap,
+} from "./event.ts";
 import { EventStatus } from "./event-status.ts";
 import { RoomMember } from "./room-member.ts";
-import { IRoomSummary, RoomSummary } from "./room-summary.ts";
+import { type IRoomSummary, RoomSummary } from "./room-summary.ts";
 import { logger } from "../logger.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import {
@@ -41,36 +47,36 @@ import {
     RelationType,
     UNSIGNED_THREAD_ID_FIELD,
 } from "../@types/event.ts";
-import { MatrixClient, PendingEventOrdering } from "../client.ts";
-import { GuestAccess, HistoryVisibility, JoinRule, ResizeMethod } from "../@types/partials.ts";
-import { Filter, IFilterDefinition } from "../filter.ts";
-import { RoomState, RoomStateEvent, RoomStateEventHandlerMap } from "./room-state.ts";
-import { BeaconEvent, BeaconEventHandlerMap } from "./beacon.ts";
+import { type MatrixClient, PendingEventOrdering } from "../client.ts";
+import { type GuestAccess, type HistoryVisibility, type JoinRule, type ResizeMethod } from "../@types/partials.ts";
+import { Filter, type IFilterDefinition } from "../filter.ts";
+import { type RoomState, RoomStateEvent, type RoomStateEventHandlerMap } from "./room-state.ts";
+import { BeaconEvent, type BeaconEventHandlerMap } from "./beacon.ts";
 import {
     Thread,
     ThreadEvent,
-    ThreadEventHandlerMap as ThreadHandlerMap,
+    type ThreadEventHandlerMap as ThreadHandlerMap,
     FILTER_RELATED_BY_REL_TYPES,
     THREAD_RELATION_TYPE,
     FILTER_RELATED_BY_SENDERS,
     ThreadFilterType,
 } from "./thread.ts";
 import {
-    CachedReceiptStructure,
+    type CachedReceiptStructure,
     MAIN_ROOM_TIMELINE,
-    Receipt,
-    ReceiptContent,
+    type Receipt,
+    type ReceiptContent,
     ReceiptType,
 } from "../@types/read_receipts.ts";
-import { IStateEventWithRoomId } from "../@types/search.ts";
+import { type IStateEventWithRoomId } from "../@types/search.ts";
 import { RelationsContainer } from "./relations-container.ts";
 import { ReadReceipt, synthesizeReceipt } from "./read-receipt.ts";
 import { isPollEvent, Poll, PollEvent } from "./poll.ts";
 import { RoomReceipts } from "./room-receipts.ts";
 import { compareEventOrdering } from "./compare-event-ordering.ts";
 import * as utils from "../utils.ts";
-import { KnownMembership, Membership } from "../@types/membership.ts";
-import { Capabilities, IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities.ts";
+import { KnownMembership, type Membership } from "../@types/membership.ts";
+import { type Capabilities, type IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities.ts";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be

--- a/src/models/search-result.ts
+++ b/src/models/search-result.ts
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import { EventContext } from "./event-context.ts";
-import { EventMapper } from "../event-mapper.ts";
-import { IResultContext, ISearchResult } from "../@types/search.ts";
+import { type EventMapper } from "../event-mapper.ts";
+import { type IResultContext, type ISearchResult } from "../@types/search.ts";
 
 export class SearchResult {
     /**

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -14,20 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
-import { MatrixClient, PendingEventOrdering } from "../client.ts";
+import { type MatrixClient, PendingEventOrdering } from "../client.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { RelationType } from "../@types/event.ts";
-import { IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event.ts";
+import { type IThreadBundledRelationship, MatrixEvent, MatrixEventEvent } from "./event.ts";
 import { Direction, EventTimeline } from "./event-timeline.ts";
-import { EventTimelineSet, EventTimelineSetHandlerMap } from "./event-timeline-set.ts";
-import { NotificationCountType, Room, RoomEvent } from "./room.ts";
-import { RoomState } from "./room-state.ts";
+import { EventTimelineSet, type EventTimelineSetHandlerMap } from "./event-timeline-set.ts";
+import { type NotificationCountType, type Room, RoomEvent } from "./room.ts";
+import { type RoomState } from "./room-state.ts";
 import { ServerControlledNamespacedValue } from "../NamespacedValue.ts";
 import { logger } from "../logger.ts";
 import { ReadReceipt } from "./read-receipt.ts";
-import { CachedReceiptStructure, Receipt, ReceiptType } from "../@types/read_receipts.ts";
+import { type CachedReceiptStructure, type Receipt, ReceiptType } from "../@types/read_receipts.ts";
 import { Feature, ServerSupport } from "../feature.ts";
 
 export enum ThreadEvent {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient } from "../matrix.ts";
-import { MatrixEvent } from "./event.ts";
+import { type MatrixClient } from "../matrix.ts";
+import { type MatrixEvent } from "./event.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 
 export enum UserEvent {

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IdTokenClaims, Log, OidcClient, SigninResponse, SigninState, WebStorageStateStore } from "oidc-client-ts";
+import { type IdTokenClaims, Log, OidcClient, SigninResponse, SigninState, WebStorageStateStore } from "oidc-client-ts";
 
 import { logger } from "../logger.ts";
 import { randomString } from "../randomstring.ts";
 import { OidcError } from "./error.ts";
 import {
-    BearerTokenResponse,
-    UserState,
+    type BearerTokenResponse,
+    type UserState,
     validateBearerTokenResponse,
-    ValidatedIssuerMetadata,
+    type ValidatedIssuerMetadata,
     validateIdToken,
     validateStoredUserState,
 } from "./validate.ts";

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -18,7 +18,7 @@ import { MetadataService, OidcClientSettingsStore } from "oidc-client-ts";
 
 import { isValidatedIssuerMetadata, validateOIDCIssuerWellKnown } from "./validate.ts";
 import { Method, timeoutSignal } from "../http-api/index.ts";
-import { OidcClientConfig } from "./index.ts";
+import { type OidcClientConfig } from "./index.ts";
 
 /**
  * @experimental

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type { SigningKey } from "oidc-client-ts";
-import { ValidatedIssuerConfig, ValidatedIssuerMetadata } from "./validate.ts";
+import { type ValidatedIssuerConfig, type ValidatedIssuerMetadata } from "./validate.ts";
 
 export * from "./authorize.ts";
 export * from "./discovery.ts";

--- a/src/oidc/register.ts
+++ b/src/oidc/register.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OidcClientConfig } from "./index.ts";
+import { type OidcClientConfig } from "./index.ts";
 import { OidcError } from "./error.ts";
 import { Method } from "../http-api/index.ts";
 import { logger } from "../logger.ts";
-import { NonEmptyArray } from "../@types/common.ts";
+import { type NonEmptyArray } from "../@types/common.ts";
 
 /**
  * Client metadata passed to registration endpoint

--- a/src/oidc/tokenRefresher.ts
+++ b/src/oidc/tokenRefresher.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IdTokenClaims, OidcClient, WebStorageStateStore } from "oidc-client-ts";
+import { type IdTokenClaims, OidcClient, WebStorageStateStore } from "oidc-client-ts";
 
-import { AccessTokens } from "../http-api/index.ts";
+import { type AccessTokens } from "../http-api/index.ts";
 import { generateScope } from "./authorize.ts";
 import { discoverAndValidateOIDCIssuerWellKnown } from "./discovery.ts";
 import { logger } from "../logger.ts";

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { jwtDecode } from "jwt-decode";
-import { IdTokenClaims, OidcMetadata, SigninResponse } from "oidc-client-ts";
+import { type IdTokenClaims, type OidcMetadata, type SigninResponse } from "oidc-client-ts";
 
 import { logger } from "../logger.ts";
 import { OidcError } from "./error.ts";

--- a/src/pushprocessor.ts
+++ b/src/pushprocessor.ts
@@ -16,26 +16,26 @@ limitations under the License.
 
 import { deepCompare, escapeRegExp, globToRegexp, isNullOrUndefined } from "./utils.ts";
 import { logger } from "./logger.ts";
-import { MatrixClient } from "./client.ts";
-import { MatrixEvent } from "./models/event.ts";
+import { type MatrixClient } from "./client.ts";
+import { type MatrixEvent } from "./models/event.ts";
 import {
     ConditionKind,
-    IAnnotatedPushRule,
-    ICallStartedCondition,
-    ICallStartedPrefixCondition,
-    IContainsDisplayNameCondition,
-    IEventMatchCondition,
-    IEventPropertyContainsCondition,
-    IEventPropertyIsCondition,
-    IPushRule,
-    IPushRules,
-    IRoomMemberCountCondition,
-    ISenderNotificationPermissionCondition,
-    PushRuleAction,
+    type IAnnotatedPushRule,
+    type ICallStartedCondition,
+    type ICallStartedPrefixCondition,
+    type IContainsDisplayNameCondition,
+    type IEventMatchCondition,
+    type IEventPropertyContainsCondition,
+    type IEventPropertyIsCondition,
+    type IPushRule,
+    type IPushRules,
+    type IRoomMemberCountCondition,
+    type ISenderNotificationPermissionCondition,
+    type PushRuleAction,
     PushRuleActionName,
-    PushRuleCondition,
+    type PushRuleCondition,
     PushRuleKind,
-    PushRuleSet,
+    type PushRuleSet,
     RuleId,
     TweakName,
 } from "./@types/PushRules.ts";

--- a/src/receipt-accumulator.ts
+++ b/src/receipt-accumulator.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMinimalEvent } from "./sync-accumulator.ts";
+import { type IMinimalEvent } from "./sync-accumulator.ts";
 import { EventType } from "./@types/event.ts";
 import { isSupportedReceiptType, MapWithDefault, recursiveMapToObject } from "./utils.ts";
-import { IContent } from "./models/event.ts";
-import { ReceiptContent, ReceiptType } from "./@types/read_receipts.ts";
+import { type IContent } from "./models/event.ts";
+import { type ReceiptContent, type ReceiptType } from "./@types/read_receipts.ts";
 
 interface AccumulatedReceipt {
     data: IMinimalEvent;

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -20,15 +20,15 @@ import {
     ClientRendezvousFailureReason,
     MSC4108FailureReason,
     RendezvousError,
-    RendezvousFailureListener,
+    type RendezvousFailureListener,
 } from "./index.ts";
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 import { logger } from "../logger.ts";
-import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
+import { type MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
 import { MatrixError } from "../http-api/index.ts";
 import { sleep } from "../utils.ts";
-import { DEVICE_CODE_SCOPE, discoverAndValidateOIDCIssuerWellKnown, OidcClientConfig } from "../oidc/index.ts";
-import { CryptoApi } from "../crypto-api/index.ts";
+import { DEVICE_CODE_SCOPE, discoverAndValidateOIDCIssuerWellKnown, type OidcClientConfig } from "../oidc/index.ts";
+import { type CryptoApi } from "../crypto-api/index.ts";
 
 /**
  * Enum representing the payload types transmissible over [MSC4108](https://github.com/matrix-org/matrix-spec-proposals/pull/4108)

--- a/src/rendezvous/RendezvousChannel.ts
+++ b/src/rendezvous/RendezvousChannel.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousCode, RendezvousIntent, RendezvousFailureReason } from "./index.ts";
+import { type RendezvousCode, type RendezvousIntent, type RendezvousFailureReason } from "./index.ts";
 
 export interface RendezvousChannel<T> {
     /**

--- a/src/rendezvous/RendezvousCode.ts
+++ b/src/rendezvous/RendezvousCode.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousTransportDetails, RendezvousIntent } from "./index.ts";
+import { type RendezvousTransportDetails, type RendezvousIntent } from "./index.ts";
 
 export interface RendezvousCode {
     intent: RendezvousIntent;

--- a/src/rendezvous/RendezvousError.ts
+++ b/src/rendezvous/RendezvousError.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousFailureReason } from "./index.ts";
+import { type RendezvousFailureReason } from "./index.ts";
 
 export class RendezvousError extends Error {
     public constructor(

--- a/src/rendezvous/RendezvousTransport.ts
+++ b/src/rendezvous/RendezvousTransport.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RendezvousFailureListener, RendezvousFailureReason } from "./index.ts";
+import { type RendezvousFailureListener, type RendezvousFailureReason } from "./index.ts";
 
 export interface RendezvousTransportDetails {
     type: string;

--- a/src/rendezvous/channels/MSC4108SecureChannel.ts
+++ b/src/rendezvous/channels/MSC4108SecureChannel.ts
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 import {
-    Curve25519PublicKey,
+    type Curve25519PublicKey,
     Ecies,
-    EstablishedEcies,
+    type EstablishedEcies,
     QrCodeData,
     QrCodeMode,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
@@ -25,11 +25,11 @@ import {
 import {
     ClientRendezvousFailureReason,
     MSC4108FailureReason,
-    MSC4108Payload,
+    type MSC4108Payload,
     RendezvousError,
-    RendezvousFailureListener,
+    type RendezvousFailureListener,
 } from "../index.ts";
-import { MSC4108RendezvousSession } from "../transports/MSC4108RendezvousSession.ts";
+import { type MSC4108RendezvousSession } from "../transports/MSC4108RendezvousSession.ts";
 import { logger } from "../../logger.ts";
 
 /**

--- a/src/rendezvous/transports/MSC4108RendezvousSession.ts
+++ b/src/rendezvous/transports/MSC4108RendezvousSession.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import { logger } from "../../logger.ts";
 import { sleep } from "../../utils.ts";
-import { ClientRendezvousFailureReason, MSC4108FailureReason, RendezvousFailureListener } from "../index.ts";
-import { MatrixClient, Method } from "../../matrix.ts";
+import { ClientRendezvousFailureReason, MSC4108FailureReason, type RendezvousFailureListener } from "../index.ts";
+import { type MatrixClient, Method } from "../../matrix.ts";
 import { ClientPrefix } from "../../http-api/index.ts";
 
 /**

--- a/src/room-hierarchy.ts
+++ b/src/room-hierarchy.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Room } from "./models/room.ts";
-import { IHierarchyRoom, IHierarchyRelation } from "./@types/spaces.ts";
-import { MatrixClient } from "./client.ts";
+import { type Room } from "./models/room.ts";
+import { type IHierarchyRoom, type IHierarchyRelation } from "./@types/spaces.ts";
+import { type MatrixClient } from "./client.ts";
 import { EventType } from "./@types/event.ts";
-import { MatrixError } from "./http-api/index.ts";
+import { type MatrixError } from "./http-api/index.ts";
 
 export class RoomHierarchy {
     // Map from room id to list of servers which are listed as a via somewhere in the loaded hierarchy

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -14,14 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine, CrossSigningStatus, CrossSigningBootstrapRequests } from "@matrix-org/matrix-sdk-crypto-wasm";
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import {
+    type OlmMachine,
+    type CrossSigningStatus,
+    type CrossSigningBootstrapRequests,
+} from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { BootstrapCrossSigningOpts } from "../crypto-api/index.ts";
+import type * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type BootstrapCrossSigningOpts } from "../crypto-api/index.ts";
 import { logger } from "../logger.ts";
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
-import { UIAuthCallback } from "../interactive-auth.ts";
-import { ServerSideSecretStorage } from "../secret-storage.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type UIAuthCallback } from "../interactive-auth.ts";
+import { type ServerSideSecretStorage } from "../secret-storage.ts";
 
 /** Manages the cross-signing keys for our own user.
  *

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -16,13 +16,13 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { encodeUri } from "../utils.ts";
-import { IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
-import { IToDeviceEvent } from "../sync-accumulator.ts";
-import { ServerSideSecretStorage } from "../secret-storage.ts";
+import { type IHttpOpts, type MatrixError, type MatrixHttpApi, Method } from "../http-api/index.ts";
+import { type IToDeviceEvent } from "../sync-accumulator.ts";
+import { type ServerSideSecretStorage } from "../secret-storage.ts";
 import { decodeBase64, encodeUnpaddedBase64 } from "../base64.ts";
-import { Logger } from "../logger.ts";
+import { type Logger } from "../logger.ts";
 
 /**
  * The response body of `GET /_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device`.

--- a/src/rust-crypto/KeyClaimManager.ts
+++ b/src/rust-crypto/KeyClaimManager.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine, UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OlmMachine, type UserId } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
-import { LogSpan } from "../logger.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type LogSpan } from "../logger.ts";
 
 /**
  * KeyClaimManager: linearises calls to OlmMachine.getMissingSessions to avoid races

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -19,7 +19,7 @@ import {
     KeysClaimRequest,
     KeysQueryRequest,
     KeysUploadRequest,
-    OlmMachine,
+    type OlmMachine,
     PutDehydratedDeviceRequest,
     RoomMessageRequest,
     SignatureUploadRequest,
@@ -28,10 +28,10 @@ import {
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { logger } from "../logger.ts";
-import { calculateRetryBackoff, IHttpOpts, MatrixHttpApi, Method } from "../http-api/index.ts";
-import { logDuration, QueryDict, sleep } from "../utils.ts";
-import { AuthDict, UIAuthCallback } from "../interactive-auth.ts";
-import { UIAResponse } from "../@types/uia.ts";
+import { calculateRetryBackoff, type IHttpOpts, type MatrixHttpApi, Method } from "../http-api/index.ts";
+import { logDuration, type QueryDict, sleep } from "../utils.ts";
+import { type AuthDict, type UIAuthCallback } from "../interactive-auth.ts";
+import { type UIAResponse } from "../@types/uia.ts";
 import { ToDeviceMessageId } from "../@types/event.ts";
 import { UnstablePrefix as DehydrationUnstablePrefix } from "./DehydratedDeviceManager.ts";
 

--- a/src/rust-crypto/OutgoingRequestsManager.ts
+++ b/src/rust-crypto/OutgoingRequestsManager.ts
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
-import { Logger } from "../logger.ts";
-import { defer, IDeferred, logDuration } from "../utils.ts";
+import { type OutgoingRequest, type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type Logger } from "../logger.ts";
+import { defer, type IDeferred, logDuration } from "../utils.ts";
 
 /**
  * OutgoingRequestsManager: responsible for processing outgoing requests from the OlmMachine.

--- a/src/rust-crypto/PerSessionKeyBackupDownloader.ts
+++ b/src/rust-crypto/PerSessionKeyBackupDownloader.ts
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
-import { OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Curve25519AuthData, KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.ts";
+import type * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type Curve25519AuthData, type KeyBackupInfo, type KeyBackupSession } from "../crypto-api/keybackup.ts";
 import { CryptoEvent } from "../crypto-api/index.ts";
-import { Logger } from "../logger.ts";
-import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
-import { RustBackupManager } from "./backup.ts";
+import { type Logger } from "../logger.ts";
+import { ClientPrefix, type IHttpOpts, MatrixError, type MatrixHttpApi, Method } from "../http-api/index.ts";
+import { type RustBackupManager } from "./backup.ts";
 import { encodeUri, sleep } from "../utils.ts";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
+import { type BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
 
 // The minimum time to wait between two retries in case of errors. To avoid hammering the server.
 const KEY_BACKUP_BACKOFF = 5000; // ms

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -20,23 +20,23 @@ import {
     EncryptionAlgorithm,
     EncryptionSettings,
     HistoryVisibility as RustHistoryVisibility,
-    OlmMachine,
+    type OlmMachine,
     RoomId,
-    ToDeviceRequest,
+    type ToDeviceRequest,
     UserId,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { EventType } from "../@types/event.ts";
-import { IContent, MatrixEvent } from "../models/event.ts";
-import { Room } from "../models/room.ts";
-import { Logger, logger, LogSpan } from "../logger.ts";
-import { KeyClaimManager } from "./KeyClaimManager.ts";
-import { RoomMember } from "../models/room-member.ts";
+import { type IContent, type MatrixEvent } from "../models/event.ts";
+import { type Room } from "../models/room.ts";
+import { type Logger, logger, LogSpan } from "../logger.ts";
+import { type KeyClaimManager } from "./KeyClaimManager.ts";
+import { type RoomMember } from "../models/room-member.ts";
 import { HistoryVisibility } from "../@types/partials.ts";
-import { OutgoingRequestsManager } from "./OutgoingRequestsManager.ts";
+import { type OutgoingRequestsManager } from "./OutgoingRequestsManager.ts";
 import { logDuration } from "../utils.ts";
 import { KnownMembership } from "../@types/membership.ts";
-import { DeviceIsolationMode, DeviceIsolationModeKind } from "../crypto-api/index.ts";
+import { type DeviceIsolationMode, DeviceIsolationModeKind } from "../crypto-api/index.ts";
 
 /**
  * RoomEncryptor: responsible for encrypting messages to a given room

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -14,30 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OlmMachine, SignatureVerification } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OlmMachine, type SignatureVerification } from "@matrix-org/matrix-sdk-crypto-wasm";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
-    BackupTrustInfo,
-    Curve25519AuthData,
-    KeyBackupCheck,
-    KeyBackupInfo,
-    KeyBackupSession,
-    Curve25519SessionData,
-    KeyBackupRestoreOpts,
-    KeyBackupRestoreResult,
-    KeyBackupRoomSessions,
+    type BackupTrustInfo,
+    type Curve25519AuthData,
+    type KeyBackupCheck,
+    type KeyBackupInfo,
+    type KeyBackupSession,
+    type Curve25519SessionData,
+    type KeyBackupRestoreOpts,
+    type KeyBackupRestoreResult,
+    type KeyBackupRoomSessions,
 } from "../crypto-api/keybackup.ts";
 import { logger } from "../logger.ts";
-import { ClientPrefix, IHttpOpts, MatrixError, MatrixHttpApi, Method } from "../http-api/index.ts";
+import { ClientPrefix, type IHttpOpts, MatrixError, type MatrixHttpApi, Method } from "../http-api/index.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { encodeUri, logDuration } from "../utils.ts";
-import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { sleep } from "../utils.ts";
-import { BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
-import { ImportRoomKeyProgressData, ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
-import { IMegolmSessionData } from "../@types/crypto.ts";
+import { type BackupDecryptor } from "../common-crypto/CryptoBackend.ts";
+import { type ImportRoomKeyProgressData, type ImportRoomKeysOpts, CryptoEvent } from "../crypto-api/index.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type IMegolmSessionData } from "../@types/crypto.ts";
 
 /** Authentification of the backup info, depends on algorithm */
 type AuthData = KeyBackupInfo["auth_data"];

--- a/src/rust-crypto/device-converter.ts
+++ b/src/rust-crypto/device-converter.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { Device, DeviceVerification } from "../models/device.ts";
-import { DeviceKeys } from "../client.ts";
+import { type DeviceKeys } from "../client.ts";
 
 /**
  * Convert a {@link RustSdkCryptoJs.Device} to a {@link Device}

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -18,16 +18,16 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { StoreHandle } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { RustCrypto } from "./rust-crypto.ts";
-import { IHttpOpts, MatrixHttpApi } from "../http-api/index.ts";
-import { ServerSideSecretStorage } from "../secret-storage.ts";
-import { Logger } from "../logger.ts";
-import { CryptoStore, MigrationState } from "../crypto/store/base.ts";
+import { type IHttpOpts, type MatrixHttpApi } from "../http-api/index.ts";
+import { type ServerSideSecretStorage } from "../secret-storage.ts";
+import { type Logger } from "../logger.ts";
+import { type CryptoStore, MigrationState } from "../crypto/store/base.ts";
 import {
     migrateFromLegacyCrypto,
     migrateLegacyLocalTrustIfNeeded,
     migrateRoomSettingsFromLegacyCrypto,
 } from "./libolm_migration.ts";
-import { CryptoCallbacks } from "../crypto-api/index.ts";
+import { type CryptoCallbacks } from "../crypto-api/index.ts";
 
 /**
  * Create a new `RustCrypto` implementation

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -16,18 +16,18 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { Logger } from "../logger.ts";
-import { CryptoStore, MigrationState, SecretStorePrivateKeys } from "../crypto/store/base.ts";
+import { type Logger } from "../logger.ts";
+import { type CryptoStore, MigrationState, type SecretStorePrivateKeys } from "../crypto/store/base.ts";
 import { IndexedDBCryptoStore } from "../crypto/store/indexeddb-crypto-store.ts";
-import { IHttpOpts, MatrixHttpApi } from "../http-api/index.ts";
+import { type IHttpOpts, type MatrixHttpApi } from "../http-api/index.ts";
 import { requestKeyBackupVersion } from "./backup.ts";
-import { CrossSigningKeyInfo, Curve25519AuthData } from "../crypto-api/index.ts";
-import { RustCrypto } from "./rust-crypto.ts";
-import { KeyBackupInfo } from "../crypto-api/keybackup.ts";
+import { type CrossSigningKeyInfo, type Curve25519AuthData } from "../crypto-api/index.ts";
+import { type RustCrypto } from "./rust-crypto.ts";
+import { type KeyBackupInfo } from "../crypto-api/keybackup.ts";
 import { sleep } from "../utils.ts";
 import { encodeBase64 } from "../base64.ts";
 import decryptAESSecretStorageItem from "../utils/decryptAESSecretStorageItem.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 
 interface LegacyRoomEncryption {
     algorithm: string;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -22,56 +22,60 @@ import { KnownMembership } from "../@types/membership.ts";
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.ts";
 import type { IEncryptedEventInfo } from "../crypto/api.ts";
 import type { ToDevicePayload, ToDeviceBatch } from "../models/ToDeviceMessage.ts";
-import { MatrixEvent, MatrixEventEvent } from "../models/event.ts";
-import { Room } from "../models/room.ts";
-import { RoomMember } from "../models/room-member.ts";
+import { type MatrixEvent, MatrixEventEvent } from "../models/event.ts";
+import { type Room } from "../models/room.ts";
+import { type RoomMember } from "../models/room-member.ts";
 import {
-    BackupDecryptor,
-    CryptoBackend,
+    type BackupDecryptor,
+    type CryptoBackend,
     DecryptionError,
-    OnSyncCompletedData,
+    type OnSyncCompletedData,
 } from "../common-crypto/CryptoBackend.ts";
-import { logger, Logger, LogSpan } from "../logger.ts";
-import { IHttpOpts, MatrixHttpApi, Method } from "../http-api/index.ts";
+import { logger, type Logger, LogSpan } from "../logger.ts";
+import { type IHttpOpts, type MatrixHttpApi, Method } from "../http-api/index.ts";
 import { RoomEncryptor } from "./RoomEncryptor.ts";
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { KeyClaimManager } from "./KeyClaimManager.ts";
 import { logDuration, MapWithDefault } from "../utils.ts";
 import {
-    BackupTrustInfo,
-    BootstrapCrossSigningOpts,
-    CreateSecretStorageOpts,
+    type BackupTrustInfo,
+    type BootstrapCrossSigningOpts,
+    type CreateSecretStorageOpts,
     CrossSigningKey,
-    CrossSigningKeyInfo,
-    CrossSigningStatus,
-    CryptoApi,
-    CryptoCallbacks,
+    type CrossSigningKeyInfo,
+    type CrossSigningStatus,
+    type CryptoApi,
+    type CryptoCallbacks,
     DecryptionFailureCode,
     DeviceVerificationStatus,
-    EventEncryptionInfo,
+    type EventEncryptionInfo,
     EventShieldColour,
     EventShieldReason,
-    GeneratedSecretStorageKey,
-    ImportRoomKeysOpts,
-    KeyBackupCheck,
-    KeyBackupInfo,
-    OwnDeviceKeys,
+    type GeneratedSecretStorageKey,
+    type ImportRoomKeysOpts,
+    type KeyBackupCheck,
+    type KeyBackupInfo,
+    type OwnDeviceKeys,
     UserVerificationStatus,
-    VerificationRequest,
+    type VerificationRequest,
     encodeRecoveryKey,
     deriveRecoveryKeyFromPassphrase,
-    DeviceIsolationMode,
+    type DeviceIsolationMode,
     AllDevicesIsolationMode,
     DeviceIsolationModeKind,
     CryptoEvent,
-    CryptoEventHandlerMap,
-    KeyBackupRestoreOpts,
-    KeyBackupRestoreResult,
+    type CryptoEventHandlerMap,
+    type KeyBackupRestoreOpts,
+    type KeyBackupRestoreResult,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
-import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
-import { Device, DeviceMap } from "../models/device.ts";
-import { SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorageKey, ServerSideSecretStorage } from "../secret-storage.ts";
+import { type IDownloadKeyResult, type IQueryKeysRequest } from "../client.ts";
+import { type Device, type DeviceMap } from "../models/device.ts";
+import {
+    SECRET_STORAGE_ALGORITHM_V1_AES,
+    type SecretStorageKey,
+    type ServerSideSecretStorage,
+} from "../secret-storage.ts";
 import { CrossSigningIdentity } from "./CrossSigningIdentity.ts";
 import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } from "./secret-storage.ts";
 import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification.ts";
@@ -81,7 +85,7 @@ import { decryptionKeyMatchesKeyBackupInfo, RustBackupManager } from "./backup.t
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { randomString } from "../randomstring.ts";
 import { ClientStoppedError } from "../errors.ts";
-import { ISignatures } from "../@types/signed.ts";
+import { type ISignatures } from "../@types/signed.ts";
 import { decodeBase64, encodeBase64 } from "../base64.ts";
 import { OutgoingRequestsManager } from "./OutgoingRequestsManager.ts";
 import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader.ts";

--- a/src/rust-crypto/secret-storage.ts
+++ b/src/rust-crypto/secret-storage.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { SecretStorageKey, ServerSideSecretStorage } from "../secret-storage.ts";
+import { type SecretStorageKey, type ServerSideSecretStorage } from "../secret-storage.ts";
 
 /**
  * Check that the private cross signing keys (master, self signing, user signing) are stored in the secret storage and encrypted with the default secret storage key.

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -18,23 +18,23 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
-    GeneratedSas,
-    ShowQrCodeCallbacks,
-    ShowSasCallbacks,
+    type GeneratedSas,
+    type ShowQrCodeCallbacks,
+    type ShowSasCallbacks,
     VerificationPhase,
-    VerificationRequest,
+    type VerificationRequest,
     VerificationRequestEvent,
-    VerificationRequestEventHandlerMap,
-    Verifier,
+    type VerificationRequestEventHandlerMap,
+    type Verifier,
     VerifierEvent,
-    VerifierEventHandlerMap,
+    type VerifierEventHandlerMap,
 } from "../crypto-api/verification.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { OutgoingRequest, OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type OutgoingRequest, type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { EventType, MsgType } from "../@types/event.ts";
-import { defer, IDeferred } from "../utils.ts";
+import { defer, type IDeferred } from "../utils.ts";
 import { VerificationMethod } from "../types.ts";
 
 /**

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -19,11 +19,11 @@ limitations under the License.
  * of requests.
  */
 import { logger } from "./logger.ts";
-import { MatrixEvent } from "./models/event.ts";
+import { type MatrixEvent } from "./models/event.ts";
 import { EventType } from "./@types/event.ts";
-import { defer, IDeferred, removeElement } from "./utils.ts";
-import { calculateRetryBackoff, MatrixError } from "./http-api/index.ts";
-import { ISendEventResponse } from "./@types/requests.ts";
+import { defer, type IDeferred, removeElement } from "./utils.ts";
+import { calculateRetryBackoff, type MatrixError } from "./http-api/index.ts";
+import { type ISendEventResponse } from "./@types/requests.ts";
 
 const DEBUG = false; // set true to enable console logging.
 

--- a/src/secret-storage.ts
+++ b/src/secret-storage.ts
@@ -20,15 +20,15 @@ limitations under the License.
  * @see https://spec.matrix.org/v1.6/client-server-api/#storage
  */
 
-import { TypedEventEmitter } from "./models/typed-event-emitter.ts";
-import { ClientEvent, ClientEventHandlerMap } from "./client.ts";
-import { MatrixEvent } from "./models/event.ts";
+import { type TypedEventEmitter } from "./models/typed-event-emitter.ts";
+import { ClientEvent, type ClientEventHandlerMap } from "./client.ts";
+import { type MatrixEvent } from "./models/event.ts";
 import { randomString } from "./randomstring.ts";
 import { logger } from "./logger.ts";
 import encryptAESSecretStorageItem from "./utils/encryptAESSecretStorageItem.ts";
 import decryptAESSecretStorageItem from "./utils/decryptAESSecretStorageItem.ts";
-import { AESEncryptedSecretStoragePayload } from "./@types/AESEncryptedSecretStoragePayload.ts";
-import { AccountDataEvents, SecretStorageAccountDataEvents } from "./@types/event.ts";
+import { type AESEncryptedSecretStoragePayload } from "./@types/AESEncryptedSecretStoragePayload.ts";
+import { type AccountDataEvents, type SecretStorageAccountDataEvents } from "./@types/event.ts";
 
 export const SECRET_STORAGE_ALGORITHM_V1_AES = "m.secret_storage.v1.aes-hmac-sha2";
 

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.ts";
+import { type IHttpOpts, type MatrixHttpApi, Method } from "./http-api/index.ts";
 import { logger } from "./logger.ts";
 
 // How often we update the server capabilities.

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -19,31 +19,37 @@ import { NotificationCountType, Room, RoomEvent } from "./models/room.ts";
 import { logger } from "./logger.ts";
 import { promiseMapSeries } from "./utils.ts";
 import { EventTimeline } from "./models/event-timeline.ts";
-import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client.ts";
+import { ClientEvent, type IStoredClientOpts, type MatrixClient } from "./client.ts";
 import {
-    ISyncStateData,
+    type ISyncStateData,
     SyncState,
     _createAndReEmitRoom,
-    SyncApiOptions,
+    type SyncApiOptions,
     defaultClientOpts,
     defaultSyncApiOpts,
-    SetPresence,
+    type SetPresence,
 } from "./sync.ts";
-import { MatrixEvent } from "./models/event.ts";
-import { Crypto } from "./crypto/index.ts";
-import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator.ts";
+import { type MatrixEvent } from "./models/event.ts";
+import { type Crypto } from "./crypto/index.ts";
+import {
+    type IMinimalEvent,
+    type IRoomEvent,
+    type IStateEvent,
+    type IStrippedState,
+    type ISyncResponse,
+} from "./sync-accumulator.ts";
 import { MatrixError } from "./http-api/index.ts";
 import {
-    Extension,
+    type Extension,
     ExtensionState,
-    MSC3575RoomData,
-    MSC3575SlidingSyncResponse,
-    SlidingSync,
+    type MSC3575RoomData,
+    type MSC3575SlidingSyncResponse,
+    type SlidingSync,
     SlidingSyncEvent,
     SlidingSyncState,
 } from "./sliding-sync.ts";
 import { EventType } from "./@types/event.ts";
-import { IPushRules } from "./@types/PushRules.ts";
+import { type IPushRules } from "./@types/PushRules.ts";
 import { RoomStateEvent } from "./models/room-state.ts";
 import { RoomMemberEvent } from "./models/room-member.ts";
 import { KnownMembership } from "./@types/membership.ts";

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 import { logger } from "./logger.ts";
-import { MatrixClient } from "./client.ts";
-import { IRoomEvent, IStateEvent } from "./sync-accumulator.ts";
+import { type MatrixClient } from "./client.ts";
+import { type IRoomEvent, type IStateEvent } from "./sync-accumulator.ts";
 import { TypedEventEmitter } from "./models/typed-event-emitter.ts";
-import { sleep, IDeferred, defer } from "./utils.ts";
-import { HTTPError } from "./http-api/index.ts";
+import { sleep, type IDeferred, defer } from "./utils.ts";
+import { type HTTPError } from "./http-api/index.ts";
 
 // /sync requests allow you to set a timeout= but the request may continue
 // beyond that and wedge forever, so we need to track how long we are willing

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventType } from "../@types/event.ts";
-import { Room } from "../models/room.ts";
-import { User } from "../models/user.ts";
-import { IEvent, MatrixEvent } from "../models/event.ts";
-import { Filter } from "../filter.ts";
-import { RoomSummary } from "../models/room-summary.ts";
-import { IMinimalEvent, IRooms, ISyncResponse } from "../sync-accumulator.ts";
-import { IStartClientOpts } from "../client.ts";
-import { IStateEventWithRoomId } from "../@types/search.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
-import { EventEmitterEvents } from "../models/typed-event-emitter.ts";
+import { type EventType } from "../@types/event.ts";
+import { type Room } from "../models/room.ts";
+import { type User } from "../models/user.ts";
+import { type IEvent, type MatrixEvent } from "../models/event.ts";
+import { type Filter } from "../filter.ts";
+import { type RoomSummary } from "../models/room-summary.ts";
+import { type IMinimalEvent, type IRooms, type ISyncResponse } from "../sync-accumulator.ts";
+import { type IStartClientOpts } from "../client.ts";
+import { type IStateEventWithRoomId } from "../@types/search.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type EventEmitterEvents } from "../models/typed-event-emitter.ts";
 
 export interface ISavedSync {
     nextBatch: string;

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ISavedSync } from "./index.ts";
-import { IEvent, IStateEventWithRoomId, IStoredClientOpts, ISyncResponse } from "../matrix.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type ISavedSync } from "./index.ts";
+import { type IEvent, type IStateEventWithRoomId, type IStoredClientOpts, type ISyncResponse } from "../matrix.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
 
 export interface IIndexedDBBackend {
     connect(onClose?: () => void): Promise<void>;

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IMinimalEvent, ISyncData, ISyncResponse, SyncAccumulator } from "../sync-accumulator.ts";
+import { type IMinimalEvent, type ISyncData, type ISyncResponse, SyncAccumulator } from "../sync-accumulator.ts";
 import { deepCopy, promiseTry } from "../utils.ts";
 import { exists as idbExists } from "../indexeddb-helpers.ts";
 import { logger } from "../logger.ts";
-import { IStateEventWithRoomId, IStoredClientOpts } from "../matrix.ts";
-import { ISavedSync } from "./index.ts";
-import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type IStateEventWithRoomId, type IStoredClientOpts } from "../matrix.ts";
+import { type ISavedSync } from "./index.ts";
+import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
 
 type DbMigration = (db: IDBDatabase) => void;
 const DB_MIGRATIONS: DbMigration[] = [

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 import { logger } from "../logger.ts";
-import { defer, IDeferred } from "../utils.ts";
-import { ISavedSync } from "./index.ts";
-import { IStoredClientOpts } from "../client.ts";
-import { IStateEventWithRoomId, ISyncResponse } from "../matrix.ts";
-import { IIndexedDBBackend, UserTuple } from "./indexeddb-backend.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { defer, type IDeferred } from "../utils.ts";
+import { type ISavedSync } from "./index.ts";
+import { type IStoredClientOpts } from "../client.ts";
+import { type IStateEventWithRoomId, type ISyncResponse } from "../matrix.ts";
+import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     private worker?: Worker;

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -16,18 +16,18 @@ limitations under the License.
 
 /* eslint-disable @babel/no-invalid-this */
 
-import { MemoryStore, IOpts as IBaseOpts } from "./memory.ts";
+import { MemoryStore, type IOpts as IBaseOpts } from "./memory.ts";
 import { LocalIndexedDBStoreBackend } from "./indexeddb-local-backend.ts";
 import { RemoteIndexedDBStoreBackend } from "./indexeddb-remote-backend.ts";
-import { IEvent, MatrixEvent } from "../models/event.ts";
+import { type IEvent, MatrixEvent } from "../models/event.ts";
 import { logger } from "../logger.ts";
-import { ISavedSync } from "./index.ts";
-import { IIndexedDBBackend } from "./indexeddb-backend.ts";
-import { ISyncResponse } from "../sync-accumulator.ts";
-import { EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { IStateEventWithRoomId } from "../@types/search.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
-import { IStoredClientOpts } from "../client.ts";
+import { type ISavedSync } from "./index.ts";
+import { type IIndexedDBBackend } from "./indexeddb-backend.ts";
+import { type ISyncResponse } from "../sync-accumulator.ts";
+import { type EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter.ts";
+import { type IStateEventWithRoomId } from "../@types/search.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type IStoredClientOpts } from "../client.ts";
 
 /**
  * This is an internal module. See {@link IndexedDBStore} for the public class.

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -18,19 +18,19 @@ limitations under the License.
  * This is an internal module. See {@link MemoryStore} for the public class.
  */
 
-import { EventType } from "../@types/event.ts";
-import { Room } from "../models/room.ts";
-import { User } from "../models/user.ts";
-import { IEvent, MatrixEvent } from "../models/event.ts";
-import { RoomState, RoomStateEvent } from "../models/room-state.ts";
-import { RoomMember } from "../models/room-member.ts";
-import { Filter } from "../filter.ts";
-import { ISavedSync, IStore, UserCreator } from "./index.ts";
-import { RoomSummary } from "../models/room-summary.ts";
-import { ISyncResponse } from "../sync-accumulator.ts";
-import { IStateEventWithRoomId } from "../@types/search.ts";
-import { IndexedToDeviceBatch, ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
-import { IStoredClientOpts } from "../client.ts";
+import { type EventType } from "../@types/event.ts";
+import { type Room } from "../models/room.ts";
+import { type User } from "../models/user.ts";
+import { type IEvent, type MatrixEvent } from "../models/event.ts";
+import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
+import { type RoomMember } from "../models/room-member.ts";
+import { type Filter } from "../filter.ts";
+import { type ISavedSync, type IStore, type UserCreator } from "./index.ts";
+import { type RoomSummary } from "../models/room-summary.ts";
+import { type ISyncResponse } from "../sync-accumulator.ts";
+import { type IStateEventWithRoomId } from "../@types/search.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type IStoredClientOpts } from "../client.ts";
 import { MapWithDefault } from "../utils.ts";
 import { KnownMembership } from "../@types/membership.ts";
 

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -18,17 +18,17 @@ limitations under the License.
  * This is an internal module.
  */
 
-import { EventType } from "../@types/event.ts";
-import { Room } from "../models/room.ts";
-import { User } from "../models/user.ts";
-import { IEvent, MatrixEvent } from "../models/event.ts";
-import { Filter } from "../filter.ts";
-import { ISavedSync, IStore, UserCreator } from "./index.ts";
-import { RoomSummary } from "../models/room-summary.ts";
-import { ISyncResponse } from "../sync-accumulator.ts";
-import { IStateEventWithRoomId } from "../@types/search.ts";
-import { IndexedToDeviceBatch, ToDeviceBatch } from "../models/ToDeviceMessage.ts";
-import { IStoredClientOpts } from "../client.ts";
+import { type EventType } from "../@types/event.ts";
+import { type Room } from "../models/room.ts";
+import { type User } from "../models/user.ts";
+import { type IEvent, type MatrixEvent } from "../models/event.ts";
+import { type Filter } from "../filter.ts";
+import { type ISavedSync, type IStore, type UserCreator } from "./index.ts";
+import { type RoomSummary } from "../models/room-summary.ts";
+import { type ISyncResponse } from "../sync-accumulator.ts";
+import { type IStateEventWithRoomId } from "../@types/search.ts";
+import { type IndexedToDeviceBatch, type ToDeviceBatch } from "../models/ToDeviceMessage.ts";
+import { type IStoredClientOpts } from "../client.ts";
 
 /**
  * Construct a stub store. This does no-ops on most store methods.

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -20,9 +20,9 @@ limitations under the License.
 
 import { logger } from "./logger.ts";
 import { deepCopy } from "./utils.ts";
-import { IContent, IUnsigned } from "./models/event.ts";
-import { IRoomSummary } from "./models/room-summary.ts";
-import { EventType } from "./@types/event.ts";
+import { type IContent, type IUnsigned } from "./models/event.ts";
+import { type IRoomSummary } from "./models/room-summary.ts";
+import { type EventType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { ReceiptAccumulator } from "./receipt-accumulator.ts";
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,43 +23,49 @@ limitations under the License.
  * for HTTP and WS at some point.
  */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
 import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.ts";
 import { User } from "./models/user.ts";
 import { NotificationCountType, Room, RoomEvent } from "./models/room.ts";
-import { deepCopy, defer, IDeferred, noUnsafeEventProps, promiseMapSeries, unsafeProp } from "./utils.ts";
+import { deepCopy, defer, type IDeferred, noUnsafeEventProps, promiseMapSeries, unsafeProp } from "./utils.ts";
 import { Filter } from "./filter.ts";
 import { EventTimeline } from "./models/event-timeline.ts";
 import { logger } from "./logger.ts";
-import { ClientEvent, IStoredClientOpts, MatrixClient, PendingEventOrdering, ResetTimelineCallback } from "./client.ts";
 import {
-    IEphemeral,
-    IInvitedRoom,
-    IInviteState,
-    IJoinedRoom,
-    ILeftRoom,
-    IKnockedRoom,
-    IMinimalEvent,
-    IRoomEvent,
-    IStateEvent,
-    IStrippedState,
-    ISyncResponse,
-    ITimeline,
-    IToDeviceEvent,
+    ClientEvent,
+    type IStoredClientOpts,
+    type MatrixClient,
+    PendingEventOrdering,
+    type ResetTimelineCallback,
+} from "./client.ts";
+import {
+    type IEphemeral,
+    type IInvitedRoom,
+    type IInviteState,
+    type IJoinedRoom,
+    type ILeftRoom,
+    type IKnockedRoom,
+    type IMinimalEvent,
+    type IRoomEvent,
+    type IStateEvent,
+    type IStrippedState,
+    type ISyncResponse,
+    type ITimeline,
+    type IToDeviceEvent,
 } from "./sync-accumulator.ts";
-import { MatrixEvent } from "./models/event.ts";
-import { MatrixError, Method } from "./http-api/index.ts";
-import { ISavedSync } from "./store/index.ts";
+import { type MatrixEvent } from "./models/event.ts";
+import { type MatrixError, Method } from "./http-api/index.ts";
+import { type ISavedSync } from "./store/index.ts";
 import { EventType } from "./@types/event.ts";
-import { IPushRules } from "./@types/PushRules.ts";
-import { RoomStateEvent, IMarkerFoundOptions } from "./models/room-state.ts";
+import { type IPushRules } from "./@types/PushRules.ts";
+import { RoomStateEvent, type IMarkerFoundOptions } from "./models/room-state.ts";
 import { RoomMemberEvent } from "./models/room-member.ts";
 import { BeaconEvent } from "./models/beacon.ts";
-import { IEventsResponse } from "./@types/requests.ts";
+import { type IEventsResponse } from "./@types/requests.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { Feature, ServerSupport } from "./feature.ts";
-import { Crypto } from "./crypto/index.ts";
+import { type Crypto } from "./crypto/index.ts";
 import { KnownMembership } from "./@types/membership.ts";
 
 const DEBUG = true;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -22,11 +22,11 @@ limitations under the License.
  * @packageDocumentation
  */
 
-import { IContent, IEvent, IUnsigned, MatrixEvent } from "./models/event.ts";
-import { RoomMember } from "./models/room-member.ts";
+import { type IContent, type IEvent, type IUnsigned, MatrixEvent } from "./models/event.ts";
+import { type RoomMember } from "./models/room-member.ts";
 import { EventType } from "./@types/event.ts";
-import { DecryptionFailureCode } from "./crypto-api/index.ts";
-import { DecryptionError, EventDecryptionResult } from "./common-crypto/CryptoBackend.ts";
+import { type DecryptionFailureCode } from "./crypto-api/index.ts";
+import { DecryptionError, type EventDecryptionResult } from "./common-crypto/CryptoBackend.ts";
 
 /**
  * Create a {@link MatrixEvent}.

--- a/src/thread-utils.ts
+++ b/src/thread-utils.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { THREAD_RELATION_TYPE } from "./models/thread.ts";
-import { IEvent } from "./models/event.ts";
+import { type IEvent } from "./models/event.ts";
 
 /**
  * Returns a filter function for the /relations endpoint to filter out relations directly

--- a/src/timeline-window.ts
+++ b/src/timeline-window.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
-import { Direction, EventTimeline } from "./models/event-timeline.ts";
+import { type Direction, EventTimeline } from "./models/event-timeline.ts";
 import { logger } from "./logger.ts";
-import { MatrixClient } from "./client.ts";
-import { EventTimelineSet } from "./models/event-timeline-set.ts";
-import { MatrixEvent } from "./models/event.ts";
-import { Room, RoomEvent } from "./models/room.ts";
+import { type MatrixClient } from "./client.ts";
+import { type EventTimelineSet } from "./models/event-timeline-set.ts";
+import { type MatrixEvent } from "./models/event.ts";
+import { type Room, RoomEvent } from "./models/room.ts";
 
 /**
  * @internal

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,12 +20,12 @@ limitations under the License.
 
 import unhomoglyph from "unhomoglyph";
 import promiseRetry from "p-retry";
-import { Optional } from "matrix-events-sdk";
+import { type Optional } from "matrix-events-sdk";
 
-import { IEvent, MatrixEvent } from "./models/event.ts";
+import { type IEvent, type MatrixEvent } from "./models/event.ts";
 import { M_TIMESTAMP } from "./@types/location.ts";
 import { ReceiptType } from "./@types/read_receipts.ts";
-import { BaseLogger } from "./logger.ts";
+import { type BaseLogger } from "./logger.ts";
 
 const interns = new Map<string, string>();
 

--- a/src/utils/decryptAESSecretStorageItem.ts
+++ b/src/utils/decryptAESSecretStorageItem.ts
@@ -16,7 +16,7 @@
 
 import { decodeBase64 } from "../base64.ts";
 import { deriveKeys } from "./internal/deriveKeys.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 
 /**
  * Decrypt an AES-encrypted Secret Storage item.

--- a/src/utils/encryptAESSecretStorageItem.ts
+++ b/src/utils/encryptAESSecretStorageItem.ts
@@ -16,7 +16,7 @@
 
 import { decodeBase64, encodeBase64 } from "../base64.ts";
 import { deriveKeys } from "./internal/deriveKeys.ts";
-import { AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
+import { type AESEncryptedSecretStoragePayload } from "../@types/AESEncryptedSecretStoragePayload.ts";
 
 /**
  * Encrypt a string as a secret storage item, using AES-CTR.

--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -26,33 +26,33 @@ import { parse as parseSdp, write as writeSdp } from "sdp-transform";
 
 import { logger } from "../logger.ts";
 import { checkObjectHasKeys, isNullOrUndefined, recursivelyAssign } from "../utils.ts";
-import { MatrixEvent } from "../models/event.ts";
-import { EventType, TimelineEvents, ToDeviceMessageId } from "../@types/event.ts";
-import { RoomMember } from "../models/room-member.ts";
+import { type MatrixEvent } from "../models/event.ts";
+import { EventType, type TimelineEvents, ToDeviceMessageId } from "../@types/event.ts";
+import { type RoomMember } from "../models/room-member.ts";
 import { randomString } from "../randomstring.ts";
 import {
-    MCallReplacesEvent,
-    MCallAnswer,
-    MCallInviteNegotiate,
-    CallCapabilities,
+    type MCallReplacesEvent,
+    type MCallAnswer,
+    type MCallInviteNegotiate,
+    type CallCapabilities,
     SDPStreamMetadataPurpose,
-    SDPStreamMetadata,
+    type SDPStreamMetadata,
     SDPStreamMetadataKey,
-    MCallSDPStreamMetadataChanged,
-    MCallSelectAnswer,
-    MCAllAssertedIdentity,
-    MCallCandidates,
-    MCallBase,
-    MCallHangupReject,
+    type MCallSDPStreamMetadataChanged,
+    type MCallSelectAnswer,
+    type MCAllAssertedIdentity,
+    type MCallCandidates,
+    type MCallBase,
+    type MCallHangupReject,
 } from "./callEventTypes.ts";
 import { CallFeed } from "./callFeed.ts";
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 import { EventEmitterEvents, TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { DeviceInfo } from "../crypto/deviceinfo.ts";
 import { GroupCallUnknownDeviceError } from "./groupCall.ts";
-import { IScreensharingOpts } from "./mediaHandler.ts";
+import { type IScreensharingOpts } from "./mediaHandler.ts";
 import { MatrixError } from "../http-api/index.ts";
-import { GroupCallStats } from "./stats/groupCallStats.ts";
+import { type GroupCallStats } from "./stats/groupCallStats.ts";
 
 interface CallOpts {
     // The room ID for this call.

--- a/src/webrtc/callEventHandler.ts
+++ b/src/webrtc/callEventHandler.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { logger } from "../logger.ts";
-import { CallDirection, CallError, CallErrorCode, CallState, createNewMatrixCall, MatrixCall } from "./call.ts";
+import { CallDirection, CallError, CallErrorCode, CallState, createNewMatrixCall, type MatrixCall } from "./call.ts";
 import { EventType } from "../@types/event.ts";
-import { ClientEvent, MatrixClient } from "../client.ts";
-import { MCallAnswer, MCallHangupReject } from "./callEventTypes.ts";
-import { GroupCall, GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from "./groupCall.ts";
+import { ClientEvent, type MatrixClient } from "../client.ts";
+import { type MCallAnswer, type MCallHangupReject } from "./callEventTypes.ts";
+import { type GroupCall, GroupCallErrorCode, GroupCallEvent, GroupCallUnknownDeviceError } from "./groupCall.ts";
 import { RoomEvent } from "../models/room.ts";
 
 // Don't ring unless we'd be ringing for at least 3 seconds: the user needs some

--- a/src/webrtc/callEventTypes.ts
+++ b/src/webrtc/callEventTypes.ts
@@ -1,7 +1,7 @@
 // allow non-camelcase as these are events type that go onto the wire
 /* eslint-disable camelcase */
 
-import { CallErrorCode } from "./call.ts";
+import { type CallErrorCode } from "./call.ts";
 
 // TODO: Change to "sdp_stream_metadata" when MSC3077 is merged
 export const SDPStreamMetadataKey = "org.matrix.msc3077.sdp_stream_metadata";

--- a/src/webrtc/callFeed.ts
+++ b/src/webrtc/callFeed.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 import { SDPStreamMetadataPurpose } from "./callEventTypes.ts";
 import { acquireContext, releaseContext } from "./audioContext.ts";
-import { MatrixClient } from "../client.ts";
-import { RoomMember } from "../models/room-member.ts";
+import { type MatrixClient } from "../client.ts";
+import { type RoomMember } from "../models/room-member.ts";
 import { logger } from "../logger.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { CallEvent, CallState, MatrixCall } from "./call.ts";
+import { CallEvent, CallState, type MatrixCall } from "./call.ts";
 
 const POLLING_INTERVAL = 200; // ms
 export const SPEAKING_THRESHOLD = -60; // dB

--- a/src/webrtc/groupCall.ts
+++ b/src/webrtc/groupCall.ts
@@ -1,36 +1,36 @@
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { CallFeed, SPEAKING_THRESHOLD } from "./callFeed.ts";
-import { MatrixClient, IMyDevice } from "../client.ts";
+import { type MatrixClient, type IMyDevice } from "../client.ts";
 import {
     CallErrorCode,
     CallEvent,
-    CallEventHandlerMap,
+    type CallEventHandlerMap,
     CallState,
     genCallID,
-    MatrixCall,
+    type MatrixCall,
     setTracksEnabled,
     createNewMatrixCall,
     CallError,
 } from "./call.ts";
-import { RoomMember } from "../models/room-member.ts";
-import { Room } from "../models/room.ts";
+import { type RoomMember } from "../models/room-member.ts";
+import { type Room } from "../models/room.ts";
 import { RoomStateEvent } from "../models/room-state.ts";
 import { logger } from "../logger.ts";
 import { ReEmitter } from "../ReEmitter.ts";
 import { SDPStreamMetadataPurpose } from "./callEventTypes.ts";
-import { MatrixEvent } from "../models/event.ts";
+import { type MatrixEvent } from "../models/event.ts";
 import { EventType } from "../@types/event.ts";
 import { CallEventHandlerEvent } from "./callEventHandler.ts";
 import { GroupCallEventHandlerEvent } from "./groupCallEventHandler.ts";
-import { IScreensharingOpts } from "./mediaHandler.ts";
+import { type IScreensharingOpts } from "./mediaHandler.ts";
 import { mapsEqual } from "../utils.ts";
 import { GroupCallStats } from "./stats/groupCallStats.ts";
 import {
-    ByteSentStatsReport,
-    CallFeedReport,
-    ConnectionStatsReport,
+    type ByteSentStatsReport,
+    type CallFeedReport,
+    type ConnectionStatsReport,
     StatsReport,
-    SummaryStatsReport,
+    type SummaryStatsReport,
 } from "./stats/statsReport.ts";
 import { SummaryStatsReportGatherer } from "./stats/summaryStatsReportGatherer.ts";
 import { CallFeedStatsReporter } from "./stats/callFeedStatsReporter.ts";

--- a/src/webrtc/groupCallEventHandler.ts
+++ b/src/webrtc/groupCallEventHandler.ts
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event.ts";
-import { MatrixClient, ClientEvent } from "../client.ts";
-import { GroupCall, GroupCallIntent, GroupCallType, IGroupCallDataChannelOptions } from "./groupCall.ts";
-import { Room } from "../models/room.ts";
-import { RoomState, RoomStateEvent } from "../models/room-state.ts";
-import { RoomMember } from "../models/room-member.ts";
+import { type MatrixEvent } from "../models/event.ts";
+import { type MatrixClient, ClientEvent } from "../client.ts";
+import { GroupCall, GroupCallIntent, GroupCallType, type IGroupCallDataChannelOptions } from "./groupCall.ts";
+import { type Room } from "../models/room.ts";
+import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
+import { type RoomMember } from "../models/room-member.ts";
 import { logger } from "../logger.ts";
 import { EventType } from "../@types/event.ts";
 import { SyncState } from "../sync.ts";

--- a/src/webrtc/mediaHandler.ts
+++ b/src/webrtc/mediaHandler.ts
@@ -20,7 +20,7 @@ limitations under the License.
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { GroupCallType, GroupCallState } from "../webrtc/groupCall.ts";
 import { logger } from "../logger.ts";
-import { MatrixClient } from "../client.ts";
+import { type MatrixClient } from "../client.ts";
 
 export enum MediaHandlerEvent {
     LocalStreamsChanged = "local_streams_changed",

--- a/src/webrtc/stats/callFeedStatsReporter.ts
+++ b/src/webrtc/stats/callFeedStatsReporter.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { CallFeedReport, CallFeedStats, TrackStats, TransceiverStats } from "./statsReport.ts";
-import { CallFeed } from "../callFeed.ts";
+import { type CallFeedReport, type CallFeedStats, type TrackStats, type TransceiverStats } from "./statsReport.ts";
+import { type CallFeed } from "../callFeed.ts";
 
 export class CallFeedStatsReporter {
     public static buildCallFeedReport(callId: string, opponentMemberId: string, pc: RTCPeerConnection): CallFeedReport {

--- a/src/webrtc/stats/callStatsReportGatherer.ts
+++ b/src/webrtc/stats/callStatsReportGatherer.ts
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import { ConnectionStats } from "./connectionStats.ts";
-import { StatsReportEmitter } from "./statsReportEmitter.ts";
-import { ByteSend, ByteSentStatsReport, TrackID } from "./statsReport.ts";
+import { type StatsReportEmitter } from "./statsReportEmitter.ts";
+import { type ByteSend, type ByteSentStatsReport, type TrackID } from "./statsReport.ts";
 import { ConnectionStatsBuilder } from "./connectionStatsBuilder.ts";
 import { TransportStatsBuilder } from "./transportStatsBuilder.ts";
 import { MediaSsrcHandler } from "./media/mediaSsrcHandler.ts";
@@ -25,7 +25,7 @@ import { MediaTrackStatsHandler } from "./media/mediaTrackStatsHandler.ts";
 import { TrackStatsBuilder } from "./trackStatsBuilder.ts";
 import { ConnectionStatsReportBuilder } from "./connectionStatsReportBuilder.ts";
 import { ValueFormatter } from "./valueFormatter.ts";
-import { CallStatsReportSummary } from "./callStatsReportSummary.ts";
+import { type CallStatsReportSummary } from "./callStatsReportSummary.ts";
 import { logger } from "../../logger.ts";
 import { CallFeedStatsReporter } from "./callFeedStatsReporter.ts";
 

--- a/src/webrtc/stats/connectionStats.ts
+++ b/src/webrtc/stats/connectionStats.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TransportStats } from "./transportStats.ts";
-import { Bitrate } from "./media/mediaTrackStats.ts";
+import { type TransportStats } from "./transportStats.ts";
+import { type Bitrate } from "./media/mediaTrackStats.ts";
 
 export interface ConnectionStatsBandwidth {
     /**

--- a/src/webrtc/stats/connectionStatsBuilder.ts
+++ b/src/webrtc/stats/connectionStatsBuilder.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { Bitrate } from "./media/mediaTrackStats.ts";
+import { type Bitrate } from "./media/mediaTrackStats.ts";
 
 export class ConnectionStatsBuilder {
     public static buildBandwidthReport(now: RTCIceCandidatePairStats): Bitrate {

--- a/src/webrtc/stats/connectionStatsReportBuilder.ts
+++ b/src/webrtc/stats/connectionStatsReportBuilder.ts
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {
-    AudioConcealment,
-    CodecMap,
-    ConnectionStatsReport,
-    FramerateMap,
-    ResolutionMap,
-    TrackID,
+    type AudioConcealment,
+    type CodecMap,
+    type ConnectionStatsReport,
+    type FramerateMap,
+    type ResolutionMap,
+    type TrackID,
 } from "./statsReport.ts";
-import { MediaTrackStats, Resolution } from "./media/mediaTrackStats.ts";
+import { type MediaTrackStats, type Resolution } from "./media/mediaTrackStats.ts";
 
 export class ConnectionStatsReportBuilder {
     public static build(stats: Map<TrackID, MediaTrackStats>): ConnectionStatsReport {

--- a/src/webrtc/stats/groupCallStats.ts
+++ b/src/webrtc/stats/groupCallStats.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 import { CallStatsReportGatherer } from "./callStatsReportGatherer.ts";
 import { StatsReportEmitter } from "./statsReportEmitter.ts";
-import { CallStatsReportSummary } from "./callStatsReportSummary.ts";
+import { type CallStatsReportSummary } from "./callStatsReportSummary.ts";
 import { SummaryStatsReportGatherer } from "./summaryStatsReportGatherer.ts";
 import { logger } from "../../logger.ts";
 

--- a/src/webrtc/stats/media/mediaTrackStats.ts
+++ b/src/webrtc/stats/media/mediaTrackStats.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { AudioConcealment } from "../statsReport.ts";
-import { TrackId } from "./mediaTrackHandler.ts";
+import { type AudioConcealment } from "../statsReport.ts";
+import { type TrackId } from "./mediaTrackHandler.ts";
 
 export interface PacketLoss {
     packetsTotal: number;

--- a/src/webrtc/stats/media/mediaTrackStatsHandler.ts
+++ b/src/webrtc/stats/media/mediaTrackStatsHandler.ts
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { TrackID } from "../statsReport.ts";
+import { type TrackID } from "../statsReport.ts";
 import { MediaTrackStats } from "./mediaTrackStats.ts";
-import { MediaTrackHandler, TrackId } from "./mediaTrackHandler.ts";
-import { MediaSsrcHandler } from "./mediaSsrcHandler.ts";
+import { type MediaTrackHandler, type TrackId } from "./mediaTrackHandler.ts";
+import { type MediaSsrcHandler } from "./mediaSsrcHandler.ts";
 
 export class MediaTrackStatsHandler {
     private readonly track2stats = new Map<TrackID, MediaTrackStats>();

--- a/src/webrtc/stats/statsReport.ts
+++ b/src/webrtc/stats/statsReport.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ConnectionStatsBandwidth, ConnectionStatsBitrate, PacketLoss } from "./connectionStats.ts";
-import { TransportStats } from "./transportStats.ts";
-import { Resolution } from "./media/mediaTrackStats.ts";
+import { type ConnectionStatsBandwidth, type ConnectionStatsBitrate, type PacketLoss } from "./connectionStats.ts";
+import { type TransportStats } from "./transportStats.ts";
+import { type Resolution } from "./media/mediaTrackStats.ts";
 
 export enum StatsReport {
     CONNECTION_STATS = "StatsReport.connection_stats",

--- a/src/webrtc/stats/statsReportEmitter.ts
+++ b/src/webrtc/stats/statsReportEmitter.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 import { TypedEventEmitter } from "../../models/typed-event-emitter.ts";
 import {
-    ByteSentStatsReport,
-    CallFeedReport,
-    ConnectionStatsReport,
+    type ByteSentStatsReport,
+    type CallFeedReport,
+    type ConnectionStatsReport,
     StatsReport,
-    SummaryStatsReport,
+    type SummaryStatsReport,
 } from "./statsReport.ts";
 
 export type StatsReportHandlerMap = {

--- a/src/webrtc/stats/summaryStatsReportGatherer.ts
+++ b/src/webrtc/stats/summaryStatsReportGatherer.ts
@@ -10,11 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { StatsReportEmitter } from "./statsReportEmitter.ts";
-import { CallStatsReportSummary } from "./callStatsReportSummary.ts";
-import { SummaryStatsReport } from "./statsReport.ts";
-import { ParticipantState } from "../groupCall.ts";
-import { RoomMember } from "../../matrix.ts";
+import { type StatsReportEmitter } from "./statsReportEmitter.ts";
+import { type CallStatsReportSummary } from "./callStatsReportSummary.ts";
+import { type SummaryStatsReport } from "./statsReport.ts";
+import { type ParticipantState } from "../groupCall.ts";
+import { type RoomMember } from "../../matrix.ts";
 
 interface CallStatsReportSummaryCounter {
     receivedAudio: number;

--- a/src/webrtc/stats/trackStatsBuilder.ts
+++ b/src/webrtc/stats/trackStatsBuilder.ts
@@ -1,6 +1,6 @@
-import { MediaTrackStats } from "./media/mediaTrackStats.ts";
+import { type MediaTrackStats } from "./media/mediaTrackStats.ts";
 import { ValueFormatter } from "./valueFormatter.ts";
-import { TrackSummary } from "./callStatsReportSummary.ts";
+import { type TrackSummary } from "./callStatsReportSummary.ts";
 
 export class TrackStatsBuilder {
     public static buildFramerateResolution(trackStats: MediaTrackStats, now: any): void {

--- a/src/webrtc/stats/transportStatsBuilder.ts
+++ b/src/webrtc/stats/transportStatsBuilder.ts
@@ -1,4 +1,4 @@
-import { TransportStats } from "./transportStats.ts";
+import { type TransportStats } from "./transportStats.ts";
 
 export class TransportStatsBuilder {
     public static buildReport(


### PR DESCRIPTION
This is a speculative PR after encountering an unexpected (and unnecessary) circular dependency in some unit tests.

Some background on this rule: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/

We already have the equivalent of this for exports from https://github.com/matrix-org/eslint-plugin-matrix-org/blob/a1ce5fbb7d425b932c504ae2bb7f985e3c07d9fd/typescript.js#L99

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
