### PR TITLE
Fix token refresh behaviour for non-expired tokens

### DIFF
--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -104,7 +104,9 @@ export class TokenRefresher {
         if (snapshot?.expiry) {
             // If our token is unknown, but it should not have expired yet, then we should not refresh
             const expiresIn = snapshot.expiry.getTime() - Date.now();
-            if (expiresIn <= REFRESH_ON_ERROR_IF_TOKEN_EXPIRES_WITHIN_MS) {
+            // If it still has plenty of time left on the clock, we assume something else must be wrong and
+            // do not refresh. Otherwise if it's expired, or will soon, we try refreshing.
+            if (expiresIn >= REFRESH_ON_ERROR_IF_TOKEN_EXPIRES_WITHIN_MS) {
                 return TokenRefreshOutcome.Logout;
             }
         }


### PR DESCRIPTION
The condition was inverted here, but the tests were passing because they didn't add enough expiry time for the token expiry to be over the threshold.

Fix the condition and tests, add another test and generally add a bunch of comments so hopefully this is less confusing for the next person.

Fixes https://github.com/element-hq/element-web/issues/29858

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
