### PR TITLE
Restore broken link to `CryptoApi`

### DIFF
--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -30,7 +30,7 @@ interface Extensible {
 
 /* eslint-disable camelcase */
 
-/** The result of a call to CryptoApi.exportRoomKeys */
+/** The result of a call to {@link crypto-api!CryptoApi.exportRoomKeys} */
 export interface IMegolmSessionData extends Extensible {
     /** Sender's Curve25519 device key */
     sender_key: string;

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -584,7 +584,7 @@ export interface CryptoApi {
     /**
      * Determine if a key backup can be trusted.
      *
-     * @param info - key backup info.
+     * @param info - key backup info dict from {@link CryptoApi.getKeyBackupInfo}.
      */
     isKeyBackupTrusted(info: KeyBackupInfo): Promise<BackupTrustInfo>;
 

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -27,7 +27,7 @@ export type DeviceMap = Map<string, Map<string, Device>>;
 type DeviceParameters = Pick<Device, "deviceId" | "userId" | "algorithms" | "keys"> & Partial<Device>;
 
 /**
- *  Information on a user's device, as returned by CryptoApi.getUserDeviceInfo.
+ *  Information on a user's device, as returned by {@link crypto-api!CryptoApi.getUserDeviceInfo}.
  */
 export class Device {
     /** id of the device */

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1079,7 +1079,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * signing the public curve25519 key with the ed25519 key.
      *
      * In general, applications should not use this method directly, but should
-     * instead use CryptoApi#getEncryptionInfoForEvent.
+     * instead use {@link crypto-api!CryptoApi#getEncryptionInfoForEvent}.
      */
     public getClaimedEd25519Key(): string | null {
         return this.claimedEd25519Key;


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-js-sdk/pull/4653

In https://github.com/matrix-org/matrix-js-sdk/pull/4672, I removed some broken link to the `CryptoApi`. Thanks to @t3chguy, I was able to fix them.