### PR TITLE
Add `CryptoApi.resetEncryption`

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1895,7 +1895,7 @@ describe("RustCrypto", () => {
             fetchMock.post("path:/_matrix/client/v3/keys/signatures/upload", {});
         });
 
-        it("key backup should stay disabled after reset", async () => {
+        it("reset should reset 4S, backup and cross-signing", async () => {
             // We don't have a key backup
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", {});
 
@@ -1939,9 +1939,9 @@ describe("RustCrypto", () => {
             );
 
             // A new key backup should be created after the reset
-            let content!: KeyBackupInfo;
+            let newKeyBackupInfo!: KeyBackupInfo;
             fetchMock.post("path:/_matrix/client/v3/room_keys/version", (res, options) => {
-                content = JSON.parse(options.body as string);
+                newKeyBackupInfo = JSON.parse(options.body as string);
                 return { version: "2" };
             });
 
@@ -1949,7 +1949,7 @@ describe("RustCrypto", () => {
             await rustCrypto.resetEncryption(authUploadDeviceSigningKeys);
 
             // A new key backup should be created
-            expect(content.auth_data).toBeTruthy();
+            expect(newKeyBackupInfo.auth_data).toBeTruthy();
             // The new cross signing keys should be uploaded
             expect(authUploadDeviceSigningKeys).toHaveBeenCalledWith(expect.any(Function));
         });

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -61,6 +61,7 @@ import {
     EventShieldReason,
     ImportRoomKeysOpts,
     KeyBackupCheck,
+    KeyBackupInfo,
     VerificationRequest,
 } from "../../../src/crypto-api";
 import * as testData from "../../test-utils/test-data";
@@ -72,6 +73,7 @@ import { Curve25519AuthData } from "../../../src/crypto-api/keybackup";
 import encryptAESSecretStorageItem from "../../../src/utils/encryptAESSecretStorageItem.ts";
 import { CryptoStore, SecretStorePrivateKeys } from "../../../src/crypto/store/base";
 import { CryptoEvent } from "../../../src/crypto-api/index.ts";
+import { RustBackupManager } from "../../../src/rust-crypto/backup.ts";
 
 const TEST_USER = "@alice:example.com";
 const TEST_DEVICE_ID = "TEST_DEVICE";
@@ -1877,6 +1879,79 @@ describe("RustCrypto", () => {
                     "sender_key": expect.any(String),
                 }),
             );
+        });
+    });
+
+    describe("resetEncryption", () => {
+        let secretStorage: ServerSideSecretStorage;
+        beforeEach(() => {
+            secretStorage = {
+                setDefaultKeyId: jest.fn(),
+                hasKey: jest.fn().mockResolvedValue(false),
+                getKey: jest.fn().mockResolvedValue(null),
+            } as unknown as ServerSideSecretStorage;
+
+            fetchMock.post("path:/_matrix/client/v3/keys/upload", { one_time_key_counts: {} });
+            fetchMock.post("path:/_matrix/client/v3/keys/signatures/upload", {});
+        });
+
+        it("key backup should stay disabled after reset", async () => {
+            // We don't have a key backup
+            fetchMock.get("path:/_matrix/client/v3/room_keys/version", {});
+
+            const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), undefined, undefined, secretStorage);
+
+            const authUploadDeviceSigningKeys = jest.fn();
+            await rustCrypto.resetEncryption(authUploadDeviceSigningKeys);
+
+            // The default key id should be deleted
+            expect(secretStorage.setDefaultKeyId).toHaveBeenCalledWith(null);
+            expect(await rustCrypto.getActiveSessionBackupVersion()).toBeNull();
+            // The new cross signing keys should be uploaded
+            expect(authUploadDeviceSigningKeys).toHaveBeenCalledWith(expect.any(Function));
+        });
+
+        it("key backup should be re-enabled after reset", async () => {
+            fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
+            // When we will delete the key backup
+            fetchMock.delete("path:/_matrix/client/v3/room_keys/version/1", {});
+
+            // We consider the key backup as trusted
+            jest.spyOn(RustBackupManager.prototype, "isKeyBackupTrusted").mockResolvedValue({
+                trusted: true,
+                matchesDecryptionKey: true,
+            });
+
+            const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), undefined, undefined, secretStorage);
+            // We have a key backup
+            expect(await rustCrypto.getActiveSessionBackupVersion()).not.toBeNull();
+
+            let nbCalls = 0;
+            fetchMock.get(
+                "path:/_matrix/client/v3/room_keys/version",
+                () => {
+                    // First call is when we check if the key backup is enabled.
+                    // Second call is when we get the next backup after we deleted the first key backup,
+                    // we return an empty object because we don't have a key backup anymore.
+                    return ++nbCalls === 1 ? testData.SIGNED_BACKUP_DATA : {};
+                },
+                { overwriteRoutes: true },
+            );
+
+            // A new key backup should be created after the reset
+            let content!: KeyBackupInfo;
+            fetchMock.post("path:/_matrix/client/v3/room_keys/version", (res, options) => {
+                content = JSON.parse(options.body as string);
+                return { version: "2" };
+            });
+
+            const authUploadDeviceSigningKeys = jest.fn();
+            await rustCrypto.resetEncryption(authUploadDeviceSigningKeys);
+
+            // A new key backup should be created
+            expect(content.auth_data).toBeTruthy();
+            // The new cross signing keys should be uploaded
+            expect(authUploadDeviceSigningKeys).toHaveBeenCalledWith(expect.any(Function));
         });
     });
 });

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -396,6 +396,19 @@ export interface CryptoApi {
         payload: ToDevicePayload,
     ): Promise<ToDeviceBatch>;
 
+    /**
+     * Reset the encryption of the user by going through the following steps:
+     * - Disable backing up room keys and delete any existing backup.
+     * - Remove the default secret storage key from the account data (ie: the recovery key).
+     * - Reset the cross-signing keys.
+     * - Re-enable backing up room keys if enabled before.
+     *
+     * @param authUploadDeviceSigningKeys - Callback to authenticate the upload of device signing keys.
+     *                                      Used when resetting the cross signing keys.
+     *                                      See {@link BootstrapCrossSigningOpts#authUploadDeviceSigningKeys}.
+     */
+    resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void>;
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //
     // Device/User verification

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -398,14 +398,14 @@ export interface CryptoApi {
 
     /**
      * Reset the encryption of the user by going through the following steps:
-     * - Disable backing up room keys and delete any existing backup.
+     * - Disable backing up room keys and delete any existing backups.
      * - Remove the default secret storage key from the account data (ie: the recovery key).
      * - Reset the cross-signing keys.
      * - Re-enable backing up room keys if enabled before.
      *
      * @param authUploadDeviceSigningKeys - Callback to authenticate the upload of device signing keys.
-     *                                      Used when resetting the cross signing keys.
-     *                                      See {@link BootstrapCrossSigningOpts#authUploadDeviceSigningKeys}.
+     *      Used when resetting the cross signing keys.
+     *      See {@link BootstrapCrossSigningOpts#authUploadDeviceSigningKeys}.
      */
     resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void>;
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4340,6 +4340,13 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     ): Promise<KeyBackupRestoreResult> {
         throw new Error("Not implemented");
     }
+
+    /**
+     * Stub function -- resetEncryption is not implemented here, so throw error
+     */
+    public resetEncryption(): Promise<void> {
+        throw new Error("Not implemented");
+    }
 }
 
 /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1479,7 +1479,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     public async resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void> {
         const backupEnabled = (await this.backupManager.getActiveBackupVersion()) !== null;
 
-        // Delete all the backup
+        // Disable backup, and delete all the backups from the server
         await this.backupManager.deleteAllKeyBackupVersions();
 
         // Disable the recovery key and the secret storage

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -88,6 +88,7 @@ import { PerSessionKeyBackupDownloader } from "./PerSessionKeyBackupDownloader.t
 import { DehydratedDeviceManager } from "./DehydratedDeviceManager.ts";
 import { VerificationMethod } from "../types.ts";
 import { keyFromAuthData } from "../common-crypto/key-passphrase.ts";
+import { UIAuthCallback } from "../interactive-auth.ts";
 
 const ALL_VERIFICATION_METHODS = [
     VerificationMethod.Sas,
@@ -1470,6 +1471,30 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         );
 
         return batch;
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#resetEncryption}.
+     */
+    public async resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void> {
+        const backupEnabled = (await this.backupManager.getActiveBackupVersion()) !== null;
+
+        // Delete all the backup
+        await this.backupManager.deleteAllKeyBackupVersions();
+
+        // Disable the recovery key and the secret storage
+        await this.secretStorage.setDefaultKeyId(null);
+
+        // Reset the cross-signing keys
+        await this.crossSigningIdentity.bootstrapCrossSigning({
+            setupNewCrossSigning: true,
+            authUploadDeviceSigningKeys,
+        });
+
+        // If key backup was enabled, we create a new backup
+        if (backupEnabled) {
+            await this.resetKeyBackup();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/28977
Require https://github.com/matrix-org/matrix-js-sdk/pull/4615
Add `CryptoApi.resetEncryption`.

The goal of this new api is to give an easy to reset the current encryption state of the user:
- Disable backing up room keys and delete any existing backup.
- Remove the default secret storage key from the account data (ie: the recovery key).
- Reset the cross-signing keys.
- Re-enable backing up room keys if enabled before.