### PR TITLE
Add authenticated media to getAvatarUrl in room and room-member models

### DIFF
--- a/spec/unit/room-member.spec.ts
+++ b/spec/unit/room-member.spec.ts
@@ -65,6 +65,40 @@ describe("RoomMember", function () {
             const url = member.getAvatarUrl(hsUrl, 64, 64, "crop", false, false);
             expect(url).toEqual(null);
         });
+
+        it("should return unauthenticated media URL if useAuthentication is not set", function () {
+            member.events.member = utils.mkEvent({
+                event: true,
+                type: "m.room.member",
+                skey: userA,
+                room: roomId,
+                user: userA,
+                content: {
+                    membership: KnownMembership.Join,
+                    avatar_url: "mxc://flibble/wibble",
+                },
+            });
+            const url = member.getAvatarUrl(hsUrl, 1, 1, "", false, false);
+            // Check for unauthenticated media prefix
+            expect(url?.indexOf("/_matrix/media/v3/")).not.toEqual(-1);
+        });
+
+        it("should return authenticated media URL if useAuthentication=true", function () {
+            member.events.member = utils.mkEvent({
+                event: true,
+                type: "m.room.member",
+                skey: userA,
+                room: roomId,
+                user: userA,
+                content: {
+                    membership: KnownMembership.Join,
+                    avatar_url: "mxc://flibble/wibble",
+                },
+            });
+            const url = member.getAvatarUrl(hsUrl, 1, 1, "", false, false, true);
+            // Check for authenticated media prefix
+            expect(url?.indexOf("/_matrix/client/v1/media/")).not.toEqual(-1);
+        });
     });
 
     describe("setPowerLevelEvent", function () {

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -299,6 +299,48 @@ describe("Room", function () {
             const url = room.getAvatarUrl(hsUrl, 64, 64, "crop", false);
             expect(url).toEqual(null);
         });
+
+        it("should return unauthenticated media URL if useAuthentication is not set", function () {
+            // @ts-ignore - mocked doesn't handle overloads sanely
+            mocked(room.currentState.getStateEvents).mockImplementation(function (type, key) {
+                if (type === EventType.RoomAvatar && key === "") {
+                    return utils.mkEvent({
+                        event: true,
+                        type: EventType.RoomAvatar,
+                        skey: "",
+                        room: roomId,
+                        user: userA,
+                        content: {
+                            url: "mxc://flibble/wibble",
+                        },
+                    });
+                }
+            });
+            const url = room.getAvatarUrl(hsUrl, 100, 100, "scale");
+            // Check for unauthenticated media prefix
+            expect(url?.indexOf("/_matrix/media/v3/")).not.toEqual(-1);
+        });
+
+        it("should return authenticated media URL if useAuthentication=true", function () {
+            // @ts-ignore - mocked doesn't handle overloads sanely
+            mocked(room.currentState.getStateEvents).mockImplementation(function (type, key) {
+                if (type === EventType.RoomAvatar && key === "") {
+                    return utils.mkEvent({
+                        event: true,
+                        type: EventType.RoomAvatar,
+                        skey: "",
+                        room: roomId,
+                        user: userA,
+                        content: {
+                            url: "mxc://flibble/wibble",
+                        },
+                    });
+                }
+            });
+            const url = room.getAvatarUrl(hsUrl, 100, 100, "scale", undefined, true);
+            // Check for authenticated media prefix
+            expect(url?.indexOf("/_matrix/client/v1/media/")).not.toEqual(-1);
+        });
     });
 
     describe("getMember", function () {

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -368,6 +368,11 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
      * If false, any non-matrix content URLs will be ignored. Setting this option to
      * true will expose URLs that, if fetched, will leak information about the user
      * to anyone who they share a room with.
+     * @param useAuthentication - (optional) If true, the caller supports authenticated
+     * media and wants an authentication-required URL. Note that server support for
+     * authenticated media will not be checked - it is the caller's responsibility
+     * to do so before calling this function. Note also that useAuthentication
+     * implies allowRedirects. Defaults to false (unauthenticated endpoints).
      * @returns the avatar URL or null.
      */
     public getAvatarUrl(
@@ -377,13 +382,23 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
         resizeMethod: string,
         allowDefault = true,
         allowDirectLinks: boolean,
+        useAuthentication: boolean = false,
     ): string | null {
         const rawUrl = this.getMxcAvatarUrl();
 
         if (!rawUrl && !allowDefault) {
             return null;
         }
-        const httpUrl = getHttpUriForMxc(baseUrl, rawUrl, width, height, resizeMethod, allowDirectLinks);
+        const httpUrl = getHttpUriForMxc(
+            baseUrl,
+            rawUrl,
+            width,
+            height,
+            resizeMethod,
+            allowDirectLinks,
+            undefined,
+            useAuthentication,
+        );
         if (httpUrl) {
             return httpUrl;
         }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1661,6 +1661,11 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * "crop" or "scale".
      * @param allowDefault - True to allow an identicon for this room if an
      * avatar URL wasn't explicitly set. Default: true. (Deprecated)
+     * @param useAuthentication - (optional) If true, the caller supports authenticated
+     * media and wants an authentication-required URL. Note that server support for
+     * authenticated media will not be checked - it is the caller's responsibility
+     * to do so before calling this function. Note also that useAuthentication
+     * implies allowRedirects. Defaults to false (unauthenticated endpoints).
      * @returns the avatar URL or null.
      */
     public getAvatarUrl(
@@ -1669,6 +1674,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         height: number,
         resizeMethod: ResizeMethod,
         allowDefault = true,
+        useAuthentication: boolean = false,
     ): string | null {
         const roomAvatarEvent = this.currentState.getStateEvents(EventType.RoomAvatar, "");
         if (!roomAvatarEvent && !allowDefault) {
@@ -1677,7 +1683,16 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
 
         const mainUrl = roomAvatarEvent ? roomAvatarEvent.getContent().url : null;
         if (mainUrl) {
-            return getHttpUriForMxc(baseUrl, mainUrl, width, height, resizeMethod);
+            return getHttpUriForMxc(
+                baseUrl,
+                mainUrl,
+                width,
+                height,
+                resizeMethod,
+                undefined,
+                undefined,
+                useAuthentication,
+            );
         }
 
         return null;


### PR DESCRIPTION
Fixes getAvatarUrl in src/models/room.ts and src/models/room-member.ts not working on homeservers that enforce authenticated media

Signed-off-by: Maurizio Abbruzzo [maurizio@abbruzzosantiago.de](mailto:maurizio@abbruzzosantiago.de)

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
