### PR TITLE
Allow customizing the IndexedDB database prefix used by Rust crypto.

### DIFF
--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -77,7 +77,7 @@ describe("MatrixClient.initRustCrypto", () => {
         // No databases.
         expect(await indexedDB.databases()).toHaveLength(0);
 
-        await matrixClient.initRustCrypto({ databasePrefix: "my-prefix" });
+        await matrixClient.initRustCrypto({ cryptoDatabasePrefix: "my-prefix" });
 
         // should have an indexed db now
         const databaseNames = (await indexedDB.databases()).map((db) => db.name);
@@ -503,11 +503,11 @@ describe("MatrixClient.clearStores", () => {
         // No databases.
         expect(await indexedDB.databases()).toHaveLength(0);
 
-        await matrixClient.initRustCrypto({ databasePrefix: "my-prefix" });
+        await matrixClient.initRustCrypto({ cryptoDatabasePrefix: "my-prefix" });
         expect(await indexedDB.databases()).toHaveLength(1);
         await matrixClient.stopClient();
 
-        await matrixClient.clearStores({ databasePrefix: "my-prefix" });
+        await matrixClient.clearStores({ cryptoDatabasePrefix: "my-prefix" });
         expect(await indexedDB.databases()).toHaveLength(0);
     });
 });

--- a/spec/integ/crypto/rust-crypto.spec.ts
+++ b/spec/integ/crypto/rust-crypto.spec.ts
@@ -67,6 +67,23 @@ describe("MatrixClient.initRustCrypto", () => {
         expect(databaseNames).toEqual(expect.arrayContaining(["matrix-js-sdk::matrix-sdk-crypto"]));
     });
 
+    it("should create the indexed db with a custom prefix", async () => {
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+        });
+
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
+        await matrixClient.initRustCrypto({ databasePrefix: "my-prefix" });
+
+        // should have an indexed db now
+        const databaseNames = (await indexedDB.databases()).map((db) => db.name);
+        expect(databaseNames).toEqual(expect.arrayContaining(["my-prefix::matrix-sdk-crypto"]));
+    });
+
     it("should create the meta db if given a storageKey", async () => {
         const matrixClient = createClient({
             baseUrl: "http://test.server",
@@ -474,5 +491,23 @@ describe("MatrixClient.clearStores", () => {
 
         await matrixClient.clearStores();
         // No error thrown in clearStores
+    });
+
+    it("should clear the indexeddbs with a custom prefix", async () => {
+        const matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+        });
+
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
+        await matrixClient.initRustCrypto({ databasePrefix: "my-prefix" });
+        expect(await indexedDB.databases()).toHaveLength(1);
+        await matrixClient.stopClient();
+
+        await matrixClient.clearStores({ databasePrefix: "my-prefix" });
+        expect(await indexedDB.databases()).toHaveLength(0);
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1527,9 +1527,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * Clear any data out of the persistent stores used by the client.
      *
+     * @param args.databasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
      * @returns Promise which resolves when the stores have been cleared.
      */
-    public clearStores(): Promise<void> {
+    public clearStores(
+        args: {
+            databasePrefix?: string;
+        } = {},
+    ): Promise<void> {
         if (this.clientRunning) {
             throw new Error("Cannot clear stores while client is running");
         }
@@ -1552,8 +1557,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 return;
             }
             for (const dbname of [
-                `${RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto`,
-                `${RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto-meta`,
+                `${args.databasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto`,
+                `${args.databasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto-meta`,
             ]) {
                 const prom = new Promise((resolve, reject) => {
                     this.logger.info(`Removing IndexedDB instance ${dbname}`);
@@ -1901,6 +1906,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * ensuring that only one `MatrixClient` issue is instantiated at a time.
      *
      * @param args.useIndexedDB - True to use an indexeddb store, false to use an in-memory store. Defaults to 'true'.
+     * @param args.databasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
+     *    Unused if useIndexedDB is 'false'.
      * @param args.storageKey - A key with which to encrypt the indexeddb store. If provided, it must be exactly
      *    32 bytes of data, and must be the same each time the client is initialised for a given device.
      *    If both this and `storagePassword` are unspecified, the store will be unencrypted.
@@ -1914,6 +1921,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public async initRustCrypto(
         args: {
             useIndexedDB?: boolean;
+            databasePrefix?: string;
             storageKey?: Uint8Array;
             storagePassword?: string;
         } = {},
@@ -1950,7 +1958,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             deviceId: deviceId,
             secretStorage: this.secretStorage,
             cryptoCallbacks: this.cryptoCallbacks,
-            storePrefix: args.useIndexedDB === false ? null : RUST_SDK_STORE_PREFIX,
+            storePrefix: args.useIndexedDB === false ? null : (args.databasePrefix ?? RUST_SDK_STORE_PREFIX),
             storeKey: args.storageKey,
             storePassphrase: args.storagePassword,
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1527,12 +1527,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * Clear any data out of the persistent stores used by the client.
      *
-     * @param args.databasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
+     * @param args.cryptoDatabasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
      * @returns Promise which resolves when the stores have been cleared.
      */
     public clearStores(
         args: {
-            databasePrefix?: string;
+            cryptoDatabasePrefix?: string;
         } = {},
     ): Promise<void> {
         if (this.clientRunning) {
@@ -1557,8 +1557,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 return;
             }
             for (const dbname of [
-                `${args.databasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto`,
-                `${args.databasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto-meta`,
+                `${args.cryptoDatabasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto`,
+                `${args.cryptoDatabasePrefix ?? RUST_SDK_STORE_PREFIX}::matrix-sdk-crypto-meta`,
             ]) {
                 const prom = new Promise((resolve, reject) => {
                     this.logger.info(`Removing IndexedDB instance ${dbname}`);
@@ -1906,7 +1906,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * ensuring that only one `MatrixClient` issue is instantiated at a time.
      *
      * @param args.useIndexedDB - True to use an indexeddb store, false to use an in-memory store. Defaults to 'true'.
-     * @param args.databasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
+     * @param args.cryptoDatabasePrefix - The database name to use for indexeddb, defaults to 'matrix-js-sdk'.
      *    Unused if useIndexedDB is 'false'.
      * @param args.storageKey - A key with which to encrypt the indexeddb store. If provided, it must be exactly
      *    32 bytes of data, and must be the same each time the client is initialised for a given device.
@@ -1921,7 +1921,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public async initRustCrypto(
         args: {
             useIndexedDB?: boolean;
-            databasePrefix?: string;
+            cryptoDatabasePrefix?: string;
             storageKey?: Uint8Array;
             storagePassword?: string;
         } = {},
@@ -1958,7 +1958,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             deviceId: deviceId,
             secretStorage: this.secretStorage,
             cryptoCallbacks: this.cryptoCallbacks,
-            storePrefix: args.useIndexedDB === false ? null : (args.databasePrefix ?? RUST_SDK_STORE_PREFIX),
+            storePrefix: args.useIndexedDB === false ? null : (args.cryptoDatabasePrefix ?? RUST_SDK_STORE_PREFIX),
             storeKey: args.storageKey,
             storePassphrase: args.storagePassword,
 


### PR DESCRIPTION
Related to #3974

I'm not 100% sure this makes sense, but I think it'll do what I want. (Which is having completely separate databases, but under the same principal/domain in IndexedDB.)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
