### PR TITLE
Clean up legacy stores

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -429,13 +429,18 @@ describe("initRustCrypto", () => {
             expect(session.senderSigningKey).toBe(undefined);
         }, 10000);
 
-        async function encryptAndStoreSecretKey(type: string, key: Uint8Array, pickleKey: string, store: CryptoStore) {
+        async function encryptAndStoreSecretKey(
+            type: string,
+            key: Uint8Array,
+            pickleKey: string,
+            store: MemoryCryptoStore,
+        ) {
             const encryptedKey = await encryptAESSecretStorageItem(encodeBase64(key), Buffer.from(pickleKey), type);
             store.storeSecretStorePrivateKey(undefined, type as keyof SecretStorePrivateKeys, encryptedKey);
         }
 
         /** Create a bunch of fake Olm sessions and stash them in the DB. */
-        function createSessions(store: CryptoStore, nDevices: number, nSessionsPerDevice: number) {
+        function createSessions(store: MemoryCryptoStore, nDevices: number, nSessionsPerDevice: number) {
             for (let i = 0; i < nDevices; i++) {
                 for (let j = 0; j < nSessionsPerDevice; j++) {
                     const sessionData = {
@@ -450,7 +455,7 @@ describe("initRustCrypto", () => {
         }
 
         /** Create a bunch of fake Megolm sessions and stash them in the DB. */
-        function createMegolmSessions(store: CryptoStore, nDevices: number, nSessionsPerDevice: number) {
+        function createMegolmSessions(store: MemoryCryptoStore, nDevices: number, nSessionsPerDevice: number) {
             for (let i = 0; i < nDevices; i++) {
                 for (let j = 0; j < nSessionsPerDevice; j++) {
                     store.storeEndToEndInboundGroupSession(

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -25,12 +25,6 @@ import { ISignatures } from "../../@types/signed.ts";
  */
 
 export interface SecretStorePrivateKeys {
-    "dehydration": {
-        keyInfo: { [props: string]: any };
-        key: AESEncryptedSecretStoragePayload;
-        deviceDisplayName: string;
-        time: number;
-    } | null;
     "m.megolm_backup.v1": AESEncryptedSecretStoragePayload;
 }
 
@@ -75,17 +69,11 @@ export interface CryptoStore {
 
     // Olm Account
     getAccount(txn: unknown, func: (accountPickle: string | null) => void): void;
-    storeAccount(txn: unknown, accountPickle: string): void;
     getCrossSigningKeys(txn: unknown, func: (keys: Record<string, CrossSigningKeyInfo> | null) => void): void;
     getSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
         txn: unknown,
         func: (key: SecretStorePrivateKeys[K] | null) => void,
         type: K,
-    ): void;
-    storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
-        txn: unknown,
-        type: K,
-        key: SecretStorePrivateKeys[K],
     ): void;
 
     // Olm Sessions
@@ -101,7 +89,6 @@ export interface CryptoStore {
         txn: unknown,
         func: (sessions: { [sessionId: string]: ISessionInfo }) => void,
     ): void;
-    storeEndToEndSession(deviceKey: string, sessionId: string, sessionInfo: ISessionInfo, txn: unknown): void;
 
     /**
      * Get a batch of end-to-end sessions from the database.
@@ -126,12 +113,6 @@ export interface CryptoStore {
         sessionId: string,
         txn: unknown,
         func: (groupSession: InboundGroupSessionData | null, groupSessionWithheld: IWithheld | null) => void,
-    ): void;
-    storeEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: unknown,
     ): void;
 
     /**

--- a/src/crypto/store/base.ts
+++ b/src/crypto/store/base.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.ts";
 import { RoomKeyRequestState } from "../OutgoingRoomKeyRequestManager.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
 import { TrackingStatus } from "../DeviceList.ts";
 import { IRoomEncryption } from "../RoomList.ts";
 import { IDevice } from "../deviceinfo.ts";
@@ -81,22 +80,6 @@ export interface CryptoStore {
      */
     setMigrationState(migrationState: MigrationState): Promise<void>;
 
-    getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest>;
-    getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null>;
-    getOutgoingRoomKeyRequestByState(wantedStates: number[]): Promise<OutgoingRoomKeyRequest | null>;
-    getAllOutgoingRoomKeyRequestsByState(wantedState: number): Promise<OutgoingRoomKeyRequest[]>;
-    getOutgoingRoomKeyRequestsByTarget(
-        userId: string,
-        deviceId: string,
-        wantedStates: number[],
-    ): Promise<OutgoingRoomKeyRequest[]>;
-    updateOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-        updates: Partial<OutgoingRoomKeyRequest>,
-    ): Promise<OutgoingRoomKeyRequest | null>;
-    deleteOutgoingRoomKeyRequest(requestId: string, expectedState: number): Promise<OutgoingRoomKeyRequest | null>;
-
     // Olm Account
     getAccount(txn: unknown, func: (accountPickle: string | null) => void): void;
     storeAccount(txn: unknown, accountPickle: string): void;
@@ -106,7 +89,6 @@ export interface CryptoStore {
         func: (key: SecretStorePrivateKeys[K] | null) => void,
         type: K,
     ): void;
-    storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void;
     storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
         txn: unknown,
         type: K,
@@ -126,11 +108,7 @@ export interface CryptoStore {
         txn: unknown,
         func: (sessions: { [sessionId: string]: ISessionInfo }) => void,
     ): void;
-    getAllEndToEndSessions(txn: unknown, func: (session: ISessionInfo | null) => void): void;
     storeEndToEndSession(deviceKey: string, sessionId: string, sessionInfo: ISessionInfo, txn: unknown): void;
-    storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void>;
-    getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null>;
-    filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]>;
 
     /**
      * Get a batch of end-to-end sessions from the database.
@@ -156,23 +134,10 @@ export interface CryptoStore {
         txn: unknown,
         func: (groupSession: InboundGroupSessionData | null, groupSessionWithheld: IWithheld | null) => void,
     ): void;
-    getAllEndToEndInboundGroupSessions(txn: unknown, func: (session: ISession | null) => void): void;
-    addEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: unknown,
-    ): void;
     storeEndToEndInboundGroupSession(
         senderCurve25519Key: string,
         sessionId: string,
         sessionData: InboundGroupSessionData,
-        txn: unknown,
-    ): void;
-    storeEndToEndInboundGroupSessionWithheld(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: IWithheld,
         txn: unknown,
     ): void;
 
@@ -201,21 +166,8 @@ export interface CryptoStore {
     deleteEndToEndInboundGroupSessionsBatch(sessions: { senderKey: string; sessionId: string }[]): Promise<void>;
 
     // Device Data
-    getEndToEndDeviceData(txn: unknown, func: (deviceData: IDeviceData | null) => void): void;
-    storeEndToEndDeviceData(deviceData: IDeviceData, txn: unknown): void;
-    storeEndToEndRoom(roomId: string, roomInfo: IRoomEncryption, txn: unknown): void;
     getEndToEndRooms(txn: unknown, func: (rooms: Record<string, IRoomEncryption>) => void): void;
-    getSessionsNeedingBackup(limit: number): Promise<ISession[]>;
-    countSessionsNeedingBackup(txn?: unknown): Promise<number>;
-    unmarkSessionsNeedingBackup(sessions: ISession[], txn?: unknown): Promise<void>;
     markSessionsNeedingBackup(sessions: ISession[], txn?: unknown): Promise<void>;
-    addSharedHistoryInboundGroupSession(roomId: string, senderKey: string, sessionId: string, txn?: unknown): void;
-    getSharedHistoryInboundGroupSessions(
-        roomId: string,
-        txn?: unknown,
-    ): Promise<[senderKey: string, sessionId: string][]>;
-    addParkedSharedHistory(roomId: string, data: ParkedSharedHistory, txn?: unknown): void;
-    takeParkedSharedHistory(roomId: string, txn?: unknown): Promise<ParkedSharedHistory[]>;
 
     // Session key backups
     doTxn<T>(mode: Mode, stores: Iterable<string>, func: (txn: unknown) => T, log?: Logger): Promise<T>;

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -15,25 +15,19 @@ limitations under the License.
 */
 
 import { Logger, logger } from "../../logger.ts";
-import { deepCompare } from "../../utils.ts";
 import {
     CryptoStore,
     IDeviceData,
-    IProblem,
     ISession,
     SessionExtended,
     ISessionInfo,
     IWithheld,
     MigrationState,
     Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base.ts";
-import { IRoomKeyRequestBody, IRoomKeyRequestRecipient } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
 import { IRoomEncryption } from "../RoomList.ts";
 import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { IndexedDBCryptoStore } from "./indexeddb-crypto-store.ts";
@@ -106,297 +100,6 @@ export class Backend implements CryptoStore {
         });
     }
 
-    /**
-     * Look for an existing outgoing room key request, and if none is found,
-     * add a new one
-     *
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}: either the
-     *    same instance as passed in, or the existing one.
-     */
-    public getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest> {
-        const requestBody = request.requestBody;
-
-        return new Promise((resolve, reject) => {
-            const txn = this.db.transaction("outgoingRoomKeyRequests", "readwrite");
-            txn.onerror = reject;
-
-            // first see if we already have an entry for this request.
-            this._getOutgoingRoomKeyRequest(txn, requestBody, (existing) => {
-                if (existing) {
-                    // this entry matches the request - return it.
-                    logger.log(
-                        `already have key request outstanding for ` +
-                            `${requestBody.room_id} / ${requestBody.session_id}: ` +
-                            `not sending another`,
-                    );
-                    resolve(existing);
-                    return;
-                }
-
-                // we got to the end of the list without finding a match
-                // - add the new request.
-                logger.log(`enqueueing key request for ${requestBody.room_id} / ` + requestBody.session_id);
-                txn.oncomplete = (): void => {
-                    resolve(request);
-                };
-                const store = txn.objectStore("outgoingRoomKeyRequests");
-                store.add(request);
-            });
-        });
-    }
-
-    /**
-     * Look for an existing room key request
-     *
-     * @param requestBody - existing request to look for
-     *
-     * @returns resolves to the matching
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    not found
-     */
-    public getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null> {
-        return new Promise((resolve, reject) => {
-            const txn = this.db.transaction("outgoingRoomKeyRequests", "readonly");
-            txn.onerror = reject;
-
-            this._getOutgoingRoomKeyRequest(txn, requestBody, (existing) => {
-                resolve(existing);
-            });
-        });
-    }
-
-    /**
-     * look for an existing room key request in the db
-     *
-     * @internal
-     * @param txn -  database transaction
-     * @param requestBody - existing request to look for
-     * @param callback -  function to call with the results of the
-     *    search. Either passed a matching
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    not found.
-     */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    private _getOutgoingRoomKeyRequest(
-        txn: IDBTransaction,
-        requestBody: IRoomKeyRequestBody,
-        callback: (req: OutgoingRoomKeyRequest | null) => void,
-    ): void {
-        const store = txn.objectStore("outgoingRoomKeyRequests");
-
-        const idx = store.index("session");
-        const cursorReq = idx.openCursor([requestBody.room_id, requestBody.session_id]);
-
-        cursorReq.onsuccess = (): void => {
-            const cursor = cursorReq.result;
-            if (!cursor) {
-                // no match found
-                callback(null);
-                return;
-            }
-
-            const existing = cursor.value;
-
-            if (deepCompare(existing.requestBody, requestBody)) {
-                // got a match
-                callback(existing);
-                return;
-            }
-
-            // look at the next entry in the index
-            cursor.continue();
-        };
-    }
-
-    /**
-     * Look for room key requests by state
-     *
-     * @param wantedStates - list of acceptable states
-     *
-     * @returns resolves to the a
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    there are no pending requests in those states. If there are multiple
-     *    requests in those states, an arbitrary one is chosen.
-     */
-    public getOutgoingRoomKeyRequestByState(wantedStates: number[]): Promise<OutgoingRoomKeyRequest | null> {
-        if (wantedStates.length === 0) {
-            return Promise.resolve(null);
-        }
-
-        // this is a bit tortuous because we need to make sure we do the lookup
-        // in a single transaction, to avoid having a race with the insertion
-        // code.
-
-        // index into the wantedStates array
-        let stateIndex = 0;
-        let result: OutgoingRoomKeyRequest;
-
-        function onsuccess(this: IDBRequest<IDBCursorWithValue | null>): void {
-            const cursor = this.result;
-            if (cursor) {
-                // got a match
-                result = cursor.value;
-                return;
-            }
-
-            // try the next state in the list
-            stateIndex++;
-            if (stateIndex >= wantedStates.length) {
-                // no matches
-                return;
-            }
-
-            const wantedState = wantedStates[stateIndex];
-            const cursorReq = (this.source as IDBIndex).openCursor(wantedState);
-            cursorReq.onsuccess = onsuccess;
-        }
-
-        const txn = this.db.transaction("outgoingRoomKeyRequests", "readonly");
-        const store = txn.objectStore("outgoingRoomKeyRequests");
-
-        const wantedState = wantedStates[stateIndex];
-        const cursorReq = store.index("state").openCursor(wantedState);
-        cursorReq.onsuccess = onsuccess;
-
-        return promiseifyTxn(txn).then(() => result);
-    }
-
-    /**
-     *
-     * @returns All elements in a given state
-     */
-    public getAllOutgoingRoomKeyRequestsByState(wantedState: number): Promise<OutgoingRoomKeyRequest[]> {
-        return new Promise((resolve, reject) => {
-            const txn = this.db.transaction("outgoingRoomKeyRequests", "readonly");
-            const store = txn.objectStore("outgoingRoomKeyRequests");
-            const index = store.index("state");
-            const request = index.getAll(wantedState);
-
-            request.onsuccess = (): void => resolve(request.result);
-            request.onerror = (): void => reject(request.error);
-        });
-    }
-
-    public getOutgoingRoomKeyRequestsByTarget(
-        userId: string,
-        deviceId: string,
-        wantedStates: number[],
-    ): Promise<OutgoingRoomKeyRequest[]> {
-        let stateIndex = 0;
-        const results: OutgoingRoomKeyRequest[] = [];
-
-        function onsuccess(this: IDBRequest<IDBCursorWithValue | null>): void {
-            const cursor = this.result;
-            if (cursor) {
-                const keyReq = cursor.value;
-                if (
-                    keyReq.recipients.some(
-                        (recipient: IRoomKeyRequestRecipient) =>
-                            recipient.userId === userId && recipient.deviceId === deviceId,
-                    )
-                ) {
-                    results.push(keyReq);
-                }
-                cursor.continue();
-            } else {
-                // try the next state in the list
-                stateIndex++;
-                if (stateIndex >= wantedStates.length) {
-                    // no matches
-                    return;
-                }
-
-                const wantedState = wantedStates[stateIndex];
-                const cursorReq = (this.source as IDBIndex).openCursor(wantedState);
-                cursorReq.onsuccess = onsuccess;
-            }
-        }
-
-        const txn = this.db.transaction("outgoingRoomKeyRequests", "readonly");
-        const store = txn.objectStore("outgoingRoomKeyRequests");
-
-        const wantedState = wantedStates[stateIndex];
-        const cursorReq = store.index("state").openCursor(wantedState);
-        cursorReq.onsuccess = onsuccess;
-
-        return promiseifyTxn(txn).then(() => results);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and update it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     * @param updates -        name/value map of updates to apply
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}
-     *    updated request, or null if no matching row was found
-     */
-    public updateOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-        updates: Partial<OutgoingRoomKeyRequest>,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        let result: OutgoingRoomKeyRequest | null = null;
-
-        function onsuccess(this: IDBRequest<IDBCursorWithValue | null>): void {
-            const cursor = this.result;
-            if (!cursor) {
-                return;
-            }
-            const data = cursor.value;
-            if (data.state != expectedState) {
-                logger.warn(
-                    `Cannot update room key request from ${expectedState} ` +
-                        `as it was already updated to ${data.state}`,
-                );
-                return;
-            }
-            Object.assign(data, updates);
-            cursor.update(data);
-            result = data;
-        }
-
-        const txn = this.db.transaction("outgoingRoomKeyRequests", "readwrite");
-        const cursorReq = txn.objectStore("outgoingRoomKeyRequests").openCursor(requestId);
-        cursorReq.onsuccess = onsuccess;
-        return promiseifyTxn(txn).then(() => result);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and delete it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     *
-     * @returns resolves once the operation is completed
-     */
-    public deleteOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        const txn = this.db.transaction("outgoingRoomKeyRequests", "readwrite");
-        const cursorReq = txn.objectStore("outgoingRoomKeyRequests").openCursor(requestId);
-        cursorReq.onsuccess = (): void => {
-            const cursor = cursorReq.result;
-            if (!cursor) {
-                return;
-            }
-            const data = cursor.value;
-            if (data.state != expectedState) {
-                logger.warn(`Cannot delete room key request in state ${data.state} ` + `(expected ${expectedState})`);
-                return;
-            }
-            cursor.delete();
-        };
-        return promiseifyTxn<OutgoingRoomKeyRequest | null>(txn);
-    }
-
     // Olm Account
 
     public getAccount(txn: IDBTransaction, func: (accountPickle: string | null) => void): void {
@@ -445,11 +148,6 @@ export class Backend implements CryptoStore {
                 abortWithException(txn, <Error>e);
             }
         };
-    }
-
-    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, CrossSigningKeyInfo>): void {
-        const objectStore = txn.objectStore("account");
-        objectStore.put(keys, "crossSigningKeys");
     }
 
     public storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
@@ -526,24 +224,6 @@ export class Backend implements CryptoStore {
         };
     }
 
-    public getAllEndToEndSessions(txn: IDBTransaction, func: (session: ISessionInfo | null) => void): void {
-        const objectStore = txn.objectStore("sessions");
-        const getReq = objectStore.openCursor();
-        getReq.onsuccess = function (): void {
-            try {
-                const cursor = getReq.result;
-                if (cursor) {
-                    func(cursor.value);
-                    cursor.continue();
-                } else {
-                    func(null);
-                }
-            } catch (e) {
-                abortWithException(txn, <Error>e);
-            }
-        };
-    }
-
     public storeEndToEndSession(
         deviceKey: string,
         sessionId: string,
@@ -557,76 +237,6 @@ export class Backend implements CryptoStore {
             session: sessionInfo.session,
             lastReceivedMessageTs: sessionInfo.lastReceivedMessageTs,
         });
-    }
-
-    public async storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {
-        const txn = this.db.transaction("session_problems", "readwrite");
-        const objectStore = txn.objectStore("session_problems");
-        objectStore.put({
-            deviceKey,
-            type,
-            fixed,
-            time: Date.now(),
-        });
-        await promiseifyTxn(txn);
-    }
-
-    public async getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null> {
-        let result: IProblem | null = null;
-        const txn = this.db.transaction("session_problems", "readwrite");
-        const objectStore = txn.objectStore("session_problems");
-        const index = objectStore.index("deviceKey");
-        const req = index.getAll(deviceKey);
-        req.onsuccess = (): void => {
-            const problems = req.result;
-            if (!problems.length) {
-                result = null;
-                return;
-            }
-            problems.sort((a, b) => {
-                return a.time - b.time;
-            });
-            const lastProblem = problems[problems.length - 1];
-            for (const problem of problems) {
-                if (problem.time > timestamp) {
-                    result = Object.assign({}, problem, { fixed: lastProblem.fixed });
-                    return;
-                }
-            }
-            if (lastProblem.fixed) {
-                result = null;
-            } else {
-                result = lastProblem;
-            }
-        };
-        await promiseifyTxn(txn);
-        return result;
-    }
-
-    // FIXME: we should probably prune this when devices get deleted
-    public async filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]> {
-        const txn = this.db.transaction("notified_error_devices", "readwrite");
-        const objectStore = txn.objectStore("notified_error_devices");
-
-        const ret: IOlmDevice[] = [];
-
-        await Promise.all(
-            devices.map((device) => {
-                return new Promise<void>((resolve) => {
-                    const { userId, deviceInfo } = device;
-                    const getReq = objectStore.get([userId, deviceInfo.deviceId]);
-                    getReq.onsuccess = function (): void {
-                        if (!getReq.result) {
-                            objectStore.put({ userId, deviceId: deviceInfo.deviceId });
-                            ret.push(device);
-                        }
-                        resolve();
-                    };
-                });
-            }),
-        );
-
-        return ret;
     }
 
     /**
@@ -730,57 +340,6 @@ export class Backend implements CryptoStore {
         };
     }
 
-    public getAllEndToEndInboundGroupSessions(txn: IDBTransaction, func: (session: ISession | null) => void): void {
-        const objectStore = txn.objectStore("inbound_group_sessions");
-        const getReq = objectStore.openCursor();
-        getReq.onsuccess = function (): void {
-            const cursor = getReq.result;
-            if (cursor) {
-                try {
-                    func({
-                        senderKey: cursor.value.senderCurve25519Key,
-                        sessionId: cursor.value.sessionId,
-                        sessionData: cursor.value.session,
-                    });
-                } catch (e) {
-                    abortWithException(txn, <Error>e);
-                }
-                cursor.continue();
-            } else {
-                try {
-                    func(null);
-                } catch (e) {
-                    abortWithException(txn, <Error>e);
-                }
-            }
-        };
-    }
-
-    public addEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: IDBTransaction,
-    ): void {
-        const objectStore = txn.objectStore("inbound_group_sessions");
-        const addReq = objectStore.add({
-            senderCurve25519Key,
-            sessionId,
-            session: sessionData,
-        });
-        addReq.onerror = (ev): void => {
-            if (addReq.error?.name === "ConstraintError") {
-                // This stops the error from triggering the txn's onerror
-                ev.stopPropagation();
-                // ...and this stops it from aborting the transaction
-                ev.preventDefault();
-                logger.log("Ignoring duplicate inbound group session: " + senderCurve25519Key + " / " + sessionId);
-            } else {
-                abortWithException(txn, new Error("Failed to add inbound group session: " + addReq.error?.name));
-            }
-        };
-    }
-
     public storeEndToEndInboundGroupSession(
         senderCurve25519Key: string,
         sessionId: string,
@@ -788,20 +347,6 @@ export class Backend implements CryptoStore {
         txn: IDBTransaction,
     ): void {
         const objectStore = txn.objectStore("inbound_group_sessions");
-        objectStore.put({
-            senderCurve25519Key,
-            sessionId,
-            session: sessionData,
-        });
-    }
-
-    public storeEndToEndInboundGroupSessionWithheld(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: IWithheld,
-        txn: IDBTransaction,
-    ): void {
-        const objectStore = txn.objectStore("inbound_group_sessions_withheld");
         objectStore.put({
             senderCurve25519Key,
             sessionId,
@@ -912,16 +457,6 @@ export class Backend implements CryptoStore {
         };
     }
 
-    public storeEndToEndDeviceData(deviceData: IDeviceData, txn: IDBTransaction): void {
-        const objectStore = txn.objectStore("device_data");
-        objectStore.put(deviceData, "-");
-    }
-
-    public storeEndToEndRoom(roomId: string, roomInfo: IRoomEncryption, txn: IDBTransaction): void {
-        const objectStore = txn.objectStore("rooms");
-        objectStore.put(roomInfo, roomId);
-    }
-
     public getEndToEndRooms(txn: IDBTransaction, func: (rooms: Record<string, IRoomEncryption>) => void): void {
         const rooms: Parameters<Parameters<Backend["getEndToEndRooms"]>[1]>[0] = {};
         const objectStore = txn.objectStore("rooms");
@@ -941,67 +476,6 @@ export class Backend implements CryptoStore {
         };
     }
 
-    // session backups
-
-    public getSessionsNeedingBackup(limit: number): Promise<ISession[]> {
-        return new Promise((resolve, reject) => {
-            const sessions: ISession[] = [];
-
-            const txn = this.db.transaction(["sessions_needing_backup", "inbound_group_sessions"], "readonly");
-            txn.onerror = reject;
-            txn.oncomplete = function (): void {
-                resolve(sessions);
-            };
-            const objectStore = txn.objectStore("sessions_needing_backup");
-            const sessionStore = txn.objectStore("inbound_group_sessions");
-            const getReq = objectStore.openCursor();
-            getReq.onsuccess = function (): void {
-                const cursor = getReq.result;
-                if (cursor) {
-                    const sessionGetReq = sessionStore.get(cursor.key);
-                    sessionGetReq.onsuccess = function (): void {
-                        sessions.push({
-                            senderKey: sessionGetReq.result.senderCurve25519Key,
-                            sessionId: sessionGetReq.result.sessionId,
-                            sessionData: sessionGetReq.result.session,
-                        });
-                    };
-                    if (!limit || sessions.length < limit) {
-                        cursor.continue();
-                    }
-                }
-            };
-        });
-    }
-
-    public countSessionsNeedingBackup(txn?: IDBTransaction): Promise<number> {
-        if (!txn) {
-            txn = this.db.transaction("sessions_needing_backup", "readonly");
-        }
-        const objectStore = txn.objectStore("sessions_needing_backup");
-        return new Promise((resolve, reject) => {
-            const req = objectStore.count();
-            req.onerror = reject;
-            req.onsuccess = (): void => resolve(req.result);
-        });
-    }
-
-    public async unmarkSessionsNeedingBackup(sessions: ISession[], txn?: IDBTransaction): Promise<void> {
-        if (!txn) {
-            txn = this.db.transaction("sessions_needing_backup", "readwrite");
-        }
-        const objectStore = txn.objectStore("sessions_needing_backup");
-        await Promise.all(
-            sessions.map((session) => {
-                return new Promise((resolve, reject) => {
-                    const req = objectStore.delete([session.senderKey, session.sessionId]);
-                    req.onsuccess = resolve;
-                    req.onerror = reject;
-                });
-            }),
-        );
-    }
-
     public async markSessionsNeedingBackup(sessions: ISession[], txn?: IDBTransaction): Promise<void> {
         if (!txn) {
             txn = this.db.transaction("sessions_needing_backup", "readwrite");
@@ -1019,75 +493,6 @@ export class Backend implements CryptoStore {
                 });
             }),
         );
-    }
-
-    public addSharedHistoryInboundGroupSession(
-        roomId: string,
-        senderKey: string,
-        sessionId: string,
-        txn?: IDBTransaction,
-    ): void {
-        if (!txn) {
-            txn = this.db.transaction("shared_history_inbound_group_sessions", "readwrite");
-        }
-        const objectStore = txn.objectStore("shared_history_inbound_group_sessions");
-        const req = objectStore.get([roomId]);
-        req.onsuccess = (): void => {
-            const { sessions } = req.result || { sessions: [] };
-            sessions.push([senderKey, sessionId]);
-            objectStore.put({ roomId, sessions });
-        };
-    }
-
-    public getSharedHistoryInboundGroupSessions(
-        roomId: string,
-        txn?: IDBTransaction,
-    ): Promise<[senderKey: string, sessionId: string][]> {
-        if (!txn) {
-            txn = this.db.transaction("shared_history_inbound_group_sessions", "readonly");
-        }
-        const objectStore = txn.objectStore("shared_history_inbound_group_sessions");
-        const req = objectStore.get([roomId]);
-        return new Promise((resolve, reject) => {
-            req.onsuccess = (): void => {
-                const { sessions } = req.result || { sessions: [] };
-                resolve(sessions);
-            };
-            req.onerror = reject;
-        });
-    }
-
-    public addParkedSharedHistory(roomId: string, parkedData: ParkedSharedHistory, txn?: IDBTransaction): void {
-        if (!txn) {
-            txn = this.db.transaction("parked_shared_history", "readwrite");
-        }
-        const objectStore = txn.objectStore("parked_shared_history");
-        const req = objectStore.get([roomId]);
-        req.onsuccess = (): void => {
-            const { parked } = req.result || { parked: [] };
-            parked.push(parkedData);
-            objectStore.put({ roomId, parked });
-        };
-    }
-
-    public takeParkedSharedHistory(roomId: string, txn?: IDBTransaction): Promise<ParkedSharedHistory[]> {
-        if (!txn) {
-            txn = this.db.transaction("parked_shared_history", "readwrite");
-        }
-        const cursorReq = txn.objectStore("parked_shared_history").openCursor(roomId);
-        return new Promise((resolve, reject) => {
-            cursorReq.onsuccess = (): void => {
-                const cursor = cursorReq.result;
-                if (!cursor) {
-                    resolve([]);
-                    return;
-                }
-                const data = cursor.value;
-                cursor.delete();
-                resolve(data);
-            };
-            cursorReq.onerror = reject;
-        });
     }
 
     public doTxn<T>(

--- a/src/crypto/store/indexeddb-crypto-store-backend.ts
+++ b/src/crypto/store/indexeddb-crypto-store-backend.ts
@@ -27,9 +27,9 @@ import {
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
+    InboundGroupSessionData,
+    IRoomEncryption,
 } from "./base.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { IndexedDBCryptoStore } from "./indexeddb-crypto-store.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -22,21 +22,15 @@ import { InvalidCryptoStoreError, InvalidCryptoStoreState } from "../../errors.t
 import * as IndexedDBHelpers from "../../indexeddb-helpers.ts";
 import {
     CryptoStore,
-    IDeviceData,
-    IProblem,
     ISession,
     SessionExtended,
     ISessionInfo,
     IWithheld,
     MigrationState,
     Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
     SecretStorePrivateKeys,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
 } from "./base.ts";
-import { IRoomKeyRequestBody } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
 import { IRoomEncryption } from "../RoomList.ts";
 import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
@@ -282,110 +276,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
         return this.backend!.setMigrationState(migrationState);
     }
 
-    /**
-     * Look for an existing outgoing room key request, and if none is found,
-     * add a new one
-     *
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}: either the
-     *    same instance as passed in, or the existing one.
-     */
-    public getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest> {
-        return this.backend!.getOrAddOutgoingRoomKeyRequest(request);
-    }
-
-    /**
-     * Look for an existing room key request
-     *
-     * @param requestBody - existing request to look for
-     *
-     * @returns resolves to the matching
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    not found
-     */
-    public getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null> {
-        return this.backend!.getOutgoingRoomKeyRequest(requestBody);
-    }
-
-    /**
-     * Look for room key requests by state
-     *
-     * @param wantedStates - list of acceptable states
-     *
-     * @returns resolves to the a
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    there are no pending requests in those states. If there are multiple
-     *    requests in those states, an arbitrary one is chosen.
-     */
-    public getOutgoingRoomKeyRequestByState(wantedStates: number[]): Promise<OutgoingRoomKeyRequest | null> {
-        return this.backend!.getOutgoingRoomKeyRequestByState(wantedStates);
-    }
-
-    /**
-     * Look for room key requests by state –
-     * unlike above, return a list of all entries in one state.
-     *
-     * @returns Returns an array of requests in the given state
-     */
-    public getAllOutgoingRoomKeyRequestsByState(wantedState: number): Promise<OutgoingRoomKeyRequest[]> {
-        return this.backend!.getAllOutgoingRoomKeyRequestsByState(wantedState);
-    }
-
-    /**
-     * Look for room key requests by target device and state
-     *
-     * @param userId - Target user ID
-     * @param deviceId - Target device ID
-     * @param wantedStates - list of acceptable states
-     *
-     * @returns resolves to a list of all the
-     *    {@link OutgoingRoomKeyRequest}
-     */
-    public getOutgoingRoomKeyRequestsByTarget(
-        userId: string,
-        deviceId: string,
-        wantedStates: number[],
-    ): Promise<OutgoingRoomKeyRequest[]> {
-        return this.backend!.getOutgoingRoomKeyRequestsByTarget(userId, deviceId, wantedStates);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and update it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     * @param updates -        name/value map of updates to apply
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}
-     *    updated request, or null if no matching row was found
-     */
-    public updateOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-        updates: Partial<OutgoingRoomKeyRequest>,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        return this.backend!.updateOutgoingRoomKeyRequest(requestId, expectedState, updates);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and delete it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     *
-     * @returns resolves once the operation is completed
-     */
-    public deleteOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        return this.backend!.deleteOutgoingRoomKeyRequest(requestId, expectedState);
-    }
-
     // Olm Account
 
     /*
@@ -436,16 +326,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
         type: K,
     ): void {
         this.backend!.getSecretStorePrivateKey(txn, func, type);
-    }
-
-    /**
-     * Write the cross-signing keys back to the store
-     *
-     * @param txn - An active transaction. See doTxn().
-     * @param keys - keys object as getCrossSigningKeys()
-     */
-    public storeCrossSigningKeys(txn: IDBTransaction, keys: Record<string, CrossSigningKeyInfo>): void {
-        this.backend!.storeCrossSigningKeys(txn, keys);
     }
 
     /**
@@ -515,17 +395,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
     }
 
     /**
-     * Retrieve all end-to-end sessions
-     * @param txn - An active transaction. See doTxn().
-     * @param func - Called one for each session with
-     *     an object with, deviceKey, lastReceivedMessageTs, sessionId
-     *     and session keys.
-     */
-    public getAllEndToEndSessions(txn: IDBTransaction, func: (session: ISessionInfo | null) => void): void {
-        this.backend!.getAllEndToEndSessions(txn, func);
-    }
-
-    /**
      * Store a session between the logged-in user and another device
      * @param deviceKey - The public key of the other device.
      * @param sessionId - The ID for this end-to-end session.
@@ -539,18 +408,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
         txn: IDBTransaction,
     ): void {
         this.backend!.storeEndToEndSession(deviceKey, sessionId, sessionInfo, txn);
-    }
-
-    public storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {
-        return this.backend!.storeEndToEndSessionProblem(deviceKey, type, fixed);
-    }
-
-    public getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null> {
-        return this.backend!.getEndToEndSessionProblem(deviceKey, timestamp);
-    }
-
-    public filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]> {
-        return this.backend!.filterOutNotifiedErrorDevices(devices);
     }
 
     /**
@@ -607,35 +464,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
     }
 
     /**
-     * Fetches all inbound group sessions in the store
-     * @param txn - An active transaction. See doTxn().
-     * @param func - Called once for each group session
-     *     in the store with an object having keys `{senderKey, sessionId, sessionData}`,
-     *     then once with null to indicate the end of the list.
-     */
-    public getAllEndToEndInboundGroupSessions(txn: IDBTransaction, func: (session: ISession | null) => void): void {
-        this.backend!.getAllEndToEndInboundGroupSessions(txn, func);
-    }
-
-    /**
-     * Adds an end-to-end inbound group session to the store.
-     * If there already exists an inbound group session with the same
-     * senderCurve25519Key and sessionID, the session will not be added.
-     * @param senderCurve25519Key - The sender's curve 25519 key
-     * @param sessionId - The ID of the session
-     * @param sessionData - The session data structure
-     * @param txn - An active transaction. See doTxn().
-     */
-    public addEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: IDBTransaction,
-    ): void {
-        this.backend!.addEndToEndInboundGroupSession(senderCurve25519Key, sessionId, sessionData, txn);
-    }
-
-    /**
      * Writes an end-to-end inbound group session to the store.
      * If there already exists an inbound group session with the same
      * senderCurve25519Key and sessionID, it will be overwritten.
@@ -651,15 +479,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
         txn: IDBTransaction,
     ): void {
         this.backend!.storeEndToEndInboundGroupSession(senderCurve25519Key, sessionId, sessionData, txn);
-    }
-
-    public storeEndToEndInboundGroupSessionWithheld(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: IWithheld,
-        txn: IDBTransaction,
-    ): void {
-        this.backend!.storeEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId, sessionData, txn);
     }
 
     /**
@@ -686,44 +505,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
         return this.backend!.deleteEndToEndInboundGroupSessionsBatch(sessions);
     }
 
-    // End-to-end device tracking
-
-    /**
-     * Store the state of all tracked devices
-     * This contains devices for each user, a tracking state for each user
-     * and a sync token matching the point in time the snapshot represents.
-     * These all need to be written out in full each time such that the snapshot
-     * is always consistent, so they are stored in one object.
-     *
-     * @param txn - An active transaction. See doTxn().
-     */
-    public storeEndToEndDeviceData(deviceData: IDeviceData, txn: IDBTransaction): void {
-        this.backend!.storeEndToEndDeviceData(deviceData, txn);
-    }
-
-    /**
-     * Get the state of all tracked devices
-     *
-     * @param txn - An active transaction. See doTxn().
-     * @param func - Function called with the
-     *     device data
-     */
-    public getEndToEndDeviceData(txn: IDBTransaction, func: (deviceData: IDeviceData | null) => void): void {
-        this.backend!.getEndToEndDeviceData(txn, func);
-    }
-
-    // End to End Rooms
-
-    /**
-     * Store the end-to-end state for a room.
-     * @param roomId - The room's ID.
-     * @param roomInfo - The end-to-end info for the room.
-     * @param txn - An active transaction. See doTxn().
-     */
-    public storeEndToEndRoom(roomId: string, roomInfo: IRoomEncryption, txn: IDBTransaction): void {
-        this.backend!.storeEndToEndRoom(roomId, roomInfo, txn);
-    }
-
     /**
      * Get an object of `roomId->roomInfo` for all e2e rooms in the store
      * @param txn - An active transaction. See doTxn().
@@ -731,37 +512,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
      */
     public getEndToEndRooms(txn: IDBTransaction, func: (rooms: Record<string, IRoomEncryption>) => void): void {
         this.backend!.getEndToEndRooms(txn, func);
-    }
-
-    // session backups
-
-    /**
-     * Get the inbound group sessions that need to be backed up.
-     * @param limit - The maximum number of sessions to retrieve.  0
-     * for no limit.
-     * @returns resolves to an array of inbound group sessions
-     */
-    public getSessionsNeedingBackup(limit: number): Promise<ISession[]> {
-        return this.backend!.getSessionsNeedingBackup(limit);
-    }
-
-    /**
-     * Count the inbound group sessions that need to be backed up.
-     * @param txn - An active transaction. See doTxn(). (optional)
-     * @returns resolves to the number of sessions
-     */
-    public countSessionsNeedingBackup(txn?: IDBTransaction): Promise<number> {
-        return this.backend!.countSessionsNeedingBackup(txn);
-    }
-
-    /**
-     * Unmark sessions as needing to be backed up.
-     * @param sessions - The sessions that need to be backed up.
-     * @param txn - An active transaction. See doTxn(). (optional)
-     * @returns resolves when the sessions are unmarked
-     */
-    public unmarkSessionsNeedingBackup(sessions: ISession[], txn?: IDBTransaction): Promise<void> {
-        return this.backend!.unmarkSessionsNeedingBackup(sessions, txn);
     }
 
     /**
@@ -772,49 +522,6 @@ export class IndexedDBCryptoStore implements CryptoStore {
      */
     public markSessionsNeedingBackup(sessions: ISession[], txn?: IDBTransaction): Promise<void> {
         return this.backend!.markSessionsNeedingBackup(sessions, txn);
-    }
-
-    /**
-     * Add a shared-history group session for a room.
-     * @param roomId - The room that the key belongs to
-     * @param senderKey - The sender's curve 25519 key
-     * @param sessionId - The ID of the session
-     * @param txn - An active transaction. See doTxn(). (optional)
-     */
-    public addSharedHistoryInboundGroupSession(
-        roomId: string,
-        senderKey: string,
-        sessionId: string,
-        txn?: IDBTransaction,
-    ): void {
-        this.backend!.addSharedHistoryInboundGroupSession(roomId, senderKey, sessionId, txn);
-    }
-
-    /**
-     * Get the shared-history group session for a room.
-     * @param roomId - The room that the key belongs to
-     * @param txn - An active transaction. See doTxn(). (optional)
-     * @returns Promise which resolves to an array of [senderKey, sessionId]
-     */
-    public getSharedHistoryInboundGroupSessions(
-        roomId: string,
-        txn?: IDBTransaction,
-    ): Promise<[senderKey: string, sessionId: string][]> {
-        return this.backend!.getSharedHistoryInboundGroupSessions(roomId, txn);
-    }
-
-    /**
-     * Park a shared-history group session for a room we may be invited to later.
-     */
-    public addParkedSharedHistory(roomId: string, parkedData: ParkedSharedHistory, txn?: IDBTransaction): void {
-        this.backend!.addParkedSharedHistory(roomId, parkedData, txn);
-    }
-
-    /**
-     * Pop out all shared-history group sessions for a room.
-     */
-    public takeParkedSharedHistory(roomId: string, txn?: IDBTransaction): Promise<ParkedSharedHistory[]> {
-        return this.backend!.takeParkedSharedHistory(roomId, txn);
     }
 
     /**

--- a/src/crypto/store/indexeddb-crypto-store.ts
+++ b/src/crypto/store/indexeddb-crypto-store.ts
@@ -30,9 +30,9 @@ import {
     Mode,
     SecretStorePrivateKeys,
     ACCOUNT_OBJECT_KEY_MIGRATION_STATE,
+    InboundGroupSessionData,
+    IRoomEncryption,
 } from "./base.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 /*

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -18,8 +18,6 @@ import { logger } from "../../logger.ts";
 import { MemoryCryptoStore } from "./memory-crypto-store.ts";
 import {
     CryptoStore,
-    IDeviceData,
-    IProblem,
     ISession,
     SessionExtended,
     ISessionInfo,
@@ -29,10 +27,8 @@ import {
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
 } from "./base.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
 import { IRoomEncryption } from "../RoomList.ts";
 import { InboundGroupSessionData } from "../OlmDevice.ts";
-import { safeSet } from "../../utils.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 /**
@@ -47,8 +43,6 @@ const E2E_PREFIX = "crypto.";
 const KEY_END_TO_END_MIGRATION_STATE = E2E_PREFIX + "migration";
 const KEY_END_TO_END_ACCOUNT = E2E_PREFIX + "account";
 const KEY_CROSS_SIGNING_KEYS = E2E_PREFIX + "cross_signing_keys";
-const KEY_NOTIFIED_ERROR_DEVICES = E2E_PREFIX + "notified_error_devices";
-const KEY_DEVICE_DATA = E2E_PREFIX + "device_data";
 const KEY_INBOUND_SESSION_PREFIX = E2E_PREFIX + "inboundgroupsessions/";
 const KEY_INBOUND_SESSION_WITHHELD_PREFIX = E2E_PREFIX + "inboundgroupsessions.withheld/";
 const KEY_ROOMS_PREFIX = E2E_PREFIX + "rooms/";
@@ -56,10 +50,6 @@ const KEY_SESSIONS_NEEDING_BACKUP = E2E_PREFIX + "sessionsneedingbackup";
 
 function keyEndToEndSessions(deviceKey: string): string {
     return E2E_PREFIX + "sessions/" + deviceKey;
-}
-
-function keyEndToEndSessionProblems(deviceKey: string): string {
-    return E2E_PREFIX + "session.problems/" + deviceKey;
 }
 
 function keyEndToEndInboundGroupSession(senderKey: string, sessionId: string): string {
@@ -173,73 +163,10 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         func(this._getEndToEndSessions(deviceKey) ?? {});
     }
 
-    public getAllEndToEndSessions(txn: unknown, func: (session: ISessionInfo) => void): void {
-        for (let i = 0; i < this.store.length; ++i) {
-            if (this.store.key(i)?.startsWith(keyEndToEndSessions(""))) {
-                const deviceKey = this.store.key(i)!.split("/")[1];
-                for (const sess of Object.values(this._getEndToEndSessions(deviceKey))) {
-                    func(sess);
-                }
-            }
-        }
-    }
-
     public storeEndToEndSession(deviceKey: string, sessionId: string, sessionInfo: ISessionInfo, txn: unknown): void {
         const sessions = this._getEndToEndSessions(deviceKey) || {};
         sessions[sessionId] = sessionInfo;
         setJsonItem(this.store, keyEndToEndSessions(deviceKey), sessions);
-    }
-
-    public async storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {
-        const key = keyEndToEndSessionProblems(deviceKey);
-        const problems = getJsonItem<IProblem[]>(this.store, key) || [];
-        problems.push({ type, fixed, time: Date.now() });
-        problems.sort((a, b) => {
-            return a.time - b.time;
-        });
-        setJsonItem(this.store, key, problems);
-    }
-
-    public async getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null> {
-        const key = keyEndToEndSessionProblems(deviceKey);
-        const problems = getJsonItem<IProblem[]>(this.store, key) || [];
-        if (!problems.length) {
-            return null;
-        }
-        const lastProblem = problems[problems.length - 1];
-        for (const problem of problems) {
-            if (problem.time > timestamp) {
-                return Object.assign({}, problem, { fixed: lastProblem.fixed });
-            }
-        }
-        if (lastProblem.fixed) {
-            return null;
-        } else {
-            return lastProblem;
-        }
-    }
-
-    public async filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]> {
-        const notifiedErrorDevices =
-            getJsonItem<MemoryCryptoStore["notifiedErrorDevices"]>(this.store, KEY_NOTIFIED_ERROR_DEVICES) || {};
-        const ret: IOlmDevice[] = [];
-
-        for (const device of devices) {
-            const { userId, deviceInfo } = device;
-            if (userId in notifiedErrorDevices) {
-                if (!(deviceInfo.deviceId in notifiedErrorDevices[userId])) {
-                    ret.push(device);
-                    safeSet(notifiedErrorDevices[userId], deviceInfo.deviceId, true);
-                }
-            } else {
-                ret.push(device);
-                safeSet(notifiedErrorDevices, userId, { [deviceInfo.deviceId]: true });
-            }
-        }
-
-        setJsonItem(this.store, KEY_NOTIFIED_ERROR_DEVICES, notifiedErrorDevices);
-
-        return ret;
     }
 
     /**
@@ -306,37 +233,6 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         );
     }
 
-    public getAllEndToEndInboundGroupSessions(txn: unknown, func: (session: ISession | null) => void): void {
-        for (let i = 0; i < this.store.length; ++i) {
-            const key = this.store.key(i);
-            if (key?.startsWith(KEY_INBOUND_SESSION_PREFIX)) {
-                // we can't use split, as the components we are trying to split out
-                // might themselves contain '/' characters. We rely on the
-                // senderKey being a (32-byte) curve25519 key, base64-encoded
-                // (hence 43 characters long).
-
-                func({
-                    senderKey: key.slice(KEY_INBOUND_SESSION_PREFIX.length, KEY_INBOUND_SESSION_PREFIX.length + 43),
-                    sessionId: key.slice(KEY_INBOUND_SESSION_PREFIX.length + 44),
-                    sessionData: getJsonItem(this.store, key)!,
-                });
-            }
-        }
-        func(null);
-    }
-
-    public addEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: unknown,
-    ): void {
-        const existing = getJsonItem(this.store, keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId));
-        if (!existing) {
-            this.storeEndToEndInboundGroupSession(senderCurve25519Key, sessionId, sessionData, txn);
-        }
-    }
-
     public storeEndToEndInboundGroupSession(
         senderCurve25519Key: string,
         sessionId: string,
@@ -344,15 +240,6 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         txn: unknown,
     ): void {
         setJsonItem(this.store, keyEndToEndInboundGroupSession(senderCurve25519Key, sessionId), sessionData);
-    }
-
-    public storeEndToEndInboundGroupSessionWithheld(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: IWithheld,
-        txn: unknown,
-    ): void {
-        setJsonItem(this.store, keyEndToEndInboundGroupSessionWithheld(senderCurve25519Key, sessionId), sessionData);
     }
 
     /**
@@ -431,18 +318,6 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
         }
     }
 
-    public getEndToEndDeviceData(txn: unknown, func: (deviceData: IDeviceData | null) => void): void {
-        func(getJsonItem(this.store, KEY_DEVICE_DATA));
-    }
-
-    public storeEndToEndDeviceData(deviceData: IDeviceData, txn: unknown): void {
-        setJsonItem(this.store, KEY_DEVICE_DATA, deviceData);
-    }
-
-    public storeEndToEndRoom(roomId: string, roomInfo: IRoomEncryption, txn: unknown): void {
-        setJsonItem(this.store, keyEndToEndRoomsPrefix(roomId), roomInfo);
-    }
-
     public getEndToEndRooms(txn: unknown, func: (rooms: Record<string, IRoomEncryption>) => void): void {
         const result: Record<string, IRoomEncryption> = {};
         const prefix = keyEndToEndRoomsPrefix("");
@@ -455,47 +330,6 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
             }
         }
         func(result);
-    }
-
-    public getSessionsNeedingBackup(limit: number): Promise<ISession[]> {
-        const sessionsNeedingBackup = getJsonItem<string[]>(this.store, KEY_SESSIONS_NEEDING_BACKUP) || {};
-        const sessions: ISession[] = [];
-
-        for (const session in sessionsNeedingBackup) {
-            if (Object.prototype.hasOwnProperty.call(sessionsNeedingBackup, session)) {
-                // see getAllEndToEndInboundGroupSessions for the magic number explanations
-                const senderKey = session.slice(0, 43);
-                const sessionId = session.slice(44);
-                this.getEndToEndInboundGroupSession(senderKey, sessionId, null, (sessionData) => {
-                    sessions.push({
-                        senderKey: senderKey,
-                        sessionId: sessionId,
-                        sessionData: sessionData!,
-                    });
-                });
-                if (limit && sessions.length >= limit) {
-                    break;
-                }
-            }
-        }
-        return Promise.resolve(sessions);
-    }
-
-    public countSessionsNeedingBackup(): Promise<number> {
-        const sessionsNeedingBackup = getJsonItem(this.store, KEY_SESSIONS_NEEDING_BACKUP) || {};
-        return Promise.resolve(Object.keys(sessionsNeedingBackup).length);
-    }
-
-    public unmarkSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
-        const sessionsNeedingBackup =
-            getJsonItem<{
-                [senderKeySessionId: string]: string;
-            }>(this.store, KEY_SESSIONS_NEEDING_BACKUP) || {};
-        for (const session of sessions) {
-            delete sessionsNeedingBackup[session.senderKey + "/" + session.sessionId];
-        }
-        setJsonItem(this.store, KEY_SESSIONS_NEEDING_BACKUP, sessionsNeedingBackup);
-        return Promise.resolve();
     }
 
     public markSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
@@ -543,10 +377,6 @@ export class LocalStorageCryptoStore extends MemoryCryptoStore implements Crypto
     ): void {
         const key = getJsonItem<SecretStorePrivateKeys[K]>(this.store, E2E_PREFIX + `ssss_cache.${type}`);
         func(key);
-    }
-
-    public storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void {
-        setJsonItem(this.store, KEY_CROSS_SIGNING_KEYS, keys);
     }
 
     public storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(

--- a/src/crypto/store/localStorage-crypto-store.ts
+++ b/src/crypto/store/localStorage-crypto-store.ts
@@ -26,9 +26,9 @@ import {
     Mode,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
+    InboundGroupSessionData,
+    IRoomEncryption,
 } from "./base.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 /**

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -25,9 +25,9 @@ import {
     Mode,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
+    InboundGroupSessionData,
+    IRoomEncryption,
 } from "./base.ts";
-import { IRoomEncryption } from "../RoomList.ts";
-import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
 
 function encodeSessionKey(senderCurve25519Key: string, sessionId: string): string {

--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -14,25 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger } from "../../logger.ts";
-import { deepCompare, promiseTry, safeSet } from "../../utils.ts";
+import { safeSet } from "../../utils.ts";
 import {
     CryptoStore,
-    IDeviceData,
-    IProblem,
     ISession,
     SessionExtended,
     ISessionInfo,
     IWithheld,
     MigrationState,
     Mode,
-    OutgoingRoomKeyRequest,
-    ParkedSharedHistory,
     SecretStorePrivateKeys,
     SESSION_BATCH_SIZE,
 } from "./base.ts";
-import { IRoomKeyRequestBody } from "../index.ts";
-import { IOlmDevice } from "../algorithms/megolm.ts";
 import { IRoomEncryption } from "../RoomList.ts";
 import { InboundGroupSessionData } from "../OlmDevice.ts";
 import { CrossSigningKeyInfo } from "../../crypto-api/index.ts";
@@ -54,22 +47,16 @@ function decodeSessionKey(key: string): { senderKey: string; sessionId: string }
 
 export class MemoryCryptoStore implements CryptoStore {
     private migrationState: MigrationState = MigrationState.NOT_STARTED;
-    private outgoingRoomKeyRequests: OutgoingRoomKeyRequest[] = [];
     private account: string | null = null;
     private crossSigningKeys: Record<string, CrossSigningKeyInfo> | null = null;
     private privateKeys: Partial<SecretStorePrivateKeys> = {};
 
     private sessions: { [deviceKey: string]: { [sessionId: string]: ISessionInfo } } = {};
-    private sessionProblems: { [deviceKey: string]: IProblem[] } = {};
-    private notifiedErrorDevices: { [userId: string]: { [deviceId: string]: boolean } } = {};
     private inboundGroupSessions: { [sessionKey: string]: InboundGroupSessionData } = {};
     private inboundGroupSessionsWithheld: Record<string, IWithheld> = {};
     // Opaque device data object
-    private deviceData: IDeviceData | null = null;
     private rooms: { [roomId: string]: IRoomEncryption } = {};
     private sessionsNeedingBackup: { [sessionKey: string]: boolean } = {};
-    private sharedHistoryInboundGroupSessions: { [roomId: string]: [senderKey: string, sessionId: string][] } = {};
-    private parkedSharedHistory = new Map<string, ParkedSharedHistory[]>(); // keyed by room ID
 
     /**
      * Returns true if this CryptoStore has ever been initialised (ie, it might contain data).
@@ -126,189 +113,6 @@ export class MemoryCryptoStore implements CryptoStore {
         this.migrationState = migrationState;
     }
 
-    /**
-     * Look for an existing outgoing room key request, and if none is found,
-     * add a new one
-     *
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}: either the
-     *    same instance as passed in, or the existing one.
-     */
-    public getOrAddOutgoingRoomKeyRequest(request: OutgoingRoomKeyRequest): Promise<OutgoingRoomKeyRequest> {
-        const requestBody = request.requestBody;
-
-        return promiseTry(() => {
-            // first see if we already have an entry for this request.
-            const existing = this._getOutgoingRoomKeyRequest(requestBody);
-
-            if (existing) {
-                // this entry matches the request - return it.
-                logger.log(
-                    `already have key request outstanding for ` +
-                        `${requestBody.room_id} / ${requestBody.session_id}: ` +
-                        `not sending another`,
-                );
-                return existing;
-            }
-
-            // we got to the end of the list without finding a match
-            // - add the new request.
-            logger.log(`enqueueing key request for ${requestBody.room_id} / ` + requestBody.session_id);
-            this.outgoingRoomKeyRequests.push(request);
-            return request;
-        });
-    }
-
-    /**
-     * Look for an existing room key request
-     *
-     * @param requestBody - existing request to look for
-     *
-     * @returns resolves to the matching
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    not found
-     */
-    public getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): Promise<OutgoingRoomKeyRequest | null> {
-        return Promise.resolve(this._getOutgoingRoomKeyRequest(requestBody));
-    }
-
-    /**
-     * Looks for existing room key request, and returns the result synchronously.
-     *
-     * @internal
-     *
-     * @param requestBody - existing request to look for
-     *
-     * @returns
-     *    the matching request, or null if not found
-     */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    private _getOutgoingRoomKeyRequest(requestBody: IRoomKeyRequestBody): OutgoingRoomKeyRequest | null {
-        for (const existing of this.outgoingRoomKeyRequests) {
-            if (deepCompare(existing.requestBody, requestBody)) {
-                return existing;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Look for room key requests by state
-     *
-     * @param wantedStates - list of acceptable states
-     *
-     * @returns resolves to the a
-     *    {@link OutgoingRoomKeyRequest}, or null if
-     *    there are no pending requests in those states
-     */
-    public getOutgoingRoomKeyRequestByState(wantedStates: number[]): Promise<OutgoingRoomKeyRequest | null> {
-        for (const req of this.outgoingRoomKeyRequests) {
-            for (const state of wantedStates) {
-                if (req.state === state) {
-                    return Promise.resolve(req);
-                }
-            }
-        }
-        return Promise.resolve(null);
-    }
-
-    /**
-     *
-     * @returns All OutgoingRoomKeyRequests in state
-     */
-    public getAllOutgoingRoomKeyRequestsByState(wantedState: number): Promise<OutgoingRoomKeyRequest[]> {
-        return Promise.resolve(this.outgoingRoomKeyRequests.filter((r) => r.state == wantedState));
-    }
-
-    public getOutgoingRoomKeyRequestsByTarget(
-        userId: string,
-        deviceId: string,
-        wantedStates: number[],
-    ): Promise<OutgoingRoomKeyRequest[]> {
-        const results: OutgoingRoomKeyRequest[] = [];
-
-        for (const req of this.outgoingRoomKeyRequests) {
-            for (const state of wantedStates) {
-                if (
-                    req.state === state &&
-                    req.recipients.some((recipient) => recipient.userId === userId && recipient.deviceId === deviceId)
-                ) {
-                    results.push(req);
-                }
-            }
-        }
-        return Promise.resolve(results);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and update it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     * @param updates -        name/value map of updates to apply
-     *
-     * @returns resolves to
-     *    {@link OutgoingRoomKeyRequest}
-     *    updated request, or null if no matching row was found
-     */
-    public updateOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-        updates: Partial<OutgoingRoomKeyRequest>,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        for (const req of this.outgoingRoomKeyRequests) {
-            if (req.requestId !== requestId) {
-                continue;
-            }
-
-            if (req.state !== expectedState) {
-                logger.warn(
-                    `Cannot update room key request from ${expectedState} ` +
-                        `as it was already updated to ${req.state}`,
-                );
-                return Promise.resolve(null);
-            }
-            Object.assign(req, updates);
-            return Promise.resolve(req);
-        }
-
-        return Promise.resolve(null);
-    }
-
-    /**
-     * Look for an existing room key request by id and state, and delete it if
-     * found
-     *
-     * @param requestId -      ID of request to update
-     * @param expectedState -  state we expect to find the request in
-     *
-     * @returns resolves once the operation is completed
-     */
-    public deleteOutgoingRoomKeyRequest(
-        requestId: string,
-        expectedState: number,
-    ): Promise<OutgoingRoomKeyRequest | null> {
-        for (let i = 0; i < this.outgoingRoomKeyRequests.length; i++) {
-            const req = this.outgoingRoomKeyRequests[i];
-
-            if (req.requestId !== requestId) {
-                continue;
-            }
-
-            if (req.state != expectedState) {
-                logger.warn(`Cannot delete room key request in state ${req.state} ` + `(expected ${expectedState})`);
-                return Promise.resolve(null);
-            }
-
-            this.outgoingRoomKeyRequests.splice(i, 1);
-            return Promise.resolve(req);
-        }
-
-        return Promise.resolve(null);
-    }
-
     // Olm Account
 
     public getAccount(txn: unknown, func: (accountPickle: string | null) => void): void {
@@ -330,10 +134,6 @@ export class MemoryCryptoStore implements CryptoStore {
     ): void {
         const result = this.privateKeys[type] as SecretStorePrivateKeys[K] | undefined;
         func(result || null);
-    }
-
-    public storeCrossSigningKeys(txn: unknown, keys: Record<string, CrossSigningKeyInfo>): void {
-        this.crossSigningKeys = keys;
     }
 
     public storeSecretStorePrivateKey<K extends keyof SecretStorePrivateKeys>(
@@ -372,18 +172,6 @@ export class MemoryCryptoStore implements CryptoStore {
         func(this.sessions[deviceKey] || {});
     }
 
-    public getAllEndToEndSessions(txn: unknown, func: (session: ISessionInfo) => void): void {
-        Object.entries(this.sessions).forEach(([deviceKey, deviceSessions]) => {
-            Object.entries(deviceSessions).forEach(([sessionId, session]) => {
-                func({
-                    ...session,
-                    deviceKey,
-                    sessionId,
-                });
-            });
-        });
-    }
-
     public storeEndToEndSession(deviceKey: string, sessionId: string, sessionInfo: ISessionInfo, txn: unknown): void {
         let deviceSessions = this.sessions[deviceKey];
         if (deviceSessions === undefined) {
@@ -391,52 +179,6 @@ export class MemoryCryptoStore implements CryptoStore {
             this.sessions[deviceKey] = deviceSessions;
         }
         safeSet(deviceSessions, sessionId, sessionInfo);
-    }
-
-    public async storeEndToEndSessionProblem(deviceKey: string, type: string, fixed: boolean): Promise<void> {
-        const problems = (this.sessionProblems[deviceKey] = this.sessionProblems[deviceKey] || []);
-        problems.push({ type, fixed, time: Date.now() });
-        problems.sort((a, b) => {
-            return a.time - b.time;
-        });
-    }
-
-    public async getEndToEndSessionProblem(deviceKey: string, timestamp: number): Promise<IProblem | null> {
-        const problems = this.sessionProblems[deviceKey] || [];
-        if (!problems.length) {
-            return null;
-        }
-        const lastProblem = problems[problems.length - 1];
-        for (const problem of problems) {
-            if (problem.time > timestamp) {
-                return Object.assign({}, problem, { fixed: lastProblem.fixed });
-            }
-        }
-        if (lastProblem.fixed) {
-            return null;
-        } else {
-            return lastProblem;
-        }
-    }
-
-    public async filterOutNotifiedErrorDevices(devices: IOlmDevice[]): Promise<IOlmDevice[]> {
-        const notifiedErrorDevices = this.notifiedErrorDevices;
-        const ret: IOlmDevice[] = [];
-
-        for (const device of devices) {
-            const { userId, deviceInfo } = device;
-            if (userId in notifiedErrorDevices) {
-                if (!(deviceInfo.deviceId in notifiedErrorDevices[userId])) {
-                    ret.push(device);
-                    safeSet(notifiedErrorDevices[userId], deviceInfo.deviceId, true);
-                }
-            } else {
-                ret.push(device);
-                safeSet(notifiedErrorDevices, userId, { [deviceInfo.deviceId]: true });
-            }
-        }
-
-        return ret;
     }
 
     /**
@@ -496,28 +238,6 @@ export class MemoryCryptoStore implements CryptoStore {
         func(this.inboundGroupSessions[k] || null, this.inboundGroupSessionsWithheld[k] || null);
     }
 
-    public getAllEndToEndInboundGroupSessions(txn: unknown, func: (session: ISession | null) => void): void {
-        for (const key of Object.keys(this.inboundGroupSessions)) {
-            func({
-                ...decodeSessionKey(key),
-                sessionData: this.inboundGroupSessions[key],
-            });
-        }
-        func(null);
-    }
-
-    public addEndToEndInboundGroupSession(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: InboundGroupSessionData,
-        txn: unknown,
-    ): void {
-        const k = encodeSessionKey(senderCurve25519Key, sessionId);
-        if (this.inboundGroupSessions[k] === undefined) {
-            this.inboundGroupSessions[k] = sessionData;
-        }
-    }
-
     public storeEndToEndInboundGroupSession(
         senderCurve25519Key: string,
         sessionId: string,
@@ -526,16 +246,6 @@ export class MemoryCryptoStore implements CryptoStore {
     ): void {
         const k = encodeSessionKey(senderCurve25519Key, sessionId);
         this.inboundGroupSessions[k] = sessionData;
-    }
-
-    public storeEndToEndInboundGroupSessionWithheld(
-        senderCurve25519Key: string,
-        sessionId: string,
-        sessionData: IWithheld,
-        txn: unknown,
-    ): void {
-        const k = encodeSessionKey(senderCurve25519Key, sessionId);
-        this.inboundGroupSessionsWithheld[k] = sessionData;
     }
 
     /**
@@ -594,52 +304,10 @@ export class MemoryCryptoStore implements CryptoStore {
         }
     }
 
-    // Device Data
-
-    public getEndToEndDeviceData(txn: unknown, func: (deviceData: IDeviceData | null) => void): void {
-        func(this.deviceData);
-    }
-
-    public storeEndToEndDeviceData(deviceData: IDeviceData, txn: unknown): void {
-        this.deviceData = deviceData;
-    }
-
     // E2E rooms
-
-    public storeEndToEndRoom(roomId: string, roomInfo: IRoomEncryption, txn: unknown): void {
-        this.rooms[roomId] = roomInfo;
-    }
 
     public getEndToEndRooms(txn: unknown, func: (rooms: Record<string, IRoomEncryption>) => void): void {
         func(this.rooms);
-    }
-
-    public getSessionsNeedingBackup(limit: number): Promise<ISession[]> {
-        const sessions: ISession[] = [];
-        for (const session in this.sessionsNeedingBackup) {
-            if (this.inboundGroupSessions[session]) {
-                sessions.push({
-                    ...decodeSessionKey(session),
-                    sessionData: this.inboundGroupSessions[session],
-                });
-                if (limit && session.length >= limit) {
-                    break;
-                }
-            }
-        }
-        return Promise.resolve(sessions);
-    }
-
-    public countSessionsNeedingBackup(): Promise<number> {
-        return Promise.resolve(Object.keys(this.sessionsNeedingBackup).length);
-    }
-
-    public unmarkSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
-        for (const session of sessions) {
-            const sessionKey = encodeSessionKey(session.senderKey, session.sessionId);
-            delete this.sessionsNeedingBackup[sessionKey];
-        }
-        return Promise.resolve();
     }
 
     public markSessionsNeedingBackup(sessions: ISession[]): Promise<void> {
@@ -648,28 +316,6 @@ export class MemoryCryptoStore implements CryptoStore {
             this.sessionsNeedingBackup[sessionKey] = true;
         }
         return Promise.resolve();
-    }
-
-    public addSharedHistoryInboundGroupSession(roomId: string, senderKey: string, sessionId: string): void {
-        const sessions = this.sharedHistoryInboundGroupSessions[roomId] || [];
-        sessions.push([senderKey, sessionId]);
-        this.sharedHistoryInboundGroupSessions[roomId] = sessions;
-    }
-
-    public getSharedHistoryInboundGroupSessions(roomId: string): Promise<[senderKey: string, sessionId: string][]> {
-        return Promise.resolve(this.sharedHistoryInboundGroupSessions[roomId] || []);
-    }
-
-    public addParkedSharedHistory(roomId: string, parkedData: ParkedSharedHistory): void {
-        const parked = this.parkedSharedHistory.get(roomId) ?? [];
-        parked.push(parkedData);
-        this.parkedSharedHistory.set(roomId, parked);
-    }
-
-    public takeParkedSharedHistory(roomId: string): Promise<ParkedSharedHistory[]> {
-        const parked = this.parkedSharedHistory.get(roomId) ?? [];
-        this.parkedSharedHistory.delete(roomId);
-        return Promise.resolve(parked);
     }
 
     // Session key backups


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

The migration from the legacy crypto to the rust crypto uses the legacy stores. In order to be able to delete the rest of the legacy crypto, these stores shouldn't rely on the types of the legacy crypto.

This PR does:
- Keep the store methods which are needed in the migration and in the tests
- Extract the types of the legacy crypto in put then in. `src/crypto/store/base.ts`

The legacy crypto tests and linting are in failure due to the removal of the store methods. The legacy crypto will be removed in the next PR.
