### PR TITLE
Add `EventType.SecretRequest` and `EventType.SecretSend`

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -138,6 +138,8 @@ export enum EventType {
     RoomKeyRequest = "m.room_key_request",
     ForwardedRoomKey = "m.forwarded_room_key",
     Dummy = "m.dummy",
+    SecretRequest = "m.secret.request",
+    SecretSend = "m.secret.send",
 
     // Group call events
     GroupCallPrefix = "org.matrix.msc3401.call",


### PR DESCRIPTION
A couple of to-device message types which are in the spec but not in the js-sdk.