### PR TITLE
Stabilise MSC3765

### DIFF
--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -197,12 +197,12 @@ describe("Topic content helpers", () => {
                 topic: "pizza",
                 [M_TOPIC.name]: [
                     {
-                        body: "pizza",
-                        mimetype: "text/plain",
-                    },
-                    {
                         body: "<b>pizza</b>",
                         mimetype: "text/html",
+                    },
+                    {
+                        body: "pizza",
+                        mimetype: "text/plain",
                     },
                 ],
             });

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -42,20 +42,17 @@ import { type IMessageRendering } from "./extensible_events.ts";
 /**
  * The event type for an m.topic event (in content)
  */
-export const M_TOPIC = new NamespacedValue("m.topic", "org.matrix.msc3765.topic");
+export const M_TOPIC = new NamespacedValue("m.topic");
 
 /**
  * The event content for an m.topic event (in content)
  */
 export type MTopicContent = IMessageRendering[];
 
-type MTopicStable = { [K in Exclude<typeof M_TOPIC.altName, null | undefined>]: MTopicContent };
-type MTopicUnstable = { [M_TOPIC.name]: MTopicContent };
-
 /**
  * The event definition for an m.topic event (in content)
  */
-export type MTopicEvent = (MTopicStable & MTopicUnstable) | MTopicStable | MTopicUnstable;
+export type MTopicEvent = { "m.topic": MTopicContent };
 
 /**
  * The event content for an m.room.topic event

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { UnstableValue } from "../NamespacedValue.ts";
+import { NamespacedValue } from "../NamespacedValue.ts";
 import { type IMessageRendering } from "./extensible_events.ts";
 
 /**
@@ -42,14 +42,14 @@ import { type IMessageRendering } from "./extensible_events.ts";
 /**
  * The event type for an m.topic event (in content)
  */
-export const M_TOPIC = new UnstableValue("m.topic", "org.matrix.msc3765.topic");
+export const M_TOPIC = new NamespacedValue("m.topic", "org.matrix.msc3765.topic");
 
 /**
  * The event content for an m.topic event (in content)
  */
 export type MTopicContent = IMessageRendering[];
 
-type MTopicStable = { [M_TOPIC.altName]: MTopicContent };
+type MTopicStable = { [K in Exclude<typeof M_TOPIC.altName, null | undefined>]: MTopicContent };
 type MTopicUnstable = { [M_TOPIC.name]: MTopicContent };
 
 /**

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -189,11 +189,13 @@ export type MakeTopicContent = (topic: string | null | undefined, htmlTopic?: st
 
 export const makeTopicContent: MakeTopicContent = (topic, htmlTopic) => {
     const renderings = [];
-    if (isProvided(topic)) {
-        renderings.push({ body: topic, mimetype: "text/plain" });
-    }
+    // Put HTML first because clients will render the first type in
+    // the array that they understand
     if (isProvided(htmlTopic)) {
         renderings.push({ body: htmlTopic, mimetype: "text/html" });
+    }
+    if (isProvided(topic)) {
+        renderings.push({ body: topic, mimetype: "text/plain" });
     }
     return { topic, [M_TOPIC.name]: renderings };
 };


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/pull/3765 was merged which means we can switch to stable identifiers and the final state of the proposal.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
