### PR TITLE
Add disableKeyStorage() to crypto API

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2321,8 +2321,7 @@ describe("RustCrypto", () => {
 
     describe("disableKeyStorage", () => {
         it("should disable key storage", async () => {
-            let secretStorage: ServerSideSecretStorage;
-            secretStorage = {
+            const secretStorage = {
                 getDefaultKeyId: jest.fn().mockResolvedValue("bloop"),
                 setDefaultKeyId: jest.fn(),
                 store: jest.fn(),

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2318,6 +2318,44 @@ describe("RustCrypto", () => {
             expect(dehydratedDeviceIsDeleted).toBeTruthy();
         });
     });
+
+    describe("disableKeyStorage", () => {
+        it("should disable key storage", async () => {
+            let secretStorage: ServerSideSecretStorage;
+            secretStorage = {
+                getDefaultKeyId: jest.fn().mockResolvedValue("bloop"),
+                setDefaultKeyId: jest.fn(),
+                store: jest.fn(),
+            } as unknown as ServerSideSecretStorage;
+
+            fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
+
+            let backupIsDeleted = false;
+            fetchMock.delete("path:/_matrix/client/v3/room_keys/version/1", () => {
+                backupIsDeleted = true;
+                return {};
+            });
+
+            let dehydratedDeviceIsDeleted = false;
+            fetchMock.delete("path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device", () => {
+                dehydratedDeviceIsDeleted = true;
+                return { device_id: "ADEVICEID" };
+            });
+
+            const rustCrypto = await makeTestRustCrypto(makeMatrixHttpApi(), undefined, undefined, secretStorage);
+            await rustCrypto.disableKeyStorage();
+
+            expect(secretStorage.store).toHaveBeenCalledWith("m.cross_signing.master", null);
+            expect(secretStorage.store).toHaveBeenCalledWith("m.cross_signing.self_signing", null);
+            expect(secretStorage.store).toHaveBeenCalledWith("m.cross_signing.user_signing", null);
+            expect(secretStorage.store).toHaveBeenCalledWith("m.megolm_backup.v1", null);
+            expect(secretStorage.store).toHaveBeenCalledWith("m.secret_storage.key.bloop", null);
+            expect(secretStorage.setDefaultKeyId).toHaveBeenCalledWith(null);
+
+            expect(backupIsDeleted).toBeTruthy();
+            expect(dehydratedDeviceIsDeleted).toBeTruthy();
+        });
+    });
 });
 
 /** Build a MatrixHttpApi instance */

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -636,8 +636,6 @@ export interface CryptoApi {
      *    known 4S data (cross-signing keys and the megolm key backup key).
      *  * Deletes any dehydrated devices.
      *  * Sets the "m.org.matrix.custom.backup_disabled" account data flag to indicate that the user has disabled backups.
-     *
-     * @throws {Error} if encryption is not enabled.
      */
     disableKeyStorage(): Promise<void>;
 

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -630,6 +630,18 @@ export interface CryptoApi {
     resetKeyBackup(): Promise<void>;
 
     /**
+     * Disables server-side key storage and deletes server-side backups.
+     *  * Deletes the current key backup version, if any (but not any previous versions).
+     *  * Disables 4S, deleting the info for the default key, the default key pointer itself and any
+     *    known 4S data (cross-signing keys and the megolm key backup key).
+     *  * Deletes any dehydrated devices.
+     *  * Sets the "m.org.matrix.custom.backup_disabled" account data flag to indicate that the user has disabled backups.
+     *
+     * @throws {Error} if encryption is not enabled.
+     */
+    disableKeyStorage(): Promise<void>;
+
+    /**
      * Deletes the given key backup.
      *
      * @param version - The backup version to delete.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1277,6 +1277,24 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     }
 
     /**
+     * Implementation of {@link CryptoApi#disableKeyStorage}.
+     */
+    public async disableKeyStorage(): Promise<void> {
+        // Get the key backup version we're using
+        const info = await this.getKeyBackupInfo();
+        if (info?.version) {
+            await this.deleteKeyBackupVersion(info.version);
+        } else {
+            logger.error("Can't delete key backup version: no version available");
+        }
+
+        // also turn off 4S, since this is also storing keys on the server.
+        await this.deleteSecretStorage();
+
+        await this.dehydratedDeviceManager.delete();
+    }
+
+    /**
      * Signs the given object with the current device and current identity (if available).
      * As defined in {@link https://spec.matrix.org/v1.8/appendices/#signing-json | Signing JSON}.
      *
@@ -1447,17 +1465,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         // Disable backup, and delete all the backups from the server
         await this.backupManager.deleteAllKeyBackupVersions();
 
-        // Remove the stored secrets in the secret storage
-        await this.secretStorage.store("m.cross_signing.master", null);
-        await this.secretStorage.store("m.cross_signing.self_signing", null);
-        await this.secretStorage.store("m.cross_signing.user_signing", null);
-        await this.secretStorage.store("m.megolm_backup.v1", null);
-
-        // Remove the recovery key
-        const defaultKeyId = await this.secretStorage.getDefaultKeyId();
-        if (defaultKeyId) await this.secretStorage.store(`m.secret_storage.key.${defaultKeyId}`, null);
-        // Disable the recovery key and the secret storage
-        await this.secretStorage.setDefaultKeyId(null);
+        this.deleteSecretStorage();
 
         // Reset the cross-signing keys
         await this.crossSigningIdentity.bootstrapCrossSigning({
@@ -1469,6 +1477,24 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         await this.resetKeyBackup();
 
         this.logger.debug("resetEncryption: ended");
+    }
+
+    /**
+     * Removes the secret storage key, default key pointer and all (known) secret storage data
+     * from the user's account data
+     */
+    private async deleteSecretStorage(): Promise<void> {
+        // Remove the stored secrets in the secret storage
+        await this.secretStorage.store("m.cross_signing.master", null);
+        await this.secretStorage.store("m.cross_signing.self_signing", null);
+        await this.secretStorage.store("m.cross_signing.user_signing", null);
+        await this.secretStorage.store("m.megolm_backup.v1", null);
+
+        // Remove the recovery key
+        const defaultKeyId = await this.secretStorage.getDefaultKeyId();
+        if (defaultKeyId) await this.secretStorage.store(`m.secret_storage.key.${defaultKeyId}`, null);
+        // Disable the recovery key and the secret storage
+        await this.secretStorage.setDefaultKeyId(null);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As an all-in-one method for deleting all server side key storage on the user's account (as the doc hopefully explains).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
