### PR TITLE
Remove support for `FetchHttpApi` without `onlyData: true`

### DIFF
--- a/spec/unit/http-api/index.spec.ts
+++ b/spec/unit/http-api/index.spec.ts
@@ -62,7 +62,7 @@ describe("MatrixHttpApi", () => {
     it("should fall back to `fetch` where xhr is unavailable", async () => {
         globalThis.XMLHttpRequest = undefined!;
         const fetchFn = jest.fn().mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue({}) });
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn, onlyData: true });
         upload = api.uploadContent({} as File);
         await upload;
         expect(fetchFn).toHaveBeenCalled();
@@ -70,7 +70,7 @@ describe("MatrixHttpApi", () => {
 
     it("should prefer xhr where available", () => {
         const fetchFn = jest.fn().mockResolvedValue({ ok: true });
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, fetchFn, onlyData: true });
         upload = api.uploadContent({} as File);
         expect(fetchFn).not.toHaveBeenCalled();
         expect(xhr.open).toHaveBeenCalled();
@@ -82,6 +82,7 @@ describe("MatrixHttpApi", () => {
             prefix,
             accessToken: "token",
             useAuthorizationHeader: false,
+            onlyData: true,
         });
         upload = api.uploadContent({} as File);
         expect(xhr.open).toHaveBeenCalledWith(
@@ -96,6 +97,7 @@ describe("MatrixHttpApi", () => {
             baseUrl,
             prefix,
             accessToken: "token",
+            onlyData: true,
         });
         upload = api.uploadContent({} as File);
         expect(xhr.open).toHaveBeenCalledWith(Method.Post, baseUrl.toLowerCase() + "/_matrix/media/v3/upload");
@@ -103,7 +105,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should include filename by default", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File, { name: "name" });
         expect(xhr.open).toHaveBeenCalledWith(
             Method.Post,
@@ -112,13 +114,13 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should allow not sending the filename", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File, { name: "name", includeFilename: false });
         expect(xhr.open).toHaveBeenCalledWith(Method.Post, baseUrl.toLowerCase() + "/_matrix/media/v3/upload");
     });
 
     it("should abort xhr when the upload is aborted", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
         api.cancelUpload(upload);
         expect(xhr.abort).toHaveBeenCalled();
@@ -126,7 +128,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should timeout if no progress in 30s", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
         jest.advanceTimersByTime(25000);
         // @ts-ignore
@@ -138,7 +140,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should call progressHandler", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         const progressHandler = jest.fn();
         upload = api.uploadContent({} as File, { progressHandler });
         const progressEvent = new Event("progress") as ProgressEvent;
@@ -154,7 +156,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should error when no response body", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
 
         xhr.readyState = DONE;
@@ -167,7 +169,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should error on a 400-code", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
 
         xhr.readyState = DONE;
@@ -184,7 +186,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should return response on successful upload", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
 
         xhr.readyState = DONE;
@@ -198,14 +200,14 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should abort xhr when calling `cancelUpload`", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
         expect(api.cancelUpload(upload)).toBeTruthy();
         expect(xhr.abort).toHaveBeenCalled();
     });
 
     it("should return false when `cancelUpload` is called but unsuccessful", async () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
 
         xhr.readyState = DONE;
@@ -220,7 +222,7 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should return active uploads in `getCurrentUploads`", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, onlyData: true });
         upload = api.uploadContent({} as File);
         expect(api.getCurrentUploads().find((u) => u.promise === upload)).toBeTruthy();
         api.cancelUpload(upload);
@@ -228,7 +230,12 @@ describe("MatrixHttpApi", () => {
     });
 
     it("should return expected object from `getContentUri`", () => {
-        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), { baseUrl, prefix, accessToken: "token" });
+        const api = new MatrixHttpApi(new TypedEventEmitter<any, any>(), {
+            baseUrl,
+            prefix,
+            accessToken: "token",
+            onlyData: true,
+        });
         expect(api.getContentUri()).toMatchSnapshot();
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -6843,9 +6843,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      *
      * @param opts -  options object
      *
-     * @returns Promise which resolves to response object, as
-     *    determined by this.opts.onlyData, opts.rawResponse, and
-     *    opts.onlyContentUri.  Rejects with an error (usually a MatrixError).
+     * @returns Promise which resolves to response object, or rejects with an error (usually a MatrixError).
      */
     public uploadContent(file: FileType, opts?: UploadOpts): Promise<UploadResponse> {
         return this.http.uploadContent(file, opts);

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -48,9 +48,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
      *
      * @param opts - options object
      *
-     * @returns Promise which resolves to response object, as
-     *    determined by this.opts.onlyData, opts.rawResponse, and
-     *    opts.onlyContentUri.  Rejects with an error (usually a MatrixError).
+     * @returns Promise which resolves to response object, or rejects with an error (usually a MatrixError).
      */
     public uploadContent(file: FileType, opts: UploadOpts = {}): Promise<UploadResponse> {
         const includeFilename = opts.includeFilename ?? true;
@@ -149,11 +147,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
                 prefix: MediaPrefix.V3,
                 headers,
                 abortSignal: abortController.signal,
-            })
-                .then((response) => {
-                    return this.opts.onlyData ? <UploadResponse>response : response.json();
-                })
-                .then(uploadResolvers.resolve, uploadResolvers.reject);
+            }).then(uploadResolvers.resolve, uploadResolvers.reject);
         }
 
         // remove the upload from the list on completion

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -69,10 +69,7 @@ export interface IHttpOpts {
     tokenRefreshFunction?: TokenRefreshFunction;
     useAuthorizationHeader?: boolean; // defaults to true
 
-    /**
-     * Normally, methods in `FetchHttpApi` will return a {@link https://developer.mozilla.org/en-US/docs/Web/API/Response Response} object.
-     * If this is set to `true`, they instead return the response body.
-     */
+    /** For historical reasons, must be set to `true`. Will eventually be removed. */
     onlyData?: boolean;
 
     localTimeoutMs?: number;
@@ -103,11 +100,10 @@ export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
      *
      *  * Set `Accept: application/json` in the request headers (again, unless overridden by {@link headers}).
      *
-     *  * If `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, parse the response as
-     *    JSON and return the parsed response.
+     *  * Parse the response as JSON and return the parsed response.
      *
-     * Setting this to `false` inhibits all three behaviors, and (if `IHTTPOpts.onlyData` is set to `true`) the response
-     * is instead parsed as a UTF-8 string. It defaults to `true`, unless {@link rawResponseBody} is set.
+     * Setting this to `false` inhibits all three behaviors, and the response is instead parsed as a UTF-8 string. It
+     * defaults to `true`, unless {@link rawResponseBody} is set.
      *
      * @deprecated Instead of setting this to `false`, set {@link rawResponseBody} to `true`.
      */
@@ -118,9 +114,8 @@ export interface BaseRequestOpts extends Pick<RequestInit, "priority"> {
      *
      *  * Inhibits the automatic addition of `Accept: application/json` in the request headers.
      *
-     *  * Assuming `IHTTPOpts.onlyData` is set to `true` on the `FetchHttpApi` instance, causes the
-     *    raw response to be returned as a {@link https://developer.mozilla.org/en-US/docs/Web/API/Blob|Blob}
-     *    instead of parsing it as `json`.
+     *  * Causes the raw response to be returned as a {@link https://developer.mozilla.org/en-US/docs/Web/API/Blob|Blob}
+     *    instead of parsing it as JSON.
      */
     rawResponseBody?: boolean;
 }


### PR DESCRIPTION
`FetchHttpApi` is never used without `onlyData: true`, and there is a bunch of type and code boilerplate to support it. Let's remove support for running without `onlyData: true`, as part of a longer-term mission to remove it altogehter.

This PR targets the `vNext` branch, with the intention that it be part of the next major release of the js sdk.