### PR TITLE
Fix documentation on `CryptoEvent`

### DIFF
--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Cryptography-related events emitted by the {@link MatrixClient}.
+ * Cryptography-related events emitted by the {@link matrix.MatrixClient}.
  */
 export enum CryptoEvent {
     /**

--- a/src/crypto-api/CryptoEvent.ts
+++ b/src/crypto-api/CryptoEvent.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Events emitted by the {@link CryptoApi}
+ * Cryptography-related events emitted by the {@link MatrixClient}.
  */
 export enum CryptoEvent {
     /**


### PR DESCRIPTION
`CryptoApi` itself does not emit events (or at least, its public type information does not allow you to listen for events emitted by CryptoApi).