### PR TITLE
fetch api: add support for downloading raw response

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -131,6 +131,29 @@ describe("FetchHttpApi", () => {
         ).resolves.toBe(text);
     });
 
+    it("should return a blob if rawResponseBody is true", async () => {
+        const blob = new Blob(["blobby"]);
+        const fetchFn = jest.fn().mockResolvedValue({ ok: true, blob: jest.fn().mockResolvedValue(blob) });
+        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn, onlyData: true });
+        await expect(
+            api.requestOtherUrl(Method.Get, "http://url", undefined, {
+                rawResponseBody: true,
+            }),
+        ).resolves.toBe(blob);
+    });
+
+    it("should throw an error if both `json` and `rawResponseBody` are defined", async () => {
+        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {
+            baseUrl,
+            prefix,
+            fetchFn: jest.fn(),
+            onlyData: true,
+        });
+        await expect(
+            api.requestOtherUrl(Method.Get, "http://url", undefined, { rawResponseBody: false, json: true }),
+        ).rejects.toThrow("Invalid call to `FetchHttpApi`");
+    });
+
     it("should send token via query params if useAuthorizationHeader=false", async () => {
         const fetchFn = jest.fn().mockResolvedValue({ ok: true });
         const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -23,6 +23,7 @@ import { type TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { Method } from "./method.ts";
 import { ConnectionError, MatrixError, TokenRefreshError } from "./errors.ts";
 import {
+    type BaseRequestOpts,
     HttpApiEvent,
     type HttpApiEventHandlerMap,
     type IHttpOpts,
@@ -263,7 +264,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         method: Method,
         url: URL | string,
         body?: Body,
-        opts: Pick<IRequestOpts, "headers" | "json" | "localTimeoutMs" | "keepAlive" | "abortSignal" | "priority"> = {},
+        opts: BaseRequestOpts = {},
     ): Promise<ResponseType<T, O>> {
         const urlForLogs = this.sanitizeUrlForLogs(url);
         this.opts.logger?.debug(`FetchHttpApi: --> ${method} ${urlForLogs}`);

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -276,7 +276,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
 
         const headers = Object.assign({}, opts.headers || {});
 
-        const jsonResponse = opts.json !== false;
+        const jsonResponse = !opts.rawResponseBody && opts.json !== false;
         if (jsonResponse) {
             if (!headers["Accept"]) {
                 headers["Accept"] = "application/json";

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -47,6 +47,8 @@ export type AccessTokens = {
  * Can be passed to HttpApi instance as {@link IHttpOpts.tokenRefreshFunction} during client creation {@link ICreateClientOpts}
  */
 export type TokenRefreshFunction = (refreshToken: string) => Promise<AccessTokens>;
+
+/** Options object for `FetchHttpApi` and {@link MatrixHttpApi}. */
 export interface IHttpOpts {
     fetchFn?: typeof globalThis.fetch;
 
@@ -67,7 +69,12 @@ export interface IHttpOpts {
     tokenRefreshFunction?: TokenRefreshFunction;
     useAuthorizationHeader?: boolean; // defaults to true
 
+    /**
+     * Normally, methods in `FetchHttpApi` will return a {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Response} object.
+     * If this is set to `true`, they instead return the response body.
+     */
     onlyData?: boolean;
+
     localTimeoutMs?: number;
 
     /** Optional logger instance. If provided, requests and responses will be logged. */
@@ -87,7 +94,36 @@ export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
      */
     localTimeoutMs?: number;
     keepAlive?: boolean; // defaults to false
-    json?: boolean; // defaults to true
+
+    /**
+     * By default, we will:
+     *
+     *  *  If the `body` is an object, we will JSON-encode it and set `Content-Type: application/json` in the
+     *     request headers (again, unless overridden by {@link headers}).
+     *
+     *  * Set `Accept: application/json` in the request headers (unless overridden by {@link headers}).
+     *
+     *  * If `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, parse the response as
+     *    JSON and return the parsed response.
+     *
+     * Setting this to `false` overrides inhibits all three behaviors, and the response is instead parsed as a UTF-8
+     * string. It defaults to `true`, unless {@link rawResponseBody} is set.
+     *
+     * @deprecated Instead of setting this to `false`, set {@link rawResponseBody} to `true`.
+     */
+    json?: boolean;
+
+    /**
+     * By default, we will:
+     *
+     *  * Set `Accept: application/json` in the request headers (unless overridden by {@link headers}).
+     *
+     *  * If `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, parse the response as
+     *    JSON and return the parsed response.
+     *
+     * Setting this to `true` overrides inhibits this behavior, and the raw response is returned as a {@link https://developer.mozilla.org/en-US/docs/Web/API/Blob|Blob}.
+     */
+    rawResponseBody?: boolean;
 }
 
 export interface IRequestOpts extends BaseRequestOpts {

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -99,29 +99,28 @@ export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
      * By default, we will:
      *
      *  *  If the `body` is an object, we will JSON-encode it and set `Content-Type: application/json` in the
-     *     request headers (again, unless overridden by {@link headers}).
+     *     request headers (unless overridden by {@link headers}).
      *
-     *  * Set `Accept: application/json` in the request headers (unless overridden by {@link headers}).
+     *  * Set `Accept: application/json` in the request headers (again, unless overridden by {@link headers}).
      *
      *  * If `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, parse the response as
      *    JSON and return the parsed response.
      *
-     * Setting this to `false` overrides inhibits all three behaviors, and the response is instead parsed as a UTF-8
-     * string. It defaults to `true`, unless {@link rawResponseBody} is set.
+     * Setting this to `false` inhibits all three behaviors, and (if `IHTTPOpts.onlyData` is set to `true`) the response
+     * is instead parsed as a UTF-8 string. It defaults to `true`, unless {@link rawResponseBody} is set.
      *
      * @deprecated Instead of setting this to `false`, set {@link rawResponseBody} to `true`.
      */
     json?: boolean;
 
     /**
-     * By default, we will:
+     * Setting this to `true` does two things:
      *
-     *  * Set `Accept: application/json` in the request headers (unless overridden by {@link headers}).
+     *  * Inhibits the automatic addition of `Accept: application/json` in the request headers.
      *
-     *  * If `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, parse the response as
-     *    JSON and return the parsed response.
-     *
-     * Setting this to `true` overrides inhibits this behavior, and the raw response is returned as a {@link https://developer.mozilla.org/en-US/docs/Web/API/Blob|Blob}.
+     *  * Assuming `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, causes the
+     *    raw response to be returned as a {@link https://developer.mozilla.org/en-US/docs/Web/API/Blob|Blob}
+     *    instead of parsing it as `json`.
      */
     rawResponseBody?: boolean;
 }

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -70,7 +70,7 @@ export interface IHttpOpts {
     useAuthorizationHeader?: boolean; // defaults to true
 
     /**
-     * Normally, methods in `FetchHttpApi` will return a {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Response} object.
+     * Normally, methods in `FetchHttpApi` will return a {@link https://developer.mozilla.org/en-US/docs/Web/API/Response Response} object.
      * If this is set to `true`, they instead return the response body.
      */
     onlyData?: boolean;
@@ -98,7 +98,7 @@ export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
     /**
      * By default, we will:
      *
-     *  *  If the `body` is an object, we will JSON-encode it and set `Content-Type: application/json` in the
+     *  *  If the `body` is an object, JSON-encode it and set `Content-Type: application/json` in the
      *     request headers (unless overridden by {@link headers}).
      *
      *  * Set `Accept: application/json` in the request headers (again, unless overridden by {@link headers}).

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -74,17 +74,8 @@ export interface IHttpOpts {
     logger?: Logger;
 }
 
-export interface IRequestOpts extends Pick<RequestInit, "priority"> {
-    /**
-     * The alternative base url to use.
-     * If not specified, uses this.opts.baseUrl
-     */
-    baseUrl?: string;
-    /**
-     * The full prefix to use e.g.
-     * "/_matrix/client/v2_alpha". If not specified, uses this.opts.prefix.
-     */
-    prefix?: string;
+/** Options object for `FetchHttpApi.requestOtherUrl`. */
+export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
     /**
      * map of additional request headers
      */
@@ -97,6 +88,19 @@ export interface IRequestOpts extends Pick<RequestInit, "priority"> {
     localTimeoutMs?: number;
     keepAlive?: boolean; // defaults to false
     json?: boolean; // defaults to true
+}
+
+export interface IRequestOpts extends BaseRequestOpts {
+    /**
+     * The alternative base url to use.
+     * If not specified, uses this.opts.baseUrl
+     */
+    baseUrl?: string;
+    /**
+     * The full prefix to use e.g.
+     * "/_matrix/client/v2_alpha". If not specified, uses this.opts.prefix.
+     */
+    prefix?: string;
 
     // Set to true to prevent the request function from emitting a Session.logged_out event.
     // This is intended for use on endpoints where M_UNKNOWN_TOKEN is a valid/notable error response,


### PR DESCRIPTION
I need to make an authenticated request to the media repo, and expect to get a binary file back. AFAICT there is no easy way to do that right now.