### PR TITLE
Specify typeroot

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
         "declaration": true,
         "strict": true,
         "allowImportingTsExtensions": true,
-        "lib": ["es2024"]
+        "lib": ["es2024"],
+        "baseUrl": ".",
+        "typeRoots": ["./node_modules/@types"]
     },
     "include": ["./src/**/*.ts", "./spec/**/*.ts"]
 }


### PR DESCRIPTION
This prevents tsc from picking up random types from parent directories such as in situations like an element-web layered build, and generally seems like good hygiene as we don't want to pick up random types from whatever directory we happen to be checked out into.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
