### PR TITLE
Switch OIDC primarily to new `/auth_metadata` API

### DIFF
--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -36,7 +36,7 @@ import {
     MatrixError,
     MatrixHttpApi,
 } from "../../../src";
-import { mockOpenIdConfiguration } from "../../test-utils/oidc";
+import { makeDelegatedAuthConfig } from "../../test-utils/oidc";
 
 function makeMockClient(opts: { userId: string; deviceId: string; msc4108Enabled: boolean }): MatrixClient {
     const baseUrl = "https://example.com";
@@ -57,7 +57,7 @@ function makeMockClient(opts: { userId: string; deviceId: string; msc4108Enabled
         getDomain: () => "example.com",
         getDevice: jest.fn(),
         getCrypto: jest.fn(() => crypto),
-        getAuthIssuer: jest.fn().mockResolvedValue({ issuer: "https://issuer/" }),
+        getAuthMetadata: jest.fn().mockResolvedValue(makeDelegatedAuthConfig("https://issuer/", [DEVICE_CODE_SCOPE])),
     } as unknown as MatrixClient;
     client.http = new MatrixHttpApi<IHttpOpts & { onlyData: true }>(client, {
         baseUrl: client.baseUrl,
@@ -69,10 +69,6 @@ function makeMockClient(opts: { userId: string; deviceId: string; msc4108Enabled
 
 describe("MSC4108SignInWithQR", () => {
     beforeEach(() => {
-        fetchMock.get(
-            "https://issuer/.well-known/openid-configuration",
-            mockOpenIdConfiguration("https://issuer/", [DEVICE_CODE_SCOPE]),
-        );
         fetchMock.get("https://issuer/jwks", {
             status: 200,
             headers: {

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -25,6 +25,7 @@ export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcClien
     const metadata = mockOpenIdConfiguration(issuer);
 
     return {
+        issuer,
         accountManagementEndpoint: issuer + "account",
         registrationEndpoint: metadata.registration_endpoint,
         authorizationEndpoint: metadata.authorization_endpoint,

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -19,10 +19,14 @@ import { OidcClientConfig, ValidatedIssuerMetadata } from "../../src";
 /**
  * Makes a valid OidcClientConfig with minimum valid values
  * @param issuer used as the base for all other urls
+ * @param additionalGrantTypes to add to the default grant types
  * @returns OidcClientConfig
  */
-export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcClientConfig => {
-    const metadata = mockOpenIdConfiguration(issuer);
+export const makeDelegatedAuthConfig = (
+    issuer = "https://auth.org/",
+    additionalGrantTypes: string[] = [],
+): OidcClientConfig => {
+    const metadata = mockOpenIdConfiguration(issuer, additionalGrantTypes);
 
     return {
         issuer,
@@ -37,6 +41,7 @@ export const makeDelegatedAuthConfig = (issuer = "https://auth.org/"): OidcClien
 /**
  * Useful for mocking <issuer>/.well-known/openid-configuration
  * @param issuer used as the base for all other urls
+ * @param additionalGrantTypes to add to the default grant types
  * @returns ValidatedIssuerMetadata
  */
 export const mockOpenIdConfiguration = (

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OidcClientConfig, ValidatedIssuerMetadata } from "../../src";
+import { OidcClientConfig, ValidatedAuthMetadata } from "../../src";
 
 /**
  * Makes a valid OidcClientConfig with minimum valid values
  * @param issuer used as the base for all other urls
  * @param additionalGrantTypes to add to the default grant types
  * @returns OidcClientConfig
+ * @experimental
  */
 export const makeDelegatedAuthConfig = (
     issuer = "https://auth.org/",
@@ -29,12 +30,8 @@ export const makeDelegatedAuthConfig = (
     const metadata = mockOpenIdConfiguration(issuer, additionalGrantTypes);
 
     return {
-        issuer,
-        accountManagementEndpoint: issuer + "account",
-        registrationEndpoint: metadata.registration_endpoint,
-        authorizationEndpoint: metadata.authorization_endpoint,
-        tokenEndpoint: metadata.token_endpoint,
-        metadata,
+        ...metadata,
+        signingKeys: null,
     };
 };
 
@@ -42,12 +39,13 @@ export const makeDelegatedAuthConfig = (
  * Useful for mocking <issuer>/.well-known/openid-configuration
  * @param issuer used as the base for all other urls
  * @param additionalGrantTypes to add to the default grant types
- * @returns ValidatedIssuerMetadata
+ * @returns ValidatedAuthMetadata
+ * @experimental
  */
 export const mockOpenIdConfiguration = (
     issuer = "https://auth.org/",
     additionalGrantTypes: string[] = [],
-): ValidatedIssuerMetadata => ({
+): ValidatedAuthMetadata => ({
     issuer,
     revocation_endpoint: issuer + "revoke",
     token_endpoint: issuer + "token",

--- a/spec/test-utils/oidc.ts
+++ b/spec/test-utils/oidc.ts
@@ -14,46 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OidcClientConfig, ValidatedAuthMetadata } from "../../src";
-
-/**
- * Makes a valid OidcClientConfig with minimum valid values
- * @param issuer used as the base for all other urls
- * @param additionalGrantTypes to add to the default grant types
- * @returns OidcClientConfig
- * @experimental
- */
-export const makeDelegatedAuthConfig = (
-    issuer = "https://auth.org/",
-    additionalGrantTypes: string[] = [],
-): OidcClientConfig => {
-    const metadata = mockOpenIdConfiguration(issuer, additionalGrantTypes);
-
-    return {
-        ...metadata,
-        signingKeys: null,
-    };
-};
-
-/**
- * Useful for mocking <issuer>/.well-known/openid-configuration
- * @param issuer used as the base for all other urls
- * @param additionalGrantTypes to add to the default grant types
- * @returns ValidatedAuthMetadata
- * @experimental
- */
-export const mockOpenIdConfiguration = (
-    issuer = "https://auth.org/",
-    additionalGrantTypes: string[] = [],
-): ValidatedAuthMetadata => ({
-    issuer,
-    revocation_endpoint: issuer + "revoke",
-    token_endpoint: issuer + "token",
-    authorization_endpoint: issuer + "auth",
-    registration_endpoint: issuer + "registration",
-    device_authorization_endpoint: issuer + "device",
-    jwks_uri: issuer + "jwks",
-    response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code", "refresh_token", ...additionalGrantTypes],
-    code_challenge_methods_supported: ["S256"],
-});
+export { makeDelegatedAuthConfig, mockOpenIdConfiguration } from "../../src/testing.ts";

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -40,8 +40,8 @@ jest.mock("jwt-decode");
 
 describe("oidc authorization", () => {
     const delegatedAuthConfig = makeDelegatedAuthConfig();
-    const authorizationEndpoint = delegatedAuthConfig.authorizationEndpoint;
-    const tokenEndpoint = delegatedAuthConfig.tokenEndpoint;
+    const authorizationEndpoint = delegatedAuthConfig.authorization_endpoint;
+    const tokenEndpoint = delegatedAuthConfig.token_endpoint;
     const clientId = "xyz789";
     const baseUrl = "https://test.com";
 
@@ -52,10 +52,7 @@ describe("oidc authorization", () => {
         jest.spyOn(logger, "warn");
         jest.setSystemTime(now);
 
-        fetchMock.get(
-            delegatedAuthConfig.metadata.issuer + ".well-known/openid-configuration",
-            mockOpenIdConfiguration(),
-        );
+        fetchMock.get(delegatedAuthConfig.issuer + ".well-known/openid-configuration", mockOpenIdConfiguration());
         globalThis.TextEncoder = TextEncoder;
     });
 
@@ -127,11 +124,9 @@ describe("oidc authorization", () => {
         it("should generate url with correct parameters", async () => {
             const nonce = "abc123";
 
-            const metadata = delegatedAuthConfig.metadata;
-
             const authUrl = new URL(
                 await generateOidcAuthorizationUrl({
-                    metadata,
+                    metadata: delegatedAuthConfig,
                     homeserverUrl: baseUrl,
                     clientId,
                     redirectUri: baseUrl,
@@ -156,11 +151,9 @@ describe("oidc authorization", () => {
         it("should generate url with create prompt", async () => {
             const nonce = "abc123";
 
-            const metadata = delegatedAuthConfig.metadata;
-
             const authUrl = new URL(
                 await generateOidcAuthorizationUrl({
-                    metadata,
+                    metadata: delegatedAuthConfig,
                     homeserverUrl: baseUrl,
                     clientId,
                     redirectUri: baseUrl,

--- a/spec/unit/oidc/register.spec.ts
+++ b/spec/unit/oidc/register.spec.ts
@@ -42,13 +42,13 @@ describe("registerOidcClient()", () => {
     });
 
     it("should make correct request to register client", async () => {
-        fetchMockJest.post(delegatedAuthConfig.registrationEndpoint!, {
+        fetchMockJest.post(delegatedAuthConfig.registration_endpoint!, {
             status: 200,
             body: JSON.stringify({ client_id: dynamicClientId }),
         });
         expect(await registerOidcClient(delegatedAuthConfig, metadata)).toEqual(dynamicClientId);
         expect(fetchMockJest).toHaveBeenCalledWith(
-            delegatedAuthConfig.registrationEndpoint!,
+            delegatedAuthConfig.registration_endpoint,
             expect.objectContaining({
                 headers: {
                     "Accept": "application/json",
@@ -72,7 +72,7 @@ describe("registerOidcClient()", () => {
     });
 
     it("should throw when registration request fails", async () => {
-        fetchMockJest.post(delegatedAuthConfig.registrationEndpoint!, {
+        fetchMockJest.post(delegatedAuthConfig.registration_endpoint!, {
             status: 500,
         });
         await expect(() => registerOidcClient(delegatedAuthConfig, metadata)).rejects.toThrow(
@@ -81,7 +81,7 @@ describe("registerOidcClient()", () => {
     });
 
     it("should throw when registration response is invalid", async () => {
-        fetchMockJest.post(delegatedAuthConfig.registrationEndpoint!, {
+        fetchMockJest.post(delegatedAuthConfig.registration_endpoint!, {
             status: 200,
             // no clientId in response
             body: "{}",
@@ -96,7 +96,7 @@ describe("registerOidcClient()", () => {
             registerOidcClient(
                 {
                     ...delegatedAuthConfig,
-                    registrationEndpoint: undefined,
+                    registration_endpoint: undefined,
                 },
                 metadata,
             ),
@@ -108,10 +108,7 @@ describe("registerOidcClient()", () => {
             registerOidcClient(
                 {
                     ...delegatedAuthConfig,
-                    metadata: {
-                        ...delegatedAuthConfig.metadata,
-                        grant_types_supported: [delegatedAuthConfig.metadata.grant_types_supported[0]],
-                    },
+                    grant_types_supported: [delegatedAuthConfig.grant_types_supported[0]],
                 },
                 metadata,
             ),

--- a/spec/unit/oidc/tokenRefresher.spec.ts
+++ b/spec/unit/oidc/tokenRefresher.spec.ts
@@ -55,8 +55,8 @@ describe("OidcTokenRefresher", () => {
     });
 
     beforeEach(() => {
-        fetchMock.get(`${config.metadata.issuer}.well-known/openid-configuration`, config.metadata);
-        fetchMock.get(`${config.metadata.issuer}jwks`, {
+        fetchMock.get(`${config.issuer}.well-known/openid-configuration`, config);
+        fetchMock.get(`${config.issuer}jwks`, {
             status: 200,
             headers: {
                 "Content-Type": "application/json",
@@ -64,7 +64,7 @@ describe("OidcTokenRefresher", () => {
             keys: [],
         });
 
-        fetchMock.post(config.tokenEndpoint, {
+        fetchMock.post(config.token_endpoint, {
             status: 200,
             headers: {
                 "Content-Type": "application/json",
@@ -81,7 +81,7 @@ describe("OidcTokenRefresher", () => {
     it("throws when oidc client cannot be initialised", async () => {
         jest.spyOn(logger, "error");
         fetchMock.get(
-            `${config.metadata.issuer}.well-known/openid-configuration`,
+            `${config.issuer}.well-known/openid-configuration`,
             {
                 ok: false,
                 status: 404,
@@ -126,7 +126,7 @@ describe("OidcTokenRefresher", () => {
 
             const result = await refresher.doRefreshAccessToken("refresh-token");
 
-            expect(fetchMock).toHaveFetched(config.tokenEndpoint, {
+            expect(fetchMock).toHaveFetched(config.token_endpoint, {
                 method: "POST",
             });
 
@@ -153,7 +153,7 @@ describe("OidcTokenRefresher", () => {
         it("should only have one inflight refresh request at once", async () => {
             fetchMock
                 .postOnce(
-                    config.tokenEndpoint,
+                    config.token_endpoint,
                     {
                         status: 200,
                         headers: {
@@ -164,7 +164,7 @@ describe("OidcTokenRefresher", () => {
                     { overwriteRoutes: true },
                 )
                 .postOnce(
-                    config.tokenEndpoint,
+                    config.token_endpoint,
                     {
                         status: 200,
                         headers: {
@@ -188,7 +188,7 @@ describe("OidcTokenRefresher", () => {
             const result2 = await first;
 
             // only one call to token endpoint
-            expect(fetchMock).toHaveFetchedTimes(1, config.tokenEndpoint);
+            expect(fetchMock).toHaveFetchedTimes(1, config.token_endpoint);
             expect(result1).toEqual({
                 accessToken: "first-new-access-token",
                 refreshToken: "first-new-refresh-token",
@@ -208,7 +208,7 @@ describe("OidcTokenRefresher", () => {
 
         it("should log and rethrow when token refresh fails", async () => {
             fetchMock.post(
-                config.tokenEndpoint,
+                config.token_endpoint,
                 {
                     status: 503,
                     headers: {
@@ -228,7 +228,7 @@ describe("OidcTokenRefresher", () => {
             // make sure inflight request is cleared after a failure
             fetchMock
                 .postOnce(
-                    config.tokenEndpoint,
+                    config.token_endpoint,
                     {
                         status: 503,
                         headers: {
@@ -238,7 +238,7 @@ describe("OidcTokenRefresher", () => {
                     { overwriteRoutes: true },
                 )
                 .postOnce(
-                    config.tokenEndpoint,
+                    config.token_endpoint,
                     {
                         status: 200,
                         headers: {

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -18,13 +18,14 @@ import { mocked } from "jest-mock";
 import { jwtDecode } from "jwt-decode";
 
 import { logger } from "../../../src/logger";
-import { validateIdToken, validateOIDCIssuerWellKnown } from "../../../src/oidc/validate";
+import { ValidatedIssuerMetadata, validateIdToken, validateOIDCIssuerWellKnown } from "../../../src/oidc/validate";
 import { OidcError } from "../../../src/oidc/error";
 
 jest.mock("jwt-decode");
 
 describe("validateOIDCIssuerWellKnown", () => {
-    const validWk: any = {
+    const validWk: ValidatedIssuerMetadata = {
+        issuer: "https://test.org",
         authorization_endpoint: "https://test.org/authorize",
         token_endpoint: "https://authorize.org/token",
         registration_endpoint: "https://authorize.org/regsiter",
@@ -63,6 +64,7 @@ describe("validateOIDCIssuerWellKnown", () => {
 
     it("should return validated issuer config", () => {
         expect(validateOIDCIssuerWellKnown(validWk)).toEqual({
+            issuer: validWk.issuer,
             authorizationEndpoint: validWk.authorization_endpoint,
             tokenEndpoint: validWk.token_endpoint,
             registrationEndpoint: validWk.registration_endpoint,
@@ -72,9 +74,9 @@ describe("validateOIDCIssuerWellKnown", () => {
     });
 
     it("should return validated issuer config without registrationendpoint", () => {
-        const wk = { ...validWk };
-        delete wk.registration_endpoint;
+        const { registration_endpoint: _, ...wk } = validWk;
         expect(validateOIDCIssuerWellKnown(wk)).toEqual({
+            issuer: validWk.issuer,
             authorizationEndpoint: validWk.authorization_endpoint,
             tokenEndpoint: validWk.token_endpoint,
             registrationEndpoint: undefined,

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -28,8 +28,8 @@ describe("validateOIDCIssuerWellKnown", () => {
         issuer: "https://test.org",
         authorization_endpoint: "https://test.org/authorize",
         token_endpoint: "https://authorize.org/token",
-        registration_endpoint: "https://authorize.org/regsiter",
-        revocation_endpoint: "https://authorize.org/regsiter",
+        registration_endpoint: "https://authorize.org/register",
+        revocation_endpoint: "https://authorize.org/revoke",
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code"],
         code_challenge_methods_supported: ["S256"],
@@ -63,25 +63,31 @@ describe("validateOIDCIssuerWellKnown", () => {
     });
 
     it("should return validated issuer config", () => {
-        expect(validateAuthMetadata(validWk)).toEqual({
-            issuer: validWk.issuer,
-            authorizationEndpoint: validWk.authorization_endpoint,
-            tokenEndpoint: validWk.token_endpoint,
-            registrationEndpoint: validWk.registration_endpoint,
-            accountManagementActionsSupported: ["org.matrix.cross_signing_reset"],
-            accountManagementEndpoint: "https://authorize.org/account",
-        });
+        expect(validateAuthMetadata(validWk)).toEqual(
+            expect.objectContaining({
+                issuer: validWk.issuer,
+                authorization_endpoint: validWk.authorization_endpoint,
+                token_endpoint: validWk.token_endpoint,
+                registration_endpoint: validWk.registration_endpoint,
+                account_management_actions_supported: ["org.matrix.cross_signing_reset"],
+                account_management_uri: "https://authorize.org/account",
+            }),
+        );
     });
 
-    it("should return validated issuer config without registrationendpoint", () => {
+    it("should return validated issuer config without registration_endpoint", () => {
         const { registration_endpoint: _, ...wk } = validWk;
         expect(validateAuthMetadata(wk)).toEqual({
             issuer: validWk.issuer,
-            authorizationEndpoint: validWk.authorization_endpoint,
-            tokenEndpoint: validWk.token_endpoint,
-            registrationEndpoint: undefined,
-            accountManagementActionsSupported: ["org.matrix.cross_signing_reset"],
-            accountManagementEndpoint: "https://authorize.org/account",
+            authorization_endpoint: validWk.authorization_endpoint,
+            token_endpoint: validWk.token_endpoint,
+            revocation_endpoint: validWk.revocation_endpoint,
+            registration_endpoint: undefined,
+            account_management_actions_supported: ["org.matrix.cross_signing_reset"],
+            account_management_uri: "https://authorize.org/account",
+            code_challenge_methods_supported: ["S256"],
+            grant_types_supported: ["authorization_code"],
+            response_types_supported: ["code"],
         });
     });
 

--- a/spec/unit/oidc/validate.spec.ts
+++ b/spec/unit/oidc/validate.spec.ts
@@ -18,13 +18,13 @@ import { mocked } from "jest-mock";
 import { jwtDecode } from "jwt-decode";
 
 import { logger } from "../../../src/logger";
-import { ValidatedIssuerMetadata, validateIdToken, validateOIDCIssuerWellKnown } from "../../../src/oidc/validate";
+import { ValidatedAuthMetadata, validateIdToken, validateAuthMetadata } from "../../../src/oidc/validate";
 import { OidcError } from "../../../src/oidc/error";
 
 jest.mock("jwt-decode");
 
 describe("validateOIDCIssuerWellKnown", () => {
-    const validWk: ValidatedIssuerMetadata = {
+    const validWk: ValidatedAuthMetadata = {
         issuer: "https://test.org",
         authorization_endpoint: "https://test.org/authorize",
         token_endpoint: "https://authorize.org/token",
@@ -45,14 +45,14 @@ describe("validateOIDCIssuerWellKnown", () => {
 
     it("should throw OP support error when wellKnown is not an object", () => {
         expect(() => {
-            validateOIDCIssuerWellKnown([]);
+            validateAuthMetadata([]);
         }).toThrow(OidcError.OpSupport);
         expect(logger.error).toHaveBeenCalledWith("Issuer configuration not found or malformed");
     });
 
     it("should log all errors before throwing", () => {
         expect(() => {
-            validateOIDCIssuerWellKnown({
+            validateAuthMetadata({
                 ...validWk,
                 authorization_endpoint: undefined,
                 response_types_supported: [],
@@ -63,7 +63,7 @@ describe("validateOIDCIssuerWellKnown", () => {
     });
 
     it("should return validated issuer config", () => {
-        expect(validateOIDCIssuerWellKnown(validWk)).toEqual({
+        expect(validateAuthMetadata(validWk)).toEqual({
             issuer: validWk.issuer,
             authorizationEndpoint: validWk.authorization_endpoint,
             tokenEndpoint: validWk.token_endpoint,
@@ -75,7 +75,7 @@ describe("validateOIDCIssuerWellKnown", () => {
 
     it("should return validated issuer config without registrationendpoint", () => {
         const { registration_endpoint: _, ...wk } = validWk;
-        expect(validateOIDCIssuerWellKnown(wk)).toEqual({
+        expect(validateAuthMetadata(wk)).toEqual({
             issuer: validWk.issuer,
             authorizationEndpoint: validWk.authorization_endpoint,
             tokenEndpoint: validWk.token_endpoint,
@@ -108,7 +108,7 @@ describe("validateOIDCIssuerWellKnown", () => {
             ...validWk,
             [key]: value,
         };
-        expect(() => validateOIDCIssuerWellKnown(wk)).toThrow(OidcError.OpSupport);
+        expect(() => validateAuthMetadata(wk)).toThrow(OidcError.OpSupport);
     });
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,7 +19,7 @@ limitations under the License.
  */
 
 import { Optional } from "matrix-events-sdk";
-import { MetadataService, OidcClientSettingsStore, OidcMetadata } from "oidc-client-ts";
+import { MetadataService, OidcClientSettingsStore } from "oidc-client-ts";
 
 import type { IDeviceKeys, IMegolmSessionData, IOneTimeKey } from "./@types/crypto.ts";
 import { ISyncStateData, SetPresence, SyncApi, SyncApiOptions, SyncState } from "./sync.ts";

--- a/src/client.ts
+++ b/src/client.ts
@@ -252,6 +252,7 @@ import {
     discoverAndValidateOIDCIssuerWellKnown,
     isValidatedIssuerMetadata,
     OidcClientConfig,
+    ValidatedIssuerMetadata,
     validateOIDCIssuerWellKnown,
 } from "./oidc/index.ts";
 
@@ -10357,11 +10358,17 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @experimental - part of MSC2965
      */
     public async getAuthMetadata(): Promise<OidcClientConfig> {
-        let authMetadata: OidcMetadata | undefined;
+        let authMetadata: ValidatedIssuerMetadata | undefined;
         try {
-            authMetadata = await this.http.request<OidcMetadata>(Method.Get, "/auth_metadata", undefined, undefined, {
-                prefix: ClientPrefix.Unstable + "/org.matrix.msc2965",
-            });
+            authMetadata = await this.http.request<ValidatedIssuerMetadata>(
+                Method.Get,
+                "/auth_metadata",
+                undefined,
+                undefined,
+                {
+                    prefix: ClientPrefix.Unstable + "/org.matrix.msc2965",
+                },
+            );
         } catch (e) {
             if (e instanceof MatrixError && e.errcode === "M_UNRECOGNIZED") {
                 const { issuer } = await this.getAuthIssuer();

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -23,7 +23,7 @@ import {
     BearerTokenResponse,
     UserState,
     validateBearerTokenResponse,
-    ValidatedIssuerMetadata,
+    ValidatedAuthMetadata,
     validateIdToken,
     validateStoredUserState,
 } from "./validate.ts";
@@ -138,7 +138,7 @@ export const generateOidcAuthorizationUrl = async ({
     urlState,
 }: {
     clientId: string;
-    metadata: ValidatedIssuerMetadata;
+    metadata: ValidatedAuthMetadata;
     homeserverUrl: string;
     identityServerUrl?: string;
     redirectUri: string;

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -30,6 +30,7 @@ import { OidcClientConfig } from "./index.ts";
  * @param issuer - the OIDC issuer as returned by the /auth_issuer API
  * @returns validated authentication metadata and optionally signing keys
  * @throws when delegated auth config is invalid or unreachable
+ * @deprecated in favour of {@link MatrixClient#getAuthMetadata}
  */
 export const discoverAndValidateOIDCIssuerWellKnown = async (issuer: string): Promise<OidcClientConfig> => {
     const issuerOpenIdConfigUrl = new URL(".well-known/openid-configuration", issuer);

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -43,8 +43,10 @@ export const discoverAndValidateOIDCIssuerWellKnown = async (issuer: string): Pr
 };
 
 /**
- *
- * @param authMetadata
+ * @experimental
+ * Validate the authentication metadata and fetch the signing keys from the jwks_uri in the metadata
+ * @param authMetadata - the authentication metadata to validate
+ * @returns validated authentication metadata and signing keys
  */
 export const validateAuthMetadataAndKeys = async (authMetadata: unknown): Promise<OidcClientConfig> => {
     const validatedIssuerConfig = validateAuthMetadata(authMetadata);

--- a/src/oidc/index.ts
+++ b/src/oidc/index.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type { SigningKey } from "oidc-client-ts";
-import { ValidatedIssuerConfig, ValidatedIssuerMetadata } from "./validate.ts";
+import { ValidatedAuthMetadata } from "./validate.ts";
 
 export * from "./authorize.ts";
 export * from "./discovery.ts";
@@ -28,7 +28,6 @@ export * from "./validate.ts";
  * Validated config for native OIDC authentication, as returned by {@link discoverAndValidateOIDCIssuerWellKnown}.
  * Contains metadata and signing keys from the issuer's well-known (https://oidc-issuer.example.com/.well-known/openid-configuration).
  */
-export interface OidcClientConfig extends ValidatedIssuerConfig {
-    metadata: ValidatedIssuerMetadata;
-    signingKeys?: SigningKey[];
+export interface OidcClientConfig extends ValidatedAuthMetadata {
+    signingKeys: SigningKey[] | null;
 }

--- a/src/oidc/register.ts
+++ b/src/oidc/register.ts
@@ -65,12 +65,12 @@ export const registerOidcClient = async (
     delegatedAuthConfig: OidcClientConfig,
     clientMetadata: OidcRegistrationClientMetadata,
 ): Promise<string> => {
-    if (!delegatedAuthConfig.registrationEndpoint) {
+    if (!delegatedAuthConfig.registration_endpoint) {
         throw new Error(OidcError.DynamicRegistrationNotSupported);
     }
 
     const grantTypes: NonEmptyArray<string> = ["authorization_code", "refresh_token"];
-    if (grantTypes.some((scope) => !delegatedAuthConfig.metadata.grant_types_supported.includes(scope))) {
+    if (grantTypes.some((scope) => !delegatedAuthConfig.grant_types_supported.includes(scope))) {
         throw new Error(OidcError.DynamicRegistrationNotSupported);
     }
 
@@ -95,7 +95,7 @@ export const registerOidcClient = async (
     };
 
     try {
-        const response = await fetch(delegatedAuthConfig.registrationEndpoint, {
+        const response = await fetch(delegatedAuthConfig.registration_endpoint, {
             method: Method.Post,
             headers,
             body: JSON.stringify(metadata),

--- a/src/oidc/tokenRefresher.ts
+++ b/src/oidc/tokenRefresher.ts
@@ -77,11 +77,12 @@ export class OidcTokenRefresher {
             const scope = generateScope(deviceId);
 
             this.oidcClient = new OidcClient({
-                ...config.metadata,
+                metadata: config,
+                signingKeys: config.signingKeys ?? undefined,
                 client_id: clientId,
                 scope,
                 redirect_uri: redirectUri,
-                authority: config.metadata.issuer,
+                authority: config.issuer,
                 stateStore: new WebStorageStateStore({ prefix: "mx_oidc_", store: window.sessionStorage }),
             });
         } catch (error) {

--- a/src/oidc/validate.ts
+++ b/src/oidc/validate.ts
@@ -21,6 +21,7 @@ import { logger } from "../logger.ts";
 import { OidcError } from "./error.ts";
 
 export type ValidatedIssuerConfig = {
+    issuer: string;
     authorizationEndpoint: string;
     tokenEndpoint: string;
     registrationEndpoint?: string;
@@ -78,6 +79,7 @@ export const validateOIDCIssuerWellKnown = (wellKnown: unknown): ValidatedIssuer
     }
 
     const isInvalid = [
+        requiredStringProperty(wellKnown, "issuer"),
         requiredStringProperty(wellKnown, "authorization_endpoint"),
         requiredStringProperty(wellKnown, "token_endpoint"),
         requiredStringProperty(wellKnown, "revocation_endpoint"),
@@ -92,6 +94,7 @@ export const validateOIDCIssuerWellKnown = (wellKnown: unknown): ValidatedIssuer
 
     if (!isInvalid) {
         return {
+            issuer: <string>wellKnown["issuer"],
             authorizationEndpoint: <string>wellKnown["authorization_endpoint"],
             tokenEndpoint: <string>wellKnown["token_endpoint"],
             registrationEndpoint: <string>wellKnown["registration_endpoint"],

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -27,7 +27,7 @@ import { logger } from "../logger.ts";
 import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
 import { MatrixError } from "../http-api/index.ts";
 import { sleep } from "../utils.ts";
-import { DEVICE_CODE_SCOPE, discoverAndValidateOIDCIssuerWellKnown, OidcClientConfig } from "../oidc/index.ts";
+import { DEVICE_CODE_SCOPE, OidcClientConfig } from "../oidc/index.ts";
 import { CryptoApi } from "../crypto-api/index.ts";
 
 /**
@@ -189,8 +189,7 @@ export class MSC4108SignInWithQR {
                 // MSC4108-Flow: NewScanned -send protocols message
                 let oidcClientConfig: OidcClientConfig | undefined;
                 try {
-                    const { issuer } = await this.client!.getAuthIssuer();
-                    oidcClientConfig = await discoverAndValidateOIDCIssuerWellKnown(issuer);
+                    oidcClientConfig = await this.client!.getAuthMetadata();
                 } catch (e) {
                     logger.error("Failed to discover OIDC metadata", e);
                 }

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -194,7 +194,7 @@ export class MSC4108SignInWithQR {
                     logger.error("Failed to discover OIDC metadata", e);
                 }
 
-                if (oidcClientConfig?.metadata.grant_types_supported.includes(DEVICE_CODE_SCOPE)) {
+                if (oidcClientConfig?.grant_types_supported.includes(DEVICE_CODE_SCOPE)) {
                     await this.send<ProtocolsPayload>({
                         type: PayloadType.Protocols,
                         protocols: ["device_authorization_grant"],

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -188,3 +188,5 @@ export async function decryptExistingEvent(
     } as Parameters<MatrixEvent["attemptDecryption"]>[0];
     await mxEvent.attemptDecryption(mockCrypto);
 }
+
+export * from "../spec/test-utils/oidc.ts";


### PR DESCRIPTION
Updates to latest variant of https://github.com/sandhose/matrix-spec-proposals/blob/msc/sandhose/oidc-discovery/proposals/2965-auth-metadata.md

Also drastically simplifies the overly-duplicated config/metadata interfaces