### PR TITLE
Use the client logger in more places

### DIFF
--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -126,7 +126,7 @@ describe("SlidingSyncSdk", () => {
     // assign client/httpBackend globals
     const setupClient = async (testOpts?: Partial<IStoredClientOpts & { withCrypto: boolean }>) => {
         testOpts = testOpts || {};
-        const syncOpts: SyncApiOptions = {};
+        const syncOpts: SyncApiOptions = { logger };
         const testClient = new TestClient(selfUserId, "DEVICE", selfAccessToken);
         httpBackend = testClient.httpBackend;
         client = testClient.client;

--- a/spec/unit/ToDeviceMessageQueue.spec.ts
+++ b/spec/unit/ToDeviceMessageQueue.spec.ts
@@ -5,6 +5,7 @@ import { getMockClientWithEventEmitter } from "../test-utils/client";
 import { StubStore } from "../../src/store/stub";
 import { type IndexedToDeviceBatch } from "../../src/models/ToDeviceMessage";
 import { SyncState } from "../../src/sync";
+import { logger } from "../../src/logger.ts";
 
 describe("onResumedSync", () => {
     let batch: IndexedToDeviceBatch | null;
@@ -55,7 +56,7 @@ describe("onResumedSync", () => {
             }
         });
 
-        queue = new ToDeviceMessageQueue(mockClient);
+        queue = new ToDeviceMessageQueue(mockClient, logger);
     });
 
     it("resends queue after connectivity restored", async () => {

--- a/spec/unit/pushprocessor.spec.ts
+++ b/spec/unit/pushprocessor.spec.ts
@@ -28,6 +28,7 @@ import {
     TweakName,
 } from "../../src";
 import { mockClientMethodsUser } from "../test-utils/client";
+import { logger } from "../../src/logger.ts";
 
 const msc3914RoomCallRule: IPushRule = {
     rule_id: ".org.matrix.msc3914.rule.room.call",
@@ -209,7 +210,7 @@ describe("NotificationService", function () {
                 msgtype: "m.text",
             },
         });
-        matrixClient.pushRules = PushProcessor.rewriteDefaultRules(matrixClient.pushRules!);
+        matrixClient.pushRules = PushProcessor.rewriteDefaultRules(logger, matrixClient.pushRules!);
         pushProcessor = new PushProcessor(matrixClient);
     });
 
@@ -731,7 +732,7 @@ describe("Test PushProcessor.partsForDottedKey", function () {
 
 describe("rewriteDefaultRules", () => {
     it("should add default rules in the correct order", () => {
-        const pushRules = PushProcessor.rewriteDefaultRules({
+        const pushRules = PushProcessor.rewriteDefaultRules(logger, {
             device: {},
             global: {
                 content: [],
@@ -867,7 +868,7 @@ describe("rewriteDefaultRules", () => {
     });
 
     it("should add missing msc3914 rule in correct place", () => {
-        const pushRules = PushProcessor.rewriteDefaultRules({
+        const pushRules = PushProcessor.rewriteDefaultRules(logger, {
             device: {},
             global: {
                 // Sample push rules from a Synapse user.

--- a/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
+++ b/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
@@ -20,6 +20,7 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { CrossSigningIdentity } from "../../../src/rust-crypto/CrossSigningIdentity";
 import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { type ServerSideSecretStorage } from "../../../src/secret-storage";
+import { logger } from "../../../src/logger.ts";
 
 describe("CrossSigningIdentity", () => {
     describe("bootstrapCrossSigning", () => {
@@ -55,7 +56,7 @@ describe("CrossSigningIdentity", () => {
                 store: jest.fn(),
             } as unknown as Mocked<ServerSideSecretStorage>;
 
-            crossSigning = new CrossSigningIdentity(olmMachine, outgoingRequestProcessor, secretStorage);
+            crossSigning = new CrossSigningIdentity(logger, olmMachine, outgoingRequestProcessor, secretStorage);
         });
 
         it("should do nothing if keys are present on-device and in secret storage", async () => {

--- a/spec/unit/rust-crypto/KeyClaimManager.spec.ts
+++ b/spec/unit/rust-crypto/KeyClaimManager.spec.ts
@@ -53,7 +53,7 @@ describe("KeyClaimManager", () => {
             markRequestAsSent: jest.fn(),
         } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
-        const outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, httpApi);
+        const outgoingRequestProcessor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
 
         keyClaimManager = new KeyClaimManager(olmMachine, outgoingRequestProcessor);
     });

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -40,6 +40,7 @@ import {
     type UIAuthCallback,
 } from "../../../src";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+import { logger } from "../../../src/logger.ts";
 
 describe("OutgoingRequestProcessor", () => {
     /** the OutgoingRequestProcessor implementation under test */
@@ -76,7 +77,7 @@ describe("OutgoingRequestProcessor", () => {
             markRequestAsSent: jest.fn(),
         } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
-        processor = new OutgoingRequestProcessor(olmMachine, httpApi);
+        processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
     });
 
     /* simple requests that map directly to the request body */
@@ -293,7 +294,7 @@ describe("OutgoingRequestProcessor", () => {
                     return await authRequestResultResolvers.promise;
                 },
             } as unknown as Mocked<MatrixHttpApi<IHttpOpts & { onlyData: true }>>;
-            processor = new OutgoingRequestProcessor(olmMachine, mockHttpApi);
+            processor = new OutgoingRequestProcessor(logger, olmMachine, mockHttpApi);
         });
 
         // build a request
@@ -325,7 +326,7 @@ describe("OutgoingRequestProcessor", () => {
                 onlyData: true,
             });
 
-            processor = new OutgoingRequestProcessor(olmMachine, httpApi);
+            processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
         });
 
         afterEach(() => {

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -36,6 +36,7 @@ import {
     AllDevicesIsolationMode,
     OnlySignedDevicesIsolationMode,
 } from "../../../src/crypto-api";
+import { logger } from "../../../src/logger.ts";
 
 describe("RoomEncryptor", () => {
     describe("History Visibility", () => {
@@ -108,6 +109,7 @@ describe("RoomEncryptor", () => {
             } as unknown as Mocked<Room>;
 
             roomEncryptor = new RoomEncryptor(
+                logger,
                 mockOlmMachine,
                 mockKeyClaimManager,
                 mockOutgoingRequestManager,

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -8,6 +8,7 @@ import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/Outgoing
 import * as testData from "../../test-utils/test-data";
 import * as TestData from "../../test-utils/test-data";
 import { RustBackupManager, type KeyBackup } from "../../../src/rust-crypto/backup";
+import { logger } from "../../../src/logger.ts";
 
 describe("Upload keys to backup", () => {
     /** The backup manager under test */
@@ -63,7 +64,7 @@ describe("Upload keys to backup", () => {
             makeOutgoingRequest: jest.fn(),
         } as unknown as Mocked<OutgoingRequestProcessor>;
 
-        rustBackupManager = new RustBackupManager(mockOlmMachine, httpAPi, outgoingRequestProcessor);
+        rustBackupManager = new RustBackupManager(logger, mockOlmMachine, httpAPi, outgoingRequestProcessor);
 
         fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1362,7 +1362,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         // NB. We initialise MatrixRTC whether we have call support or not: this is just
         // the underlying session management and doesn't use any actual media capabilities
-        this.matrixRTC = new MatrixRTCSessionManager(this);
+        this.matrixRTC = new MatrixRTCSessionManager(this.logger, this);
 
         this.serverCapabilitiesService = new ServerCapabilities(this.logger, this.http);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -7325,7 +7325,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      */
     public setPushRules(rules: IPushRules): void {
         // Fix-up defaults, if applicable.
-        this.pushRules = PushProcessor.rewriteDefaultRules(rules, this.getUserId()!);
+        this.pushRules = PushProcessor.rewriteDefaultRules(this.logger, rules, this.getUserId()!);
         // Pre-calculate any necessary caches.
         this.pushProcessor.updateCachedPushRuleKeys(this.pushRules);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1503,6 +1503,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 }
                 return this.canResetTimelineCallback(roomId);
             },
+            logger: this.logger.getChild("sync"),
         };
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1364,7 +1364,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // the underlying session management and doesn't use any actual media capabilities
         this.matrixRTC = new MatrixRTCSessionManager(this);
 
-        this.serverCapabilitiesService = new ServerCapabilities(this.http);
+        this.serverCapabilitiesService = new ServerCapabilities(this.logger, this.http);
 
         this.on(ClientEvent.Sync, this.fixupRoomNotifications);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1386,7 +1386,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.roomNameGenerator = opts.roomNameGenerator;
 
-        this.toDeviceMessageQueue = new ToDeviceMessageQueue(this);
+        this.toDeviceMessageQueue = new ToDeviceMessageQueue(this, this.logger);
 
         // The SDK doesn't really provide a clean way for events to recalculate the push
         // actions for themselves, so we have to kinda help them out when they are encrypted.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -160,6 +160,9 @@ function getPrefixedLogger(prefix?: string): PrefixedLogger {
 /**
  * Drop-in replacement for `console` using {@link https://www.npmjs.com/package/loglevel|loglevel}.
  * Can be tailored down to specific use cases if needed.
+ *
+ * @deprecated avoid the use of this unless you are the constructor of `MatrixClient`: you should be using the logger
+ *    associated with `MatrixClient`.
  */
 export const logger = getPrefixedLogger() as LoggerWithLogMethod;
 

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger as rootLogger, type Logger } from "../logger.ts";
+import { type Logger } from "../logger.ts";
 import { type MatrixClient, ClientEvent } from "../client.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { type Room } from "../models/room.ts";
@@ -48,8 +48,12 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
     // longer the correct session object for the room.
     private roomSessions = new Map<string, MatrixRTCSession>();
 
-    private logger: Logger;
-    public constructor(private client: MatrixClient) {
+    private readonly logger: Logger;
+
+    public constructor(
+        rootLogger: Logger,
+        private client: MatrixClient,
+    ) {
         super();
         this.logger = rootLogger.getChild("[MatrixRTCSessionManager]");
     }

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -212,7 +212,7 @@ export class RoomEncryptor {
         // This could end up being racy (if two calls to ensureEncryptionSession happen at the same time), but that's
         // not a particular problem, since `OlmMachine.updateTrackedUsers` just adds any users that weren't already tracked.
         if (!this.lazyLoadedMembersResolved) {
-            await logDuration(this.prefixedLogger, "loadMembersIfNeeded: updateTrackedUsers", async () => {
+            await logDuration(logger, "loadMembersIfNeeded: updateTrackedUsers", async () => {
                 await this.olmMachine.updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId)));
             });
             logger.debug(`Updated tracked users`);
@@ -229,7 +229,7 @@ export class RoomEncryptor {
             // XXX future improvement process only KeysQueryRequests for the users that have never been queried.
             logger.debug(`Processing outgoing requests`);
 
-            await logDuration(this.prefixedLogger, "doProcessOutgoingRequests", async () => {
+            await logDuration(logger, "doProcessOutgoingRequests", async () => {
                 await this.outgoingRequestManager.doProcessOutgoingRequests();
             });
         } else {
@@ -250,7 +250,7 @@ export class RoomEncryptor {
 
         const userList = members.map((u) => new UserId(u.userId));
 
-        await logDuration(this.prefixedLogger, "ensureSessionsForUsers", async () => {
+        await logDuration(logger, "ensureSessionsForUsers", async () => {
             await this.keyClaimManager.ensureSessionsForUsers(logger, userList);
         });
 
@@ -289,7 +289,7 @@ export class RoomEncryptor {
                 break;
         }
 
-        await logDuration(this.prefixedLogger, "shareRoomKey", async () => {
+        await logDuration(logger, "shareRoomKey", async () => {
             const shareMessages: ToDeviceRequest[] = await this.olmMachine.shareRoomKey(
                 new RoomId(this.room.roomId),
                 // safe to pass without cloning, as it's not reused here (before or after)

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -155,6 +155,7 @@ async function initOlmMachine(
         new RustSdkCryptoJs.UserId(userId),
         new RustSdkCryptoJs.DeviceId(deviceId),
         storeHandle,
+        logger,
     );
 
     // A final migration step, now that we have an OlmMachine.

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { type IHttpOpts, type MatrixHttpApi, Method } from "./http-api/index.ts";
-import { logger } from "./logger.ts";
+import { type Logger } from "./logger.ts";
 
 // How often we update the server capabilities.
 // 6 hours - an arbitrary value, but they should change very infrequently.
@@ -78,7 +78,10 @@ export class ServerCapabilities {
     private retryTimeout?: ReturnType<typeof setTimeout>;
     private refreshTimeout?: ReturnType<typeof setInterval>;
 
-    public constructor(private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>) {}
+    public constructor(
+        private readonly logger: Logger,
+        private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+    ) {}
 
     /**
      * Starts periodically fetching the server capabilities.
@@ -117,12 +120,12 @@ export class ServerCapabilities {
             await this.fetchCapabilities();
             this.clearTimeouts();
             this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
-            logger.debug("Fetched new server capabilities");
+            this.logger.debug("Fetched new server capabilities");
         } catch (e) {
             this.clearTimeouts();
             const howLong = Math.floor(CAPABILITIES_RETRY_MS + Math.random() * 5000);
             this.retryTimeout = setTimeout(this.poll, howLong);
-            logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
+            this.logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
         }
     };
 


### PR DESCRIPTION
There is a `Logger` instance associated with each MatrixClient, which we should be using in preference to the global logger, to make it easier to debug systems where multiple clients are running, or where the application wants to use a `Logger` implementation other than `console.log`.

This PR goes through a number of places that are currently doing the wrong thing, and then marks the global logger as deprecated. There's more to be done here, but it's a significant improvement for simple usecases.