### PR TITLE
Use client logger in more places (crypto code)

### DIFF
--- a/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
+++ b/spec/unit/rust-crypto/CrossSigningIdentity.spec.ts
@@ -20,6 +20,7 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 import { CrossSigningIdentity } from "../../../src/rust-crypto/CrossSigningIdentity";
 import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
 import { type ServerSideSecretStorage } from "../../../src/secret-storage";
+import { logger } from "../../../src/logger.ts";
 
 describe("CrossSigningIdentity", () => {
     describe("bootstrapCrossSigning", () => {
@@ -55,7 +56,7 @@ describe("CrossSigningIdentity", () => {
                 store: jest.fn(),
             } as unknown as Mocked<ServerSideSecretStorage>;
 
-            crossSigning = new CrossSigningIdentity(olmMachine, outgoingRequestProcessor, secretStorage);
+            crossSigning = new CrossSigningIdentity(logger, olmMachine, outgoingRequestProcessor, secretStorage);
         });
 
         it("should do nothing if keys are present on-device and in secret storage", async () => {

--- a/spec/unit/rust-crypto/KeyClaimManager.spec.ts
+++ b/spec/unit/rust-crypto/KeyClaimManager.spec.ts
@@ -53,7 +53,7 @@ describe("KeyClaimManager", () => {
             markRequestAsSent: jest.fn(),
         } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
-        const outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, httpApi);
+        const outgoingRequestProcessor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
 
         keyClaimManager = new KeyClaimManager(olmMachine, outgoingRequestProcessor);
     });

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -40,6 +40,7 @@ import {
     type UIAuthCallback,
 } from "../../../src";
 import { OutgoingRequestProcessor } from "../../../src/rust-crypto/OutgoingRequestProcessor";
+import { logger } from "../../../src/logger.ts";
 
 describe("OutgoingRequestProcessor", () => {
     /** the OutgoingRequestProcessor implementation under test */
@@ -76,7 +77,7 @@ describe("OutgoingRequestProcessor", () => {
             markRequestAsSent: jest.fn(),
         } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
 
-        processor = new OutgoingRequestProcessor(olmMachine, httpApi);
+        processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
     });
 
     /* simple requests that map directly to the request body */
@@ -293,7 +294,7 @@ describe("OutgoingRequestProcessor", () => {
                     return await authRequestResultResolvers.promise;
                 },
             } as unknown as Mocked<MatrixHttpApi<IHttpOpts & { onlyData: true }>>;
-            processor = new OutgoingRequestProcessor(olmMachine, mockHttpApi);
+            processor = new OutgoingRequestProcessor(logger, olmMachine, mockHttpApi);
         });
 
         // build a request
@@ -325,7 +326,7 @@ describe("OutgoingRequestProcessor", () => {
                 onlyData: true,
             });
 
-            processor = new OutgoingRequestProcessor(olmMachine, httpApi);
+            processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi);
         });
 
         afterEach(() => {

--- a/spec/unit/rust-crypto/RoomEncryptor.spec.ts
+++ b/spec/unit/rust-crypto/RoomEncryptor.spec.ts
@@ -36,6 +36,7 @@ import {
     AllDevicesIsolationMode,
     OnlySignedDevicesIsolationMode,
 } from "../../../src/crypto-api";
+import { logger } from "../../../src/logger.ts";
 
 describe("RoomEncryptor", () => {
     describe("History Visibility", () => {
@@ -108,6 +109,7 @@ describe("RoomEncryptor", () => {
             } as unknown as Mocked<Room>;
 
             roomEncryptor = new RoomEncryptor(
+                logger,
                 mockOlmMachine,
                 mockKeyClaimManager,
                 mockOutgoingRequestManager,

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -8,6 +8,7 @@ import { type OutgoingRequestProcessor } from "../../../src/rust-crypto/Outgoing
 import * as testData from "../../test-utils/test-data";
 import * as TestData from "../../test-utils/test-data";
 import { RustBackupManager, type KeyBackup } from "../../../src/rust-crypto/backup";
+import { logger } from "../../../src/logger.ts";
 
 describe("Upload keys to backup", () => {
     /** The backup manager under test */
@@ -63,7 +64,7 @@ describe("Upload keys to backup", () => {
             makeOutgoingRequest: jest.fn(),
         } as unknown as Mocked<OutgoingRequestProcessor>;
 
-        rustBackupManager = new RustBackupManager(mockOlmMachine, httpAPi, outgoingRequestProcessor);
+        rustBackupManager = new RustBackupManager(logger, mockOlmMachine, httpAPi, outgoingRequestProcessor);
 
         fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
     });

--- a/src/rust-crypto/RoomEncryptor.ts
+++ b/src/rust-crypto/RoomEncryptor.ts
@@ -212,7 +212,7 @@ export class RoomEncryptor {
         // This could end up being racy (if two calls to ensureEncryptionSession happen at the same time), but that's
         // not a particular problem, since `OlmMachine.updateTrackedUsers` just adds any users that weren't already tracked.
         if (!this.lazyLoadedMembersResolved) {
-            await logDuration(this.prefixedLogger, "loadMembersIfNeeded: updateTrackedUsers", async () => {
+            await logDuration(logger, "loadMembersIfNeeded: updateTrackedUsers", async () => {
                 await this.olmMachine.updateTrackedUsers(members.map((u) => new RustSdkCryptoJs.UserId(u.userId)));
             });
             logger.debug(`Updated tracked users`);
@@ -229,7 +229,7 @@ export class RoomEncryptor {
             // XXX future improvement process only KeysQueryRequests for the users that have never been queried.
             logger.debug(`Processing outgoing requests`);
 
-            await logDuration(this.prefixedLogger, "doProcessOutgoingRequests", async () => {
+            await logDuration(logger, "doProcessOutgoingRequests", async () => {
                 await this.outgoingRequestManager.doProcessOutgoingRequests();
             });
         } else {
@@ -250,7 +250,7 @@ export class RoomEncryptor {
 
         const userList = members.map((u) => new UserId(u.userId));
 
-        await logDuration(this.prefixedLogger, "ensureSessionsForUsers", async () => {
+        await logDuration(logger, "ensureSessionsForUsers", async () => {
             await this.keyClaimManager.ensureSessionsForUsers(logger, userList);
         });
 
@@ -289,7 +289,7 @@ export class RoomEncryptor {
                 break;
         }
 
-        await logDuration(this.prefixedLogger, "shareRoomKey", async () => {
+        await logDuration(logger, "shareRoomKey", async () => {
             const shareMessages: ToDeviceRequest[] = await this.olmMachine.shareRoomKey(
                 new RoomId(this.room.roomId),
                 // safe to pass without cloning, as it's not reused here (before or after)

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -163,7 +163,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         private readonly cryptoCallbacks: CryptoCallbacks,
     ) {
         super();
-        this.outgoingRequestProcessor = new OutgoingRequestProcessor(olmMachine, http);
+        this.outgoingRequestProcessor = new OutgoingRequestProcessor(logger, olmMachine, http);
         this.outgoingRequestsManager = new OutgoingRequestsManager(
             this.logger,
             olmMachine,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -172,7 +172,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
 
         this.keyClaimManager = new KeyClaimManager(olmMachine, this.outgoingRequestProcessor);
 
-        this.backupManager = new RustBackupManager(olmMachine, http, this.outgoingRequestProcessor);
+        this.backupManager = new RustBackupManager(logger, olmMachine, http, this.outgoingRequestProcessor);
         this.perSessionBackupDownloader = new PerSessionKeyBackupDownloader(
             this.logger,
             this.olmMachine,

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -206,7 +206,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             CryptoEvent.DehydratedDeviceRotationError,
         ]);
 
-        this.crossSigningIdentity = new CrossSigningIdentity(olmMachine, this.outgoingRequestProcessor, secretStorage);
+        this.crossSigningIdentity = new CrossSigningIdentity(
+            logger,
+            olmMachine,
+            this.outgoingRequestProcessor,
+            secretStorage,
+        );
 
         // Check and start in background the key backup connection
         this.checkKeyBackupAndEnable();

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1630,6 +1630,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             existingEncryptor.onCryptoEvent(config);
         } else {
             this.roomEncryptors[room.roomId] = new RoomEncryptor(
+                this.logger.getChild(`[${room.roomId} encryption]`),
                 this.olmMachine,
                 this.keyClaimManager,
                 this.outgoingRequestsManager,


### PR DESCRIPTION
There is a `Logger` instance associated with each `MatrixClient`, which we should be using in preference to the global logger, to make it easier to debug systems where multiple clients are running, or where the application wants to use a Logger implementation other than `console.log`.

This PR is one of a series that fixes up parts of the code to use the right logger. This one affects crypto code.

Suggest review commit-by-commit.