### PR TITLE
Add authenticated media parameter to getMediaConfig

### DIFF
--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -157,6 +157,30 @@ describe("MatrixClient", function () {
         });
     });
 
+    describe("mediaConfig", function () {
+        it("should get media config on unauthenticated media call", async () => {
+            httpBackend.when("GET", "/_matrix/media/v3/config").respond(200, '{"m.upload.size": 50000000}', true);
+
+            const prom = client.getMediaConfig();
+
+            httpBackend.flushAllExpected();
+
+            expect((await prom)["m.upload.size"]).toEqual(50000000);
+        });
+
+        it("should get media config on authenticated media call", async () => {
+            httpBackend
+                .when("GET", "/_matrix/client/v1/media/config")
+                .respond(200, '{"m.upload.size": 50000000}', true);
+
+            const prom = client.getMediaConfig(true);
+
+            httpBackend.flushAllExpected();
+
+            expect((await prom)["m.upload.size"]).toEqual(50000000);
+        });
+    });
+
     describe("joinRoom", function () {
         it("should no-op given the ID of a room you've already joined", async () => {
             const roomId = "!foo:bar";

--- a/src/client.ts
+++ b/src/client.ts
@@ -2069,11 +2069,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * Get the config for the media repository.
+     *
+     * @param useAuthenticatedMedia - If true, the caller supports authenticated
+     * media and wants an authentication-required URL. Note that server support
+     * for authenticated media will *not* be checked - it is the caller's responsibility
+     * to do so before calling this function.
+     *
      * @returns Promise which resolves with an object containing the config.
      */
-    public getMediaConfig(): Promise<IMediaConfig> {
-        return this.http.authedRequest(Method.Get, "/config", undefined, undefined, {
-            prefix: MediaPrefix.V3,
+    public getMediaConfig(useAuthenticatedMedia: boolean = false): Promise<IMediaConfig> {
+        const path = useAuthenticatedMedia ? "/media/config" : "/config";
+        return this.http.authedRequest(Method.Get, path, undefined, undefined, {
+            prefix: useAuthenticatedMedia ? ClientPrefix.V1 : MediaPrefix.V3,
         });
     }
 


### PR DESCRIPTION
Adds parameter to getMediaConfig (client.ts) to use authenticated media call for media config.

Signed-off-by: Maurizio Abbruzzo [maurizio@abbruzzosantiago.de](mailto:maurizio@abbruzzosantiago.de)

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
