### PR TITLE
`MatrixClient.setAccountData`: await remote echo.

### DIFF
--- a/spec/integ/crypto/cross-signing.spec.ts
+++ b/spec/integ/crypto/cross-signing.spec.ts
@@ -269,7 +269,7 @@ describe("cross-signing", () => {
             // a *different* device. Then, when we call `bootstrapCrossSigning` again, it should do the honours.
 
             mockSetupCrossSigningRequests();
-            const accountDataAccumulator = new AccountDataAccumulator();
+            const accountDataAccumulator = new AccountDataAccumulator(syncResponder);
             accountDataAccumulator.interceptGetAccountData();
 
             const authDict = { type: "test" };

--- a/spec/test-utils/AccountDataAccumulator.ts
+++ b/spec/test-utils/AccountDataAccumulator.ts
@@ -19,15 +19,22 @@ import fetchMock from "fetch-mock-jest";
 import { type ISyncResponder } from "./SyncResponder";
 
 /**
- *  An object which intercepts `account_data` get and set requests via fetch-mock.
+ * An object which intercepts `account_data` get and set requests via fetch-mock.
+ *
+ * To use this, call {@link interceptSetAccountData} for each type of account date that should be handled. The updated
+ * account data will be stored in {@link accountDataEvents}; it will also trigger a sync response echoing the updated
+ * data.
+ *
+ * Optionally, you can also call {@link interceptGetAccountData}.
  */
 export class AccountDataAccumulator {
     /**
      * The account data events to be returned by the sync.
      * Will be updated when fetchMock intercepts calls to PUT `/_matrix/client/v3/user/:userId/account_data/`.
-     * Will be used by `sendSyncResponseWithUpdatedAccountData`
      */
     public accountDataEvents: Map<string, any> = new Map();
+
+    public constructor(private syncResponder: ISyncResponder) {}
 
     /**
      * Intercept requests to set a particular type of account data.
@@ -53,6 +60,9 @@ export class AccountDataAccumulator {
                     // update account data for sync response
                     this.accountDataEvents.set(type!, content);
                     resolve(content);
+
+                    // return a sync response
+                    this.sendSyncResponseWithUpdatedAccountData();
                     return {};
                 },
                 opts,
@@ -90,9 +100,9 @@ export class AccountDataAccumulator {
     /**
      * Send a sync response the current account data events.
      */
-    public sendSyncResponseWithUpdatedAccountData(syncResponder: ISyncResponder): void {
+    private sendSyncResponseWithUpdatedAccountData(): void {
         try {
-            syncResponder.sendOrQueueSyncResponse({
+            this.syncResponder.sendOrQueueSyncResponse({
                 next_batch: 1,
                 account_data: {
                     events: Array.from(this.accountDataEvents, ([type, content]) => ({

--- a/spec/test-utils/mockEndpoints.ts
+++ b/spec/test-utils/mockEndpoints.ts
@@ -22,8 +22,9 @@ import { type KeyBackupInfo } from "../../src/crypto-api";
  * Mock out the endpoints that the js-sdk calls when we call `MatrixClient.start()`.
  *
  * @param homeserverUrl - the homeserver url for the client under test
+ * @param userId - the local user's ID. Defaults to `@alice:localhost`.
  */
-export function mockInitialApiRequests(homeserverUrl: string) {
+export function mockInitialApiRequests(homeserverUrl: string, userId: string = "@alice:localhost") {
     fetchMock.getOnce(
         new URL("/_matrix/client/versions", homeserverUrl).toString(),
         { versions: ["v1.1"] },
@@ -35,7 +36,7 @@ export function mockInitialApiRequests(homeserverUrl: string) {
         { overwriteRoutes: true },
     );
     fetchMock.postOnce(
-        new URL("/_matrix/client/v3/user/%40alice%3Alocalhost/filter", homeserverUrl).toString(),
+        new URL(`/_matrix/client/v3/user/${encodeURIComponent(userId)}/filter`, homeserverUrl).toString(),
         { filter_id: "fid" },
         { overwriteRoutes: true },
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -2200,9 +2200,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.addListener(ClientEvent.AccountData, accountDataListener);
 
         try {
-            const setAccountDataPromise = retryNetworkOperation(5, () => this.setAccountDataRaw(eventType, content));
-            const res = await Promise.all([setAccountDataPromise, updatedDefer.promise]);
-            return res[0];
+            const result = await retryNetworkOperation(5, () => this.setAccountDataRaw(eventType, content));
+            await updatedDefer.promise;
+            return result;
         } finally {
             this.removeListener(ClientEvent.AccountData, accountDataListener);
         }


### PR DESCRIPTION
Wait for the echo to come back from the server before we assume the account data has been successfully set.

We have a bit of a problem in the dehydration setup code in that it calls `bootstrapSecretStorage` and, not unreasonably, expects `isSecretStorageReady` to return true. Currently, it doesn't, because `isSecretStorageReady` checks the in-memory account data cache, which isn't updated until the echo comes back down `/sync`.

So, the thing to do seems to be to wait for the echo to come back before proceeding. But I'm not really sure where this fits best: I considered putting it in `ServerSideSecretStorageImpl` or even `bootstrapSecretStorage`, but it really feels like this is a wider problem than just secret storage.

(A prerequisite for https://github.com/element-hq/element-web/issues/29135)