### PR TITLE
Custom abort timeout logic for restarting delayed events that is compatible with the widget api

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -79,7 +79,7 @@ export interface SessionConfig {
 // - we use delayedLeaveEvent if the option is related to the delayed leave event.
 // - we use membershipEvent if the option is related to the rtc member state event.
 // - we use the technical term expiry if the option is related to the expiry field of the membership state event.
-// - we use a `MS` postfix if the option is a duration to avoid using words like:
+// - we use a `Ms` postfix if the option is a duration to avoid using words like:
 //   `time`, `duration`, `delay`, `timeout`... that might be mistaken/confused with technical terms.
 export interface MembershipConfig {
     /**
@@ -143,6 +143,7 @@ export interface MembershipConfig {
      * failed to send due to a network error. (send membership event, send delayed event, restart delayed event...)
      */
     networkErrorRetryMs?: number;
+
     /** @deprecated renamed to `networkErrorRetryMs`*/
     callMemberEventRetryDelayMinimum?: number;
 
@@ -150,6 +151,13 @@ export interface MembershipConfig {
      * If true, use the new to-device transport for sending encryption keys.
      */
     useExperimentalToDeviceTransport?: boolean;
+    /**
+     * In the presence of network packet loss (hurting TCP connections), the custom delayedEventRestartLocalTimeoutMs
+     * helps by keeping more delayed event reset candidates in flight,
+     * improving the chances of a successful reset. (its is equivalent to the js-sdk `localTimeout` configuration,
+     * but only applies to calls to the `_unstable_updateDelayedEvent` endpoint with a body of `{action:"restart"}`.)
+     */
+    delayedLeaveEventRestartLocalTimeoutMs?: number;
 }
 
 export interface EncryptionConfig {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -151,7 +151,11 @@ export interface MembershipConfig {
      * If true, use the new to-device transport for sending encryption keys.
      */
     useExperimentalToDeviceTransport?: boolean;
+
     /**
+     * The time (in milliseconds) after which a we consider a delayed event restart http request to have failed.
+     * Setting this to a lower value will result in more frequent retries but also a higher chance of failiour.
+     *
      * In the presence of network packet loss (hurting TCP connections), the custom delayedEventRestartLocalTimeoutMs
      * helps by keeping more delayed event reset candidates in flight,
      * improving the chances of a successful reset. (its is equivalent to the js-sdk `localTimeout` configuration,

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -570,7 +570,13 @@ export class MembershipManager
                 // Since restarting the delayed event is a "send and forget" kind of operation, it is acceptable that this might result in
                 // unhandled errors in the case of a timeout.
                 if (e === TIMEOUT_ERROR) {
-                    return createInsertActionUpdate(MembershipActionType.RestartDelayedEvent);
+                    // retry boundary
+                    const retries = this.state.networkErrorRetries.get(MembershipActionType.RestartDelayedEvent) ?? 0;
+
+                    if (retries < this.maximumNetworkErrorRetryCount) {
+                        this.state.networkErrorRetries.set(MembershipActionType.RestartDelayedEvent, retries + 1);
+                        return createInsertActionUpdate(MembershipActionType.RestartDelayedEvent);
+                    }
                 }
                 const repeatActionType = MembershipActionType.RestartDelayedEvent;
                 if (this.isNotFoundError(e)) {


### PR DESCRIPTION
This adds a `race` so that restart delayed events can be timed out before the js-sdk local timeout happens.

This has to be done this way because the local timeout cannot be passed to the widget driver via the widget api for a specific request.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
