### PR TITLE
Allow the embedded client to work without update_state support

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -104,6 +104,10 @@ class MockWidgetApi extends EventEmitter {
         sendComplete: jest.fn(),
     };
 
+    /**
+     * This mocks the widget's view of what is supported by its environment.
+     * @param clientVersions The versions that the widget believes are supported by the host client's widget driver.
+     */
     public constructor(clientVersions: ApiVersion[]) {
         super();
         this.getClientVersions.mockResolvedValue(clientVersions);

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -45,6 +45,7 @@ import { type ToDeviceBatch } from "../../src/models/ToDeviceMessage";
 import { sleep } from "../../src/utils";
 import { SlidingSync } from "../../src/sliding-sync";
 import { logger } from "../../src/logger";
+import { flushPromises } from "../test-utils/flushPromises";
 
 const testOIDCToken = {
     access_token: "12345678",
@@ -681,7 +682,7 @@ describe("RoomWidgetClient", () => {
                 }),
             );
             // Allow the getClientVersions promise to resolve
-            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+            await flushPromises();
             // It should now have changed the room state
             expect(room!.currentState.getStateEvents("org.example.foo", "bar")?.getEffectiveEvent()).toEqual(event);
         });

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -261,7 +261,7 @@ export class RoomWidgetClient extends MatrixClient {
     }
 
     public async supportUpdateState(): Promise<boolean> {
-        return (await this.widgetApi.getClientVersions())?.includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
+        return (await this.widgetApi.getClientVersions()).includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
     }
 
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -29,6 +29,7 @@ import {
     type IWidgetApiResponse,
     type IWidgetApiResponseData,
     type IUpdateStateToWidgetActionRequest,
+    UnstableApiVersion,
 } from "matrix-widget-api";
 
 import { MatrixEvent, type IEvent, type IContent, EventStatus } from "./models/event.ts";
@@ -259,6 +260,10 @@ export class RoomWidgetClient extends MatrixClient {
         if (sendContentLoaded) widgetApi.sendContentLoaded();
     }
 
+    public async supportUpdateState(): Promise<boolean> {
+        return (await this.widgetApi.getClientVersions())?.includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
+    }
+
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {
         this.lifecycle = new AbortController();
 
@@ -283,14 +288,41 @@ export class RoomWidgetClient extends MatrixClient {
 
         await this.widgetApiReady;
 
+        // sync room state:
+        if (await this.supportUpdateState()) {
+            // This will resolve once the client driver has sent us all the allowed room state.
+            await this.roomStateSynced;
+        } else {
+            // Backfill the requested events
+            // We only get the most recent event for every type + state key combo,
+            // so it doesn't really matter what order we inject them in
+            await Promise.all(
+                this.capabilities.receiveState?.map(async ({ eventType, stateKey }) => {
+                    const rawEvents = await this.widgetApi.readStateEvents(eventType, undefined, stateKey, [
+                        this.roomId,
+                    ]);
+                    const events = rawEvents.map((rawEvent) => new MatrixEvent(rawEvent as Partial<IEvent>));
+
+                    if (this.syncApi instanceof SyncApi) {
+                        // Passing events as `stateAfterEventList` will update the state.
+                        await this.syncApi.injectRoomEvents(this.room!, undefined, events);
+                    } else {
+                        await this.syncApi!.injectRoomEvents(this.room!, events); // Sliding Sync
+                    }
+                    events.forEach((event) => {
+                        this.emit(ClientEvent.Event, event);
+                        logger.info(`Backfilled event ${event.getId()} ${event.getType()} ${event.getStateKey()}`);
+                    });
+                }) ?? [],
+            );
+        }
+
         if (opts.clientWellKnownPollPeriod !== undefined) {
             this.clientWellKnownIntervalID = setInterval(() => {
                 this.fetchClientWellKnown();
             }, 1000 * opts.clientWellKnownPollPeriod);
             this.fetchClientWellKnown();
         }
-
-        await this.roomStateSynced;
         this.setSyncState(SyncState.Syncing);
         logger.info("Finished initial sync");
 
@@ -589,11 +621,24 @@ export class RoomWidgetClient extends MatrixClient {
             await this.updateTxId(event);
 
             if (this.syncApi instanceof SyncApi) {
-                await this.syncApi.injectRoomEvents(this.room!, undefined, [], [event]);
+                if (await this.supportUpdateState()) {
+                    await this.syncApi.injectRoomEvents(this.room!, undefined, [], [event]);
+                } else {
+                    // Passing undefined for `stateAfterEventList` will make `injectRoomEvents` run in legacy mode
+                    // -> state events in `timelineEventList` will update the state.
+                    await this.syncApi.injectRoomEvents(this.room!, [], undefined, [event]);
+                }
             } else {
                 // Sliding Sync
-                await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
+                if (await this.supportUpdateState()) {
+                    await this.syncApi!.injectRoomEvents(this.room!, [], [event]);
+                } else {
+                    logger.error(
+                        "slididng sync cannot be used in widget mode if the client widget driver does not support the version: 'org.matrix.msc2762_update_state'",
+                    );
+                }
             }
+
             this.emit(ClientEvent.Event, event);
             this.setSyncState(SyncState.Syncing);
             logger.info(`Received event ${event.getId()} ${event.getType()}`);
@@ -623,7 +668,11 @@ export class RoomWidgetClient extends MatrixClient {
 
     private onStateUpdate = async (ev: CustomEvent<IUpdateStateToWidgetActionRequest>): Promise<void> => {
         ev.preventDefault();
-
+        if (!(await this.supportUpdateState())) {
+            logger.warn(
+                "received update_state widget action but the widget driver did not claim to support 'org.matrix.msc2762_update_state'",
+            );
+        }
         for (const rawEvent of ev.detail.data.state) {
             // Verify the room ID matches, since it's possible for the client to
             // send us state updates from other rooms if this widget is always


### PR DESCRIPTION
I've revived the changes from https://github.com/matrix-org/matrix-js-sdk/pull/4662 that allow RoomWidgetClient to function even if the client into which it is embedded does not support the `update_state` action.

This seems useful for easing the transition outlined at https://github.com/element-hq/voip-internal/issues/289 with our upcoming Element Call release (for which we want to test some unrelated mobile changes, where mobile currently does not support `update_state`), so I propose we add this compatibility layer.