### PR TITLE
Use `SyncCryptoCallback` api instead of legacy crypto in sliding sync

### DIFF
--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -30,7 +30,6 @@ import {
     SetPresence,
 } from "./sync.ts";
 import { MatrixEvent } from "./models/event.ts";
-import { Crypto } from "./crypto/index.ts";
 import { IMinimalEvent, IRoomEvent, IStateEvent, IStrippedState, ISyncResponse } from "./sync-accumulator.ts";
 import { MatrixError } from "./http-api/index.ts";
 import {
@@ -66,7 +65,7 @@ type ExtensionE2EEResponse = Pick<
 >;
 
 class ExtensionE2EE implements Extension<ExtensionE2EERequest, ExtensionE2EEResponse> {
-    public constructor(private readonly crypto: Crypto) {}
+    public constructor(private readonly crypto: SyncCryptoCallbacks) {}
 
     public name(): string {
         return "e2ee";
@@ -373,8 +372,8 @@ export class SlidingSyncSdk {
             new ExtensionTyping(this.client),
             new ExtensionReceipts(this.client),
         ];
-        if (this.syncOpts.crypto) {
-            extensions.push(new ExtensionE2EE(this.syncOpts.crypto));
+        if (this.syncOpts.cryptoCallbacks) {
+            extensions.push(new ExtensionE2EE(this.syncOpts.cryptoCallbacks));
         }
         extensions.forEach((ext) => {
             this.slidingSync.registerExtension(ext);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Replace the usage of deprecated `MatrixClient.crypto` by the [`SyncCryptoCallback` api](https://matrix-org.github.io/matrix-js-sdk/interfaces/matrix._internal_.SyncCryptoCallbacks.html).

Hopefully, they can be swapped without any difficulty because `ExtensionE2EE` is using shared methods between legacy crypto and `SyncCryptoCallback`:
https://github.com/matrix-org/matrix-js-sdk/blob/1dfeaac0796d239a1e41ea3ddd5eb8c6431b4f33/src/sliding-sync-sdk.ts#L67-L101

The `syncCryptoCallback` parameter is already provided in the matrixClient:
https://github.com/matrix-org/matrix-js-sdk/blob/1dfeaac0796d239a1e41ea3ddd5eb8c6431b4f33/src/client.ts#L1552-L1566

