### PR TITLE
Update matrix-rust-sdk-crypto-wasm to v14.0.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^14.0.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^14.0.1",
         "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^13.0.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^14.0.0",
         "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -27,6 +27,7 @@ import {
     SignatureUploadRequest,
     UploadSigningKeysRequest,
     ToDeviceRequest,
+    type OutgoingRequest,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 import fetchMock from "fetch-mock-jest";
 
@@ -271,7 +272,7 @@ describe("OutgoingRequestProcessor", () => {
     });
 
     it("does not explode with unknown requests", async () => {
-        const outgoingRequest = { id: "5678", type: 987 };
+        const outgoingRequest = { id: "5678", type: 987 } as unknown as OutgoingRequest;
         const markSentCallPromise = awaitCallToMarkAsSent();
         await Promise.all([processor.makeOutgoingRequest(outgoingRequest), markSentCallPromise]);
         expect(olmMachine.markRequestAsSent).toHaveBeenCalledWith("5678", 987, "");

--- a/spec/unit/rust-crypto/OutgoingRequestsManager.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestsManager.spec.ts
@@ -16,8 +16,9 @@ limitations under the License.
 
 import { type Mocked } from "jest-mock";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OutgoingRequest } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { type OutgoingRequest, type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { OutgoingRequestsManager } from "../../../src/rust-crypto/OutgoingRequestsManager";
 import { defer, type IDeferred } from "../../../src/utils";
 import { logger } from "../../../src/logger";
@@ -72,7 +73,7 @@ describe("OutgoingRequestsManager", () => {
             const firstOutgoingRequestDefer = defer<OutgoingRequest[]>();
 
             olmMachine.outgoingRequests
-                .mockImplementationOnce(async (): Promise<OutgoingRequest[]> => {
+                .mockImplementationOnce(async () => {
                     return firstOutgoingRequestDefer.promise;
                 })
                 .mockImplementationOnce(async () => {

--- a/spec/unit/rust-crypto/verification.spec.ts
+++ b/spec/unit/rust-crypto/verification.spec.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { type Mocked } from "jest-mock";
+import { type OutgoingRequest } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
     isVerificationEvent,
@@ -28,7 +29,7 @@ import {
     type Verifier,
     VerifierEvent,
 } from "../../../src/crypto-api/verification";
-import { type OutgoingRequest, type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { type IDeviceKeys } from "../../../src/@types/crypto";
 import { EventType, MatrixEvent, MsgType } from "../../../src";
 

--- a/src/@types/matrix-sdk-crypto-wasm.d.ts
+++ b/src/@types/matrix-sdk-crypto-wasm.d.ts
@@ -17,16 +17,6 @@ limitations under the License.
 import type * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 declare module "@matrix-org/matrix-sdk-crypto-wasm" {
-    interface OlmMachine {
-        importSecretsBundle(bundle: RustSdkCryptoJs.SecretsBundle): Promise<void>;
-        exportSecretsBundle(): Promise<RustSdkCryptoJs.SecretsBundle>;
-        importCrossSigningKeys(
-            master_key?: string,
-            self_signing_key?: string,
-            user_signing_key?: string,
-        ): Promise<RustSdkCryptoJs.CrossSigningStatus>;
-    }
-
     interface SecretsBundle {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         to_json(): Promise<{

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -20,6 +20,7 @@ import {
     KeysQueryRequest,
     KeysUploadRequest,
     type OlmMachine,
+    type OutgoingRequest,
     PutDehydratedDeviceRequest,
     RoomMessageRequest,
     SignatureUploadRequest,
@@ -33,16 +34,6 @@ import { logDuration, type QueryDict, sleep } from "../utils.ts";
 import { type AuthDict, type UIAuthCallback } from "../interactive-auth.ts";
 import { ToDeviceMessageId } from "../@types/event.ts";
 import { UnstablePrefix as DehydrationUnstablePrefix } from "./DehydratedDeviceManager.ts";
-
-/**
- * Common interface for all the request types returned by `OlmMachine.outgoingRequests`.
- *
- * @internal
- */
-export interface OutgoingRequest {
-    readonly id: string | undefined;
-    readonly type: number;
-}
 
 /**
  * OutgoingRequestManager: turns `OutgoingRequest`s from the rust sdk into HTTP requests

--- a/src/rust-crypto/OutgoingRequestsManager.ts
+++ b/src/rust-crypto/OutgoingRequestsManager.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type OlmMachine } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OlmMachine, type OutgoingRequest } from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import { type OutgoingRequest, type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { type Logger } from "../logger.ts";
 import { defer, type IDeferred, logDuration } from "../utils.ts";
 

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
-import { QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
+import { type OutgoingRequest, QrState } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import {
     type GeneratedSas,
@@ -30,7 +30,7 @@ import {
     type VerifierEventHandlerMap,
 } from "../crypto-api/verification.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
-import { type OutgoingRequest, type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
+import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { type MatrixEvent } from "../models/event.ts";
 import { EventType, MsgType } from "../@types/event.ts";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,9 +1522,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@matrix-org/matrix-sdk-crypto-wasm@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.0.0.tgz#0e895fb20d5898814fd6d3cc251be0dd37f3e969"
-  integrity sha512-haZ+5vGOFP0h+bEa3UcrSBRlscxtYUMXs6yT4EKwT+jnRxuRBgRizYC8TqRghRarh2bqzoNeoleQb1ixAHwQZQ==
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.0.1.tgz#e258ef84bcc7889f0e7eb3a7dbecf0830a6dd606"
+  integrity sha512-CgLpHs6nTw5pjSsMBi9xbQnBXf2l8YhImQP9cv8nbGSCYdYjFI0FilMXffzjWV5HThpNHri/3pF20ahZtuS3VA==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,7 +1521,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^14.0.0":
+"@matrix-org/matrix-sdk-crypto-wasm@^14.0.1":
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.0.1.tgz#e258ef84bcc7889f0e7eb3a7dbecf0830a6dd606"
   integrity sha512-CgLpHs6nTw5pjSsMBi9xbQnBXf2l8YhImQP9cv8nbGSCYdYjFI0FilMXffzjWV5HThpNHri/3pF20ahZtuS3VA==
@@ -1769,14 +1769,6 @@
   integrity sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==
   dependencies:
     "@babel/types" "^7.20.7"
-
-"@types/bs58@^4.0.1":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.4.tgz#49fbcb0c7db5f7cea26f0e0f61dc4a41a2445aab"
-  integrity sha512-0IEpMFXXQi2zXaXl9GJ3sRwQo0uEkD+yFOv+FnAU5lkPtcu6h61xb7jc2CFPEZ5BUOaiP13ThuGc9HD4R8lR5g==
-  dependencies:
-    "@types/node" "*"
-    base-x "^3.0.6"
 
 "@types/content-type@^1.1.5":
   version "1.1.8"
@@ -2393,13 +2385,6 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base-x@^3.0.6:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.10.tgz#62de58653f8762b5d6f8d9fe30fa75f7b2585a75"
-  integrity sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==
-  dependencies:
-    safe-buffer "^5.0.1"
 
 base-x@^5.0.0:
   version "5.0.0"
@@ -5725,11 +5710,6 @@ safe-array-concat@^1.1.2:
     get-intrinsic "^1.2.4"
     has-symbols "^1.0.3"
     isarray "^2.0.5"
-
-safe-buffer@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,10 +1521,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-13.0.0.tgz#658bed951e4c8a06a6dd545575a79cf32022d4ba"
-  integrity sha512-2gtpjnxL42sdJAgkwitpMMI4cw7Gcjf5sW0MXoe+OAlXPlxIzyM+06F5JJ8ENvBeHkuV2RqtFIRrh8i90HLsMw==
+"@matrix-org/matrix-sdk-crypto-wasm@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.0.0.tgz#0e895fb20d5898814fd6d3cc251be0dd37f3e969"
+  integrity sha512-haZ+5vGOFP0h+bEa3UcrSBRlscxtYUMXs6yT4EKwT+jnRxuRBgRizYC8TqRghRarh2bqzoNeoleQb1ixAHwQZQ==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
Relevant changes are:

-   Accept stable identifier `sender_device_keys` for MSC4147 (Including device  keys with Olm-encrypted events). ([#4420](https://github.com/matrix-org/matrix-rust-sdk/pull/4420))

-   Room keys are not shared with unsigned dehydrated devices. ([#4551](https://github.com/matrix-org/matrix-rust-sdk/pull/4551))
