### PR TITLE
Provide more options for starting dehydration

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1894,6 +1894,168 @@ describe("RustCrypto", () => {
             await rehydrationCompletedPromise;
             await rustCrypto2.stop();
         });
+
+        it("should handle dehydration start options", async () => {
+            const secretStorageCallbacks = {
+                getSecretStorageKey: async (keys: any, name: string) => {
+                    return [[...Object.keys(keys.keys)][0], new Uint8Array(32)];
+                },
+            } as SecretStorageCallbacks;
+            const secretStorage = new ServerSideSecretStorageImpl(new DummyAccountDataClient(), secretStorageCallbacks);
+
+            const e2eKeyReceiver = new E2EKeyReceiver("http://server");
+            const e2eKeyResponder = new E2EKeyResponder("http://server");
+            e2eKeyResponder.addKeyReceiver(TEST_USER, e2eKeyReceiver);
+            fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                status: 404,
+                body: {
+                    errcode: "M_NOT_FOUND",
+                    error: "Not found",
+                },
+            });
+            fetchMock.post("path:/_matrix/client/v3/keys/device_signing/upload", {
+                status: 200,
+                body: {},
+            });
+            fetchMock.post("path:/_matrix/client/v3/keys/signatures/upload", {
+                status: 200,
+                body: {},
+            });
+            const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), TEST_USER, TEST_DEVICE_ID, secretStorage);
+
+            // dehydration requires secret storage and cross signing
+            async function createSecretStorageKey() {
+                return {
+                    keyInfo: {} as AddSecretStorageKeyOpts,
+                    privateKey: new Uint8Array(32),
+                };
+            }
+            await rustCrypto.bootstrapCrossSigning({ setupNewCrossSigning: true });
+            await rustCrypto.bootstrapSecretStorage({
+                createSecretStorageKey,
+                setupNewSecretStorage: true,
+                setupNewKeyBackup: false,
+            });
+            // we need to process a sync so that the OlmMachine will upload keys
+            await rustCrypto.preprocessToDeviceMessages([]);
+            await rustCrypto.onSyncCompleted({});
+
+            // set up mocks needed for device dehydration
+            let dehydratedDeviceInfo: Record<string, any> | undefined;
+            const getDehydratedDeviceMock = jest.fn(() => {
+                if (dehydratedDeviceInfo) {
+                    return {
+                        status: 200,
+                        body: dehydratedDeviceInfo,
+                    };
+                } else {
+                    return {
+                        status: 404,
+                        body: {
+                            errcode: "M_NOT_FOUND",
+                            error: "Not found",
+                        },
+                    };
+                }
+            });
+            fetchMock.get(
+                "path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
+                getDehydratedDeviceMock,
+            );
+            const putDehydratedDeviceMock = jest.fn((path, opts) => {
+                const content = JSON.parse(opts.body as string);
+                dehydratedDeviceInfo = {
+                    device_id: content.device_id,
+                    device_data: content.device_data,
+                };
+                return {
+                    status: 200,
+                    body: {
+                        device_id: content.device_id,
+                    },
+                };
+            });
+            fetchMock.put(
+                "path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
+                putDehydratedDeviceMock,
+            );
+            fetchMock.post(/_matrix\/client\/unstable\/org.matrix.msc3814.v1\/dehydrated_device\/.*\/events/, {
+                status: 200,
+                body: {
+                    events: [],
+                    next_batch: "foo",
+                },
+            });
+
+            fetchMock.mockClear();
+
+            // Start with testing `onlyIfKeyCached: true`.  Since this is our
+            // first run, there is no key cached, so should do nothing.  i.e. it
+            // should not make any HTTP requests and should not create a new key.
+            await rustCrypto.startDehydration({ onlyIfKeyCached: true });
+            expect(getDehydratedDeviceMock).not.toHaveBeenCalled();
+            expect(putDehydratedDeviceMock).not.toHaveBeenCalled();
+            expect(await secretStorage.get("org.matrix.msc3814")).toBeFalsy();
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            // With default options and no key is available, should create new
+            // key and create new dehydrated device (so it will `PUT
+            // /dehydrated_device`).  It won't try to rehydrate the device,
+            // since it has no dehydration key yet.
+            await rustCrypto.startDehydration();
+            expect(putDehydratedDeviceMock).toHaveBeenCalled();
+            const origDehydrationKey = await secretStorage.get("org.matrix.msc3814");
+            expect(origDehydrationKey).toBeTruthy();
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            // Start again with default options, but this time it will try to
+            // rehydrate a device (so it will `GET /dehydrated_device`).  It
+            // should keep the same dehydration key.
+            await rustCrypto.startDehydration();
+            expect(getDehydratedDeviceMock).toHaveBeenCalled();
+            expect(putDehydratedDeviceMock).toHaveBeenCalled();
+            expect(await secretStorage.get("org.matrix.msc3814")).toEqual(origDehydrationKey);
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            // Again try "onlyIfKeyCached: true", but this time we already have
+            // a cached key, so it will rehydrate the device and create a new
+            // dehydrated device.  It should keep the same dehydration key.
+            await rustCrypto.startDehydration({ onlyIfKeyCached: true });
+            expect(getDehydratedDeviceMock).toHaveBeenCalled();
+            expect(putDehydratedDeviceMock).toHaveBeenCalled();
+            expect(await secretStorage.get("org.matrix.msc3814")).toEqual(origDehydrationKey);
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            // With "rehydrate: false", it should not try to rehydrate, but
+            // still create a new dehydrated device.  It should keep the same
+            // dehydration key.
+            await rustCrypto.startDehydration({ rehydrate: false });
+            expect(getDehydratedDeviceMock).not.toHaveBeenCalled();
+            expect(putDehydratedDeviceMock).toHaveBeenCalled();
+            expect(await secretStorage.get("org.matrix.msc3814")).toEqual(origDehydrationKey);
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            // With "createNewKey: true", it should create a new dehydration key
+            await rustCrypto.startDehydration({ createNewKey: true });
+            expect(getDehydratedDeviceMock).toHaveBeenCalled();
+            expect(putDehydratedDeviceMock).toHaveBeenCalled();
+            expect(await secretStorage.get("org.matrix.msc3814")).not.toEqual(origDehydrationKey);
+
+            getDehydratedDeviceMock.mockClear();
+            putDehydratedDeviceMock.mockClear();
+
+            rustCrypto.stop();
+        });
     });
 
     describe("import & export secrets bundle", () => {

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -42,6 +42,18 @@ import { MatrixEvent } from "../models/event.ts";
  */
 
 /**
+ * The options to start device dehydration.
+ */
+export interface StartDehydrationOpts {
+    /** Force creation of a new dehydration key. Defaults to `false`. */
+    createNewKey?: boolean;
+    /** Only start dehydration if we have a cached key. Defaults to `false`. */
+    onlyIfKeyCached?: boolean;
+    /** Try to rehydrate a device before creating a new dehydrated device. Defaults to `true`. */
+    rehydrate?: boolean;
+}
+
+/**
  * Public interface to the cryptography parts of the js-sdk
  *
  * @remarks Currently, this is a work-in-progress. In time, more methods will be added here.
@@ -649,10 +661,11 @@ export interface CryptoApi {
     /**
      * Start using device dehydration.
      *
-     * - Rehydrates a dehydrated device, if one is available.
+     * - Rehydrates a dehydrated device, if one is available and `opts.rehydrate`
+     *   is `true`.
      * - Creates a new dehydration key, if necessary, and stores it in Secret
      *   Storage.
-     *   - If `createNewKey` is set to true, always creates a new key.
+     *   - If `opts.createNewKey` is set to true, always creates a new key.
      *   - If a dehydration key is not available, creates a new one.
      * - Creates a new dehydrated device, and schedules periodically creating
      *   new dehydrated devices.
@@ -661,11 +674,11 @@ export interface CryptoApi {
      * `true`, and must not be called until after cross-signing and secret
      * storage have been set up.
      *
-     * @param createNewKey - whether to force creation of a new dehydration key.
-     *   This can be used, for example, if Secret Storage is being reset.  Defaults
-     *   to false.
+     * @param opts - options for device dehydration. For backwards compatibility
+     *     with old code, a boolean can be given here, which will be treated as
+     *     the `createNewKey` option. However, this is deprecated.
      */
-    startDehydration(createNewKey?: boolean): Promise<void>;
+    startDehydration(opts?: StartDehydrationOpts | boolean): Promise<void>;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -45,11 +45,30 @@ import { MatrixEvent } from "../models/event.ts";
  * The options to start device dehydration.
  */
 export interface StartDehydrationOpts {
-    /** Force creation of a new dehydration key. Defaults to `false`. */
+    /**
+     * Force creation of a new dehydration key, even if there is already an
+     * existing dehydration key. If `false`, and `onlyIfKeyCached` is `false`, a
+     * new key will be created if there is no existing dehydration key, whether
+     * already cached in our local storage or stored in Secret Storage.
+     *
+     * Checking for the presence of the key in Secret Storage may result in the
+     * `getSecretStorageKey` callback being called.
+     *
+     * Defaults to `false`.
+     */
     createNewKey?: boolean;
-    /** Only start dehydration if we have a cached key. Defaults to `false`. */
+    /**
+     * Only start dehydration if we have a dehydration key cached in our local
+     * storage. If `true`, Secret Storage will not be checked. Defaults to
+     * `false`.
+     */
     onlyIfKeyCached?: boolean;
-    /** Try to rehydrate a device before creating a new dehydrated device. Defaults to `true`. */
+    /**
+     * Try to rehydrate a device before creating a new dehydrated device.
+     * Setting this to `false` may be useful for situations where the client is
+     * known to pre-date the dehydrated device, and so rehydration is
+     * unnecessary. Defaults to `true`.
+     */
     rehydrate?: boolean;
 }
 

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -105,6 +105,7 @@ import {
     CryptoEventHandlerMap as CryptoApiCryptoEventHandlerMap,
     KeyBackupRestoreResult,
     KeyBackupRestoreOpts,
+    StartDehydrationOpts,
 } from "../crypto-api/index.ts";
 import { Device, DeviceMap } from "../models/device.ts";
 import { deviceInfoToDevice } from "./device-converter.ts";
@@ -4327,7 +4328,7 @@ export class Crypto extends TypedEventEmitter<CryptoEvent, CryptoEventHandlerMap
     /**
      * Stub function -- dehydration is not implemented here, so throw error
      */
-    public async startDehydration(createNewKey?: boolean): Promise<void> {
+    public async startDehydration(createNewKey?: StartDehydrationOpts | boolean): Promise<void> {
         throw new Error("Not implemented");
     }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -67,6 +67,7 @@ import {
     CryptoEventHandlerMap,
     KeyBackupRestoreOpts,
     KeyBackupRestoreResult,
+    StartDehydrationOpts,
 } from "../crypto-api/index.ts";
 import { deviceKeysToDeviceMap, rustDeviceToJsDevice } from "./device-converter.ts";
 import { IDownloadKeyResult, IQueryKeysRequest } from "../client.ts";
@@ -1425,11 +1426,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     /**
      * Implementation of {@link CryptoApi#startDehydration}.
      */
-    public async startDehydration(createNewKey?: boolean): Promise<void> {
+    public async startDehydration(opts: StartDehydrationOpts | boolean = {}): Promise<void> {
         if (!(await this.isCrossSigningReady()) || !(await this.isSecretStorageReady())) {
             throw new Error("Device dehydration requires cross-signing and secret storage to be set up");
         }
-        return await this.dehydratedDeviceManager.start(createNewKey);
+        return await this.dehydratedDeviceManager.start(opts || {});
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Needed for starting dehydration after restart -- since we only want to do that if we already have a key cached, and we don't need to try to rehydrate a device.

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/4484

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
