### PR TITLE
Mention caveat in README about IndexedDB outside browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ const matrixClient = sdk.createClient({
 await matrixClient.initRustCrypto();
 ```
 
+Note that by default it will attempt to use the Indexed DB provided by the browser as a crypto store. If running outside the browser, you will need to pass [an options object](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#initrustcrypto) which includes `useIndexedDB: false`, to use an ephemeral in-memory store instead. Note that without a persistent store, you'll need to create a new device on the server side (with [`MatrixClient.loginRequest`](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#loginrequest)) each time your application starts.
+
 After calling `initRustCrypto`, you can obtain a reference to the [`CryptoApi`](https://matrix-org.github.io/matrix-js-sdk/interfaces/crypto_api.CryptoApi.html) interface, which is the main entry point for end-to-end encryption, by calling [`MatrixClient.getCrypto`](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#getCrypto).
 
 **WARNING**: the cryptography stack is not thread-safe. Having multiple `MatrixClient` instances connected to the same Indexed DB will cause data corruption and decryption failures. The application layer is responsible for ensuring that only one `MatrixClient` issue is instantiated at a time.


### PR DESCRIPTION
If using the SDK outside the browser with end-to-end encryption, IndexedDB usage needs to be disabled otherwise it will cause the Rust code to panic.

See also:

- https://github.com/matrix-org/matrix-js-sdk/issues/4570
- https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/issues/168
- https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/issues/195#issuecomment-2661510343

Signed-off-by: Adam Spiers <github@adamspiers.org>

```
Notes: none
```

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
