### PR TITLE
Inherit `methodFactory` extensions from the parent to the child loggers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "bs58": "^6.0.0",
         "content-type": "^1.0.4",
         "jwt-decode": "^4.0.0",
-        "loglevel": "^1.7.1",
+        "loglevel": "^1.9.2",
         "matrix-events-sdk": "0.0.1",
         "matrix-widget-api": "^1.10.0",
         "oidc-client-ts": "^3.0.1",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -131,22 +131,20 @@ interface PrefixedLogger extends loglevel.Logger, LoggerWithLogMethod {
 function getPrefixedLogger(prefix?: string): PrefixedLogger {
     const loggerName = DEFAULT_NAMESPACE + (prefix === undefined ? "" : `-${prefix}`);
     const prefixLogger = loglevel.getLogger(loggerName) as PrefixedLogger;
-    // This is a save cast since export const logger is constructed with getPrefixedLogger
-    // It is downcastet to `Logger` to minimize the public/exported api.
+
     if (prefixLogger.getChild === undefined) {
         // This is a new loglevel Logger which has not been turned into a PrefixedLogger yet.
         prefixLogger.prefix = prefix;
         prefixLogger.getChild = (childPrefix): Logger => {
-            const rootLogger = logger as PrefixedLogger;
             // create the new child logger
             const childLogger = getPrefixedLogger((prefix ?? "") + childPrefix);
             // assign the same methodFactory as the root logger.
             // this is useful if we add extensions to the root logger that modify
             // its methodFactory. (an example extension is: storing each log to a rageshake db)
-            childLogger.methodFactory = rootLogger.methodFactory;
+            childLogger.methodFactory = prefixLogger.methodFactory;
             // rebuild the child logger with the new methodFactory.
             childLogger.rebuild();
-            return childLogger as Logger;
+            return childLogger;
         };
         prefixLogger.setLevel(loglevel.levels.DEBUG, false);
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -128,18 +128,25 @@ interface PrefixedLogger extends loglevel.Logger, LoggerWithLogMethod {
  *
  * @param prefix Prefix to add to each logged line. If undefined, no prefix will be added.
  */
-function getPrefixedLogger(prefix?: string): LoggerWithLogMethod {
+function getPrefixedLogger(prefix?: string): PrefixedLogger {
     const loggerName = DEFAULT_NAMESPACE + (prefix === undefined ? "" : `-${prefix}`);
     const prefixLogger = loglevel.getLogger(loggerName) as PrefixedLogger;
-
+    // This is a save cast since export const logger is constructed with getPrefixedLogger
+    // It is downcastet to `Logger` to minimize the public/exported api.
     if (prefixLogger.getChild === undefined) {
         // This is a new loglevel Logger which has not been turned into a PrefixedLogger yet.
         prefixLogger.prefix = prefix;
         prefixLogger.getChild = (childPrefix): Logger => {
-            const childLogger = getPrefixedLogger((prefix ?? "") + childPrefix) as unknown as loglevel.Logger;
-            childLogger.methodFactory = (logger as unknown as loglevel.Logger).methodFactory;
-            childLogger.setLevel(childLogger.getLevel());
-            return childLogger as unknown as Logger;
+            const rootLogger = logger as PrefixedLogger;
+            // create the new child logger
+            const childLogger = getPrefixedLogger((prefix ?? "") + childPrefix);
+            // assign the same methodFactory as the root logger.
+            // this is useful if we add extensions to the root logger that modify
+            // its methodFactory. (an example extension is: storing each log to a rageshake db)
+            childLogger.methodFactory = rootLogger.methodFactory;
+            // rebuild the child logger with the new methodFactory.
+            childLogger.rebuild();
+            return childLogger as Logger;
         };
         prefixLogger.setLevel(loglevel.levels.DEBUG, false);
     }
@@ -151,7 +158,7 @@ function getPrefixedLogger(prefix?: string): LoggerWithLogMethod {
  * Drop-in replacement for `console` using {@link https://www.npmjs.com/package/loglevel|loglevel}.
  * Can be tailored down to specific use cases if needed.
  */
-export const logger = getPrefixedLogger();
+export const logger = getPrefixedLogger() as LoggerWithLogMethod;
 
 /**
  * A "span" for grouping related log lines together.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,6 +33,10 @@ interface LoggerWithLogMethod extends Logger {
 export interface Logger extends BaseLogger {
     /**
      * Create a child logger.
+     * This child will apply the methodFactory of the parent. So any log extensions applied to the parent
+     * at the time of calling `getChild` will be applied to the child as well.
+     * It will NOT apply changes to the parents methodFactory after the child was created.
+     * Those changes will not be applied manually to the child.
      *
      * @param namespace - name to add to the current logger to generate the child. Some implementations of `Logger`
      *    use this as a prefix; others use a different mechanism.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import loglevel, { LoggingMethod } from "loglevel";
+import loglevel from "loglevel";
 
 /** Backwards-compatibility hack to expose `log` to applications that might still be relying on it. */
 interface LoggerWithLogMethod extends Logger {
@@ -137,18 +137,8 @@ function getPrefixedLogger(prefix?: string): LoggerWithLogMethod {
         prefixLogger.prefix = prefix;
         prefixLogger.getChild = (childPrefix): Logger => {
             const childLogger = getPrefixedLogger((prefix ?? "") + childPrefix) as unknown as loglevel.Logger;
-            childLogger.methodFactory = (methodName, configLevel, loggerName): LoggingMethod => {
-                const method = (logger as unknown as loglevel.Logger).methodFactory(
-                    methodName,
-                    configLevel,
-                    loggerName,
-                );
-                return (...args): void => {
-                    method.apply(childLogger, args);
-                };
-            };
+            childLogger.methodFactory = (logger as unknown as loglevel.Logger).methodFactory;
             childLogger.setLevel(childLogger.getLevel());
-
             return childLogger as unknown as Logger;
         };
         prefixLogger.setLevel(loglevel.levels.DEBUG, false);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,10 +33,11 @@ interface LoggerWithLogMethod extends Logger {
 export interface Logger extends BaseLogger {
     /**
      * Create a child logger.
-     * This child will apply the methodFactory of the parent. So any log extensions applied to the parent
+     *
+     * This child will use the `methodFactory` of the parent, so any log extensions applied to the parent
      * at the time of calling `getChild` will be applied to the child as well.
-     * It will NOT apply changes to the parents methodFactory after the child was created.
-     * Those changes will not be applied manually to the child.
+     * It will NOT apply changes to the parent's `methodFactory` after the child was created.
+     * Those changes need to be applied to the child manually.
      *
      * @param namespace - name to add to the current logger to generate the child. Some implementations of `Logger`
      *    use this as a prefix; others use a different mechanism.
@@ -142,11 +143,11 @@ function getPrefixedLogger(prefix?: string): PrefixedLogger {
         prefixLogger.getChild = (childPrefix): Logger => {
             // create the new child logger
             const childLogger = getPrefixedLogger((prefix ?? "") + childPrefix);
-            // assign the same methodFactory as the root logger.
-            // this is useful if we add extensions to the root logger that modify
-            // its methodFactory. (an example extension is: storing each log to a rageshake db)
+            // Assign the methodFactory from the parent logger.
+            // This is useful if we add extensions to the parent logger that modifies
+            // its methodFactory. (An example extension is: storing each log to a rageshake db)
             childLogger.methodFactory = prefixLogger.methodFactory;
-            // rebuild the child logger with the new methodFactory.
+            // Rebuild the child logger with the new methodFactory.
             childLogger.rebuild();
             return childLogger;
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5081,7 +5081,7 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loglevel@^1.7.1:
+loglevel@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
   integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==


### PR DESCRIPTION
This fixes an issue where a log extension (a modification to the `methodFactory`) applied to a parent logger would ONLY be executed when logging with the parent but not on any of the children created with `getChild()`.

This PR changes `getChild` to also inherit the `methodFactory` from the parent.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
