### PR TITLE
MatrixRTC: comply with the `manageMediaKeys` EncryptionConfig option

### DIFF
--- a/spec/unit/matrixrtc/RTCEncryptionManager.spec.ts
+++ b/spec/unit/matrixrtc/RTCEncryptionManager.spec.ts
@@ -448,6 +448,23 @@ describe("RTCEncryptionManager", () => {
 
             expect(statistics.counters.roomEventEncryptionKeysSent).toBe(2);
         });
+
+        it("Should not distribute keys if encryption is disabled", async () => {
+            jest.useFakeTimers();
+            const members = [
+                aCallMembership("@bob:example.org", "BOBDEVICE"),
+                aCallMembership("@bob:example.org", "BOBDEVICE2"),
+                aCallMembership("@carl:example.org", "CARLDEVICE"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            encryptionManager.join({ manageMediaKeys: false });
+            encryptionManager.onMembershipsUpdate();
+            await jest.runOnlyPendingTimersAsync();
+
+            expect(mockTransport.sendKey).not.toHaveBeenCalled();
+            expect(onEncryptionKeysChanged).not.toHaveBeenCalled();
+        });
     });
 
     describe("Receiving Keys", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

The new `RTCEncryptionManager` was not complying to the `EncryptionConfig.manageMediaKeys`.
The result is that in clear rooms, keys were sent for nothing, generating un-needed traffic.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
