### PR TITLE
Fix topic types

### DIFF
--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -13,9 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-import { EitherAnd } from "matrix-events-sdk";
-
 import { UnstableValue } from "../NamespacedValue.ts";
 import { IMessageRendering } from "./extensible_events.ts";
 
@@ -52,12 +49,17 @@ export const M_TOPIC = new UnstableValue("m.topic", "org.matrix.msc3765.topic");
  */
 export type MTopicContent = IMessageRendering[];
 
+type MTopicStable = { [M_TOPIC.altName]: MTopicContent };
+type MTopicUnstable = { [M_TOPIC.name]: MTopicContent };
+
 /**
  * The event definition for an m.topic event (in content)
  */
-export type MTopicEvent = EitherAnd<{ [M_TOPIC.name]: MTopicContent }, { [M_TOPIC.altName]: MTopicContent }>;
+export type MTopicEvent = (MTopicStable & MTopicUnstable) | MTopicStable | MTopicUnstable;
 
 /**
  * The event content for an m.room.topic event
  */
-export type MRoomTopicEventContent = { topic: string | null | undefined } & (MTopicEvent | {});
+export type MRoomTopicEventContent = {
+    topic: string | null | undefined;
+} & Partial<MTopicEvent>;


### PR DESCRIPTION
Leftover from https://github.com/matrix-org/matrix-js-sdk/pull/4673#discussion_r1938973139

I've taken the choice to remove the relatively trivial type we import from `matrix-events-sdk` due to it being abandoned anyway.