### PR TITLE
Use the logger associated with MatrixClient in rust sdk

### DIFF
--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -130,8 +130,8 @@ describe("initRustCrypto", () => {
             storePassphrase: "storePassphrase",
         });
 
-        expect(StoreHandle.open).toHaveBeenCalledWith("storePrefix", "storePassphrase");
-        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
+        expect(StoreHandle.open).toHaveBeenCalledWith("storePrefix", "storePassphrase", logger);
+        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore, logger);
     });
 
     it("passes through the store params (key)", async () => {
@@ -154,8 +154,8 @@ describe("initRustCrypto", () => {
             storeKey: storeKey,
         });
 
-        expect(StoreHandle.openWithKey).toHaveBeenCalledWith("storePrefix", storeKey);
-        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
+        expect(StoreHandle.openWithKey).toHaveBeenCalledWith("storePrefix", storeKey, logger);
+        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore, logger);
     });
 
     it("suppresses the storePassphrase and storeKey if storePrefix is unset", async () => {
@@ -178,8 +178,8 @@ describe("initRustCrypto", () => {
             storePassphrase: "storePassphrase",
         });
 
-        expect(StoreHandle.open).toHaveBeenCalledWith();
-        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore);
+        expect(StoreHandle.open).toHaveBeenCalledWith(null, null, logger);
+        expect(OlmMachine.initFromStore).toHaveBeenCalledWith(expect.anything(), expect.anything(), mockStore, logger);
     });
 
     it("Should get secrets from inbox on start", async () => {
@@ -278,6 +278,7 @@ describe("initRustCrypto", () => {
                 expect.any(BaseMigrationData),
                 new Uint8Array(Buffer.from(PICKLE_KEY)),
                 mockStore,
+                logger,
             );
             const data = mocked(Migration.migrateBaseData).mock.calls[0][0];
             expect(data.pickledAccount).toEqual("not a real account");
@@ -294,6 +295,7 @@ describe("initRustCrypto", () => {
                 expect.any(Array),
                 new Uint8Array(Buffer.from(PICKLE_KEY)),
                 mockStore,
+                logger,
             );
             // First call should have 50 entries; second should have 10
             const sessions1: PickledSession[] = mocked(Migration.migrateOlmSessions).mock.calls[0][0];
@@ -316,6 +318,7 @@ describe("initRustCrypto", () => {
                 expect.any(Array),
                 new Uint8Array(Buffer.from(PICKLE_KEY)),
                 mockStore,
+                logger,
             );
             // First call should have 50 entries; second should have 10
             const megolmSessions1: PickledInboundGroupSession[] = mocked(Migration.migrateMegolmSessions).mock
@@ -424,6 +427,7 @@ describe("initRustCrypto", () => {
                 expect.any(Array),
                 new Uint8Array(Buffer.from(PICKLE_KEY)),
                 mockStore,
+                logger,
             );
             const megolmSessions: PickledInboundGroupSession[] = mocked(Migration.migrateMegolmSessions).mock
                 .calls[0][0];

--- a/src/rust-crypto/index.ts
+++ b/src/rust-crypto/index.ts
@@ -98,19 +98,16 @@ export async function initRustCrypto(args: {
     logger.debug("Initialising Rust crypto-sdk WASM artifact");
     await RustSdkCryptoJs.initAsync();
 
-    // enable tracing in the rust-sdk
-    new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
-
     logger.debug("Opening Rust CryptoStore");
     let storeHandle;
     if (args.storePrefix) {
         if (args.storeKey) {
-            storeHandle = await StoreHandle.openWithKey(args.storePrefix, args.storeKey);
+            storeHandle = await StoreHandle.openWithKey(args.storePrefix, args.storeKey, logger);
         } else {
-            storeHandle = await StoreHandle.open(args.storePrefix, args.storePassphrase);
+            storeHandle = await StoreHandle.open(args.storePrefix, args.storePassphrase, logger);
         }
     } else {
-        storeHandle = await StoreHandle.open();
+        storeHandle = await StoreHandle.open(null, null, logger);
     }
 
     if (args.legacyCryptoStore) {
@@ -155,6 +152,7 @@ async function initOlmMachine(
         new RustSdkCryptoJs.UserId(userId),
         new RustSdkCryptoJs.DeviceId(deviceId),
         storeHandle,
+        logger,
     );
 
     // A final migration step, now that we have an OlmMachine.

--- a/src/rust-crypto/libolm_migration.ts
+++ b/src/rust-crypto/libolm_migration.ts
@@ -80,9 +80,6 @@ export async function migrateFromLegacyCrypto(args: {
     // initialise the rust matrix-sdk-crypto-wasm, if it hasn't already been done
     await RustSdkCryptoJs.initAsync();
 
-    // enable tracing in the rust-sdk
-    new RustSdkCryptoJs.Tracing(RustSdkCryptoJs.LoggerLevel.Debug).turnOn();
-
     if (!(await legacyStore.containsData())) {
         // This store was never used. Nothing to migrate.
         return;
@@ -230,7 +227,7 @@ async function migrateBaseData(
         pickleKey,
         "user_signing",
     );
-    await RustSdkCryptoJs.Migration.migrateBaseData(migrationData, pickleKey, storeHandle);
+    await RustSdkCryptoJs.Migration.migrateBaseData(migrationData, pickleKey, storeHandle, logger);
 }
 
 async function countOlmSessions(logger: Logger, legacyStore: CryptoStore): Promise<number> {
@@ -269,7 +266,7 @@ async function migrateOlmSessions(
             migrationData.push(pickledSession);
         }
 
-        await RustSdkCryptoJs.Migration.migrateOlmSessions(migrationData, pickleKey, storeHandle);
+        await RustSdkCryptoJs.Migration.migrateOlmSessions(migrationData, pickleKey, storeHandle, logger);
         await legacyStore.deleteEndToEndSessionsBatch(batch);
         onBatchDone(batch.length);
     }
@@ -343,7 +340,7 @@ async function migrateMegolmSessions(
             migrationData.push(pickledSession);
         }
 
-        await RustSdkCryptoJs.Migration.migrateMegolmSessions(migrationData, pickleKey, storeHandle);
+        await RustSdkCryptoJs.Migration.migrateMegolmSessions(migrationData, pickleKey, storeHandle, logger);
         await legacyStore.deleteEndToEndInboundGroupSessionsBatch(batch);
         onBatchDone(batch.length);
     }


### PR DESCRIPTION
Currently, all the logging from the rust crypto sdk goes to `console`, regardless of whether a logger as passed to the MatrixClient. This fixes that problem.