### PR TITLE
Update matrix-sdk-crypto-wasm to `15.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^14.2.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^15.0.0",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",
         "content-type": "^1.0.4",

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -35,7 +35,7 @@ import { type IHttpOpts, type MatrixHttpApi, Method } from "../http-api/index.ts
 import { RoomEncryptor } from "./RoomEncryptor.ts";
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { KeyClaimManager } from "./KeyClaimManager.ts";
-import { logDuration, MapWithDefault } from "../utils.ts";
+import { MapWithDefault } from "../utils.ts";
 import {
     type BackupTrustInfo,
     type BootstrapCrossSigningOpts,
@@ -1494,17 +1494,14 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         unusedFallbackKeys?: Set<string>;
         devices?: RustSdkCryptoJs.DeviceLists;
     }): Promise<IToDeviceEvent[]> {
-        const result = await logDuration(logger, "receiveSyncChanges", async () => {
-            return await this.olmMachine.receiveSyncChanges(
-                events ? JSON.stringify(events) : "[]",
-                devices,
-                oneTimeKeysCounts,
-                unusedFallbackKeys,
-            );
-        });
+        const result = await this.olmMachine.receiveSyncChanges(
+            events ? JSON.stringify(events) : "[]",
+            devices,
+            oneTimeKeysCounts,
+            unusedFallbackKeys,
+        );
 
-        // receiveSyncChanges returns a JSON-encoded list of decrypted to-device messages.
-        return JSON.parse(result);
+        return result.map((processed) => JSON.parse(processed.rawEvent));
     }
 
     /** called by the sync loop to preprocess incoming to-device messages

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,10 +1705,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^14.2.0":
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-14.2.1.tgz#f760b09cab7b48b0ad59332dd255756e1ee80eb4"
-  integrity sha512-HDCaAnIxz/3jJTB2EUYKFgVaI+auS0piIZxPDXHhk1Kn7yZWwKvVvCHkFqBJgBhZOAazbDU7MVArvrtn8QFkoQ==
+"@matrix-org/matrix-sdk-crypto-wasm@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-15.0.0.tgz#5b29ca1c62f3aface9db06d7441d0a9ba2cd3439"
+  integrity sha512-tzBGf/jugrOw190Na77LljZIQMTSL6SAnZaATKMlb2j1XOfc5Q+bSJTb9ZWBR7TFs0d8K9spcwRHPc4S/7CMYw==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"


### PR DESCRIPTION
For js-sdk users, this includes the following:

-   Send stable identifier `sender_device_keys` for MSC4147 (Including device keys with Olm-encrypted events).
    ([#4964](https://github.com/matrix-org/matrix-rust-sdk/pull/4964))

-   Check the `sender_device_keys` field on _all_ incoming Olm-encrypted to-device messages and ignore any to-device messages which include the field but whose data is invalid (as per [MSC4147](https://github.com/matrix-org/matrix-spec-proposals/pull/4147)).
    ([#4922](https://github.com/matrix-org/matrix-rust-sdk/pull/4922))

-   Fix bug which caused room keys to be unnecessarily rotated on every send in the presence of blacklisted/withheld devices in the room.
    ([#4954](https://github.com/matrix-org/matrix-rust-sdk/pull/4954))

-   Fix [matrix-rust-sdk#2729](https://github.com/matrix-org/matrix-rust-sdk/issues/2729) which in rare cases can cause room key oversharing.
    ([#4975](https://github.com/matrix-org/matrix-rust-sdk/pull/4975))