### PR TITLE
Distinguish room state and timeline events in embedded clients (#4574)

### DIFF
--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -289,7 +289,11 @@ export class RoomWidgetClient extends MatrixClient {
 
         await this.widgetApiReady;
 
-        if (!(await this.supportUpdateState())) {
+        // sync room state:
+        if (await this.supportUpdateState()) {
+            // This will resolve once the client driver has sent us all the allowed room state.
+            await this.roomStateSynced;
+        } else {
             // Backfill the requested events
             // We only get the most recent event for every type + state key combo,
             // so it doesn't really matter what order we inject them in
@@ -320,8 +324,6 @@ export class RoomWidgetClient extends MatrixClient {
             }, 1000 * opts.clientWellKnownPollPeriod);
             this.fetchClientWellKnown();
         }
-
-        await this.roomStateSynced;
         this.setSyncState(SyncState.Syncing);
         logger.info("Finished initial sync");
 

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -28,6 +28,7 @@ import {
     WidgetApiAction,
     IWidgetApiResponse,
     IWidgetApiResponseData,
+    IUpdateStateToWidgetActionRequest,
 } from "matrix-widget-api";
 
 import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event.ts";
@@ -136,6 +137,7 @@ export type EventHandlerMap = { [RoomWidgetClientEvent.PendingEventsChanged]: ()
 export class RoomWidgetClient extends MatrixClient {
     private room?: Room;
     private readonly widgetApiReady: Promise<void>;
+    private readonly roomStateSynced: Promise<void>;
     private lifecycle?: AbortController;
     private syncState: SyncState | null = null;
 
@@ -189,6 +191,11 @@ export class RoomWidgetClient extends MatrixClient {
         };
 
         this.widgetApiReady = new Promise<void>((resolve) => this.widgetApi.once("ready", resolve));
+        this.roomStateSynced = capabilities.receiveState?.length
+            ? new Promise<void>((resolve) =>
+                  this.widgetApi.once(`action:${WidgetApiToWidgetAction.UpdateState}`, resolve),
+              )
+            : Promise.resolve();
 
         // Request capabilities for the functionality this client needs to support
         if (
@@ -241,6 +248,7 @@ export class RoomWidgetClient extends MatrixClient {
 
         widgetApi.on(`action:${WidgetApiToWidgetAction.SendEvent}`, this.onEvent);
         widgetApi.on(`action:${WidgetApiToWidgetAction.SendToDevice}`, this.onToDevice);
+        widgetApi.on(`action:${WidgetApiToWidgetAction.UpdateState}`, this.onStateUpdate);
 
         // Open communication with the host
         widgetApi.start();
@@ -276,28 +284,6 @@ export class RoomWidgetClient extends MatrixClient {
 
         await this.widgetApiReady;
 
-        // Backfill the requested events
-        // We only get the most recent event for every type + state key combo,
-        // so it doesn't really matter what order we inject them in
-        await Promise.all(
-            this.capabilities.receiveState?.map(async ({ eventType, stateKey }) => {
-                const rawEvents = await this.widgetApi.readStateEvents(eventType, undefined, stateKey, [this.roomId]);
-                const events = rawEvents.map((rawEvent) => new MatrixEvent(rawEvent as Partial<IEvent>));
-
-                if (this.syncApi instanceof SyncApi) {
-                    // Passing undefined for `stateAfterEventList` allows will make `injectRoomEvents` run in legacy mode
-                    // -> state events in `timelineEventList` will update the state.
-                    await this.syncApi.injectRoomEvents(this.room!, undefined, events);
-                } else {
-                    await this.syncApi!.injectRoomEvents(this.room!, events); // Sliding Sync
-                }
-                events.forEach((event) => {
-                    this.emit(ClientEvent.Event, event);
-                    logger.info(`Backfilled event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
-                });
-            }) ?? [],
-        );
-
         if (opts.clientWellKnownPollPeriod !== undefined) {
             this.clientWellKnownIntervalID = setInterval(() => {
                 this.fetchClientWellKnown();
@@ -305,8 +291,9 @@ export class RoomWidgetClient extends MatrixClient {
             this.fetchClientWellKnown();
         }
 
+        await this.roomStateSynced;
         this.setSyncState(SyncState.Syncing);
-        logger.info("Finished backfilling events");
+        logger.info("Finished initial sync");
 
         this.matrixRTC.start();
 
@@ -317,6 +304,7 @@ export class RoomWidgetClient extends MatrixClient {
     public stopClient(): void {
         this.widgetApi.off(`action:${WidgetApiToWidgetAction.SendEvent}`, this.onEvent);
         this.widgetApi.off(`action:${WidgetApiToWidgetAction.SendToDevice}`, this.onToDevice);
+        this.widgetApi.off(`action:${WidgetApiToWidgetAction.UpdateState}`, this.onStateUpdate);
 
         super.stopClient();
         this.lifecycle!.abort(); // Signal to other async tasks that the client has stopped
@@ -574,36 +562,15 @@ export class RoomWidgetClient extends MatrixClient {
             // Only inject once we have update the txId
             await this.updateTxId(event);
 
-            // The widget API does not tell us whether a state event came from `state_after` or not so we assume legacy behaviour for now.
             if (this.syncApi instanceof SyncApi) {
-                // The code will want to be something like:
-                // ```
-                // if (!params.addToTimeline && !params.addToState) {
-                // // Passing undefined for `stateAfterEventList` makes `injectRoomEvents` run in "legacy mode"
-                // // -> state events part of the `timelineEventList` parameter will update the state.
-                //     this.injectRoomEvents(this.room!, [], undefined, [event]);
-                // } else {
-                //     this.injectRoomEvents(this.room!, undefined, params.addToState ? [event] : [], params.addToTimeline ? [event] : []);
-                // }
-                // ```
-
-                // Passing undefined for `stateAfterEventList` allows will make `injectRoomEvents` run in legacy mode
-                // -> state events in `timelineEventList` will update the state.
-                await this.syncApi.injectRoomEvents(this.room!, [], undefined, [event]);
+                await this.syncApi.injectRoomEvents(this.room!, undefined, [], [event]);
             } else {
-                // The code will want to be something like:
-                // ```
-                // if (!params.addToTimeline && !params.addToState) {
-                //     this.injectRoomEvents(this.room!, [], [event]);
-                // } else {
-                //     this.injectRoomEvents(this.room!, params.addToState ? [event] : [], params.addToTimeline ? [event] : []);
-                // }
-                // ```
-                await this.syncApi!.injectRoomEvents(this.room!, [], [event]); // Sliding Sync
+                // Sliding Sync
+                await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
             }
             this.emit(ClientEvent.Event, event);
             this.setSyncState(SyncState.Syncing);
-            logger.info(`Received event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
+            logger.info(`Received event ${event.getId()} ${event.getType()}`);
         } else {
             const { event_id: eventId, room_id: roomId } = ev.detail.data;
             logger.info(`Received event ${eventId} for a different room ${roomId}; discarding`);
@@ -625,6 +592,32 @@ export class RoomWidgetClient extends MatrixClient {
 
         this.emit(ClientEvent.ToDeviceEvent, event);
         this.setSyncState(SyncState.Syncing);
+        await this.ack(ev);
+    };
+
+    private onStateUpdate = async (ev: CustomEvent<IUpdateStateToWidgetActionRequest>): Promise<void> => {
+        ev.preventDefault();
+
+        for (const rawEvent of ev.detail.data.state) {
+            // Verify the room ID matches, since it's possible for the client to
+            // send us state updates from other rooms if this widget is always
+            // on screen
+            if (rawEvent.room_id === this.roomId) {
+                const event = new MatrixEvent(rawEvent as Partial<IEvent>);
+
+                if (this.syncApi instanceof SyncApi) {
+                    await this.syncApi.injectRoomEvents(this.room!, undefined, [event]);
+                } else {
+                    // Sliding Sync
+                    await this.syncApi!.injectRoomEvents(this.room!, [event]);
+                }
+                logger.info(`Updated state entry ${event.getType()} ${event.getStateKey()} to ${event.getId()}`);
+            } else {
+                const { event_id: eventId, room_id: roomId } = ev.detail.data;
+                logger.info(`Received state entry ${eventId} for a different room ${roomId}; discarding`);
+            }
+        }
+
         await this.ack(ev);
     };
 

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -29,6 +29,7 @@ import {
     IWidgetApiResponse,
     IWidgetApiResponseData,
     IUpdateStateToWidgetActionRequest,
+    UnstableApiVersion,
 } from "matrix-widget-api";
 
 import { MatrixEvent, IEvent, IContent, EventStatus } from "./models/event.ts";
@@ -260,6 +261,10 @@ export class RoomWidgetClient extends MatrixClient {
         if (sendContentLoaded) widgetApi.sendContentLoaded();
     }
 
+    public async supportUpdateState(): Promise<boolean> {
+        return (await this.widgetApi.getClientVersions())?.includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
+    }
+
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {
         this.lifecycle = new AbortController();
 
@@ -283,6 +288,31 @@ export class RoomWidgetClient extends MatrixClient {
         this.store.storeRoom(this.room);
 
         await this.widgetApiReady;
+
+        if (!(await this.supportUpdateState())) {
+            // Backfill the requested events
+            // We only get the most recent event for every type + state key combo,
+            // so it doesn't really matter what order we inject them in
+            await Promise.all(
+                this.capabilities.receiveState?.map(async ({ eventType, stateKey }) => {
+                    const rawEvents = await this.widgetApi.readStateEvents(eventType, undefined, stateKey, [
+                        this.roomId,
+                    ]);
+                    const events = rawEvents.map((rawEvent) => new MatrixEvent(rawEvent as Partial<IEvent>));
+
+                    if (this.syncApi instanceof SyncApi) {
+                        // Passing events as `stateAfterEventList` will update the state.
+                        await this.syncApi.injectRoomEvents(this.room!, undefined, events);
+                    } else {
+                        await this.syncApi!.injectRoomEvents(this.room!, events); // Sliding Sync
+                    }
+                    events.forEach((event) => {
+                        this.emit(ClientEvent.Event, event);
+                        logger.info(`Backfilled event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
+                    });
+                }) ?? [],
+            );
+        }
 
         if (opts.clientWellKnownPollPeriod !== undefined) {
             this.clientWellKnownIntervalID = setInterval(() => {
@@ -563,11 +593,24 @@ export class RoomWidgetClient extends MatrixClient {
             await this.updateTxId(event);
 
             if (this.syncApi instanceof SyncApi) {
-                await this.syncApi.injectRoomEvents(this.room!, undefined, [], [event]);
+                if (await this.supportUpdateState()) {
+                    await this.syncApi.injectRoomEvents(this.room!, undefined, [], [event]);
+                } else {
+                    // Passing undefined for `stateAfterEventList` will make `injectRoomEvents` run in legacy mode
+                    // -> state events in `timelineEventList` will update the state.
+                    await this.syncApi.injectRoomEvents(this.room!, [], undefined, [event]);
+                }
             } else {
                 // Sliding Sync
-                await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
+                if (await this.supportUpdateState()) {
+                    await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
+                } else {
+                    logger.error(
+                        "slididng sync cannot be used in widget mode if the client widget driver does not support the version: 'org.matrix.msc2762_update_state'",
+                    );
+                }
             }
+
             this.emit(ClientEvent.Event, event);
             this.setSyncState(SyncState.Syncing);
             logger.info(`Received event ${event.getId()} ${event.getType()}`);
@@ -597,7 +640,11 @@ export class RoomWidgetClient extends MatrixClient {
 
     private onStateUpdate = async (ev: CustomEvent<IUpdateStateToWidgetActionRequest>): Promise<void> => {
         ev.preventDefault();
-
+        if (!(await this.supportUpdateState())) {
+            logger.warn(
+                "received update_state widget action but the widget driver did not claim to support 'org.matrix.msc2762_update_state'",
+            );
+        }
         for (const rawEvent of ev.detail.data.state) {
             // Verify the room ID matches, since it's possible for the client to
             // send us state updates from other rooms if this widget is always

--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,9 +4875,9 @@ matrix-mock-request@^2.5.0:
     expect "^28.1.0"
 
 matrix-widget-api@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
-  integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.12.0.tgz#b3d22bab1670051c8eeee66bb96d08b33148bc99"
+  integrity sha512-6JRd9fJGGvuBRhcTg9wX+Skn/Q1wox3jdp5yYQKJ6pPw4urW9bkTR90APBKVDB1vorJKT44jml+lCzkDMRBjww==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,9 +4875,9 @@ matrix-mock-request@^2.5.0:
     expect "^28.1.0"
 
 matrix-widget-api@^1.10.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.12.0.tgz#b3d22bab1670051c8eeee66bb96d08b33148bc99"
-  integrity sha512-6JRd9fJGGvuBRhcTg9wX+Skn/Q1wox3jdp5yYQKJ6pPw4urW9bkTR90APBKVDB1vorJKT44jml+lCzkDMRBjww==
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.0.tgz#40344b264b08d6d98ab9d547a41eb74dd6d8c3f7"
+  integrity sha512-+LrvwkR1izL4h2euX8PDrvG/3PZZDEd6As+lmnR3jAVwbFJtU5iTnwmZGnCca9ddngCvXvAHkcpJBEPyPTZneQ==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
* Distinguish room state and timeline events in embedded clients

This change enables room widget clients to take advantage of the more reliable method of communicating room state over the widget API provided by a recent update to MSC2762.

* Add missing awaits

* Upgrade matrix-widget-api<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
