### PR TITLE
Remove legacy crypto export in `matrix.ts`

### DIFF
--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -21,7 +21,6 @@ import { Mocked } from "jest-mock";
 
 import {
     createClient,
-    Crypto,
     encodeBase64,
     ICreateClientOpts,
     IEvent,
@@ -44,7 +43,7 @@ import * as testData from "../../test-utils/test-data";
 import { KeyBackupInfo, KeyBackupSession } from "../../../src/crypto-api/keybackup";
 import { flushPromises } from "../../test-utils/flushPromises";
 import { defer, IDeferred } from "../../../src/utils";
-import { decodeRecoveryKey, DecryptionFailureCode, CryptoEvent } from "../../../src/crypto-api";
+import { decodeRecoveryKey, DecryptionFailureCode, CryptoEvent, CryptoApi } from "../../../src/crypto-api";
 import { KeyBackup } from "../../../src/rust-crypto/backup.ts";
 
 const ROOM_ID = testData.TEST_ROOM_ID;
@@ -311,7 +310,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
     });
 
     describe("recover from backup", () => {
-        let aliceCrypto: Crypto.CryptoApi;
+        let aliceCrypto: CryptoApi;
 
         beforeEach(async () => {
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -85,7 +85,6 @@ export * from "./models/related-relations.ts";
 export type { RoomSummary } from "./client.ts";
 export * as ContentHelpers from "./content-helpers.ts";
 export * as SecretStorage from "./secret-storage.ts";
-export type { ICryptoCallbacks } from "./crypto/index.ts"; // used to be located here
 export { createNewMatrixCall, CallEvent } from "./webrtc/call.ts";
 export type { MatrixCall } from "./webrtc/call.ts";
 export {
@@ -97,10 +96,6 @@ export {
     GroupCallStatsReportEvent,
 } from "./webrtc/groupCall.ts";
 
-export {
-    /** @deprecated Use {@link Crypto.CryptoEvent} instead */
-    CryptoEvent,
-} from "./crypto/index.ts";
 export { SyncState, SetPresence } from "./sync.ts";
 export type { ISyncStateData as SyncStateData } from "./sync.ts";
 export { SlidingSyncEvent } from "./sliding-sync.ts";
@@ -114,9 +109,6 @@ export { IdentityProviderBrand, SSOAction } from "./@types/auth.ts";
 export type { ISSOFlow as SSOFlow, LoginFlow } from "./@types/auth.ts";
 export type { IHierarchyRelation as HierarchyRelation, IHierarchyRoom as HierarchyRoom } from "./@types/spaces.ts";
 export { LocationAssetType } from "./@types/location.ts";
-
-/** @deprecated Backwards-compatibility re-export. Import from `crypto-api` directly. */
-export * as Crypto from "./crypto-api/index.ts";
 
 let cryptoStoreFactory = (): CryptoStore => new MemoryCryptoStore();
 


### PR DESCRIPTION

Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

Remove  deprecated export in `matrix.ts`