### PR TITLE
Remove usage of legacy crypto in `embedded.ts`

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -40,7 +40,6 @@ import { SyncState } from "../../src/sync";
 import { ICapabilities, RoomWidgetClient } from "../../src/embedded";
 import { MatrixEvent } from "../../src/models/event";
 import { ToDeviceBatch } from "../../src/models/ToDeviceMessage";
-import { DeviceInfo } from "../../src/crypto/deviceinfo";
 import { sleep } from "../../src/utils";
 
 const testOIDCToken = {
@@ -731,8 +730,8 @@ describe("RoomWidgetClient", () => {
             const embeddedClient = client as RoomWidgetClient;
             await embeddedClient.encryptAndSendToDevices(
                 [
-                    { userId: "@alice:example.org", deviceInfo: new DeviceInfo("aliceWeb") },
-                    { userId: "@bob:example.org", deviceInfo: new DeviceInfo("bobDesktop") },
+                    { userId: "@alice:example.org", deviceId: "aliceWeb" },
+                    { userId: "@bob:example.org", deviceId: "bobDesktop" },
                 ],
                 payload,
             );


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

The interface of `encryptAndSendToDevices` changes because `DeviceInfo` is from the legacy crypto. In fact `encryptAndSendToDevices` only need pairs of `userId` and `deviceId`.

We need to update the interface and we can simplify it.

The CI is in failure because the root branch (which is a feature branch) has removed deprecated `MatrixClient` methods used by the legacy crypto. Legacy crypto which will be removed in this feature branch.