### PR TITLE
Remove deprecated methods of `CryptoBackend`

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1008,34 +1008,6 @@ describe("RustCrypto", () => {
         });
     });
 
-    describe(".getEventEncryptionInfo", () => {
-        let rustCrypto: RustCrypto;
-
-        beforeEach(async () => {
-            rustCrypto = await makeTestRustCrypto();
-        });
-
-        it("should handle unencrypted events", () => {
-            const event = mkEvent({ event: true, type: "m.room.message", content: { body: "xyz" } });
-            const res = rustCrypto.getEventEncryptionInfo(event);
-            expect(res.encrypted).toBeFalsy();
-        });
-
-        it("should handle encrypted events", async () => {
-            const event = mkEvent({ event: true, type: "m.room.encrypted", content: { algorithm: "fake_alg" } });
-            const mockCryptoBackend = {
-                decryptEvent: () =>
-                    ({
-                        senderCurve25519Key: "1234",
-                    }) as IEventDecryptionResult,
-            } as unknown as CryptoBackend;
-            await event.attemptDecryption(mockCryptoBackend);
-
-            const res = rustCrypto.getEventEncryptionInfo(event);
-            expect(res.encrypted).toBeTruthy();
-        });
-    });
-
     describe(".getEncryptionInfoForEvent", () => {
         let rustCrypto: RustCrypto;
         let olmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -18,8 +18,6 @@ import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.ts";
 import { IClearEvent, MatrixEvent } from "../models/event.ts";
 import { Room } from "../models/room.ts";
 import { CryptoApi, DecryptionFailureCode, ImportRoomKeysOpts } from "../crypto-api/index.ts";
-import { CrossSigningInfo, UserTrustLevel } from "../crypto/CrossSigning.ts";
-import { IEncryptedEventInfo } from "../crypto/api.ts";
 import { KeyBackupInfo, KeyBackupSession } from "../crypto-api/keybackup.ts";
 import { IMegolmSessionData } from "../@types/crypto.ts";
 
@@ -46,15 +44,6 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
     stop(): void;
 
     /**
-     * Get the verification level for a given user
-     *
-     * @param userId - user to be checked
-     *
-     * @deprecated Superceded by {@link CryptoApi#getUserVerificationStatus}.
-     */
-    checkUserTrust(userId: string): UserTrustLevel;
-
-    /**
      * Encrypt an event according to the configuration of the room.
      *
      * @param event -  event to be sent
@@ -73,35 +62,6 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
      * Rejects with an error if there is a problem decrypting the event.
      */
     decryptEvent(event: MatrixEvent): Promise<EventDecryptionResult>;
-
-    /**
-     * Get information about the encryption of an event
-     *
-     * @param event - event to be checked
-     * @deprecated Use {@link CryptoApi#getEncryptionInfoForEvent} instead
-     */
-    getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo;
-
-    /**
-     * Get the cross signing information for a given user.
-     *
-     * The cross-signing API is currently UNSTABLE and may change without notice.
-     *
-     * @param userId - the user ID to get the cross-signing info for.
-     *
-     * @returns the cross signing information for the user.
-     * @deprecated Prefer {@link CryptoApi#userHasCrossSigningKeys}
-     */
-    getStoredCrossSigningForUser(userId: string): CrossSigningInfo | null;
-
-    /**
-     * Check the cross signing trust of the current user
-     *
-     * @param opts - Options object.
-     *
-     * @deprecated Unneeded for the new crypto
-     */
-    checkOwnCrossSigningTrust(opts?: CheckOwnCrossSigningTrustOpts): Promise<void>;
 
     /**
      * Get a backup decryptor capable of decrypting megolm session data encrypted with the given backup information.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -20,7 +20,6 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import type { IDeviceLists, IToDeviceEvent } from "../sync-accumulator.ts";
-import type { IEncryptedEventInfo } from "../crypto/api.ts";
 import type { ToDevicePayload, ToDeviceBatch } from "../models/ToDeviceMessage.ts";
 import { MatrixEvent, MatrixEventEvent } from "../models/event.ts";
 import { Room } from "../models/room.ts";
@@ -267,64 +266,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             throw new Error("to-device event was not decrypted in preprocessToDeviceMessages");
         }
         return await this.eventDecryptor.attemptEventDecryption(event, this.deviceIsolationMode);
-    }
-
-    /**
-     * Implementation of (deprecated) {@link MatrixClient#getEventEncryptionInfo}.
-     *
-     * @param event - event to inspect
-     */
-    public getEventEncryptionInfo(event: MatrixEvent): IEncryptedEventInfo {
-        const ret: Partial<IEncryptedEventInfo> = {};
-
-        ret.senderKey = event.getSenderKey() ?? undefined;
-        ret.algorithm = event.getWireContent().algorithm;
-
-        if (!ret.senderKey || !ret.algorithm) {
-            ret.encrypted = false;
-            return ret as IEncryptedEventInfo;
-        }
-        ret.encrypted = true;
-        ret.authenticated = true;
-        ret.mismatchedSender = true;
-        return ret as IEncryptedEventInfo;
-    }
-
-    /**
-     * Implementation of {@link CryptoBackend#checkUserTrust}.
-     *
-     * Stub for backwards compatibility.
-     *
-     */
-    public checkUserTrust(userId: string): UserVerificationStatus {
-        return new UserVerificationStatus(false, false, false);
-    }
-
-    /**
-     * Get the cross signing information for a given user.
-     *
-     * The cross-signing API is currently UNSTABLE and may change without notice.
-     *
-     * @param userId - the user ID to get the cross-signing info for.
-     *
-     * @returns the cross signing information for the user.
-     */
-    public getStoredCrossSigningForUser(userId: string): null {
-        // TODO
-        return null;
-    }
-
-    /**
-     * This function is unneeded for the rust-crypto.
-     * The cross signing key import and the device verification are done in {@link CryptoApi#bootstrapCrossSigning}
-     *
-     * The function is stub to keep the compatibility with the old crypto.
-     * More information: https://github.com/vector-im/element-web/issues/25648
-     *
-     * Implementation of {@link CryptoBackend#checkOwnCrossSigningTrust}
-     */
-    public async checkOwnCrossSigningTrust(): Promise<void> {
-        return;
     }
 
     /**


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

Remove deprecated methods of `CryptoBackend` and remove their implementations in `rust-crypto`

The CI is in failure because the root branch (which is a feature branch) has removed deprecated MatrixClient methods used by the legacy crypto. Legacy crypto which will be removed in this feature branch.