### PR TITLE
Deprecate parameter and functions using legacy crypto in `models/event.ts`

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -407,9 +407,12 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     public forwardLooking = true;
 
-    /* If the event is a `m.key.verification.request` (or to_device `m.key.verification.start`) event,
+    /**
+     *  If the event is a `m.key.verification.request` (or to_device `m.key.verification.start`) event,
      * `Crypto` will set this the `VerificationRequest` for the event
      * so it can be easily accessed from the timeline.
+     *
+     * @deprecated Not used by the rust crypto implementation.
      */
     public verificationRequest?: VerificationRequest;
 
@@ -897,6 +900,8 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * @param userId - the user who received this event
      *
      * @returns a promise that resolves when the request is queued
+     *
+     * @deprecated Not used by the rust crypto implementation.
      */
     public cancelAndResendKeyRequest(crypto: Crypto, userId: string): Promise<void> {
         const wireContent = this.getWireContent();
@@ -1721,6 +1726,9 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         };
     }
 
+    /**
+     * @deprecated Not used by the rust crypto implementation.
+     */
     public setVerificationRequest(request: VerificationRequest): void {
         this.verificationRequest = request;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

Deprecate parameter and functions using legacy crypto in `models/event.ts`
