### PR TITLE
Simplify code paths for building to-device `MatrixEvent`s

### DIFF
--- a/src/event-mapper.ts
+++ b/src/event-mapper.ts
@@ -25,7 +25,8 @@ export interface MapperOpts {
     preventReEmit?: boolean;
     // decrypt event proactively
     decrypt?: boolean;
-    // the event is a to_device event
+
+    /** @deprecated no longer used */
     toDevice?: boolean;
 }
 
@@ -34,10 +35,6 @@ export function eventMapperFor(client: MatrixClient, options: MapperOpts): Event
     const decrypt = options.decrypt !== false;
 
     function mapper(plainOldJsObject: Partial<IEvent>): MatrixEvent {
-        if (options.toDevice) {
-            delete plainOldJsObject.room_id;
-        }
-
         const room = client.getRoom(plainOldJsObject.room_id);
 
         let event: MatrixEvent | undefined;
@@ -74,9 +71,6 @@ export function eventMapperFor(client: MatrixClient, options: MapperOpts): Event
             event.setThread(thread);
         }
 
-        // TODO: once we get rid of the old libolm-backed crypto, we can restrict this to room events (rather than
-        //   to-device events), because the rust implementation decrypts to-device messages at a higher level.
-        //   Generally we probably want to use a different eventMapper implementation for to-device events because
         if (event.isEncrypted()) {
             if (!preventReEmit) {
                 client.reEmitter.reEmit(event, [MatrixEventEvent.Decrypted]);

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -28,6 +28,7 @@ import {
     defaultClientOpts,
     defaultSyncApiOpts,
     type SetPresence,
+    mapToDeviceEvent,
 } from "./sync.ts";
 import { type MatrixEvent } from "./models/event.ts";
 import {
@@ -151,7 +152,7 @@ class ExtensionToDevice implements Extension<ExtensionToDeviceRequest, Extension
             events = await this.cryptoCallbacks.preprocessToDeviceMessages(events);
         }
         events
-            .map(this.client.getEventMapper())
+            .map(mapToDeviceEvent)
             .map((toDeviceEvent) => {
                 // map is a cheap inline forEach
                 // We want to flag m.key.verification.start events as cancelled

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -54,7 +54,7 @@ import {
     type ITimeline,
     type IToDeviceEvent,
 } from "./sync-accumulator.ts";
-import { type MatrixEvent } from "./models/event.ts";
+import { MatrixEvent, type IEvent } from "./models/event.ts";
 import { type MatrixError, Method } from "./http-api/index.ts";
 import { type ISavedSync } from "./store/index.ts";
 import { EventType } from "./@types/event.ts";
@@ -1152,7 +1152,7 @@ export class SyncApi {
 
             const cancelledKeyVerificationTxns: string[] = [];
             toDeviceMessages
-                .map(client.getEventMapper({ toDevice: true }))
+                .map(mapToDeviceEvent)
                 .map((toDeviceEvent) => {
                     // map is a cheap inline forEach
                     // We want to flag m.key.verification.start events as cancelled
@@ -1944,4 +1944,10 @@ export function _createAndReEmitRoom(client: MatrixClient, roomId: string, opts:
     });
 
     return room;
+}
+
+export function mapToDeviceEvent(plainOldJsObject: Partial<IEvent>): MatrixEvent {
+    // to-device events should not have a `room_id` property, but let's be sure
+    delete plainOldJsObject.room_id;
+    return new MatrixEvent(plainOldJsObject);
 }


### PR DESCRIPTION
We don't need all the complicated stuff when we have a to-device event, so let's simplify.