### PR TITLE
MatrixRTC MembershipManger: remove redundant sendDelayedEventAction and expose status

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -147,7 +147,7 @@ describe.each([
                 const waitForSendState = waitForMockCall(client.sendStateEvent);
                 const waitForUpdateDelaye = waitForMockCallOnce(
                     client._unstable_updateDelayedEvent,
-                    Promise.reject(new MatrixError({ errcode: "M_NOT_FOUND" }, 429, undefined)),
+                    Promise.reject(new MatrixError({ errcode: "M_NOT_FOUND" })),
                 );
                 memberManager.join([focus], focusActive);
                 await waitForSendState;

--- a/src/matrixrtc/LegacyMembershipManager.ts
+++ b/src/matrixrtc/LegacyMembershipManager.ts
@@ -105,7 +105,7 @@ export class LegacyMembershipManager implements IMembershipManager {
 
     public off(
         event: MembershipManagerEvent.StatusChanged,
-        listener: (oldStatus: string, newStatus: string) => void,
+        listener: (oldStatus: Status, newStatus: Status) => void,
     ): this {
         logger.error("off is not implemented on LegacyMembershipManager");
         return this;
@@ -113,7 +113,7 @@ export class LegacyMembershipManager implements IMembershipManager {
 
     public on(
         event: MembershipManagerEvent.StatusChanged,
-        listener: (oldStatus: string, newStatus: string) => void,
+        listener: (oldStatus: Status, newStatus: Status) => void,
     ): this {
         logger.error("on is not implemented on LegacyMembershipManager");
         return this;

--- a/src/matrixrtc/LegacyMembershipManager.ts
+++ b/src/matrixrtc/LegacyMembershipManager.ts
@@ -27,7 +27,7 @@ import { type Focus } from "./focus.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 import { type MembershipConfig } from "./MatrixRTCSession.ts";
 import { type EmptyObject } from "../@types/common.ts";
-import { IMembershipManager, MembershipManagerEvent, Status } from "./types.ts";
+import { type IMembershipManager, type MembershipManagerEvent, Status } from "./types.ts";
 
 /**
  * This internal class is used by the MatrixRTCSession to manage the local user's own membership of the session.
@@ -103,12 +103,18 @@ export class LegacyMembershipManager implements IMembershipManager {
         private getOldestMembership: () => CallMembership | undefined,
     ) {}
 
-    off(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this {
+    public off(
+        event: MembershipManagerEvent.StatusChanged,
+        listener: (oldStatus: string, newStatus: string) => void,
+    ): this {
         logger.error("off is not implemented on LegacyMembershipManager");
         return this;
     }
 
-    on(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this {
+    public on(
+        event: MembershipManagerEvent.StatusChanged,
+        listener: (oldStatus: string, newStatus: string) => void,
+    ): this {
         logger.error("on is not implemented on LegacyMembershipManager");
         return this;
     }

--- a/src/matrixrtc/LegacyMembershipManager.ts
+++ b/src/matrixrtc/LegacyMembershipManager.ts
@@ -27,7 +27,7 @@ import { type Focus } from "./focus.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 import { type MembershipConfig } from "./MatrixRTCSession.ts";
 import { type EmptyObject } from "../@types/common.ts";
-import { type IMembershipManager } from "./NewMembershipManager.ts";
+import { IMembershipManager, MembershipManagerEvent, Status } from "./types.ts";
 
 /**
  * This internal class is used by the MatrixRTCSession to manage the local user's own membership of the session.
@@ -103,8 +103,28 @@ export class LegacyMembershipManager implements IMembershipManager {
         private getOldestMembership: () => CallMembership | undefined,
     ) {}
 
+    off(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this {
+        logger.error("off is not implemented on LegacyMembershipManager");
+        return this;
+    }
+
+    on(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this {
+        logger.error("on is not implemented on LegacyMembershipManager");
+        return this;
+    }
+
     public isJoined(): boolean {
         return this.relativeExpiry !== undefined;
+    }
+    public isActivated(): boolean {
+        return this.isJoined();
+    }
+    /**
+     * Unimplemented
+     * @returns Status.Unknown
+     */
+    public get status(): Status {
+        return Status.Unknown;
     }
 
     public join(fociPreferred: Focus[], fociActive?: Focus): void {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -25,10 +25,11 @@ import { RoomStateEvent } from "../models/room-state.ts";
 import { type Focus } from "./focus.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { type MatrixEvent } from "../models/event.ts";
-import { MembershipManager, type IMembershipManager } from "./NewMembershipManager.ts";
+import { MembershipManager } from "./NewMembershipManager.ts";
 import { EncryptionManager, type IEncryptionManager, type Statistics } from "./EncryptionManager.ts";
 import { LegacyMembershipManager } from "./LegacyMembershipManager.ts";
 import { logDurationSync } from "../utils.ts";
+import { IMembershipManager } from "./types.ts";
 
 const logger = rootLogger.getChild("MatrixRTCSession");
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -29,7 +29,7 @@ import { MembershipManager } from "./NewMembershipManager.ts";
 import { EncryptionManager, type IEncryptionManager, type Statistics } from "./EncryptionManager.ts";
 import { LegacyMembershipManager } from "./LegacyMembershipManager.ts";
 import { logDurationSync } from "../utils.ts";
-import { IMembershipManager } from "./types.ts";
+import type { IMembershipManager } from "./types.ts";
 
 const logger = rootLogger.getChild("MatrixRTCSession");
 

--- a/src/matrixrtc/NewMembershipManager.ts
+++ b/src/matrixrtc/NewMembershipManager.ts
@@ -24,7 +24,12 @@ import { type Room } from "../models/room.ts";
 import { defer, type IDeferred } from "../utils.ts";
 import { type CallMembership, DEFAULT_EXPIRE_DURATION, type SessionMembershipData } from "./CallMembership.ts";
 import { type Focus } from "./focus.ts";
-import { IMembershipManager, MembershipManagerEvent, MembershipManagerEventHandlerMap, Status } from "./types.ts";
+import {
+    type IMembershipManager,
+    type MembershipManagerEventHandlerMap,
+    MembershipManagerEvent,
+    Status,
+} from "./types.ts";
 import { isLivekitFocusActive } from "./LivekitFocus.ts";
 import { type MembershipConfig } from "./MatrixRTCSession.ts";
 import { ActionScheduler, type ActionUpdate } from "./NewMembershipManagerActionScheduler.ts";
@@ -179,8 +184,9 @@ export class MembershipManager
                 // Should already be set to false when calling `leave` in non error cases.
                 this.activated = false;
                 // Here the scheduler is not running anymore so we the `membershipLoopHandler` is not called to emit.
-                if (this.oldStatus && this.oldStatus !== this.status)
+                if (this.oldStatus && this.oldStatus !== this.status) {
                     this.emit(MembershipManagerEvent.StatusChanged, this.oldStatus, this.status);
+                }
                 if (!this.scheduler.running) {
                     this.leavePromiseDefer?.resolve(true);
                     this.leavePromiseDefer = undefined;

--- a/src/matrixrtc/NewMembershipManager.ts
+++ b/src/matrixrtc/NewMembershipManager.ts
@@ -439,13 +439,14 @@ export class MembershipManager
                 this.resetRateLimitCounter(MembershipActionType.SendDelayedEvent);
                 this.state.delayId = response.delay_id;
                 if (this.state.hasMemberStateEvent) {
-                    // Delayed event got send because it got lost due to state event auto cancel
+                    // This action was scheduled because the previous delayed event was cancelled
+                    // due to lack of https://github.com/element-hq/synapse/pull/17810
                     return createInsertActionUpdate(
                         MembershipActionType.RestartDelayedEvent,
                         this.membershipKeepAlivePeriod,
                     );
                 } else {
-                    // Delayed event got send because we just joined
+                    // This action was scheduled because we are in the process of joining  
                     return createInsertActionUpdate(MembershipActionType.SendJoinEvent);
                 }
             })
@@ -458,13 +459,14 @@ export class MembershipManager
                 if (update) return update;
 
                 if (this.state.hasMemberStateEvent) {
-                    // Delayed event got send because it got lost due to state event auto cancel
+                    // This action was scheduled because the previous delayed event was cancelled  
+                    // due to lack of https://github.com/element-hq/synapse/pull/17810  
 
                     // Don't do any other delayed event work if its not supported.
                     if (this.isUnsupportedDelayedEndpoint(e)) return {};
                     throw Error("Could not send delayed event, even though delayed events are supported. " + e);
                 } else {
-                    // Delayed event got send because we just joined
+                    // This action was scheduled because we are in the process of joining  
                     // log and fall through
                     if (this.isUnsupportedDelayedEndpoint(e)) {
                         logger.info("Not using delayed event because the endpoint is not supported");

--- a/src/matrixrtc/NewMembershipManager.ts
+++ b/src/matrixrtc/NewMembershipManager.ts
@@ -399,7 +399,7 @@ export class MembershipManager implements IMembershipManager {
             case MembershipActionType.SendDelayedEvent: {
                 // Before we start we check if we come from a state where we have a delay id.
                 if (!this.state.delayId) {
-                    this.sendOrResendDelayedLeaveEvent(); // Normal case without any previous delayed id.
+                    return this.sendOrResendDelayedLeaveEvent(); // Normal case without any previous delayed id.
                 } else {
                     // This can happen if someone else (or another client) removes our own membership event.
                     // It will trigger `onRTCSessionMemberUpdate` queue `MembershipActionType.SendFirstDelayedEvent`.

--- a/src/matrixrtc/NewMembershipManager.ts
+++ b/src/matrixrtc/NewMembershipManager.ts
@@ -375,7 +375,7 @@ export class MembershipManager
                     // This can happen if someone else (or another client) removes our own membership event.
                     // It will trigger `onRTCSessionMemberUpdate` queue `MembershipActionType.SendFirstDelayedEvent`.
                     // We might still have our delayed event from the previous participation and dependent on the server this might not
-                    // get automatically removed if the state changes. Hence It would remove our membership unexpectedly shortly after the rejoin.
+                    // get removed automatically if the state changes. Hence, it would remove our membership unexpectedly shortly after the rejoin.
                     //
                     // In this block we will try to cancel this delayed event before setting up a new one.
 

--- a/src/matrixrtc/NewMembershipManager.ts
+++ b/src/matrixrtc/NewMembershipManager.ts
@@ -446,7 +446,7 @@ export class MembershipManager
                         this.membershipKeepAlivePeriod,
                     );
                 } else {
-                    // This action was scheduled because we are in the process of joining  
+                    // This action was scheduled because we are in the process of joining
                     return createInsertActionUpdate(MembershipActionType.SendJoinEvent);
                 }
             })
@@ -459,14 +459,14 @@ export class MembershipManager
                 if (update) return update;
 
                 if (this.state.hasMemberStateEvent) {
-                    // This action was scheduled because the previous delayed event was cancelled  
-                    // due to lack of https://github.com/element-hq/synapse/pull/17810  
+                    // This action was scheduled because the previous delayed event was cancelled
+                    // due to lack of https://github.com/element-hq/synapse/pull/17810
 
                     // Don't do any other delayed event work if its not supported.
                     if (this.isUnsupportedDelayedEndpoint(e)) return {};
                     throw Error("Could not send delayed event, even though delayed events are supported. " + e);
                 } else {
-                    // This action was scheduled because we are in the process of joining  
+                    // This action was scheduled because we are in the process of joining
                     // log and fall through
                     if (this.isUnsupportedDelayedEndpoint(e)) {
                         logger.info("Not using delayed event because the endpoint is not supported");

--- a/src/matrixrtc/NewMembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/NewMembershipManagerActionScheduler.ts
@@ -73,7 +73,7 @@ export class ActionScheduler {
             return;
         }
         this.running = true;
-        this._actions = [{ ts: Date.now(), type: MembershipActionType.SendFirstDelayedEvent }];
+        this._actions = [{ ts: Date.now(), type: MembershipActionType.SendDelayedEvent }];
         try {
             while (this._actions.length > 0) {
                 // Sort so next (smallest ts) action is at the beginning
@@ -98,7 +98,7 @@ export class ActionScheduler {
                         `\nDate.now: "${Date.now()}`,
                     );
                     try {
-                        // `this.wakeup` can also be called and sets the `wakupUpdate` object while we are in the handler.
+                        // `this.wakeup` can also be called and sets the `wakeupUpdate` object while we are in the handler.
                         handlerResult = await this.membershipLoopHandler(nextAction.type as MembershipActionType);
                     } catch (e) {
                         throw Error(`The MembershipManager shut down because of the end condition: ${e}`);
@@ -125,7 +125,7 @@ export class ActionScheduler {
     }
 
     public initiateJoin(): void {
-        this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendFirstDelayedEvent }] });
+        this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendDelayedEvent }] });
     }
     public initiateLeave(): void {
         this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendScheduledDelayedLeaveEvent }] });

--- a/src/matrixrtc/index.ts
+++ b/src/matrixrtc/index.ts
@@ -20,3 +20,4 @@ export * from "./LivekitFocus.ts";
 export * from "./MatrixRTCSession.ts";
 export * from "./MatrixRTCSessionManager.ts";
 export type * from "./types.ts";
+export { Status, MembershipManagerEvent } from "./types.ts";

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { type IMentions } from "../matrix.ts";
+import { CallMembership } from "./CallMembership";
+import { Focus } from "./focus";
+
 export interface EncryptionKeyEntry {
     index: number;
     key: string;
@@ -33,4 +36,84 @@ export interface ICallNotifyContent {
     "m.mentions": IMentions;
     "notify_type": CallNotifyType;
     "call_id": string;
+}
+
+export enum Status {
+    Disconnected = "Disconnected",
+    Connecting = "Connecting",
+    ConnectingFailed = "ConnectingFailed",
+    Connected = "Connected",
+    Reconnecting = "Reconnecting",
+    Disconnecting = "Disconnecting",
+    Stuck = "Stuck",
+    Unknown = "Unknown",
+}
+
+export enum MembershipManagerEvent {
+    StatusChanged = "StatusChanged",
+}
+
+export type MembershipManagerEventHandlerMap = {
+    [MembershipManagerEvent.StatusChanged]: (prefStatus: Status, newStatus: Status) => void;
+};
+
+/**
+ * This interface defines what a MembershipManager uses and exposes.
+ * This interface is what we use to write tests and allows changing the actual implementation
+ * without breaking tests because of some internal method renaming.
+ *
+ * @internal
+ */
+export interface IMembershipManager {
+    /**
+     * If we are trying to join, or have successfully joined the session.
+     * It does not reflect if the room state is already configured to represent us being joined.
+     * It only means that the Manager should be trying to connect or to disconnect running.
+     * The Manager is still running right after isJoined becomes false to send the disconnect events.
+     * @returns true if we intend to be participating in the MatrixRTC session
+     * @deprecated This name is confusing and replaced by `isActivated()`. (Returns the same as `isActivated()`)
+     */
+    isJoined(): boolean;
+    /**
+     * If the manager is activated. This means it tries to do its job to join the call, resend state events...
+     * It does not imply that the room state is already configured to represent being joined.
+     * It means that the Manager tries to connect or is connected. ("the manager is still active")
+     * Once `leave()` is called the manager is not activated anymore but still running until `leave()` resolves.
+     * @returns `true` if we intend to be participating in the MatrixRTC session
+     */
+    isActivated(): boolean;
+    /**
+     * Get the actual connection status of the manager.
+     */
+    get status(): Status;
+    /**
+     * The current status while the manager is activated
+     */
+    /**
+     * Start sending all necessary events to make this user participate in the RTC session.
+     * @param fociPreferred the list of preferred foci to use in the joined RTC membership event.
+     * @param fociActive the active focus to use in the joined RTC membership event.
+     * @throws can throw if it exceeds a configured maximum retry.
+     */
+    join(fociPreferred: Focus[], fociActive?: Focus, onError?: (error: unknown) => void): void;
+    /**
+     * Send all necessary events to make this user leave the RTC session.
+     * @param timeout the maximum duration in ms until the promise is forced to resolve.
+     * @returns It resolves with true in case the leave was sent successfully.
+     * It resolves with false in case we hit the timeout before sending successfully.
+     */
+    leave(timeout?: number): Promise<boolean>;
+    /**
+     * Call this if the MatrixRTC session members have changed.
+     */
+    onRTCSessionMemberUpdate(memberships: CallMembership[]): Promise<void>;
+    /**
+     * The used active focus in the currently joined session.
+     * @returns the used active focus in the currently joined session or undefined if not joined.
+     */
+    getActiveFocus(): Focus | undefined;
+
+    // TypedEventEmitter methods:
+    on(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this;
+    off(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this;
 }

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -114,6 +114,6 @@ export interface IMembershipManager {
     getActiveFocus(): Focus | undefined;
 
     // TypedEventEmitter methods:
-    on(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: string, newStatus: string) => void): this;
-    off(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: string, newStatus: string) => void): this;
+    on(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: Status, newStatus: Status) => void): this;
+    off(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: Status, newStatus: Status) => void): this;
 }

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { type IMentions } from "../matrix.ts";
-import { CallMembership } from "./CallMembership";
-import { Focus } from "./focus";
+import type { IMentions } from "../matrix.ts";
+import type { CallMembership } from "./CallMembership.ts";
+import type { Focus } from "./focus.ts";
 
 export interface EncryptionKeyEntry {
     index: number;
@@ -114,6 +114,6 @@ export interface IMembershipManager {
     getActiveFocus(): Focus | undefined;
 
     // TypedEventEmitter methods:
-    on(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this;
-    off(event: MembershipManagerEvent.StatusChanged, listener: (prefStatus: string, newStatus: string) => void): this;
+    on(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: string, newStatus: string) => void): this;
+    off(event: MembershipManagerEvent.StatusChanged, listener: (oldStatus: string, newStatus: string) => void): this;
 }


### PR DESCRIPTION
We do already have the state `hasMemberEvent` that allows to distinguish the two cases. No need to create two dedicated actions.

This also moves code from `NewMemberhsipManager.ts` -> `types.ts`.

And we expose status through an event emitter for the membership manager.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
