### PR TITLE
Remove deprecated `IJoinRoomOpts.syncRoom` option

### DIFF
--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -28,11 +28,6 @@ import { type EventType, type RelationType, type RoomType } from "./event.ts";
 
 export interface IJoinRoomOpts {
     /**
-     * @deprecated does nothing
-     */
-    syncRoom?: boolean;
-
-    /**
      * If the caller has a keypair 3pid invite, the signing URL is passed in this parameter.
      */
     inviteSignUrl?: string;


### PR DESCRIPTION
This option is non-functional, and was deprecated in https://github.com/matrix-org/matrix-js-sdk/pull/4913. Remove it altogether.

This PR targets the `vNext` branch, for inclusion in the next major release.