### PR TITLE
Clean up typescript types related to rust crypto

### DIFF
--- a/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
+++ b/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
@@ -63,7 +63,7 @@ describe("CrossSigningIdentity", () => {
                 hasMaster: true,
                 hasSelfSigning: true,
                 hasUserSigning: true,
-            });
+            } as unknown as RustSdkCryptoJs.CrossSigningStatus);
             // in secret storage
             secretStorage.get.mockResolvedValue("base64-saved-in-storage");
             await crossSigning.bootstrapCrossSigning({});
@@ -72,19 +72,23 @@ describe("CrossSigningIdentity", () => {
         });
 
         it("should call bootstrapCrossSigning if a reset is forced", async () => {
-            olmMachine.bootstrapCrossSigning.mockResolvedValue([]);
+            olmMachine.bootstrapCrossSigning.mockResolvedValue(
+                [] as unknown as RustSdkCryptoJs.CrossSigningBootstrapRequests,
+            );
             await crossSigning.bootstrapCrossSigning({ setupNewCrossSigning: true });
             expect(olmMachine.bootstrapCrossSigning).toHaveBeenCalledWith(true);
         });
 
         it("Shoud update 4S on reset if 4S is set up", async () => {
-            olmMachine.bootstrapCrossSigning.mockResolvedValue([]);
+            olmMachine.bootstrapCrossSigning.mockResolvedValue(
+                [] as unknown as RustSdkCryptoJs.CrossSigningBootstrapRequests,
+            );
             secretStorage.hasKey.mockResolvedValue(true);
             olmMachine.exportCrossSigningKeys.mockResolvedValue({
                 masterKey: "base64_aaaaaaaaaa",
                 self_signing_key: "base64_bbbbbbbbbbb",
                 userSigningKey: "base64_cccccccc",
-            });
+            } as unknown as RustSdkCryptoJs.CrossSigningKeyExport);
             await crossSigning.bootstrapCrossSigning({ setupNewCrossSigning: true });
             expect(olmMachine.bootstrapCrossSigning).toHaveBeenCalledWith(true);
             expect(secretStorage.store).toHaveBeenCalledTimes(3);
@@ -95,8 +99,10 @@ describe("CrossSigningIdentity", () => {
                 hasMaster: false,
                 hasSelfSigning: false,
                 hasUserSigning: false,
-            });
-            olmMachine.bootstrapCrossSigning.mockResolvedValue([]);
+            } as RustSdkCryptoJs.CrossSigningStatus);
+            olmMachine.bootstrapCrossSigning.mockResolvedValue(
+                [] as unknown as RustSdkCryptoJs.CrossSigningBootstrapRequests,
+            );
             await crossSigning.bootstrapCrossSigning({});
             expect(olmMachine.bootstrapCrossSigning).toHaveBeenCalledWith(true);
         });

--- a/spec/unit/rust-crypto/KeyClaimManager.spec.ts
+++ b/spec/unit/rust-crypto/KeyClaimManager.spec.ts
@@ -74,7 +74,8 @@ describe("KeyClaimManager", () => {
                     // ...  and we now resolve the original promise with the resolver for that second promise.
                     resolveCalledPromise(resolveCompletePromise);
                 });
-                return completePromise;
+                await completePromise;
+                return true;
             });
         });
     }
@@ -91,7 +92,7 @@ describe("KeyClaimManager", () => {
         fetchMock.postOnce("https://example.com/_matrix/client/v3/keys/claim", '{ "k": "v" }');
 
         // also stub out olmMachine.markRequestAsSent
-        olmMachine.markRequestAsSent.mockResolvedValueOnce(undefined);
+        olmMachine.markRequestAsSent.mockResolvedValueOnce(true);
 
         // fire off the request
         await keyClaimManager.ensureSessionsForUsers(new LogSpan(logger, "test"), [u1, u2]);

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -56,6 +56,7 @@ describe("OutgoingRequestProcessor", () => {
         return new Promise((resolve, _reject) => {
             olmMachine.markRequestAsSent.mockImplementationOnce(async () => {
                 resolve(undefined);
+                return true;
             });
         });
     }

--- a/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
+++ b/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
@@ -302,7 +302,7 @@ describe("PerSessionKeyBackupDownloader", () => {
 
         beforeEach(async () => {
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(null);
-            mockOlmMachine.getBackupKeys.mockResolvedValue(null);
+            mockOlmMachine.getBackupKeys.mockResolvedValue({} as RustSdkCryptoJs.BackupKeys);
 
             // @ts-ignore access to private function
             getConfigSpy = jest.spyOn(downloader, "getOrCreateBackupConfiguration");
@@ -349,7 +349,7 @@ describe("PerSessionKeyBackupDownloader", () => {
             // it is trusted
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
             // but the key is not cached
-            mockOlmMachine.getBackupKeys.mockResolvedValue(null);
+            mockOlmMachine.getBackupKeys.mockResolvedValue({} as RustSdkCryptoJs.BackupKeys);
 
             downloader.onDecryptionKeyMissingError("!roomId", "sessionId");
 
@@ -414,7 +414,7 @@ describe("PerSessionKeyBackupDownloader", () => {
 
             // but at this point it's not trusted and we don't have the key
             mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(null);
-            mockOlmMachine.getBackupKeys.mockResolvedValue(null);
+            mockOlmMachine.getBackupKeys.mockResolvedValue({} as RustSdkCryptoJs.BackupKeys);
 
             fetchMock.get(`express:/_matrix/client/v3/room_keys/keys/:roomId/:sessionId`, mockCipherKey);
 

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -126,6 +126,7 @@ describe("RoomEncryptor", () => {
             mockOlmMachine.shareRoomKey.mockImplementationOnce(async () => {
                 insideOlmShareRoom.resolve();
                 await deferredShare.promise;
+                return [];
             });
 
             roomEncryptor.prepareForEncryption(false, defaultDevicesIsolationMode);
@@ -151,7 +152,7 @@ describe("RoomEncryptor", () => {
             const firstTargetMembers = defer<void>();
             const secondTargetMembers = defer<void>();
 
-            mockOlmMachine.shareRoomKey.mockResolvedValue(undefined);
+            mockOlmMachine.shareRoomKey.mockResolvedValue([]);
 
             // Hook into this method to demonstrate the race condition
             mockRoom.getEncryptionTargetMembers
@@ -265,6 +266,7 @@ describe("RoomEncryptor", () => {
                 capturedSettings = undefined;
                 mockOlmMachine.shareRoomKey.mockImplementationOnce(async (roomId, users, encryptionSettings) => {
                     capturedSettings = encryptionSettings.sharingStrategy;
+                    return [];
                 });
             });
 

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -95,13 +95,13 @@ describe("Upload keys to backup", () => {
             .mockResolvedValueOnce(mockBackupRequest(100))
             .mockResolvedValueOnce(mockBackupRequest(100))
             .mockResolvedValueOnce(mockBackupRequest(2))
-            .mockResolvedValue(null);
+            .mockResolvedValue(undefined);
 
         mockOlmMachine.roomKeyCounts.mockResolvedValue({
             total: 602,
             // First iteration won't call roomKeyCounts(); it will be called on the second iteration after 200 keys have been saved.
             backedUp: 200,
-        });
+        } as unknown as RustSdkCryptoJs.RoomKeyCounts);
 
         await rustBackupManager.checkKeyBackupAndEnable(false);
         await jest.runAllTimersAsync();
@@ -130,7 +130,7 @@ describe("Upload keys to backup", () => {
         });
 
         // Only returns 2 keys on the first call, then none.
-        mockOlmMachine.backupRoomKeys.mockResolvedValueOnce(mockBackupRequest(2)).mockResolvedValue(null);
+        mockOlmMachine.backupRoomKeys.mockResolvedValueOnce(mockBackupRequest(2)).mockResolvedValue(undefined);
 
         await rustBackupManager.checkKeyBackupAndEnable(false);
         await jest.runAllTimersAsync();

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -213,7 +213,7 @@ describe("initRustCrypto", () => {
             jest.spyOn(Migration, "migrateMegolmSessions").mockResolvedValue(undefined);
 
             const testOlmMachine = makeTestOlmMachine();
-            testOlmMachine.trackedUsers.mockResolvedValue([]);
+            testOlmMachine.trackedUsers.mockResolvedValue(new Set([]));
             jest.spyOn(OlmMachine, "initFromStore").mockResolvedValue(testOlmMachine);
         });
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -806,11 +806,6 @@ describe("RustCrypto", () => {
                     asJSON: jest.fn().mockReturnValue("{}"),
                 }),
                 saveBackupDecryptionKey: jest.fn(),
-                crossSigningStatus: jest.fn().mockResolvedValue({
-                    hasMaster: true,
-                    hasSelfSigning: true,
-                    hasUserSigning: true,
-                }),
                 exportCrossSigningKeys: jest.fn().mockResolvedValue({
                     masterKey: "sosecret",
                     userSigningKey: "secrets",

--- a/src/rust-crypto/CrossSigningIdentity.ts
+++ b/src/rust-crypto/CrossSigningIdentity.ts
@@ -104,10 +104,10 @@ export class CrossSigningIdentity {
                 }
 
                 // Get the current device
-                const device: RustSdkCryptoJs.Device = await this.olmMachine.getDevice(
+                const device: RustSdkCryptoJs.Device = (await this.olmMachine.getDevice(
                     this.olmMachine.userId,
                     this.olmMachine.deviceId,
-                );
+                ))!;
                 try {
                     // Sign the device with our cross-signing key and upload the signature
                     const request: RustSdkCryptoJs.SignatureUploadRequest = await device.verify();
@@ -172,7 +172,8 @@ export class CrossSigningIdentity {
      * (If secret storage is *not* configured, we assume that the export will happen when it is set up)
      */
     private async exportCrossSigningKeysToStorage(): Promise<void> {
-        const exported: RustSdkCryptoJs.CrossSigningKeyExport | null = await this.olmMachine.exportCrossSigningKeys();
+        const exported: RustSdkCryptoJs.CrossSigningKeyExport | undefined =
+            await this.olmMachine.exportCrossSigningKeys();
         /* istanbul ignore else (this function is only called when we know the olm machine has keys) */
         if (exported?.masterKey) {
             await this.secretStorage.store("m.cross_signing.master", exported.masterKey);

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -386,7 +386,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
             while (!this.stopped) {
                 // Get a batch of room keys to upload
-                let request: RustSdkCryptoJs.KeysBackupRequest | null = null;
+                let request: RustSdkCryptoJs.KeysBackupRequest | undefined = undefined;
                 try {
                     request = await logDuration(
                         logger,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -798,6 +798,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             (isNewSecretStorageKeyNeeded || !(await secretStorageContainsCrossSigningKeys(this.secretStorage)))
         ) {
             this.logger.info("bootstrapSecretStorage: cross-signing keys not yet exported; doing so now.");
+
             await this.secretStorage.store("m.cross_signing.master", crossSigningPrivateKeys.masterKey);
             await this.secretStorage.store("m.cross_signing.user_signing", crossSigningPrivateKeys.userSigningKey);
             await this.secretStorage.store("m.cross_signing.self_signing", crossSigningPrivateKeys.self_signing_key);
@@ -1807,7 +1808,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * @param name - The name of the secret received.
      */
     public async checkSecrets(name: string): Promise<void> {
-        const pendingValues: string[] = await this.olmMachine.getSecretsFromInbox(name);
+        const pendingValues: Set<string> = await this.olmMachine.getSecretsFromInbox(name);
         for (const value of pendingValues) {
             if (await this.handleSecretReceived(name, value)) {
                 // If we have a valid secret for that name there is no point of processing the other secrets values.


### PR DESCRIPTION
A forthcoming release of matrix-rust-sdk-crypto-wasm tightens up a number of
typescript types. In preparation, we need to get our house in order too.