### PR TITLE
`CryptoApi.resetEncryption` should always create a new key backup

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1896,22 +1896,6 @@ describe("RustCrypto", () => {
         });
 
         it("reset should reset 4S, backup and cross-signing", async () => {
-            // We don't have a key backup
-            fetchMock.get("path:/_matrix/client/v3/room_keys/version", {});
-
-            const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), undefined, undefined, secretStorage);
-
-            const authUploadDeviceSigningKeys = jest.fn();
-            await rustCrypto.resetEncryption(authUploadDeviceSigningKeys);
-
-            // The default key id should be deleted
-            expect(secretStorage.setDefaultKeyId).toHaveBeenCalledWith(null);
-            expect(await rustCrypto.getActiveSessionBackupVersion()).toBeNull();
-            // The new cross signing keys should be uploaded
-            expect(authUploadDeviceSigningKeys).toHaveBeenCalledWith(expect.any(Function));
-        });
-
-        it("key backup should be re-enabled after reset", async () => {
             // When we will delete the key backup
             let backupIsDeleted = false;
             fetchMock.delete("path:/_matrix/client/v3/room_keys/version/1", () => {
@@ -1923,6 +1907,13 @@ describe("RustCrypto", () => {
                 return backupIsDeleted ? {} : testData.SIGNED_BACKUP_DATA;
             });
 
+            // A new key backup should be created after the reset
+            let newKeyBackupInfo!: KeyBackupInfo;
+            fetchMock.post("path:/_matrix/client/v3/room_keys/version", (res, options) => {
+                newKeyBackupInfo = JSON.parse(options.body as string);
+                return { version: "2" };
+            });
+
             // We consider the key backup as trusted
             jest.spyOn(RustBackupManager.prototype, "isKeyBackupTrusted").mockResolvedValue({
                 trusted: true,
@@ -1932,13 +1923,6 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), undefined, undefined, secretStorage);
             // We have a key backup
             expect(await rustCrypto.getActiveSessionBackupVersion()).not.toBeNull();
-
-            // A new key backup should be created after the reset
-            let newKeyBackupInfo!: KeyBackupInfo;
-            fetchMock.post("path:/_matrix/client/v3/room_keys/version", (res, options) => {
-                newKeyBackupInfo = JSON.parse(options.body as string);
-                return { version: "2" };
-            });
 
             const authUploadDeviceSigningKeys = jest.fn();
             await rustCrypto.resetEncryption(authUploadDeviceSigningKeys);

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -401,7 +401,7 @@ export interface CryptoApi {
      * - Disable backing up room keys and delete any existing backups.
      * - Remove the default secret storage key from the account data (ie: the recovery key).
      * - Reset the cross-signing keys.
-     * - Re-enable backing up room keys if enabled before.
+     * - Create a new key backup.
      *
      * @param authUploadDeviceSigningKeys - Callback to authenticate the upload of device signing keys.
      *      Used when resetting the cross signing keys.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1477,6 +1477,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * Implementation of {@link CryptoApi#resetEncryption}.
      */
     public async resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void> {
+        this.logger.debug("resetEncryption: resetting encryption");
+
         // Disable backup, and delete all the backups from the server
         await this.backupManager.deleteAllKeyBackupVersions();
 
@@ -1491,6 +1493,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
 
         // Create a new key backup
         await this.resetKeyBackup();
+
+        this.logger.debug("resetEncryption: ended");
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1477,8 +1477,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * Implementation of {@link CryptoApi#resetEncryption}.
      */
     public async resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void> {
-        const backupEnabled = (await this.backupManager.getActiveBackupVersion()) !== null;
-
         // Disable backup, and delete all the backups from the server
         await this.backupManager.deleteAllKeyBackupVersions();
 
@@ -1491,10 +1489,8 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             authUploadDeviceSigningKeys,
         });
 
-        // If key backup was enabled, we create a new backup
-        if (backupEnabled) {
-            await this.resetKeyBackup();
-        }
+        // Create a new key backup
+        await this.resetKeyBackup();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Following discussion in https://github.com/matrix-org/matrix-js-sdk/pull/4614#discussion_r1925377884.
- We decided to always create a new key backup at the end of `resetEncryption`.
- Add logging to help futur RS.


