### PR TITLE
Handle empty m.room.topic

### DIFF
--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -268,5 +268,26 @@ describe("Topic content helpers", () => {
                 html: "<b>pizza</b>",
             });
         });
+
+        it("parses legacy event content", () => {
+            expect(
+                parseTopicContent({
+                    topic: "pizza",
+                }),
+            ).toEqual({
+                text: "pizza",
+            });
+        });
+
+        it("uses legacy event content when new topic key is invalid", () => {
+            expect(
+                parseTopicContent({
+                    "topic": "pizza",
+                    "m.topic": {} as any,
+                }),
+            ).toEqual({
+                text: "pizza",
+            });
+        });
     });
 });

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -211,13 +211,11 @@ describe("Topic content helpers", () => {
         it("creates an empty event when the topic is falsey", () => {
             expect(makeTopicContent(undefined)).toEqual({
                 topic: undefined,
-                [M_TOPIC.name]: [
-                ],
+                [M_TOPIC.name]: [],
             });
             expect(makeTopicContent(null)).toEqual({
                 topic: null,
-                [M_TOPIC.name]: [
-                ],
+                [M_TOPIC.name]: [],
             });
         });
     });

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -207,6 +207,19 @@ describe("Topic content helpers", () => {
                 ],
             });
         });
+
+        it("creates an empty event when the topic is falsey", () => {
+            expect(makeTopicContent(undefined)).toEqual({
+                topic: undefined,
+                [M_TOPIC.name]: [
+                ],
+            });
+            expect(makeTopicContent(null)).toEqual({
+                topic: null,
+                [M_TOPIC.name]: [
+                ],
+            });
+        });
     });
 
     describe("parseTopicContent()", () => {

--- a/src/@types/state_events.ts
+++ b/src/@types/state_events.ts
@@ -90,7 +90,7 @@ export interface RoomNameEventContent {
 }
 
 export interface RoomTopicEventContent {
-    topic: string;
+    topic: string | undefined | null;
 }
 
 export interface RoomAvatarEventContent {

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -60,4 +60,4 @@ export type MTopicEvent = EitherAnd<{ [M_TOPIC.name]: MTopicContent }, { [M_TOPI
 /**
  * The event content for an m.room.topic event
  */
-export type MRoomTopicEventContent = { topic: string | null | undefined } & MTopicEvent;
+export type MRoomTopicEventContent = { topic: string | null | undefined } & (MTopicEvent | {});

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd } from "matrix-events-sdk";
+import { EitherAnd, Optional } from "matrix-events-sdk";
 
 import { UnstableValue } from "../NamespacedValue.ts";
 import { IMessageRendering } from "./extensible_events.ts";
@@ -60,4 +60,4 @@ export type MTopicEvent = EitherAnd<{ [M_TOPIC.name]: MTopicContent }, { [M_TOPI
 /**
  * The event content for an m.room.topic event
  */
-export type MRoomTopicEventContent = { topic: string } & MTopicEvent;
+export type MRoomTopicEventContent = { topic: Optional<string> } & MTopicEvent;

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EitherAnd, Optional } from "matrix-events-sdk";
+import { EitherAnd } from "matrix-events-sdk";
 
 import { UnstableValue } from "../NamespacedValue.ts";
 import { IMessageRendering } from "./extensible_events.ts";
@@ -60,4 +60,4 @@ export type MTopicEvent = EitherAnd<{ [M_TOPIC.name]: MTopicContent }, { [M_TOPI
 /**
  * The event content for an m.room.topic event
  */
-export type MRoomTopicEventContent = { topic: Optional<string> } & MTopicEvent;
+export type MRoomTopicEventContent = { topic: string | null | undefined } & MTopicEvent;

--- a/src/client.ts
+++ b/src/client.ts
@@ -4490,11 +4490,13 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
+     * @param roomId - The room to update the topic in.
+     * @param topic - The plaintext topic. May be empty to remove the topic.
      * @param htmlTopic - Optional.
      * @returns Promise which resolves: TODO
      * @returns Rejects: with an error response.
      */
-    public setRoomTopic(roomId: string, topic: string, htmlTopic?: string): Promise<ISendEventResponse> {
+    public setRoomTopic(roomId: string, topic?: string, htmlTopic?: string): Promise<ISendEventResponse> {
         const content = ContentHelpers.makeTopicContent(topic, htmlTopic);
         return this.sendStateEvent(roomId, EventType.RoomTopic, content);
     }

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Optional } from "matrix-events-sdk";
-
 import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon.ts";
 import { MsgType } from "./@types/event.ts";
 import { M_TEXT, REFERENCE_RELATION } from "./@types/extensible_events.ts";
@@ -187,7 +185,7 @@ export const parseLocationEvent = (wireEventContent: LocationEventWireContent): 
 /**
  * Topic event helpers
  */
-export type MakeTopicContent = (topic: Optional<string>, htmlTopic?: string) => MRoomTopicEventContent;
+export type MakeTopicContent = (topic: string | null | undefined, htmlTopic?: string) => MRoomTopicEventContent;
 
 export const makeTopicContent: MakeTopicContent = (topic, htmlTopic) => {
     const renderings = [];
@@ -201,16 +199,17 @@ export const makeTopicContent: MakeTopicContent = (topic, htmlTopic) => {
 };
 
 export type TopicState = {
-    text: Optional<string>;
+    text?: string;
     html?: string;
 };
 
 export const parseTopicContent = (content: MRoomTopicEventContent): TopicState => {
     const mtopic = M_TOPIC.findIn<MTopicContent>(content);
     if (!Array.isArray(mtopic)) {
-        return { text: content.topic };
+        return { text: content.topic ?? undefined };
     }
-    const text = mtopic?.find((r) => !isProvided(r.mimetype) || r.mimetype === "text/plain")?.body ?? content.topic;
+    const text =
+        mtopic?.find((r) => !isProvided(r.mimetype) || r.mimetype === "text/plain")?.body ?? content.topic ?? undefined;
     const html = mtopic?.find((r) => r.mimetype === "text/html")?.body;
     return { text, html };
 };

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -31,6 +31,7 @@ import {
 } from "./@types/location.ts";
 import { MRoomTopicEventContent, MTopicContent, M_TOPIC } from "./@types/topic.ts";
 import { RoomMessageEventContent } from "./@types/events.ts";
+import { Optional } from "matrix-events-sdk";
 
 /**
  * Generates the content for a HTML Message event
@@ -185,18 +186,21 @@ export const parseLocationEvent = (wireEventContent: LocationEventWireContent): 
 /**
  * Topic event helpers
  */
-export type MakeTopicContent = (topic: string, htmlTopic?: string) => MRoomTopicEventContent;
+export type MakeTopicContent = (topic: Optional<string>, htmlTopic?: string) => MRoomTopicEventContent;
 
 export const makeTopicContent: MakeTopicContent = (topic, htmlTopic) => {
-    const renderings = [{ body: topic, mimetype: "text/plain" }];
+    const renderings = [];
+    if (isProvided(topic)) {
+        renderings.push({ body: topic, mimetype: "text/plain" });
+    }
     if (isProvided(htmlTopic)) {
-        renderings.push({ body: htmlTopic!, mimetype: "text/html" });
+        renderings.push({ body: htmlTopic, mimetype: "text/html" });
     }
     return { topic, [M_TOPIC.name]: renderings };
 };
 
 export type TopicState = {
-    text: string;
+    text: Optional<string>;
     html?: string;
 };
 

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { Optional } from "matrix-events-sdk";
+
 import { MBeaconEventContent, MBeaconInfoContent, MBeaconInfoEventContent } from "./@types/beacon.ts";
 import { MsgType } from "./@types/event.ts";
 import { M_TEXT, REFERENCE_RELATION } from "./@types/extensible_events.ts";
@@ -31,7 +33,6 @@ import {
 } from "./@types/location.ts";
 import { MRoomTopicEventContent, MTopicContent, M_TOPIC } from "./@types/topic.ts";
 import { RoomMessageEventContent } from "./@types/events.ts";
-import { Optional } from "matrix-events-sdk";
 
 /**
  * Generates the content for a HTML Message event

--- a/src/extensible_events_v1/utilities.ts
+++ b/src/extensible_events_v1/utilities.ts
@@ -21,7 +21,7 @@ import { Optional } from "matrix-events-sdk";
  * @param s - The optional to test.
  * @returns True if the value is defined.
  */
-export function isProvided<T>(s: Optional<T>): boolean {
+export function isProvided<T>(s: Optional<T>): s is T {
     return s !== null && s !== undefined;
 }
 


### PR DESCRIPTION
Pairs with https://github.com/matrix-org/matrix-spec/pull/2068, and an Element Web PR shortly.

The `topic` key of a topic may be undefined when it is removed, and this PR aims to support that use case. This may be considered a breaking change in that we're changing the Topic event content interfaces, but it's only to match up with reality.

NOTE: I was unsure what kind of `T-` this might be, I've gone with defect as I think it's resolving a problem where the js-sdk didn't match reality, but this could be construed as other things too.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
