### PR TITLE
Use client logger in `MatrixRTCSessionManager`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1362,7 +1362,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         // NB. We initialise MatrixRTC whether we have call support or not: this is just
         // the underlying session management and doesn't use any actual media capabilities
-        this.matrixRTC = new MatrixRTCSessionManager(this);
+        this.matrixRTC = new MatrixRTCSessionManager(this.logger, this);
 
         this.serverCapabilitiesService = new ServerCapabilities(this.http);
 

--- a/src/matrixrtc/MatrixRTCSessionManager.ts
+++ b/src/matrixrtc/MatrixRTCSessionManager.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { logger as rootLogger, type Logger } from "../logger.ts";
+import { type Logger } from "../logger.ts";
 import { type MatrixClient, ClientEvent } from "../client.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { type Room } from "../models/room.ts";
@@ -48,8 +48,12 @@ export class MatrixRTCSessionManager extends TypedEventEmitter<MatrixRTCSessionM
     // longer the correct session object for the room.
     private roomSessions = new Map<string, MatrixRTCSession>();
 
-    private logger: Logger;
-    public constructor(private client: MatrixClient) {
+    private readonly logger: Logger;
+
+    public constructor(
+        rootLogger: Logger,
+        private client: MatrixClient,
+    ) {
         super();
         this.logger = rootLogger.getChild("[MatrixRTCSessionManager]");
     }


### PR DESCRIPTION
There is a `Logger` instance associated with each `MatrixClient`, which we should be using in preference to the global logger, to make it easier to debug systems where multiple clients are running, or where the application wants to use a Logger implementation other than `console.log`.

This PR is one of a series that fixes up parts of the code to use the right logger. This one affects VoIP code -- specifically `MatrixRTCSessionManager`.