### PR TITLE
Delete the dehydrated device when resetEncryption is called

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2231,7 +2231,7 @@ describe("RustCrypto", () => {
             fetchMock.post("path:/_matrix/client/v3/keys/signatures/upload", {});
         });
 
-        it("reset should reset 4S, backup and cross-signing", async () => {
+        it("reset should reset 4S, backup, cross-signing, and dehydrated device", async () => {
             // When we will delete the key backup
             let backupIsDeleted = false;
             fetchMock.delete("path:/_matrix/client/v3/room_keys/version/1", () => {
@@ -2241,6 +2241,12 @@ describe("RustCrypto", () => {
             // If the backup is deleted, we will return an empty object
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", () => {
                 return backupIsDeleted ? {} : testData.SIGNED_BACKUP_DATA;
+            });
+
+            let dehydratedDeviceIsDeleted = false;
+            fetchMock.delete("path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device", () => {
+                dehydratedDeviceIsDeleted = true;
+                return { device_id: "ADEVICEID" };
             });
 
             // A new key backup should be created after the reset
@@ -2273,6 +2279,8 @@ describe("RustCrypto", () => {
             expect(newKeyBackupInfo.auth_data).toBeTruthy();
             // The new cross signing keys should be uploaded
             expect(authUploadDeviceSigningKeys).toHaveBeenCalledWith(expect.any(Function));
+            // The dehydrated device was deleted
+            expect(dehydratedDeviceIsDeleted).toBeTruthy();
         });
     });
 });

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -436,10 +436,16 @@ export interface CryptoApi {
 
     /**
      * Reset the encryption of the user by going through the following steps:
+     * - Remove the dehydrated device and stop the periodic creation of dehydrated devices.
      * - Disable backing up room keys and delete any existing backups.
      * - Remove the default secret storage key from the account data (ie: the recovery key).
      * - Reset the cross-signing keys.
      * - Create a new key backup.
+     *
+     * Note that the dehydrated device will be removed, but will not be replaced
+     * and it will not schedule creating new dehydrated devices.  To do this,
+     * {@link startDehydration} should be called after a new secret storage key
+     * is created.
      *
      * @param authUploadDeviceSigningKeys - Callback to authenticate the upload of device signing keys.
      *      Used when resetting the cross signing keys.

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -340,6 +340,35 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
             this.intervalId = undefined;
         }
     }
+
+    /**
+     * Delete the current dehydrated device and stop the dehydrated device manager.
+     */
+    public async delete(): Promise<void> {
+        this.stop();
+        try {
+            await this.http.authedRequest(
+                Method.Delete,
+                "/dehydrated_device",
+                undefined,
+                {},
+                {
+                    prefix: UnstablePrefix,
+                },
+            );
+        } catch (error) {
+            const err = error as MatrixError;
+            // If dehydrated devices aren't supported, or no dehydrated device
+            // is found, we don't consider it an error, because we we'll end up
+            // with no dehydrated device.
+            if (err.errcode === "M_UNRECOGNIZED") {
+                return;
+            } else if (err.errcode === "M_NOT_FOUND") {
+                return;
+            }
+            throw error;
+        }
+    }
 }
 
 /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1440,6 +1440,10 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     public async resetEncryption(authUploadDeviceSigningKeys: UIAuthCallback<void>): Promise<void> {
         this.logger.debug("resetEncryption: resetting encryption");
 
+        // Delete the dehydrated device, since any existing one will be signed
+        // by the wrong cross-signing key
+        this.dehydratedDeviceManager.delete();
+
         // Disable backup, and delete all the backups from the server
         await this.backupManager.deleteAllKeyBackupVersions();
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

When we reset encryption (and reset cross-signing keys), delete the dehydrated device since it is (if present) signed with the old cross-signing key.

Fixes https://github.com/element-hq/element-web/issues/29131

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
