### PR TITLE
Support for creator power level

### DIFF
--- a/spec/unit/room-member.spec.ts
+++ b/spec/unit/room-member.spec.ts
@@ -132,6 +132,24 @@ describe("RoomMember", function () {
             expect(memberB.powerLevel).toEqual(200);
         });
 
+        it("should set 'powerLevel' with a v12 room.", function () {
+            const powerLevelvent = utils.mkEvent({
+                type: "m.room.power_levels",
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        "@bertha:bar": 200,
+                        "@invalid:user": 10, // shouldn't barf on this.
+                    },
+                },
+                event: true,
+            });
+            member.setPowerLevelEvent(powerLevelvent, createEvent, "12");
+            expect(member.powerLevel).toEqual(Infinity);
+        });
+
         it("should emit 'RoomMember.powerLevel' if the power level changes.", function () {
             const powerLevelvent = utils.mkEvent({
                 type: "m.room.power_levels",

--- a/spec/unit/room-member.spec.ts
+++ b/spec/unit/room-member.spec.ts
@@ -20,8 +20,7 @@ import * as utils from "../test-utils/test-utils";
 import { RoomMember, RoomMemberEvent } from "../../src/models/room-member";
 import {
     createClient,
-    EventType,
-    MatrixClient,
+    type MatrixClient,
     MatrixEvent,
     type RoomState,
     UNSTABLE_MSC2666_MUTUAL_ROOMS,
@@ -103,14 +102,6 @@ describe("RoomMember", function () {
     });
 
     describe("setPowerLevel", function () {
-        const createEvent = utils.mkEvent({
-            type: "m.room.create",
-            room: roomId,
-            sender: userA,
-            content: {},
-            event: true,
-        });
-
         it("should set 'powerLevel'.", function () {
             member.setPowerLevel(0, new MatrixEvent());
             expect(member.powerLevel).toEqual(0);

--- a/spec/unit/room-state.spec.ts
+++ b/spec/unit/room-state.spec.ts
@@ -20,6 +20,7 @@ import * as utils from "../test-utils/test-utils";
 import { makeBeaconEvent, makeBeaconInfoEvent } from "../test-utils/beacon";
 import { filterEmitCallsByEventType } from "../test-utils/emitter";
 import { RoomState, RoomStateEvent } from "../../src/models/room-state";
+import { RoomMemberEvent } from "../../src/models/room-member";
 import { type Beacon, BeaconEvent, getBeaconInfoIdentifier } from "../../src/models/beacon";
 import { EventType, RelationType, UNSTABLE_MSC2716_MARKER } from "../../src/@types/event";
 import { MatrixEvent, MatrixEventEvent } from "../../src/models/event";
@@ -259,7 +260,7 @@ describe("RoomState", function () {
             expect(emitCount).toEqual(2);
         });
 
-        it("should call setPowerLevelEvent on each RoomMember for m.room.power_levels", function () {
+        it("should call setPowerLevel on each RoomMember for m.room.power_levels", function () {
             const powerLevelEvent = utils.mkEvent({
                 type: "m.room.power_levels",
                 room: roomId,
@@ -273,20 +274,12 @@ describe("RoomState", function () {
             });
 
             // spy on the room members
-            jest.spyOn(state.members[userA], "setPowerLevelEvent");
-            jest.spyOn(state.members[userB], "setPowerLevelEvent");
+            jest.spyOn(state.members[userA], "setPowerLevel");
+            jest.spyOn(state.members[userB], "setPowerLevel");
             state.setStateEvents([powerLevelEvent]);
 
-            expect(state.members[userA].setPowerLevelEvent).toHaveBeenCalledWith(
-                powerLevelEvent,
-                state.getStateEvents(EventType.RoomCreate, ""),
-                "1",
-            );
-            expect(state.members[userB].setPowerLevelEvent).toHaveBeenCalledWith(
-                powerLevelEvent,
-                state.getStateEvents(EventType.RoomCreate, ""),
-                "1",
-            );
+            expect(state.members[userA].setPowerLevel).toHaveBeenCalledWith(10, powerLevelEvent);
+            expect(state.members[userB].setPowerLevel).toHaveBeenCalledWith(10, powerLevelEvent);
         });
 
         it("should call setPowerLevelEvent on a new RoomMember if power levels exist", function () {
@@ -316,6 +309,156 @@ describe("RoomState", function () {
             // so we can't inject a mock :/ so we have to infer.
             expect(state.members[userC]).toBeTruthy();
             expect(state.members[userC].powerLevel).toEqual(10);
+        });
+
+        it("should calculate power level correctly", function () {
+            const powerLevelEvent = utils.mkEvent({
+                type: "m.room.power_levels",
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        [userB]: 200,
+                        "@invalid:user": 10, // shouldn't barf on this.
+                    },
+                },
+                event: true,
+            });
+            state.setStateEvents([powerLevelEvent]);
+
+            expect(state.getMember(userA)?.powerLevel).toEqual(20);
+            expect(state.getMember(userB)?.powerLevel).toEqual(200);
+        });
+
+        it("should set 'powerLevel' with a v12 room.", function () {
+            const createEventV12 = utils.mkEvent({
+                type: "m.room.create",
+                room: roomId,
+                sender: userA,
+                content: { room_version: "12" },
+                event: true,
+            });
+            const powerLevelEvent = utils.mkEvent({
+                type: "m.room.power_levels",
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        [userB]: 200,
+                        "@invalid:user": 10, // shouldn't barf on this.
+                    },
+                },
+                event: true,
+            });
+            state.setStateEvents([createEventV12, powerLevelEvent]);
+            expect(state.getMember(userA)?.powerLevel).toEqual(Infinity);
+        });
+
+        it("should honour power levels of zero.", function () {
+            const powerLevelEvent = utils.mkEvent({
+                type: "m.room.power_levels",
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        "@alice:bar": 0,
+                    },
+                },
+                event: true,
+            });
+            let emitCount = 0;
+
+            const memberA = state.getMember(userA)!;
+            // set the power level to something other than zero or we
+            // won't get an event
+            memberA.powerLevel = 1;
+            memberA.on(RoomMemberEvent.PowerLevel, function (emitEvent, emitMember) {
+                emitCount += 1;
+                expect(emitMember.userId).toEqual("@alice:bar");
+                expect(emitMember.powerLevel).toEqual(0);
+                expect(emitEvent).toEqual(powerLevelEvent);
+            });
+
+            state.setStateEvents([powerLevelEvent]);
+            expect(memberA.powerLevel).toEqual(0);
+            expect(emitCount).toEqual(1);
+        });
+
+        it("should not honor string power levels.", function () {
+            const powerLevelEvent = utils.mkEvent({
+                type: "m.room.power_levels",
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        "@alice:bar": "5",
+                    },
+                },
+                event: true,
+            });
+            let emitCount = 0;
+
+            const memberA = state.getMember(userA)!;
+            memberA.on(RoomMemberEvent.PowerLevel, function (emitEvent, emitMember) {
+                emitCount += 1;
+                expect(emitMember.userId).toEqual("@alice:bar");
+                expect(emitMember.powerLevel).toEqual(20);
+                expect(emitEvent).toEqual(powerLevelEvent);
+            });
+
+            state.setStateEvents([powerLevelEvent]);
+            expect(memberA.powerLevel).toEqual(20);
+            expect(emitCount).toEqual(1);
+        });
+
+        it("should no-op if given a non-state or unrelated event", () => {
+            const memberA = state.getMember(userA)!;
+            const fn = jest.spyOn(memberA, "emit");
+            expect(fn).not.toHaveBeenCalledWith(RoomMemberEvent.PowerLevel);
+
+            const powerLevelEvent = utils.mkEvent({
+                type: EventType.RoomPowerLevels,
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        "@alice:bar": "5",
+                    },
+                },
+                skey: "invalid",
+                event: true,
+            });
+
+            state.setStateEvents([powerLevelEvent]);
+            const nonStateEv = utils.mkEvent({
+                type: EventType.RoomPowerLevels,
+                room: roomId,
+                user: userA,
+                content: {
+                    users_default: 20,
+                    users: {
+                        "@alice:bar": "5",
+                    },
+                },
+                event: true,
+            });
+            delete nonStateEv.event.state_key;
+            state.setStateEvents([nonStateEv]);
+            state.setStateEvents([
+                utils.mkEvent({
+                    type: EventType.Sticker,
+                    room: roomId,
+                    user: userA,
+                    content: {},
+                    event: true,
+                }),
+            ]);
+            expect(fn).not.toHaveBeenCalledWith(RoomMemberEvent.PowerLevel);
         });
 
         it("should call setMembershipEvent on the right RoomMember", function () {

--- a/spec/unit/room-state.spec.ts
+++ b/spec/unit/room-state.spec.ts
@@ -277,8 +277,16 @@ describe("RoomState", function () {
             jest.spyOn(state.members[userB], "setPowerLevelEvent");
             state.setStateEvents([powerLevelEvent]);
 
-            expect(state.members[userA].setPowerLevelEvent).toHaveBeenCalledWith(powerLevelEvent);
-            expect(state.members[userB].setPowerLevelEvent).toHaveBeenCalledWith(powerLevelEvent);
+            expect(state.members[userA].setPowerLevelEvent).toHaveBeenCalledWith(
+                powerLevelEvent,
+                state.getStateEvents(EventType.RoomCreate, ""),
+                "1",
+            );
+            expect(state.members[userB].setPowerLevelEvent).toHaveBeenCalledWith(
+                powerLevelEvent,
+                state.getStateEvents(EventType.RoomCreate, ""),
+                "1",
+            );
         });
 
         it("should call setPowerLevelEvent on a new RoomMember if power levels exist", function () {

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -241,7 +241,9 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
         const oldPowerLevel = this.powerLevel;
 
         const creators = new Set<string>();
-        if (roomVersion === "org.matrix.hydra.11" || (Number.isInteger(roomVersion) && Number(roomVersion) > 12)) {
+        // This checks probably wants to be reversed once verson 12 has been around for longer
+        // (ie. assume v12 semantics except for other known versions)
+        if (roomVersion === "org.matrix.hydra.11" || roomVersion === "12") {
             const roomCreateSender = roomCreateEvent.getSender();
             if (roomCreateSender) creators.add(roomCreateSender);
             const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -247,11 +247,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
             const roomCreateSender = roomCreateEvent.getSender();
             if (roomCreateSender) creators.add(roomCreateSender);
             const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;
-            if (additionalCreators && typeof additionalCreators === "object") {
-                for (const creator of additionalCreators) {
-                    creators.add(creator);
-                }
-            }
+            if (Array.isArray(additionalCreators)) creators.push(...additionalCreators);
         }
 
         if (creators.has(this.userId)) {

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -247,7 +247,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
             const roomCreateSender = roomCreateEvent.getSender();
             if (roomCreateSender) creators.add(roomCreateSender);
             const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;
-            if (Array.isArray(additionalCreators)) creators.push(...additionalCreators);
+            if (Array.isArray(additionalCreators)) additionalCreators.forEach((c) => creators.add(c));
         }
 
         if (creators.has(this.userId)) {

--- a/src/models/room-member.ts
+++ b/src/models/room-member.ts
@@ -23,6 +23,7 @@ import { logger } from "../logger.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 import { EventType } from "../@types/event.ts";
 import { KnownMembership, type Membership } from "../@types/membership.ts";
+import { roomVersionIsHydra } from "src/utils/roomVersion.ts";
 
 export enum RoomMemberEvent {
     Membership = "RoomMember.membership",
@@ -243,7 +244,7 @@ export class RoomMember extends TypedEventEmitter<RoomMemberEvent, RoomMemberEve
         const creators = new Set<string>();
         // This checks probably wants to be reversed once verson 12 has been around for longer
         // (ie. assume v12 semantics except for other known versions)
-        if (roomVersion === "org.matrix.hydra.11" || roomVersion === "12") {
+        if (roomVersionIsHydra(roomVersion)) {
             const roomCreateSender = roomCreateEvent.getSender();
             if (roomCreateSender) creators.add(roomCreateSender);
             const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -33,7 +33,7 @@ import { TypedReEmitter } from "../ReEmitter.ts";
 import { M_BEACON, M_BEACON_INFO } from "../@types/beacon.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { type RoomJoinRulesEventContent } from "../@types/state_events.ts";
-import { roomVersionIsHydra } from "../utils/roomVersion.ts";
+import { shouldUseHydraForRoomVersion } from "../utils/roomVersion.ts";
 
 export interface IMarkerFoundOptions {
     /** Whether the timeline was empty before the marker event arrived in the
@@ -1151,7 +1151,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
  */
 function getCreators(roomVersion: string, roomCreateEvent: MatrixEvent | null): Set<string> {
     const creators = new Set<string>();
-    if (roomVersionIsHydra(roomVersion) && roomCreateEvent) {
+    if (shouldUseHydraForRoomVersion(roomVersion) && roomCreateEvent) {
         const roomCreateSender = roomCreateEvent.getSender();
         if (roomCreateSender) creators.add(roomCreateSender);
         const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -33,6 +33,7 @@ import { TypedReEmitter } from "../ReEmitter.ts";
 import { M_BEACON, M_BEACON_INFO } from "../@types/beacon.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { type RoomJoinRulesEventContent } from "../@types/state_events.ts";
+import { roomVersionIsHydra } from "../utils/roomVersion.ts";
 
 export interface IMarkerFoundOptions {
     /** Whether the timeline was empty before the marker event arrived in the
@@ -487,13 +488,20 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
                     return;
                 }
                 const members = Object.values(this.members);
+
+                const createEvent = this.getStateEvents(EventType.RoomCreate, "");
+                const creators = getCreators(this.getRoomVersion(), createEvent);
+
                 members.forEach((member) => {
                     // We only propagate `RoomState.members` event if the
                     // power levels has been changed
                     // large room suffer from large re-rendering especially when not needed
                     const oldLastModified = member.getLastModifiedTime();
-                    const createEvent = this.getStateEvents(EventType.RoomCreate, "");
-                    if (createEvent) member.setPowerLevelEvent(event, createEvent, this.getRoomVersion());
+
+                    if (createEvent) {
+                        const pl = powerLevelForUserId(member.userId, event, creators);
+                        member.setPowerLevel(pl, event);
+                    }
                     if (oldLastModified !== member.getLastModifiedTime()) {
                         this.emit(RoomStateEvent.Members, event, this, member);
                     }
@@ -648,7 +656,13 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
         const createEvent = this.getStateEvents(EventType.RoomCreate, "");
         const pwrLvlEvent = this.getStateEvents(EventType.RoomPowerLevels, "");
         if (pwrLvlEvent && createEvent) {
-            member.setPowerLevelEvent(pwrLvlEvent, createEvent, this.getRoomVersion());
+            const powerLevel = powerLevelForUserId(
+                member.userId,
+                pwrLvlEvent,
+                getCreators(this.getRoomVersion(), createEvent),
+            );
+
+            member.setPowerLevel(powerLevel, pwrLvlEvent);
         }
 
         // blow away the sentinel which is now outdated
@@ -1124,6 +1138,49 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
             const arr = this.displayNameToUserIds.get(strippedDisplayname) ?? [];
             arr.push(userId);
             this.displayNameToUserIds.set(strippedDisplayname, arr);
+        }
+    }
+}
+
+/**
+ * Get the set of creator user IDs for a room: empty if the room is not a 'hydra' room, otherwise
+ * computed from the sender of the m.room.create event plus the additional_creators field.
+ * @param roomVersion The version of the room
+ * @param roomCreateEvent The m.room.create event for the room
+ * @returns A set of user IDs of the creators of the room.
+ */
+function getCreators(roomVersion: string, roomCreateEvent: MatrixEvent | null): Set<string> {
+    const creators = new Set<string>();
+    if (roomVersionIsHydra(roomVersion) && roomCreateEvent) {
+        const roomCreateSender = roomCreateEvent.getSender();
+        if (roomCreateSender) creators.add(roomCreateSender);
+        const additionalCreators = roomCreateEvent.getDirectionalContent().additional_creators;
+        if (Array.isArray(additionalCreators)) additionalCreators.forEach((c) => creators.add(c));
+    }
+    return creators;
+}
+
+/**
+ *
+ * @param userId The user ID to compute the power level for
+ * @param powerLevelEvents The power level event for the room
+ * @param creators The set of creator user IDs for the room if the room is a 'hydra' room, otherwise the empty set.
+ */
+function powerLevelForUserId(userId: string, powerLevelEvent: MatrixEvent, creators: Set<string>): number {
+    if (creators.has(userId)) {
+        // As of "Hydra", If the user is a creator, they always have the highest power level
+        return Infinity;
+    } else {
+        const evContent = powerLevelEvent.getDirectionalContent();
+
+        const users: { [userId: string]: number } = evContent.users || {};
+
+        if (users[userId] !== undefined && Number.isInteger(users[userId])) {
+            return users[userId];
+        } else if (evContent.users_default !== undefined) {
+            return evContent.users_default;
+        } else {
+            return 0;
         }
     }
 }

--- a/src/models/room-state.ts
+++ b/src/models/room-state.ts
@@ -214,7 +214,7 @@ export class RoomState extends TypedEventEmitter<EmittedEvents, EventHandlerMap>
 
     /**
      * Gets the version of the room
-     * @returns The version of the room, or null if it could not be determined
+     * @returns The version of the room
      */
     public getRoomVersion(): string {
         const createEvent = this.getStateEvents(EventType.RoomCreate, "");

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -374,7 +374,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     private heroes: Hero[] | null = null;
     // flags to stop logspam about missing m.room.create events
     private getTypeWarning = false;
-    private getVersionWarning = false;
     private membersPromise?: Promise<boolean>;
 
     // XXX: These should be read-only
@@ -609,15 +608,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @returns The version of the room, or null if it could not be determined
      */
     public getVersion(): string {
-        const createEvent = this.currentState.getStateEvents(EventType.RoomCreate, "");
-        if (!createEvent) {
-            if (!this.getVersionWarning) {
-                logger.warn("[getVersion] Room " + this.roomId + " does not have an m.room.create event");
-                this.getVersionWarning = true;
-            }
-            return "1";
-        }
-        return createEvent.getContent()["room_version"] ?? "1";
+        return this.currentState.getRoomVersion();
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -605,7 +605,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
 
     /**
      * Gets the version of the room
-     * @returns The version of the room, or null if it could not be determined
+     * @returns The version of the room
      */
     public getVersion(): string {
         return this.currentState.getRoomVersion();

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -17,19 +17,24 @@ limitations under the License.
 /**
  * Room versions strings that we know about and do not use hydra semantics.
  */
-const PRE_HYDRA_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
+const HYDRA_ROOM_VERSIONS = ["org.matrix.hydra.11", "12"];
 
 /**
  * Checks if the given room version is one where new "hydra" power level
  * semantics (ie. room version 12 or later) should be used
  * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
- * This will return `false` for versions that are known to the js-sdk and
- * do not use hydra: any room versions unknown to the js-sdk (experimental or
- * otherwise) will cause the function to return true.
+ * This will return `true` for versions that are known to the js-sdk and
+ * use hydra: any room versions unknown to the js-sdk (experimental or
+ * otherwise) will cause the function to return `false`.
  *
  * @param roomVersion - The version of the room to check.
  * @returns `true` if hydra semantics should be used for the room version, `false` otherwise.
  */
 export function shouldUseHydraForRoomVersion(roomVersion: string): boolean {
-    return !PRE_HYDRA_ROOM_VERSIONS.includes(roomVersion);
+    // Future new room versions must obviously be added to the constant above,
+    // otherwise the js-sdk will use the old, pre-hydra semantics. At some point
+    // it would make sense to assume hydra for unknown versions but this will break
+    // any rooms using unknown versions, so at hydra switch time we've agreed all
+    // Element clients will only use hydra for the two specific hydra versions.
+    return HYDRA_ROOM_VERSIONS.includes(roomVersion);
 }

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -16,18 +16,19 @@ limitations under the License.
 
 /**
  * Checks if the given room version is a version that is known to use
- * new "hydra" power level semantics (as of room version 12)
+ * new "hydra" power level semantics (ie. room version 12 or later)
  * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
  * Note that this will only return true for versions that are known to
  * the js-sdk': any room version created subsequently will need to be added here
  * if it uses hydra semantics.
  *
  * Once hydra has been rolled out in production for "long enough", it would probably
- * makes sense to assume hydra semantiocs by default and hence check instead for room
- * versions known to use the old semantics.
+ * makes sense to assume hydra semantics by default and hence check instead for room
+ * versions known to use the old semantics using a different function (which does not exist
+ * currently).
  *
  * @param roomVersion - The version of the room to check.
- * @returns true if the room version is known to use hydra semantics, false otherwise.
+ * @returns `true` if the room version is known to use hydra semantics, `false` otherwise.
  */
 export function roomVersionIsHydra(roomVersion: string): boolean {
     return roomVersion === "org.matrix.hydra.11" || roomVersion === "12";

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -14,6 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/**
+ * Checks if the given room version is a version that is known to use
+ * new "hydra" power level semantics (as of room version 12)
+ * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
+ * Note that this will only return true for versions that are known to
+ * the js-sdk': any room version created subsequently will need to be added here
+ * if it uses hydra semantics.
+ *
+ * Once hydra has been rolled out in production for "long enough", it would probably
+ * makes sense to assume hydra semantiocs by default and hence check instead for room
+ * versions known to use the old semantics.
+ *
+ * @param roomVersion - The version of the room to check.
+ * @returns true if the room version is known to use hydra semantics, false otherwise.
+ */
 export function roomVersionIsHydra(roomVersion: string): boolean {
     return roomVersion === "org.matrix.hydra.11" || roomVersion === "12";
 }

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -15,21 +15,21 @@ limitations under the License.
 */
 
 /**
- * Checks if the given room version is a version that is known to use
- * new "hydra" power level semantics (ie. room version 12 or later)
+ * Room versions strings that we know about and do not use hydra semantics.
+ */
+const PRE_HYDRA_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
+
+/**
+ * Checks if the given room version is one where new "hydra" power level
+ * semantics (ie. room version 12 or later) should be used
  * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
- * Note that this will only return true for versions that are known to
- * the js-sdk': any room version created subsequently will need to be added here
- * if it uses hydra semantics.
- *
- * Once hydra has been rolled out in production for "long enough", it would probably
- * makes sense to assume hydra semantics by default and hence check instead for room
- * versions known to use the old semantics using a different function (which does not exist
- * currently).
+ * This will return false for versions that are known to the js-sdk' and
+ * do not use hydra: any room versions unknown to the js-sdk (experimental or
+ * otherwise) will cause the function to return true.
  *
  * @param roomVersion - The version of the room to check.
- * @returns `true` if the room version is known to use hydra semantics, `false` otherwise.
+ * @returns `true` if hydra semantics should be used for the room version, `false` otherwise.
  */
-export function roomVersionIsHydra(roomVersion: string): boolean {
-    return roomVersion === "org.matrix.hydra.11" || roomVersion === "12";
+export function shouldUseHydraForRoomVersion(roomVersion: string): boolean {
+    return !PRE_HYDRA_ROOM_VERSIONS.includes(roomVersion);
 }

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export function roomVersionIsHydra(roomVersion: string): boolean {
+    return roomVersion === "org.matrix.hydra.11" || roomVersion === "12";
+}

--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -23,7 +23,7 @@ const PRE_HYDRA_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "1
  * Checks if the given room version is one where new "hydra" power level
  * semantics (ie. room version 12 or later) should be used
  * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
- * This will return false for versions that are known to the js-sdk' and
+ * This will return `false` for versions that are known to the js-sdk and
  * do not use hydra: any room versions unknown to the js-sdk (experimental or
  * otherwise) will cause the function to return true.
  *


### PR DESCRIPTION
Adds support for infinite power level specified by [MSC4289](https://github.com/matrix-org/matrix-spec-proposals/pull/4289).

This version removes powerLevelNorm which we only use in one place in Element Web (where we probably should not) and I'm not sure is generally that sensible, so I've removed it since it's a difficult concept to keep and would at best be a slight lie when one of the PLs is always infinity (eg. we'd have to say creator is also 100, probably). This makes this a BREAKING CHANGE.

I'll leave this as draft until I have a matching PR for element.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
