### PR TITLE
Remove deprecated `DeviceInfo` in `webrtc/call.ts`

### DIFF
--- a/src/webrtc/call.ts
+++ b/src/webrtc/call.ts
@@ -640,11 +640,8 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
         if (!userId) throw new Error("Couldn't find opponent user ID to init crypto");
 
         // Here we were calling `MatrixClient.crypto.deviceList.downloadKeys` which is not supported by the rust cryptography.
-        const deviceInfoMap = new Map();
-        this.hasOpponentDeviceInfo = Boolean(deviceInfoMap.get(userId)?.get(this.opponentDeviceId));
-        if (!this.hasOpponentDeviceInfo) {
-            throw new GroupCallUnknownDeviceError(userId);
-        }
+        this.hasOpponentDeviceInfo = false;
+        throw new GroupCallUnknownDeviceError(userId);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

The deprecated `DeviceInfo` was set into `opponentDeviceInfo` however `opponentDeviceInfo` was only used for boolean operations. We can replace it with a boolean attribute.

