### PR TITLE
Add unspecced backup disable flag

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -374,6 +374,8 @@ export interface AccountDataEvents extends SecretStorageAccountDataEvents {
     [EventType.Direct]: { [userId: string]: string[] };
     [EventType.IgnoredUserList]: { [userId: string]: {} };
     "m.secret_storage.default_key": { key: string };
+    // Flag set by the rust SDK (Element X) and also used by us to mark that the user opted out of backup
+    "m.org.matrix.custom.backup_disabled": { disabled: boolean };
     "m.identity_server": { base_url: string | null };
     [key: `${typeof LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${string}`]: LocalNotificationSettings;
     [key: `m.secret_storage.key.${string}`]: SecretStorageKeyDescription;

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -375,6 +375,7 @@ export interface AccountDataEvents extends SecretStorageAccountDataEvents {
     [EventType.IgnoredUserList]: { [userId: string]: {} };
     "m.secret_storage.default_key": { key: string };
     // Flag set by the rust SDK (Element X) and also used by us to mark that the user opted out of backup
+    // (I don't know why it's m.org.matrix...)
     "m.org.matrix.custom.backup_disabled": { disabled: boolean };
     "m.identity_server": { base_url: string | null };
     [key: `${typeof LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${string}`]: LocalNotificationSettings;


### PR DESCRIPTION
Element X uses this so it knows not to turn backup on again. Add it to js-sdk so we can set it so EX doesn't go turning key backup back on again.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
