### PR TITLE
Deprecate non-functional `IJoinRoomOpts.syncRoom`

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -28,9 +28,7 @@ import { type EventType, type RelationType, type RoomType } from "./event.ts";
 
 export interface IJoinRoomOpts {
     /**
-     * True to do a room initial sync on the resulting
-     * room. If false, the <strong>returned Room object will have no current state.
-     * </strong> Default: true.
+     * @deprecated does nothing
      */
     syncRoom?: boolean;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2369,10 +2369,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Rejects: with an error response.
      */
     public async joinRoom(roomIdOrAlias: string, opts: IJoinRoomOpts = {}): Promise<Room> {
-        if (opts.syncRoom === undefined) {
-            opts.syncRoom = true;
-        }
-
         const room = this.getRoom(roomIdOrAlias);
         if (room?.hasMembershipState(this.credentials.userId!, KnownMembership.Join)) return room;
 
@@ -2408,12 +2404,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (resolvedRoom?.hasMembershipState(this.credentials.userId!, KnownMembership.Join)) return resolvedRoom;
 
         const syncApi = new SyncApi(this, this.clientOpts, this.buildSyncApiOptions());
-        const syncRoom = syncApi.createRoom(roomId);
-        if (opts.syncRoom) {
-            // v2 will do this for us
-            // return syncApi.syncRoom(room);
-        }
-        return syncRoom;
+        return syncApi.createRoom(roomId);
     }
 
     /**


### PR DESCRIPTION
I don't know when this last did something, but it's been a while.