### PR TITLE
Fix more incorrect logger use

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2209,7 +2209,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     ): Promise<EmptyObject> {
         // If the sync loop is not running, fall back to setAccountDataRaw.
         if (!this.clientRunning) {
-            logger.warn(
+            this.logger.warn(
                 "Calling `setAccountData` before the client is started: `getAccountData` may return inconsistent results.",
             );
             return await retryNetworkOperation(5, () => this.setAccountDataRaw(eventType, content));

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -30,7 +30,7 @@ import {
     DecryptionError,
     type OnSyncCompletedData,
 } from "../common-crypto/CryptoBackend.ts";
-import { logger, type Logger, LogSpan } from "../logger.ts";
+import { type Logger, LogSpan } from "../logger.ts";
 import { type IHttpOpts, type MatrixHttpApi, Method } from "../http-api/index.ts";
 import { RoomEncryptor } from "./RoomEncryptor.ts";
 import { OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
@@ -826,18 +826,18 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     private async saveBackupKeyToStorage(): Promise<void> {
         const keyBackupInfo = await this.backupManager.getServerBackupInfo();
         if (!keyBackupInfo || !keyBackupInfo.version) {
-            logger.info("Not saving backup key to secret storage: no backup info");
+            this.logger.info("Not saving backup key to secret storage: no backup info");
             return;
         }
 
         const backupKeys: RustSdkCryptoJs.BackupKeys = await this.olmMachine.getBackupKeys();
         if (!backupKeys.decryptionKey) {
-            logger.info("Not saving backup key to secret storage: no backup key");
+            this.logger.info("Not saving backup key to secret storage: no backup key");
             return;
         }
 
         if (!decryptionKeyMatchesKeyBackupInfo(backupKeys.decryptionKey, keyBackupInfo)) {
-            logger.info("Not saving backup key to secret storage: decryption key does not match backup info");
+            this.logger.info("Not saving backup key to secret storage: decryption key does not match backup info");
             return;
         }
 
@@ -1262,7 +1262,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         if (info?.version) {
             await this.deleteKeyBackupVersion(info.version);
         } else {
-            logger.error("Can't delete key backup version: no version available");
+            this.logger.error("Can't delete key backup version: no version available");
         }
 
         // also turn off 4S, since this is also storing keys on the server.


### PR DESCRIPTION
A couple of places where we were still using the legacy logger

Followup to https://github.com/matrix-org/matrix-js-sdk/pull/4899 / https://github.com/matrix-org/matrix-js-sdk/pull/4900