### PR TITLE
Remove `@matrix-org/olm` from dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@matrix-org/matrix-sdk-crypto-wasm": "^14.2.0",
-        "@matrix-org/olm": "3.2.15",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",
         "content-type": "^1.0.4",
@@ -81,6 +80,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-typescript": "^7.12.7",
         "@casualbot/jest-sonar-reporter": "2.2.7",
+        "@matrix-org/olm": "3.2.15",
         "@peculiar/webcrypto": "^1.4.5",
         "@stylistic/eslint-plugin": "^4.0.0",
         "@types/content-type": "^1.1.5",


### PR DESCRIPTION
Olm is needed at build time to run the tests, but is no longer needed at runtime.

Reverts https://github.com/matrix-org/matrix-js-sdk/commit/5568dfdd41f6e7fbb3e5d1d04c42016ed3c678a0