### PR TITLE
Fix `RustCrypto.resetEncryption` failure

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2255,10 +2255,10 @@ describe("RustCrypto", () => {
         let secretStorage: ServerSideSecretStorage;
         beforeEach(() => {
             secretStorage = {
-                setDefaultKeyId: jest.fn(),
+                setDefaultKeyId: jest.fn().mockResolvedValue(undefined),
                 hasKey: jest.fn().mockResolvedValue(false),
                 getKey: jest.fn().mockResolvedValue(null),
-                store: jest.fn(),
+                store: jest.fn().mockResolvedValue(undefined),
                 getDefaultKeyId: jest.fn().mockResolvedValue("defaultKeyId"),
             } as unknown as ServerSideSecretStorage;
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1466,6 +1466,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         await this.backupManager.deleteAllKeyBackupVersions();
 
         this.deleteSecretStorage();
+        await this.deleteSecretStorage();
 
         // Reset the cross-signing keys
         await this.crossSigningIdentity.bootstrapCrossSigning({


### PR DESCRIPTION
Regression due to https://github.com/matrix-org/matrix-js-sdk/pull/4742

When [`RustCrypto.resetEncryption`](https://github.com/matrix-org/matrix-js-sdk/blob/3657eb61d85e4848c2f849c06c3628776e29f929/src/rust-crypto/rust-crypto.ts#L1458) is called, [`CrossSigningIdentity.resetCrossSigning`](https://github.com/matrix-org/matrix-js-sdk/blob/3657eb61d85e4848c2f849c06c3628776e29f929/src/rust-crypto/CrossSigningIdentity.ts#L174) raises this error:

```
Uncaught (in promise) Error: No keys specified and no default key present
    store secret-storage.ts:525
    exportCrossSigningKeysToStorage CrossSigningIdentity.ts:184
    resetCrossSigning CrossSigningIdentity.ts:154
    bootstrapCrossSigning CrossSigningIdentity.ts:46
    resetEncryption rust-crypto.ts:1473
    onClick ResetIdentityPanel.tsx:92
    React 23
    getOrCreateStaticRoot Modal.tsx:109
    reRender Modal.tsx:415
    createDialog Modal.tsx:316
    MatrixChat MatrixChat.tsx:781
    invokeCallback dispatcher.ts:115
secret-storage.ts:525:22
```

The 4S is not completely deleted and we try to export keys that has been deleted. Due to of missing `await` on `this.deleteSecretStorage()` in 

https://github.com/matrix-org/matrix-js-sdk/blob/3657eb61d85e4848c2f849c06c3628776e29f929/src/rust-crypto/rust-crypto.ts#L1458-L1480

The secretStorage object is mocked in the test, the mock making it synchronous so the test didn't catch the race.