### PR TITLE
MatrixRTC: Fix running not representing what we need from `isJoined` in EC

### DIFF
--- a/src/matrixrtc/NewMembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/NewMembershipManagerActionScheduler.ts
@@ -115,12 +115,10 @@ export class ActionScheduler {
                     this._actions.push(...actionUpdate.insert);
                 }
             }
-            this.running = false;
-        } catch (e) {
-            // Set the rtc session "not running" state since we cannot recover from here and the consumer user of the
+        } finally {
+            // Set the rtc session running state since we cannot recover from here and the consumer user of the
             // MatrixRTCSession class needs to manually rejoin.
             this.running = false;
-            throw e;
         }
 
         logger.debug("Leave MembershipManager ActionScheduler loop (no more actions)");

--- a/src/matrixrtc/NewMembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/NewMembershipManagerActionScheduler.ts
@@ -40,6 +40,10 @@ export type ActionUpdate =
  * @internal
  */
 export class ActionScheduler {
+    /**
+     * This is tracking the state of the scheduler loop.
+     * Only used to prevent starting the loop twice.
+     */
     public running = false;
 
     public constructor(
@@ -111,13 +115,13 @@ export class ActionScheduler {
                     this._actions.push(...actionUpdate.insert);
                 }
             }
+            this.running = false;
         } catch (e) {
             // Set the rtc session "not running" state since we cannot recover from here and the consumer user of the
             // MatrixRTCSession class needs to manually rejoin.
             this.running = false;
             throw e;
         }
-        this.running = false;
 
         logger.debug("Leave MembershipManager ActionScheduler loop (no more actions)");
     }


### PR DESCRIPTION
EC expects isJoined to represent if we should be in joined state or not. It does not correlate to what our actual state of the scheduler is. We used the scheduler running state before but on leave the running state will stay true until we successfully updated the room state.
EC expects isJoined to immediately be false.

This introduces a member variable `activated` that represents if the MemberhsipManager is trying to connect or trying to disconnect independent on the current state.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
