### PR TITLE
Clean up integ test after legacy crypto removal

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -91,7 +91,7 @@ module.exports = {
         "jest/no-standalone-expect": [
             "error",
             {
-                additionalTestBlockFunctions: ["beforeAll", "beforeEach", "oldBackendOnly", "newBackendOnly"],
+                additionalTestBlockFunctions: ["beforeAll", "beforeEach", "oldBackendOnly"],
             },
         ],
     },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -86,12 +86,11 @@ module.exports = {
         // Disabled tests are a reality for now but as soon as all of the xits are
         // eliminated, we should enforce this.
         "jest/no-disabled-tests": "off",
-        // Also treat "oldBackendOnly" as a test function.
         // Used in some crypto tests.
         "jest/no-standalone-expect": [
             "error",
             {
-                additionalTestBlockFunctions: ["beforeAll", "beforeEach", "oldBackendOnly"],
+                additionalTestBlockFunctions: ["beforeAll", "beforeEach"],
             },
         ],
     },

--- a/spec/TestClient.ts
+++ b/spec/TestClient.ts
@@ -26,12 +26,10 @@ import MockHttpBackend from "matrix-mock-request";
 
 import type { IDeviceKeys, IOneTimeKey } from "../src/@types/crypto";
 import type { IE2EKeyReceiver } from "./test-utils/E2EKeyReceiver";
-import { LocalStorageCryptoStore } from "../src/crypto/store/localStorage-crypto-store";
 import { logger } from "../src/logger";
 import { syncPromise } from "./test-utils/test-utils";
 import { createClient, IStartClientOpts } from "../src/matrix";
 import { ICreateClientOpts, IDownloadKeyResult, MatrixClient, PendingEventOrdering } from "../src/client";
-import { MockStorageApi } from "./MockStorageApi";
 import { IKeysUploadResponse, IUploadKeysRequest } from "../src/client";
 import { ISyncResponder } from "./test-utils/SyncResponder";
 
@@ -55,10 +53,6 @@ export class TestClient implements IE2EKeyReceiver, ISyncResponder {
         sessionStoreBackend?: Storage,
         options?: Partial<ICreateClientOpts>,
     ) {
-        if (sessionStoreBackend === undefined) {
-            sessionStoreBackend = new MockStorageApi() as unknown as Storage;
-        }
-
         this.httpBackend = new MockHttpBackend();
 
         const fullOptions: ICreateClientOpts = {
@@ -69,10 +63,6 @@ export class TestClient implements IE2EKeyReceiver, ISyncResponder {
             fetchFn: this.httpBackend.fetchFn as typeof globalThis.fetch,
             ...options,
         };
-        if (!fullOptions.cryptoStore) {
-            // expose this so the tests can get to it
-            fullOptions.cryptoStore = new LocalStorageCryptoStore(sessionStoreBackend);
-        }
         this.client = createClient(fullOptions);
 
         this.deviceKeys = null;

--- a/spec/integ/crypto/cross-signing.spec.ts
+++ b/spec/integ/crypto/cross-signing.spec.ts
@@ -56,10 +56,6 @@ const TEST_DEVICE_ID = "xzcvb";
  * to provide the most effective integration tests possible.
  */
 describe.each(Object.entries(CRYPTO_BACKENDS))("cross-signing (%s)", (backend: string, initCrypto: InitCrypto) => {
-    // newBackendOnly is the opposite to `oldBackendOnly`: it will skip the test if we are running against the legacy
-    // backend. Once we drop support for legacy crypto, it will go away.
-    const newBackendOnly = backend === "rust-sdk" ? test : test.skip;
-
     let aliceClient: MatrixClient;
 
     /** an object which intercepts `/sync` requests from {@link #aliceClient} */
@@ -163,7 +159,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("cross-signing (%s)", (backend: s
             );
         });
 
-        newBackendOnly("get cross signing keys from secret storage and import them", async () => {
+        it("get cross signing keys from secret storage and import them", async () => {
             // Return public cross signing keys
             e2eKeyResponder.addCrossSigningData(SIGNED_CROSS_SIGNING_KEYS_DATA);
 
@@ -264,7 +260,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("cross-signing (%s)", (backend: s
             expect(calls.length).toEqual(0);
         });
 
-        newBackendOnly("will upload existing cross-signing keys to an established secret storage", async () => {
+        it("will upload existing cross-signing keys to an established secret storage", async () => {
             // This rather obscure codepath covers the case that:
             //   - 4S is set up and working
             //   - our device has private cross-signing keys, but has not published them to 4S

--- a/spec/integ/crypto/cross-signing.spec.ts
+++ b/spec/integ/crypto/cross-signing.spec.ts
@@ -417,9 +417,8 @@ describe("cross-signing", () => {
         function awaitCrossSigningKeysUpload() {
             return new Promise<any>((resolve) => {
                 fetchMock.post(
-                    // legacy crypto uses /unstable/; /v3/ is correct
                     {
-                        url: new RegExp("/_matrix/client/(unstable|v3)/keys/device_signing/upload"),
+                        url: new RegExp("/_matrix/client/v3/keys/device_signing/upload"),
                         name: "upload-keys",
                     },
                     (url, options) => {
@@ -471,9 +470,6 @@ describe("cross-signing", () => {
             syncResponder.sendOrQueueSyncResponse({ next_batch: 1 });
             await aliceClient.startClient();
             await syncPromise(aliceClient);
-
-            // Wait for legacy crypto to find the device
-            await jest.advanceTimersByTimeAsync(10);
 
             const devices = await aliceClient.getCrypto()!.getUserDeviceInfo([aliceClient.getSafeUserId()]);
             expect(devices.get(aliceClient.getSafeUserId())!.has(testData.TEST_DEVICE_ID)).toBeTruthy();

--- a/spec/integ/crypto/cross-signing.spec.ts
+++ b/spec/integ/crypto/cross-signing.spec.ts
@@ -18,7 +18,7 @@ import fetchMock from "fetch-mock-jest";
 import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 
-import { CRYPTO_BACKENDS, InitCrypto, syncPromise } from "../../test-utils/test-utils";
+import { syncPromise } from "../../test-utils/test-utils";
 import { AuthDict, createClient, MatrixClient } from "../../../src";
 import { mockInitialApiRequests, mockSetupCrossSigningRequests } from "../../test-utils/mockEndpoints";
 import encryptAESSecretStorageItem from "../../../src/utils/encryptAESSecretStorageItem.ts";
@@ -55,7 +55,7 @@ const TEST_DEVICE_ID = "xzcvb";
  * These tests work by intercepting HTTP requests via fetch-mock rather than mocking out bits of the client, so as
  * to provide the most effective integration tests possible.
  */
-describe.each(Object.entries(CRYPTO_BACKENDS))("cross-signing (%s)", (backend: string, initCrypto: InitCrypto) => {
+describe("cross-signing", () => {
     let aliceClient: MatrixClient;
 
     /** an object which intercepts `/sync` requests from {@link #aliceClient} */
@@ -104,7 +104,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("cross-signing (%s)", (backend: s
                 body: { errcode: "M_NOT_FOUND" },
             });
 
-            await initCrypto(aliceClient);
+            await aliceClient.initRustCrypto();
         },
         /* it can take a while to initialise the crypto library on the first pass, so bump up the timeout. */
         10000,

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -2318,7 +2318,7 @@ describe("crypto", () => {
             // For legacy crypto, these tests only work properly with a proper (indexeddb-based) CryptoStore, so
             // rather than using the existing `aliceClient`, create a new client. Once we drop legacy crypto, we can
             // just use `aliceClient` here.
-            // XXX: Even with the rust-crypto, we need to create to a new client. The tests fail with a timeout error.
+            // XXX: Even with the rust-crypto, we need to create a new client. The tests fail with a timeout error.
             client1 = await makeNewClient(homeserverurl, userId, "client1");
             await client1.startClient({});
         });

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -24,10 +24,8 @@ import Olm from "@matrix-org/olm";
 
 import * as testUtils from "../../test-utils/test-utils";
 import {
-    CRYPTO_BACKENDS,
     emitPromise,
     getSyncResponse,
-    InitCrypto,
     mkEventCustom,
     mkMembershipCustom,
     syncPromise,
@@ -209,7 +207,7 @@ async function expectSendMegolmMessage(
     return JSON.parse(r.plaintext);
 }
 
-describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, initCrypto: InitCrypto) => {
+describe("crypto", () => {
     if (!globalThis.Olm) {
         // currently we use libolm to implement the crypto in the tests, so need it to be present.
         logger.warn("not running megolm tests: Olm not present");
@@ -369,7 +367,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
             keyReceiver = new E2EKeyReceiver(homeserverUrl);
             syncResponder = new SyncResponder(homeserverUrl);
 
-            await initCrypto(aliceClient);
+            await aliceClient.initRustCrypto();
 
             // create a test olm device which we will use to communicate with alice. We use libolm to implement this.
             testOlmAccount = await createOlmAccount();
@@ -2441,7 +2439,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                 // For legacy crypto, these tests only work with a proper persistent cryptoStore.
                 cryptoStore: new IndexedDBCryptoStore(indexedDB, "test"),
             });
-            await initCrypto(client);
+            await client.initRustCrypto();
             mockInitialApiRequests(client.getHomeserverUrl());
             return client;
         }

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -1347,19 +1347,11 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
 
             // now check getEncryptionInfoForEvent again
             const encInfo2 = await aliceClient.getCrypto()!.getEncryptionInfoForEvent(lastEvent);
-            let expectedEncryptionInfo;
-            if (backend === "rust-sdk") {
-                // rust crypto does not trust its own device until it is cross-signed.
-                expectedEncryptionInfo = {
-                    shieldColour: EventShieldColour.RED,
-                    shieldReason: EventShieldReason.UNSIGNED_DEVICE,
-                };
-            } else {
-                expectedEncryptionInfo = {
-                    shieldColour: EventShieldColour.NONE,
-                    shieldReason: null,
-                };
-            }
+            // rust crypto does not trust its own device until it is cross-signed.
+            const expectedEncryptionInfo = {
+                shieldColour: EventShieldColour.RED,
+                shieldReason: EventShieldReason.UNSIGNED_DEVICE,
+            };
             expect(encInfo2).toEqual(expectedEncryptionInfo);
         });
     });

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -635,7 +635,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                 expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_USER_NOT_JOINED);
             });
 
-            it("fails with another error when the server reports user was a member of the room", async () => {
+            it("fails with another error when the server reports user was invited in the room", async () => {
                 // This tests that when the server reports that the user
                 // was invited at the time the event was sent, then we
                 // don't get a HISTORICAL_MESSAGE_USER_NOT_JOINED error,
@@ -656,7 +656,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("crypto (%s)", (backend: string, 
                 expect(ev.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP);
             });
 
-            it("fails with another error when the server reports user was a member of the room (MSC4115 unstable prefix)", async () => {
+            it("fails with another error when the server reports user was invited in the room (MSC4115 unstable prefix)", async () => {
                 // This tests that when the server reports that the user
                 // was invited at the time the event was sent, then we
                 // don't get a HISTORICAL_MESSAGE_USER_NOT_JOINED error,

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -32,13 +32,7 @@ import { SyncResponder } from "../../test-utils/SyncResponder";
 import { E2EKeyReceiver } from "../../test-utils/E2EKeyReceiver";
 import { E2EKeyResponder } from "../../test-utils/E2EKeyResponder";
 import { mockInitialApiRequests } from "../../test-utils/mockEndpoints";
-import {
-    advanceTimersUntil,
-    awaitDecryption,
-    CRYPTO_BACKENDS,
-    InitCrypto,
-    syncPromise,
-} from "../../test-utils/test-utils";
+import { advanceTimersUntil, awaitDecryption, syncPromise } from "../../test-utils/test-utils";
 import * as testData from "../../test-utils/test-data";
 import { KeyBackupInfo, KeyBackupSession } from "../../../src/crypto-api/keybackup";
 import { flushPromises } from "../../test-utils/flushPromises";
@@ -113,7 +107,7 @@ function mockUploadEmitter(
     return emitter;
 }
 
-describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backend: string, initCrypto: InitCrypto) => {
+describe("megolm-keys backup", () => {
     let aliceClient: MatrixClient;
     /** an object which intercepts `/sync` requests on the test homeserver */
     let syncResponder: SyncResponder;
@@ -159,7 +153,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
             deviceId: TEST_DEVICE_ID,
             ...opts,
         });
-        await initCrypto(client);
+        await client.initRustCrypto();
 
         return client;
     }

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -114,8 +114,6 @@ function mockUploadEmitter(
 }
 
 describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backend: string, initCrypto: InitCrypto) => {
-    const isNewBackend = backend === "rust-sdk";
-
     let aliceClient: MatrixClient;
     /** an object which intercepts `/sync` requests on the test homeserver */
     let syncResponder: SyncResponder;
@@ -242,11 +240,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
 
             // On the first decryption attempt, decryption fails.
             await awaitDecryption(event);
-            expect(event.decryptionFailureReason).toEqual(
-                isNewBackend
-                    ? DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP
-                    : DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID,
-            );
+            expect(event.decryptionFailureReason).toEqual(DecryptionFailureCode.HISTORICAL_MESSAGE_WORKING_BACKUP);
 
             // Eventually, decryption succeeds.
             await awaitDecryption(event, { waitOnDecryptionFailure: true });
@@ -378,13 +372,8 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
 
         it("Should import full backup in chunks", async function () {
             const importMockImpl = jest.fn();
-            if (isNewBackend) {
-                // @ts-ignore - mock a private method for testing purpose
-                jest.spyOn(aliceCrypto.backupManager, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
-            } else {
-                // @ts-ignore - mock a private method for testing purpose
-                jest.spyOn(aliceCrypto, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
-            }
+            // @ts-ignore - mock a private method for testing purpose
+            jest.spyOn(aliceCrypto.backupManager, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
 
             // We need several rooms with several sessions to test chunking
             const { response, expectedTotal } = createBackupDownloadResponse([45, 300, 345, 12, 130]);
@@ -444,13 +433,8 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("megolm-keys backup (%s)", (backe
                 // Ok for other chunks
                 .mockResolvedValue(undefined);
 
-            if (isNewBackend) {
-                // @ts-ignore - mock a private method for testing purpose
-                jest.spyOn(aliceCrypto.backupManager, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
-            } else {
-                // @ts-ignore - mock a private method for testing purpose
-                jest.spyOn(aliceCrypto, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
-            }
+            // @ts-ignore - mock a private method for testing purpose
+            jest.spyOn(aliceCrypto.backupManager, "importBackedUpRoomKeys").mockImplementation(importMockImpl);
 
             const { response, expectedTotal } = createBackupDownloadResponse([100, 300]);
 

--- a/spec/integ/crypto/to-device-messages.spec.ts
+++ b/spec/integ/crypto/to-device-messages.spec.ts
@@ -18,7 +18,7 @@ import fetchMock from "fetch-mock-jest";
 import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 
-import { CRYPTO_BACKENDS, getSyncResponse, InitCrypto, syncPromise } from "../../test-utils/test-utils";
+import { getSyncResponse, syncPromise } from "../../test-utils/test-utils";
 import { createClient, MatrixClient } from "../../../src";
 import * as testData from "../../test-utils/test-data";
 import { E2EKeyResponder } from "../../test-utils/E2EKeyResponder";
@@ -38,7 +38,7 @@ afterEach(() => {
  * These tests work by intercepting HTTP requests via fetch-mock rather than mocking out bits of the client, so as
  * to provide the most effective integration tests possible.
  */
-describe.each(Object.entries(CRYPTO_BACKENDS))("to-device-messages (%s)", (backend: string, initCrypto: InitCrypto) => {
+describe("to-device-messages", () => {
     let aliceClient: MatrixClient;
 
     /** an object which intercepts `/keys/query` requests on the test homeserver */
@@ -81,7 +81,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("to-device-messages (%s)", (backe
                 { filter_id: "fid" },
             );
 
-            await initCrypto(aliceClient);
+            await aliceClient.initRustCrypto();
         },
         /* it can take a while to initialise the crypto library on the first pass, so bump up the timeout. */
         10000,

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -989,15 +989,13 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
 
             // Rust crypto requires the sender's device keys before it accepts a
             // verification request.
-            if (backend === "rust-sdk") {
-                const crypto = aliceClient.getCrypto()!;
+            const crypto = aliceClient.getCrypto()!;
 
-                const bobDeviceKeys = getTestOlmAccountKeys(testOlmAccount, BOB_TEST_USER_ID, "BobDevice");
-                e2eKeyResponder.addDeviceKeys(bobDeviceKeys);
-                syncResponder.sendOrQueueSyncResponse({ device_lists: { changed: [BOB_TEST_USER_ID] } });
-                await syncPromise(aliceClient);
-                await crypto.getUserDeviceInfo([BOB_TEST_USER_ID]);
-            }
+            const bobDeviceKeys = getTestOlmAccountKeys(testOlmAccount, BOB_TEST_USER_ID, "BobDevice");
+            e2eKeyResponder.addDeviceKeys(bobDeviceKeys);
+            syncResponder.sendOrQueueSyncResponse({ device_lists: { changed: [BOB_TEST_USER_ID] } });
+            await syncPromise(aliceClient);
+            await crypto.getUserDeviceInfo([BOB_TEST_USER_ID]);
         });
 
         /**

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -509,16 +509,12 @@ describe("verification", () => {
             reciprocateQRCodeCallbacks.confirm();
             await sendToDevicePromise;
 
-            // Rust crypto, on the other hand, waits for the 'done' to arrive from the other side.
+            // Rust crypto waits for the 'done' to arrive from the other side.
             if (request.phase === VerificationPhase.Done) {
                 const userVerificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(TEST_USER_ID);
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(userVerificationStatus.isCrossSigningVerified()).toBeTruthy();
                 await verificationPromise;
-            } else {
-                // rust crypto: still in flight
-                // eslint-disable-next-line jest/no-conditional-expect
-                expect(request.phase).toEqual(VerificationPhase.Started);
             }
 
             // the dummy device replies with its own 'done'

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -44,14 +44,7 @@ import {
     VerifierEvent,
 } from "../../../src/crypto-api/verification";
 import { defer, escapeRegExp } from "../../../src/utils";
-import {
-    awaitDecryption,
-    CRYPTO_BACKENDS,
-    emitPromise,
-    getSyncResponse,
-    InitCrypto,
-    syncPromise,
-} from "../../test-utils/test-utils";
+import { awaitDecryption, emitPromise, getSyncResponse, syncPromise } from "../../test-utils/test-utils";
 import { SyncResponder } from "../../test-utils/SyncResponder";
 import {
     BACKUP_DECRYPTION_KEY_BASE64,
@@ -117,7 +110,7 @@ const TEST_HOMESERVER_URL = "https://alice-server.com";
  * to provide the most effective integration tests possible.
  */
 // we test with both crypto stacks...
-describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: string, initCrypto: InitCrypto) => {
+describe("verification", () => {
     /** the client under test */
     let aliceClient: MatrixClient;
 
@@ -1470,7 +1463,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             deviceId: "device_under_test",
             ...opts,
         });
-        await initCrypto(client);
+        await client.initRustCrypto();
         await client.startClient();
         return client;
     }

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -420,9 +420,8 @@ describe("verification", () => {
                 expect(requests[0].transactionId).toEqual(transactionId);
             }
 
-            // legacy crypto picks devices individually; rust crypto uses a broadcast message
-            const toDeviceMessage =
-                requestBody.messages[TEST_USER_ID]["*"] ?? requestBody.messages[TEST_USER_ID][TEST_DEVICE_ID];
+            // rust crypto uses a broadcast message
+            const toDeviceMessage = requestBody.messages[TEST_USER_ID]["*"];
             expect(toDeviceMessage.from_device).toEqual(aliceClient.deviceId);
             expect(toDeviceMessage.transaction_id).toEqual(transactionId);
         });
@@ -510,10 +509,8 @@ describe("verification", () => {
             reciprocateQRCodeCallbacks.confirm();
             await sendToDevicePromise;
 
-            // at this point, on legacy crypto, the master key is already marked as trusted, and the request is "Done".
             // Rust crypto, on the other hand, waits for the 'done' to arrive from the other side.
             if (request.phase === VerificationPhase.Done) {
-                // legacy crypto: we're all done
                 const userVerificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(TEST_USER_ID);
                 // eslint-disable-next-line jest/no-conditional-expect
                 expect(userVerificationStatus.isCrossSigningVerified()).toBeTruthy();

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -118,10 +118,6 @@ const TEST_HOMESERVER_URL = "https://alice-server.com";
  */
 // we test with both crypto stacks...
 describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: string, initCrypto: InitCrypto) => {
-    // newBackendOnly is the opposite to `oldBackendOnly`: it will skip the test if we are running against the legacy
-    // backend. Once we drop support for legacy crypto, it will go away.
-    const newBackendOnly = backend === "rust-sdk" ? test : test.skip;
-
     /** the client under test */
     let aliceClient: MatrixClient;
 
@@ -568,7 +564,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(qrCodeBuffer).toBeUndefined();
         });
 
-        newBackendOnly("can verify another by scanning their QR code", async () => {
+        it("can verify another by scanning their QR code", async () => {
             aliceClient = await startTestClient();
             // we need cross-signing keys for a QR code verification
             e2eKeyResponder.addCrossSigningData(SIGNED_CROSS_SIGNING_KEYS_DATA);
@@ -1149,43 +1145,40 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(request?.otherUserId).toBe("@bob:xyz");
         });
 
-        newBackendOnly(
-            "If the verification request is not decrypted within 5 minutes, the request is ignored",
-            async () => {
-                const p2pSession = await createOlmSession(testOlmAccount, e2eKeyReceiver);
-                const groupSession = new Olm.OutboundGroupSession();
-                groupSession.create();
+        it("If the verification request is not decrypted within 5 minutes, the request is ignored", async () => {
+            const p2pSession = await createOlmSession(testOlmAccount, e2eKeyReceiver);
+            const groupSession = new Olm.OutboundGroupSession();
+            groupSession.create();
 
-                // make the room_key event, but don't send it yet
-                const toDeviceEvent = encryptGroupSessionKeyForAlice(groupSession, p2pSession);
+            // make the room_key event, but don't send it yet
+            const toDeviceEvent = encryptGroupSessionKeyForAlice(groupSession, p2pSession);
 
-                // Add verification request from Bob to Alice in the DM between them
-                returnRoomMessageFromSync(TEST_ROOM_ID, createEncryptedVerificationRequest(groupSession));
+            // Add verification request from Bob to Alice in the DM between them
+            returnRoomMessageFromSync(TEST_ROOM_ID, createEncryptedVerificationRequest(groupSession));
 
-                // Wait for the sync response to be processed
-                await syncPromise(aliceClient);
+            // Wait for the sync response to be processed
+            await syncPromise(aliceClient);
 
-                const room = aliceClient.getRoom(TEST_ROOM_ID)!;
-                const matrixEvent = room.getLiveTimeline().getEvents()[0];
+            const room = aliceClient.getRoom(TEST_ROOM_ID)!;
+            const matrixEvent = room.getLiveTimeline().getEvents()[0];
 
-                // wait for a first attempt at decryption: should fail
-                await awaitDecryption(matrixEvent);
-                expect(matrixEvent.getContent().msgtype).toEqual("m.bad.encrypted");
+            // wait for a first attempt at decryption: should fail
+            await awaitDecryption(matrixEvent);
+            expect(matrixEvent.getContent().msgtype).toEqual("m.bad.encrypted");
 
-                // Advance time by 5mins, the verification request should be ignored after that
-                jest.advanceTimersByTime(5 * 60 * 1000);
+            // Advance time by 5mins, the verification request should be ignored after that
+            jest.advanceTimersByTime(5 * 60 * 1000);
 
-                // Send Bob the room keys
-                returnToDeviceMessageFromSync(toDeviceEvent);
+            // Send Bob the room keys
+            returnToDeviceMessageFromSync(toDeviceEvent);
 
-                // Wait for the message to be decrypted
-                await awaitDecryption(matrixEvent, { waitOnDecryptionFailure: true });
+            // Wait for the message to be decrypted
+            await awaitDecryption(matrixEvent, { waitOnDecryptionFailure: true });
 
-                const request = aliceClient.getCrypto()!.findVerificationRequestDMInProgress(TEST_ROOM_ID, "@bob:xyz");
-                // the request should not be present
-                expect(request).not.toBeDefined();
-            },
-        );
+            const request = aliceClient.getCrypto()!.findVerificationRequestDMInProgress(TEST_ROOM_ID, "@bob:xyz");
+            // the request should not be present
+            expect(request).not.toBeDefined();
+        });
     });
 
     describe("Secrets are gossiped after verification", () => {
@@ -1257,7 +1250,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             fetchMock.mockReset();
         });
 
-        newBackendOnly("Should request cross signing keys after verification", async () => {
+        it("Should request cross signing keys after verification", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();
@@ -1268,7 +1261,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             await requestPromises.get("m.cross_signing.self_signing");
         });
 
-        newBackendOnly("Should accept the backup decryption key gossip if valid", async () => {
+        it("Should accept the backup decryption key gossip if valid", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();
@@ -1287,7 +1280,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(encodeBase64(cachedKey!)).toEqual(BACKUP_DECRYPTION_KEY_BASE64);
         });
 
-        newBackendOnly("Should not accept the backup decryption key gossip if private key do not match", async () => {
+        it("Should not accept the backup decryption key gossip if private key do not match", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();
@@ -1308,7 +1301,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(cachedKey).toBeNull();
         });
 
-        newBackendOnly("Should not accept the backup decryption key gossip if backup not trusted", async () => {
+        it("Should not accept the backup decryption key gossip if backup not trusted", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();
@@ -1332,7 +1325,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(cachedKey).toBeNull();
         });
 
-        newBackendOnly("Should not accept the backup decryption key gossip if backup algorithm unknown", async () => {
+        it("Should not accept the backup decryption key gossip if backup algorithm unknown", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();
@@ -1357,7 +1350,7 @@ describe.each(Object.entries(CRYPTO_BACKENDS))("verification (%s)", (backend: st
             expect(cachedKey).toBeNull();
         });
 
-        newBackendOnly("Should not accept an invalid backup decryption key", async () => {
+        it("Should not accept an invalid backup decryption key", async () => {
             const requestPromises = mockSecretRequestAndGetPromises();
 
             await doInteractiveVerification();

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -27,7 +27,6 @@ import {
     UNSTABLE_MSC2716_MARKER,
     MatrixClient,
     ClientEvent,
-    IndexedDBCryptoStore,
     ISyncResponse,
     IRoomEvent,
     IJoinedRoom,
@@ -2571,9 +2570,8 @@ describe("MatrixClient syncing (IndexedDB version)", () => {
     };
 
     it("should emit ClientEvent.Room when invited while using indexeddb crypto store", async () => {
-        const idbTestClient = new TestClient(selfUserId, "DEVICE", selfAccessToken, undefined, {
-            cryptoStore: new IndexedDBCryptoStore(globalThis.indexedDB, "tests"),
-        });
+        // rust crypto uses by default indexeddb
+        const idbTestClient = new TestClient(selfUserId, "DEVICE", selfAccessToken);
         const idbHttpBackend = idbTestClient.httpBackend;
         const idbClient = idbTestClient.client;
         idbHttpBackend.when("GET", "/versions").respond(200, {});

--- a/spec/test-utils/test-utils.ts
+++ b/spec/test-utils/test-utils.ts
@@ -552,15 +552,6 @@ export const mkPusher = (extra: Partial<IPusher> = {}): IPusher => ({
     ...extra,
 });
 
-/**
- * a list of the supported crypto implementations, each with a callback to initialise that implementation
- * for the given client
- */
-export const CRYPTO_BACKENDS: Record<string, InitCrypto> = {};
-export type InitCrypto = (_: MatrixClient) => Promise<void>;
-
-CRYPTO_BACKENDS["rust-sdk"] = (client: MatrixClient) => client.initRustCrypto();
-
 export const emitPromise = (e: EventEmitter, k: string): Promise<any> => new Promise((r) => e.once(k, r));
 
 /**


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/issues/26922
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

- Remove `CRYPTO_BACKEND` iteration
- Remove `oldBackendOnly` remaining tests
- Replace `newBackendOnly` by `it` -> we only have the rust crypto stack!
- Clean up some comments and specific code for legacy crypto