### PR TITLE
Provide more options for starting dehydration

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^12.0.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^12.1.0",
         "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^12.1.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^13.0.0",
         "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^11.0.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^12.0.0",
         "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -50,6 +50,13 @@ import { THREAD_RELATION_TYPE } from "../../src/models/thread";
 import { IActionsObject } from "../../src/pushprocessor";
 import { KnownMembership } from "../../src/@types/membership";
 
+declare module "../../src/@types/event" {
+    interface AccountDataEvents {
+        a: {};
+        b: {};
+    }
+}
+
 describe("MatrixClient syncing", () => {
     const selfUserId = "@alice:localhost";
     const selfAccessToken = "aseukfgwef";

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -45,6 +45,13 @@ import { emitPromise } from "../test-utils/test-utils";
 import { defer } from "../../src/utils";
 import { KnownMembership } from "../../src/@types/membership";
 
+declare module "../../src/@types/event" {
+    interface AccountDataEvents {
+        global_test: {};
+        tester: {};
+    }
+}
+
 describe("SlidingSyncSdk", () => {
     let client: MatrixClient | undefined;
     let httpBackend: MockHttpBackend | undefined;

--- a/spec/unit/crypto/secrets.spec.ts
+++ b/spec/unit/crypto/secrets.spec.ts
@@ -30,6 +30,7 @@ import { ICurve25519AuthData } from "../../../src/crypto/keybackup";
 import { SecretStorageKeyDescription, SECRET_STORAGE_ALGORITHM_V1_AES } from "../../../src/secret-storage";
 import { decodeBase64 } from "../../../src/base64";
 import { CrossSigningKeyInfo } from "../../../src/crypto-api";
+import { SecretInfo } from "../../../src/secret-storage.ts";
 
 async function makeTestClient(
     userInfo: { userId: string; deviceId: string },
@@ -66,6 +67,12 @@ function sign<T extends IObject | ICurve25519AuthData>(
         signatures: ISignatures;
         unsigned?: object;
     };
+}
+
+declare module "../../../src/@types/event" {
+    interface SecretStorageAccountDataEvents {
+        foo: SecretInfo;
+    }
 }
 
 describe("Secrets", function () {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -94,6 +94,12 @@ function convertQueryDictToMap(queryDict?: QueryDict): Map<string, string> {
     return new Map(Object.entries(queryDict).map(([k, v]) => [k, String(v)]));
 }
 
+declare module "../../src/@types/event" {
+    interface AccountDataEvents {
+        "im.vector.test": {};
+    }
+}
+
 type HttpLookup = {
     method: string;
     path: string;

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -30,6 +30,7 @@ import fetchMock from "fetch-mock-jest";
 import { RustCrypto } from "../../../src/rust-crypto/rust-crypto";
 import { initRustCrypto } from "../../../src/rust-crypto";
 import {
+    AccountDataEvents,
     Device,
     DeviceVerification,
     encodeBase64,
@@ -1924,11 +1925,13 @@ class DummyAccountDataClient
         super();
     }
 
-    public async getAccountDataFromServer<T extends Record<string, any>>(eventType: string): Promise<T | null> {
+    public async getAccountDataFromServer<K extends keyof AccountDataEvents>(
+        eventType: K,
+    ): Promise<AccountDataEvents[K] | null> {
         const ret = this.storage.get(eventType);
 
         if (eventType) {
-            return ret as T;
+            return ret;
         } else {
             return null;
         }

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2114,8 +2114,6 @@ class DummyAccountDataClient
     }
 }
 
-/** emulate 
-
 /** Pad a string to 43 characters long */
 function pad43(x: string): string {
     return x + ".".repeat(43 - x.length);

--- a/spec/unit/rust-crypto/secret-storage.spec.ts
+++ b/spec/unit/rust-crypto/secret-storage.spec.ts
@@ -19,6 +19,18 @@ import {
     secretStorageContainsCrossSigningKeys,
 } from "../../../src/rust-crypto/secret-storage";
 import { ServerSideSecretStorage } from "../../../src/secret-storage";
+import { SecretInfo } from "../../../src/secret-storage.ts";
+
+declare module "../../../src/@types/event" {
+    interface SecretStorageAccountDataEvents {
+        secretA: SecretInfo;
+        secretB: SecretInfo;
+        secretC: SecretInfo;
+        secretD: SecretInfo;
+        secretE: SecretInfo;
+        Unknown: SecretInfo;
+    }
+}
 
 describe("secret-storage", () => {
     describe("secretStorageContainsCrossSigningKeys", () => {

--- a/spec/unit/secret-storage.spec.ts
+++ b/spec/unit/secret-storage.spec.ts
@@ -27,6 +27,14 @@ import {
     trimTrailingEquals,
 } from "../../src/secret-storage";
 import { randomString } from "../../src/randomstring";
+import { SecretInfo } from "../../src/secret-storage.ts";
+import { AccountDataEvents } from "../../src";
+
+declare module "../../src/@types/event" {
+    interface SecretStorageAccountDataEvents {
+        mysecret: SecretInfo;
+    }
+}
 
 describe("ServerSideSecretStorageImpl", function () {
     describe(".addKey", function () {
@@ -117,9 +125,11 @@ describe("ServerSideSecretStorageImpl", function () {
             const secretStorage = new ServerSideSecretStorageImpl(accountDataAdapter, {});
 
             const storedKey = { iv: "iv", mac: "mac" } as SecretStorageKeyDescriptionAesV1;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
+            async function mockGetAccountData<K extends keyof AccountDataEvents>(
+                eventType: string,
+            ): Promise<AccountDataEvents[K] | null> {
                 if (eventType === "m.secret_storage.key.my_key") {
-                    return storedKey as unknown as T;
+                    return storedKey as any;
                 } else {
                     throw new Error(`unexpected eventType ${eventType}`);
                 }
@@ -135,11 +145,13 @@ describe("ServerSideSecretStorageImpl", function () {
             const secretStorage = new ServerSideSecretStorageImpl(accountDataAdapter, {});
 
             const storedKey = { iv: "iv", mac: "mac" } as SecretStorageKeyDescriptionAesV1;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
+            async function mockGetAccountData<K extends keyof AccountDataEvents>(
+                eventType: string,
+            ): Promise<AccountDataEvents[K] | null> {
                 if (eventType === "m.secret_storage.default_key") {
-                    return { key: "default_key_id" } as unknown as T;
+                    return { key: "default_key_id" } as any;
                 } else if (eventType === "m.secret_storage.key.default_key_id") {
-                    return storedKey as unknown as T;
+                    return storedKey as any;
                 } else {
                     throw new Error(`unexpected eventType ${eventType}`);
                 }
@@ -236,9 +248,11 @@ describe("ServerSideSecretStorageImpl", function () {
 
             // stub out getAccountData to return a key with an unknown algorithm
             const storedKey = { algorithm: "badalg" } as SecretStorageKeyDescriptionCommon;
-            async function mockGetAccountData<T extends Record<string, any>>(eventType: string): Promise<T | null> {
+            async function mockGetAccountData<K extends keyof AccountDataEvents>(
+                eventType: string,
+            ): Promise<AccountDataEvents[K] | null> {
                 if (eventType === "m.secret_storage.key.keyid") {
-                    return storedKey as unknown as T;
+                    return storedKey as any;
                 } else {
                     throw new Error(`unexpected eventType ${eventType}`);
                 }

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -58,6 +58,10 @@ import {
 import { EncryptionKeysEventContent, ICallNotifyContent } from "../matrixrtc/types.ts";
 import { M_POLL_END, M_POLL_START, PollEndEventContent, PollStartEventContent } from "./polls.ts";
 import { SessionMembershipData } from "../matrixrtc/CallMembership.ts";
+import { LocalNotificationSettings } from "./local_notifications.ts";
+import { IPushRules } from "./PushRules.ts";
+import { SecretInfo, SecretStorageKeyDescription } from "../secret-storage.ts";
+import { POLICIES_ACCOUNT_EVENT_TYPE } from "../models/invites-ignorer-types.ts";
 
 export enum EventType {
     // Room state events
@@ -367,4 +371,34 @@ export interface StateEvents {
 
     // MSC3672
     [M_BEACON_INFO.name]: MBeaconInfoEventContent;
+}
+
+/**
+ * Mapped type from event type to content type for all specified global account_data events.
+ */
+export interface AccountDataEvents extends SecretStorageAccountDataEvents {
+    [EventType.PushRules]: IPushRules;
+    [EventType.Direct]: { [userId: string]: string[] };
+    [EventType.IgnoredUserList]: { [userId: string]: {} };
+    "m.secret_storage.default_key": { key: string };
+    "m.identity_server": { base_url: string | null };
+    [key: `${typeof LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${string}`]: LocalNotificationSettings;
+    [key: `m.secret_storage.key.${string}`]: SecretStorageKeyDescription;
+
+    // Invites-ignorer events
+    [POLICIES_ACCOUNT_EVENT_TYPE.name]: { [key: string]: any };
+    [POLICIES_ACCOUNT_EVENT_TYPE.altName]: { [key: string]: any };
+}
+
+/**
+ * Mapped type from event type to content type for all specified global events encrypted by secret storage.
+ *
+ * See https://spec.matrix.org/v1.13/client-server-api/#msecret_storagev1aes-hmac-sha2-1
+ */
+export interface SecretStorageAccountDataEvents {
+    "m.megolm_backup.v1": SecretInfo;
+    "m.cross_signing.master": SecretInfo;
+    "m.cross_signing.self_signing": SecretInfo;
+    "m.cross_signing.user_signing": SecretInfo;
+    "org.matrix.msc3814": SecretInfo;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -136,6 +136,7 @@ import {
     UpdateDelayedEventAction,
 } from "./@types/requests.ts";
 import {
+    AccountDataEvents,
     EventType,
     LOCAL_NOTIFICATION_SETTINGS_PREFIX,
     MSC3912_RELATION_BASED_REDACTIONS_PROP,
@@ -232,6 +233,7 @@ import {
 import { DeviceInfoMap } from "./crypto/DeviceList.ts";
 import {
     AddSecretStorageKeyOpts,
+    SecretStorageKey,
     SecretStorageKeyDescription,
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
@@ -3070,7 +3072,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @deprecated Use {@link MatrixClient#secretStorage} and {@link SecretStorage.ServerSideSecretStorage#isStored}.
      */
-    public isSecretStored(name: string): Promise<Record<string, SecretStorageKeyDescription> | null> {
+    public isSecretStored(name: SecretStorageKey): Promise<Record<string, SecretStorageKeyDescription> | null> {
         return this.secretStorage.isStored(name);
     }
 
@@ -4236,7 +4238,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: an empty object
      * @returns Rejects: with an error response.
      */
-    public setAccountData(eventType: EventType | string, content: IContent): Promise<{}> {
+    public setAccountData<K extends keyof AccountDataEvents>(
+        eventType: K,
+        content: AccountDataEvents[K] | Record<string, never>,
+    ): Promise<{}> {
         const path = utils.encodeUri("/user/$userId/account_data/$type", {
             $userId: this.credentials.userId!,
             $type: eventType,
@@ -4251,7 +4256,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @param eventType - The event type
      * @returns The contents of the given account data event
      */
-    public getAccountData(eventType: string): MatrixEvent | undefined {
+    public getAccountData<K extends keyof AccountDataEvents>(eventType: K): MatrixEvent | undefined {
         return this.store.getAccountData(eventType);
     }
 
@@ -4263,7 +4268,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: The contents of the given account data event.
      * @returns Rejects: with an error response.
      */
-    public async getAccountDataFromServer<T extends { [k: string]: any }>(eventType: string): Promise<T | null> {
+    public async getAccountDataFromServer<K extends keyof AccountDataEvents>(
+        eventType: K,
+    ): Promise<AccountDataEvents[K] | null> {
         if (this.isInitialSyncComplete()) {
             const event = this.store.getAccountData(eventType);
             if (!event) {
@@ -4271,7 +4278,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
             // The network version below returns just the content, so this branch
             // does the same to match.
-            return event.getContent<T>();
+            return event.getContent<AccountDataEvents[K]>();
         }
         const path = utils.encodeUri("/user/$userId/account_data/$type", {
             $userId: this.credentials.userId!,
@@ -4287,7 +4294,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
     }
 
-    public async deleteAccountData(eventType: string): Promise<void> {
+    public async deleteAccountData(eventType: keyof AccountDataEvents): Promise<void> {
         const msc3391DeleteAccountDataServerSupport = this.canSupport.get(Feature.AccountDataDeletion);
         // if deletion is not supported overwrite with empty content
         if (msc3391DeleteAccountDataServerSupport === ServerSupport.Unsupported) {
@@ -4310,7 +4317,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns The array of users that are ignored (empty if none)
      */
     public getIgnoredUsers(): string[] {
-        const event = this.getAccountData("m.ignored_user_list");
+        const event = this.getAccountData(EventType.IgnoredUserList);
         if (!event?.getContent()["ignored_users"]) return [];
         return Object.keys(event.getContent()["ignored_users"]);
     }
@@ -4326,7 +4333,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         userIds.forEach((u) => {
             content.ignored_users[u] = {};
         });
-        return this.setAccountData("m.ignored_user_list", content);
+        return this.setAccountData(EventType.IgnoredUserList, content);
     }
 
     /**
@@ -9264,7 +9271,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         deviceId: string,
         notificationSettings: LocalNotificationSettings,
     ): Promise<{}> {
-        const key = `${LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${deviceId}`;
+        const key = `${LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${deviceId}` as const;
         return this.setAccountData(key, notificationSettings);
     }
 

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -43,6 +43,18 @@ import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
  */
 
 /**
+ * The options to start device dehydration.
+ */
+export interface StartDehydrationOpts {
+    /** Force creation of a new dehydration key. Defaults to `false`. */
+    createNewKey?: boolean;
+    /** Only start dehydration if we have a cached key. Defaults to `false`. */
+    onlyIfKeyCached?: boolean;
+    /** Try to rehydrate a device before creating a new dehydrated device. Defaults to `true`. */
+    rehydrate?: boolean;
+}
+
+/**
  * Public interface to the cryptography parts of the js-sdk
  *
  * @remarks Currently, this is a work-in-progress. In time, more methods will be added here.
@@ -634,10 +646,11 @@ export interface CryptoApi {
     /**
      * Start using device dehydration.
      *
-     * - Rehydrates a dehydrated device, if one is available.
+     * - Rehydrates a dehydrated device, if one is available and `opts.rehydrate`
+     *   is `true`.
      * - Creates a new dehydration key, if necessary, and stores it in Secret
      *   Storage.
-     *   - If `createNewKey` is set to true, always creates a new key.
+     *   - If `opts.createNewKey` is set to true, always creates a new key.
      *   - If a dehydration key is not available, creates a new one.
      * - Creates a new dehydrated device, and schedules periodically creating
      *   new dehydrated devices.
@@ -646,11 +659,11 @@ export interface CryptoApi {
      * `true`, and must not be called until after cross-signing and secret
      * storage have been set up.
      *
-     * @param createNewKey - whether to force creation of a new dehydration key.
-     *   This can be used, for example, if Secret Storage is being reset.  Defaults
-     *   to false.
+     * @param opts - options for device dehydration. For backwards compatibility
+     *     with old code, a boolean can be given here, which will be treated as
+     *     the `createNewKey` option. However, this is deprecated.
      */
-    startDehydration(createNewKey?: boolean): Promise<void>;
+    startDehydration(opts?: StartDehydrationOpts | boolean): Promise<void>;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //
@@ -1286,7 +1299,7 @@ export abstract class DehydratedDevicesAPI extends TypedEventEmitter<
     }
 
     public abstract isSupported(): Promise<boolean>;
-    public abstract start(createNewKey?: boolean): Promise<void>;
+    public abstract start(opts: StartDehydrationOpts | boolean): Promise<void>;
 }
 
 export * from "./verification.ts";

--- a/src/crypto/CrossSigning.ts
+++ b/src/crypto/CrossSigning.ts
@@ -184,7 +184,7 @@ export class CrossSigningInfo {
                 }
             }
         }
-        for (const type of ["self_signing", "user_signing"]) {
+        for (const type of ["self_signing", "user_signing"] as const) {
             intersect((await secretStorage.isStored(`m.cross_signing.${type}`)) || {});
         }
         return Object.keys(stored).length ? stored : null;

--- a/src/crypto/EncryptionSetup.ts
+++ b/src/crypto/EncryptionSetup.ts
@@ -25,6 +25,7 @@ import { IKeyBackupInfo } from "./keybackup.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { AccountDataClient, SecretStorageKeyDescription } from "../secret-storage.ts";
 import { BootstrapCrossSigningOpts, CrossSigningKeyInfo } from "../crypto-api/index.ts";
+import { AccountDataEvents } from "../@types/event.ts";
 
 interface ICrossSigningKeys {
     authUpload: BootstrapCrossSigningOpts["authUploadDeviceSigningKeys"];
@@ -111,7 +112,10 @@ export class EncryptionSetupBuilder {
         userSignatures[deviceId] = signature;
     }
 
-    public async setAccountData(type: string, content: object): Promise<void> {
+    public async setAccountData<K extends keyof AccountDataEvents>(
+        type: K,
+        content: AccountDataEvents[K],
+    ): Promise<void> {
         await this.accountDataClientAdapter.setAccountData(type, content);
     }
 
@@ -160,7 +164,7 @@ export class EncryptionSetupOperation {
     /**
      */
     public constructor(
-        private readonly accountData: Map<string, object>,
+        private readonly accountData: Map<keyof AccountDataEvents, MatrixEvent>,
         private readonly crossSigningKeys?: ICrossSigningKeys,
         private readonly keyBackupInfo?: IKeyBackupInfo,
         private readonly keySignatures?: KeySignatures,
@@ -190,7 +194,7 @@ export class EncryptionSetupOperation {
         // set account data
         if (this.accountData) {
             for (const [type, content] of this.accountData) {
-                await baseApis.setAccountData(type, content);
+                await baseApis.setAccountData(type, content.getContent());
             }
         }
         // upload first cross-signing signatures with the new key
@@ -236,7 +240,7 @@ class AccountDataClientAdapter
     implements AccountDataClient
 {
     //
-    public readonly values = new Map<string, MatrixEvent>();
+    public readonly values = new Map<keyof AccountDataEvents, MatrixEvent>();
 
     /**
      * @param existingValues - existing account data
@@ -248,33 +252,26 @@ class AccountDataClientAdapter
     /**
      * @returns the content of the account data
      */
-    public getAccountDataFromServer<T extends { [k: string]: any }>(type: string): Promise<T | null> {
+    public getAccountDataFromServer<K extends keyof AccountDataEvents>(type: K): Promise<AccountDataEvents[K] | null> {
         return Promise.resolve(this.getAccountData(type));
     }
 
     /**
      * @returns the content of the account data
      */
-    public getAccountData<T extends { [k: string]: any }>(type: string): T | null {
-        const modifiedValue = this.values.get(type);
-        if (modifiedValue) {
-            return modifiedValue as unknown as T;
-        }
-        const existingValue = this.existingValues.get(type);
-        if (existingValue) {
-            return existingValue.getContent<T>();
-        }
-        return null;
+    public getAccountData<K extends keyof AccountDataEvents>(type: K): AccountDataEvents[K] | null {
+        const event = this.values.get(type) ?? this.existingValues.get(type);
+        return event?.getContent<AccountDataEvents[K]>() ?? null;
     }
 
-    public setAccountData(type: string, content: any): Promise<{}> {
+    public setAccountData<K extends keyof AccountDataEvents>(type: K, content: AccountDataEvents[K]): Promise<{}> {
+        const event = new MatrixEvent({ type, content });
         const lastEvent = this.values.get(type);
-        this.values.set(type, content);
+        this.values.set(type, event);
         // ensure accountData is emitted on the next tick,
         // as SecretStorage listens for it while calling this method
         // and it seems to rely on this.
         return Promise.resolve().then(() => {
-            const event = new MatrixEvent({ type, content });
             this.emit(ClientEvent.AccountData, event, lastEvent);
             return {};
         });

--- a/src/crypto/SecretStorage.ts
+++ b/src/crypto/SecretStorage.ts
@@ -25,12 +25,12 @@ import {
     AccountDataClient,
     ServerSideSecretStorage,
     ServerSideSecretStorageImpl,
+    SecretStorageKey,
 } from "../secret-storage.ts";
 import { ISecretRequest, SecretSharing } from "./SecretSharing.ts";
 
 /* re-exports for backwards compatibility */
 export type {
-    AccountDataClient as IAccountDataClient,
     SecretStorageKeyTuple,
     SecretStorageKeyObject,
     SECRET_STORAGE_ALGORITHM_V1_AES,
@@ -101,21 +101,21 @@ export class SecretStorage<B extends MatrixClient | undefined = MatrixClient> im
     /**
      * Store an encrypted secret on the server
      */
-    public store(name: string, secret: string, keys?: string[] | null): Promise<void> {
+    public store(name: SecretStorageKey, secret: string, keys?: string[] | null): Promise<void> {
         return this.storageImpl.store(name, secret, keys);
     }
 
     /**
      * Get a secret from storage.
      */
-    public get(name: string): Promise<string | undefined> {
+    public get(name: SecretStorageKey): Promise<string | undefined> {
         return this.storageImpl.get(name);
     }
 
     /**
      * Check if a secret is stored on the server.
      */
-    public async isStored(name: string): Promise<Record<string, SecretStorageKeyDescription> | null> {
+    public async isStored(name: SecretStorageKey): Promise<Record<string, SecretStorageKeyDescription> | null> {
         return this.storageImpl.isStored(name);
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -77,6 +77,7 @@ import {
     AddSecretStorageKeyOpts,
     calculateKeyCheck,
     SECRET_STORAGE_ALGORITHM_V1_AES,
+    SecretStorageKey,
     SecretStorageKeyDescription,
     SecretStorageKeyObject,
     SecretStorageKeyTuple,
@@ -1194,21 +1195,21 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * @deprecated Use {@link MatrixClient#secretStorage} and {@link SecretStorage.ServerSideSecretStorage#store}.
      */
-    public storeSecret(name: string, secret: string, keys?: string[]): Promise<void> {
+    public storeSecret(name: SecretStorageKey, secret: string, keys?: string[]): Promise<void> {
         return this.secretStorage.store(name, secret, keys);
     }
 
     /**
      * @deprecated Use {@link MatrixClient#secretStorage} and {@link SecretStorage.ServerSideSecretStorage#get}.
      */
-    public getSecret(name: string): Promise<string | undefined> {
+    public getSecret(name: SecretStorageKey): Promise<string | undefined> {
         return this.secretStorage.get(name);
     }
 
     /**
      * @deprecated Use {@link MatrixClient#secretStorage} and {@link SecretStorage.ServerSideSecretStorage#isStored}.
      */
-    public isSecretStored(name: string): Promise<Record<string, SecretStorageKeyDescription> | null> {
+    public isSecretStored(name: SecretStorageKey): Promise<Record<string, SecretStorageKeyDescription> | null> {
         return this.secretStorage.isStored(name);
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -105,6 +105,7 @@ import {
     CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
     KeyBackupRestoreResult,
     KeyBackupRestoreOpts,
+    DehydratedDevicesAPI,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -4321,6 +4322,10 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
      * Stub function -- dehydration is not implemented here, so throw error
      */
     public async startDehydration(createNewKey?: boolean): Promise<void> {
+        throw new Error("Not implemented");
+    }
+
+    public dehydratedDevices(): DehydratedDevicesAPI {
         throw new Error("Not implemented");
     }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -106,6 +106,7 @@ import {
     KeyBackupRestoreResult,
     KeyBackupRestoreOpts,
     DehydratedDevicesAPI,
+    StartDehydrationOpts,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -4321,7 +4322,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Stub function -- dehydration is not implemented here, so throw error
      */
-    public async startDehydration(createNewKey?: boolean): Promise<void> {
+    public async startDehydration(createNewKey?: StartDehydrationOpts | boolean): Promise<void> {
         throw new Error("Not implemented");
     }
 

--- a/src/models/invites-ignorer-types.ts
+++ b/src/models/invites-ignorer-types.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { UnstableValue } from "matrix-events-sdk";
+
+/// The event type storing the user's individual policies.
+///
+/// Exported for testing purposes.
+export const POLICIES_ACCOUNT_EVENT_TYPE = new UnstableValue("m.policies", "org.matrix.msc3847.policies");
+
+/// The key within the user's individual policies storing the user's ignored invites.
+///
+/// Exported for testing purposes.
+export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue(
+    "m.ignore.invites",
+    "org.matrix.msc3847.ignore.invites",
+);
+
+/// The types of recommendations understood.
+export enum PolicyRecommendation {
+    Ban = "m.ban",
+}
+
+/**
+ * The various scopes for policies.
+ */
+export enum PolicyScope {
+    /**
+     * The policy deals with an individual user, e.g. reject invites
+     * from this user.
+     */
+    User = "m.policy.user",
+
+    /**
+     * The policy deals with a room, e.g. reject invites towards
+     * a specific room.
+     */
+    Room = "m.policy.room",
+
+    /**
+     * The policy deals with a server, e.g. reject invites from
+     * this server.
+     */
+    Server = "m.policy.server",
+}

--- a/src/models/invites-ignorer.ts
+++ b/src/models/invites-ignorer.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { UnstableValue } from "matrix-events-sdk";
-
 import { MatrixClient } from "../client.ts";
 import { IContent, MatrixEvent } from "./event.ts";
 import { EventTimeline } from "./event-timeline.ts";
@@ -23,47 +21,14 @@ import { Preset } from "../@types/partials.ts";
 import { globToRegexp } from "../utils.ts";
 import { Room } from "./room.ts";
 import { EventType, StateEvents } from "../@types/event.ts";
+import {
+    IGNORE_INVITES_ACCOUNT_EVENT_KEY,
+    POLICIES_ACCOUNT_EVENT_TYPE,
+    PolicyRecommendation,
+    PolicyScope,
+} from "./invites-ignorer-types.ts";
 
-/// The event type storing the user's individual policies.
-///
-/// Exported for testing purposes.
-export const POLICIES_ACCOUNT_EVENT_TYPE = new UnstableValue("m.policies", "org.matrix.msc3847.policies");
-
-/// The key within the user's individual policies storing the user's ignored invites.
-///
-/// Exported for testing purposes.
-export const IGNORE_INVITES_ACCOUNT_EVENT_KEY = new UnstableValue(
-    "m.ignore.invites",
-    "org.matrix.msc3847.ignore.invites",
-);
-
-/// The types of recommendations understood.
-export enum PolicyRecommendation {
-    Ban = "m.ban",
-}
-
-/**
- * The various scopes for policies.
- */
-export enum PolicyScope {
-    /**
-     * The policy deals with an individual user, e.g. reject invites
-     * from this user.
-     */
-    User = "m.policy.user",
-
-    /**
-     * The policy deals with a room, e.g. reject invites towards
-     * a specific room.
-     */
-    Room = "m.policy.room",
-
-    /**
-     * The policy deals with a server, e.g. reject invites from
-     * this server.
-     */
-    Server = "m.policy.server",
-}
+export { IGNORE_INVITES_ACCOUNT_EVENT_KEY, POLICIES_ACCOUNT_EVENT_TYPE, PolicyRecommendation, PolicyScope };
 
 const scopeToEventTypeMap: Record<PolicyScope, keyof StateEvents> = {
     [PolicyScope.User]: EventType.PolicyRuleUser,

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -202,7 +202,7 @@ export class DehydratedDeviceManager extends DehydratedDevicesAPI {
      * Returns whether or not a dehydrated device was found.
      */
     public async rehydrateDeviceIfAvailable(): Promise<boolean> {
-        const key = (await this.getCachedKey()) || (await this.getKey(false));
+        const key = await this.getKey(false);
         if (!key) {
             return false;
         }

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -23,7 +23,7 @@ import { IToDeviceEvent } from "../sync-accumulator.ts";
 import { ServerSideSecretStorage } from "../secret-storage.ts";
 import { decodeBase64 } from "../base64.ts";
 import { Logger } from "../logger.ts";
-import { DehydratedDevicesEvents, DehydratedDevicesAPI } from "../crypto-api/index.ts";
+import { DehydratedDevicesEvents, DehydratedDevicesAPI, StartDehydrationOpts } from "../crypto-api/index.ts";
 
 /**
  * The response body of `GET /_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device`.
@@ -123,27 +123,38 @@ export class DehydratedDeviceManager extends DehydratedDevicesAPI {
     /**
      * Start using device dehydration.
      *
-     * - Rehydrates a dehydrated device, if one is available.
+     * - Rehydrates a dehydrated device, if one is available and `opts.rehydrate`
+     *   is `true`.
      * - Creates a new dehydration key, if necessary, and stores it in Secret
      *   Storage.
-     *   - If `createNewKey` is set to true, always creates a new key.
+     *   - If `opts.createNewKey` is set to true, always creates a new key.
      *   - If a dehydration key is not available, creates a new one.
      * - Creates a new dehydrated device, and schedules periodically creating
      *   new dehydrated devices.
      *
-     * @param createNewKey - whether to force creation of a new dehydration key.
-     *   This can be used, for example, if Secret Storage is being reset.
+     * @param opts - options for device dehydration. For backwards compatibility
+     *     with old code, a boolean can be given here, which will be treated as
+     *     the `createNewKey` option. However, this is deprecated.
      */
-    public async start(createNewKey?: boolean): Promise<void> {
-        this.stop();
-        try {
-            await this.rehydrateDeviceIfAvailable();
-        } catch (e) {
-            // If rehydration fails, there isn't much we can do about it.  Log
-            // the error, and create a new device.
-            this.logger.info("dehydration: Error rehydrating device:", e);
+    public async start(opts: StartDehydrationOpts | boolean = {}): Promise<void> {
+        if (typeof opts === "boolean") {
+            opts = { createNewKey: opts };
         }
-        if (createNewKey) {
+
+        if (opts.onlyIfKeyCached && !(await this.getCachedKey())) {
+            return;
+        }
+        this.stop();
+        if (opts.rehydrate !== false) {
+            try {
+                await this.rehydrateDeviceIfAvailable();
+            } catch (e) {
+                // If rehydration fails, there isn't much we can do about it.  Log
+                // the error, and create a new device.
+                this.logger.info("dehydration: Error rehydrating device:", e);
+            }
+        }
+        if (opts.createNewKey) {
             await this.resetKey();
         }
         await this.scheduleDeviceDehydration();

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -71,7 +71,7 @@ import {
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
 import { Device, DeviceMap } from "../models/device.ts";
-import { SECRET_STORAGE_ALGORITHM_V1_AES, ServerSideSecretStorage } from "../secret-storage.ts";
+import { SECRET_STORAGE_ALGORITHM_V1_AES, SecretStorageKey, ServerSideSecretStorage } from "../secret-storage.ts";
 import { CrossSigningIdentity } from "./CrossSigningIdentity.ts";
 import { secretStorageCanAccessSecrets, secretStorageContainsCrossSigningKeys } from "./secret-storage.ts";
 import { isVerificationEvent, RustVerificationRequest, verificationMethodIdentifierToMethod } from "./verification.ts";
@@ -770,7 +770,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      */
     public async isSecretStorageReady(): Promise<boolean> {
         // make sure that the cross-signing keys are stored
-        const secretsToCheck = [
+        const secretsToCheck: SecretStorageKey[] = [
             "m.cross_signing.master",
             "m.cross_signing.user_signing",
             "m.cross_signing.self_signing",

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -67,6 +67,7 @@ import {
     CryptoEventHandlerMap,
     KeyBackupRestoreOpts,
     KeyBackupRestoreResult,
+    DehydratedDevicesAPI,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
@@ -1404,6 +1405,13 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("Device dehydration requires cross-signing and secret storage to be set up");
         }
         return await this.dehydratedDeviceManager.start(createNewKey);
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#dehydratedDevices}.
+     */
+    public dehydratedDevices(): DehydratedDevicesAPI {
+        return this.dehydratedDeviceManager;
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -68,6 +68,7 @@ import {
     KeyBackupRestoreOpts,
     KeyBackupRestoreResult,
     DehydratedDevicesAPI,
+    StartDehydrationOpts,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
@@ -1400,11 +1401,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     /**
      * Implementation of {@link CryptoApi#startDehydration}.
      */
-    public async startDehydration(createNewKey?: boolean): Promise<void> {
+    public async startDehydration(opts: StartDehydrationOpts | boolean = {}): Promise<void> {
         if (!(await this.isCrossSigningReady()) || !(await this.isSecretStorageReady())) {
             throw new Error("Device dehydration requires cross-signing and secret storage to be set up");
         }
-        return await this.dehydratedDeviceManager.start(createNewKey);
+        return await this.dehydratedDeviceManager.start(opts || {});
     }
 
     /**

--- a/src/rust-crypto/secret-storage.ts
+++ b/src/rust-crypto/secret-storage.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ServerSideSecretStorage } from "../secret-storage.ts";
+import { SecretStorageKey, ServerSideSecretStorage } from "../secret-storage.ts";
 
 /**
  * Check that the private cross signing keys (master, self signing, user signing) are stored in the secret storage and encrypted with the default secret storage key.
@@ -44,7 +44,7 @@ export async function secretStorageContainsCrossSigningKeys(secretStorage: Serve
  */
 export async function secretStorageCanAccessSecrets(
     secretStorage: ServerSideSecretStorage,
-    secretNames: string[],
+    secretNames: SecretStorageKey[],
 ): Promise<boolean> {
     const defaultKeyId = await secretStorage.getDefaultKeyId();
     if (!defaultKeyId) return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-11.0.0.tgz#c49a1a0d1e367d3c00a2144a4ab23caee0b1eec2"
-  integrity sha512-a7NUH8Kjc8hwzNCPpkOGXoceFqWJiWvA8OskXeDrKyODJuDz4yKrZ/nvgaVRfQe45Ab5UC1ZXYqaME+ChlJuqg==
+"@matrix-org/matrix-sdk-crypto-wasm@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.0.0.tgz#e3a5150ccbb21d5e98ee3882e7057b9f17fb962a"
+  integrity sha512-nkkXAxUIk9UTso4TbU6Bgqsv/rJShXQXRx0ti/W+AWXHJ2HoH4sL5LsXkc7a8yYGn8tyXqxGPsYA1UeHqLwm0Q==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.1.0.tgz#2aef64eab2d30c0a1ace9c0fe876f53aa2949f14"
-  integrity sha512-NhJFu/8FOGjnW7mDssRUzaMSwXrYOcCqgAjZyAw9KQ9unNADKEi7KoIKe7GtrG2PWtm36y2bUf+hB8vhSY6Wdw==
+"@matrix-org/matrix-sdk-crypto-wasm@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-13.0.0.tgz#658bed951e4c8a06a6dd545575a79cf32022d4ba"
+  integrity sha512-2gtpjnxL42sdJAgkwitpMMI4cw7Gcjf5sW0MXoe+OAlXPlxIzyM+06F5JJ8ENvBeHkuV2RqtFIRrh8i90HLsMw==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.0.0.tgz#e3a5150ccbb21d5e98ee3882e7057b9f17fb962a"
-  integrity sha512-nkkXAxUIk9UTso4TbU6Bgqsv/rJShXQXRx0ti/W+AWXHJ2HoH4sL5LsXkc7a8yYGn8tyXqxGPsYA1UeHqLwm0Q==
+"@matrix-org/matrix-sdk-crypto-wasm@^12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.1.0.tgz#2aef64eab2d30c0a1ace9c0fe876f53aa2949f14"
+  integrity sha512-NhJFu/8FOGjnW7mDssRUzaMSwXrYOcCqgAjZyAw9KQ9unNADKEi7KoIKe7GtrG2PWtm36y2bUf+hB8vhSY6Wdw==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
Needed for starting dehydration after restart -- since we only want to do that if we already have a key cached, and we don't need to try to rehydrate a device.

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/4484

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
