### PR TITLE
MatrixRTC: MembershipManager, add a request timeout to restartDelayedEvent

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -137,6 +137,15 @@ export interface MembershipConfig {
     callMemberEventRetryDelayMinimum?: number;
 
     /**
+     * The time (in milliseconds) after which a we consider a delayed event restart http request to have failed.
+     * Setting this to a lower value will result in more frequent retries but also a higher chance of failiour.
+     *
+     * the default local timeout in the js-sdk is 5 seconds.
+     * @default 5000
+     */
+    delayedEventRestartLocalTimeoutMs?: number;
+
+    /**
      * If true, use the new to-device transport for sending encryption keys.
      */
     useExperimentalToDeviceTransport?: boolean;

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -375,6 +375,9 @@ export class MembershipManager
         return this.joinConfig?.maximumNetworkErrorRetryCount ?? 10;
     }
 
+    private get delayedEventRestartLocalTimeoutMs(): number | undefined {
+        return this.joinConfig?.delayedEventRestartLocalTimeoutMs;
+    }
     // LOOP HANDLER:
     private async membershipLoopHandler(type: MembershipActionType): Promise<ActionUpdate> {
         switch (type) {
@@ -527,7 +530,7 @@ export class MembershipManager
 
     private async restartDelayedEvent(delayId: string): Promise<ActionUpdate> {
         const requestOptions: IRequestOpts = {
-            localTimeoutMs: this.joinConfig?.delayedEventRestartLocalTimeoutMs,
+            localTimeoutMs: this.delayedEventRestartLocalTimeoutMs,
             priority: "auto",
         };
         return await this.client

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -19,7 +19,7 @@ import { UpdateDelayedEventAction } from "../@types/requests.ts";
 import { type MatrixClient } from "../client.ts";
 import { UnsupportedDelayedEventsEndpointError } from "../errors.ts";
 import { ConnectionError, HTTPError, MatrixError } from "../http-api/errors.ts";
-import { IRequestOpts } from "../http-api/index.ts";
+import { type IRequestOpts } from "../http-api/index.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { type Room } from "../models/room.ts";
 import { type CallMembership, DEFAULT_EXPIRE_DURATION, type SessionMembershipData } from "./CallMembership.ts";

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -531,7 +531,6 @@ export class MembershipManager
     private async restartDelayedEvent(delayId: string): Promise<ActionUpdate> {
         const requestOptions: IRequestOpts = {
             localTimeoutMs: this.delayedEventRestartLocalTimeoutMs,
-            priority: "auto",
         };
         return await this.client
             ._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart, requestOptions)

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -526,7 +526,10 @@ export class MembershipManager
     }
 
     private async restartDelayedEvent(delayId: string): Promise<ActionUpdate> {
-        const requestOptions: IRequestOpts = { localTimeoutMs: 2300, priority: "auto" };
+        const requestOptions: IRequestOpts = {
+            localTimeoutMs: this.joinConfig?.delayedEventRestartLocalTimeoutMs,
+            priority: "auto",
+        };
         return await this.client
             ._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart, requestOptions)
             .then(() => {

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -526,7 +526,7 @@ export class MembershipManager
     }
 
     private async restartDelayedEvent(delayId: string): Promise<ActionUpdate> {
-        const requestOptions: IRequestOpts = { localTimeoutMs: 1500, priority: "auto" };
+        const requestOptions: IRequestOpts = { localTimeoutMs: 2300, priority: "auto" };
         return await this.client
             ._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart, requestOptions)
             .then(() => {

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -19,6 +19,7 @@ import { UpdateDelayedEventAction } from "../@types/requests.ts";
 import { type MatrixClient } from "../client.ts";
 import { UnsupportedDelayedEventsEndpointError } from "../errors.ts";
 import { ConnectionError, HTTPError, MatrixError } from "../http-api/errors.ts";
+import { IRequestOpts } from "../http-api/index.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { type Room } from "../models/room.ts";
 import { type CallMembership, DEFAULT_EXPIRE_DURATION, type SessionMembershipData } from "./CallMembership.ts";
@@ -525,8 +526,9 @@ export class MembershipManager
     }
 
     private async restartDelayedEvent(delayId: string): Promise<ActionUpdate> {
+        const requestOptions: IRequestOpts = { localTimeoutMs: 1500, priority: "auto" };
         return await this.client
-            ._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart)
+            ._unstable_updateDelayedEvent(delayId, UpdateDelayedEventAction.Restart, requestOptions)
             .then(() => {
                 this.resetRateLimitCounter(MembershipActionType.RestartDelayedEvent);
                 return createInsertActionUpdate(


### PR DESCRIPTION
This PR adds a rather short timeout for the http fetch request of a `restartDelayedEvent`. This is to address situations where packet loss might impact TCP connections and to improve the likelihood of getting a delayed event reset through in a given time constraint. 


## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
