### PR TITLE
Ensure room is in store before emitting events from it

### DIFF
--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -389,6 +389,8 @@ export class SlidingSyncSdk {
                 return;
             }
             room = _createAndReEmitRoom(this.client, roomId, this.opts);
+            this.client.store.storeRoom(room);
+            this.client.emit(ClientEvent.Room, room);
         }
         await this.processRoomData(this.client, room!, roomData);
     }
@@ -644,8 +646,6 @@ export class SlidingSyncSdk {
             await this.injectRoomEvents(room, inviteStateEvents);
             if (roomData.initial) {
                 room.recalculate();
-                this.client.store.storeRoom(room);
-                this.client.emit(ClientEvent.Room, room);
             }
             inviteStateEvents.forEach((e) => {
                 this.client.emit(ClientEvent.Event, e);
@@ -723,10 +723,6 @@ export class SlidingSyncSdk {
         room.updateMyMembership(KnownMembership.Join);
 
         room.recalculate();
-        if (roomData.initial) {
-            client.store.storeRoom(room);
-            client.emit(ClientEvent.Room, room);
-        }
 
         // check if any timeline events should bing and add them to the notifEvents array:
         // we'll purge this once we've fully processed the sync response

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -23,7 +23,7 @@ import { ClientEvent, IStoredClientOpts, MatrixClient } from "./client.ts";
 import {
     ISyncStateData,
     SyncState,
-    _createAndReEmitRoom,
+    _createAndSetupRoom,
     SyncApiOptions,
     defaultClientOpts,
     defaultSyncApiOpts,
@@ -388,8 +388,7 @@ export class SlidingSyncSdk {
                 logger.debug("initial flag not set but no stored room exists for room ", roomId, roomData);
                 return;
             }
-            room = _createAndReEmitRoom(this.client, roomId, this.opts);
-            this.client.store.storeRoom(room);
+            room = _createAndSetupRoom(this.client, roomId, this.opts);
         }
         await this.processRoomData(this.client, room!, roomData);
     }

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -390,7 +390,6 @@ export class SlidingSyncSdk {
             }
             room = _createAndReEmitRoom(this.client, roomId, this.opts);
             this.client.store.storeRoom(room);
-            this.client.emit(ClientEvent.Room, room);
         }
         await this.processRoomData(this.client, room!, roomData);
     }
@@ -646,6 +645,7 @@ export class SlidingSyncSdk {
             await this.injectRoomEvents(room, inviteStateEvents);
             if (roomData.initial) {
                 room.recalculate();
+                this.client.emit(ClientEvent.Room, room);
             }
             inviteStateEvents.forEach((e) => {
                 this.client.emit(ClientEvent.Event, e);
@@ -723,6 +723,9 @@ export class SlidingSyncSdk {
         room.updateMyMembership(KnownMembership.Join);
 
         room.recalculate();
+        if (roomData.initial) {
+            this.client.emit(ClientEvent.Room, room);
+        }
 
         // check if any timeline events should bing and add them to the notifEvents array:
         // we'll purge this once we've fully processed the sync response


### PR DESCRIPTION
Otherwise things reacting to timeline/state events on the client may call `getRoom` get null and panic.