### PR TITLE
Use hydra semantics for unknown room versions

### DIFF
--- a/src/utils/roomVersion.ts
+++ b/src/utils/roomVersion.ts
@@ -17,24 +17,19 @@ limitations under the License.
 /**
  * Room versions strings that we know about and do not use hydra semantics.
  */
-const HYDRA_ROOM_VERSIONS = ["org.matrix.hydra.11", "12"];
+const PRE_HYDRA_ROOM_VERSIONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
 
 /**
  * Checks if the given room version is one where new "hydra" power level
  * semantics (ie. room version 12 or later) should be used
  * (see https://github.com/matrix-org/matrix-spec-proposals/pull/4289).
- * This will return `true` for versions that are known to the js-sdk and
- * use hydra: any room versions unknown to the js-sdk (experimental or
- * otherwise) will cause the function to return `false`.
+ * This will return `false` for versions that are known to the js-sdk and
+ * do not use hydra: any room versions unknown to the js-sdk (experimental or
+ * otherwise) will cause the function to return true.
  *
  * @param roomVersion - The version of the room to check.
  * @returns `true` if hydra semantics should be used for the room version, `false` otherwise.
  */
 export function shouldUseHydraForRoomVersion(roomVersion: string): boolean {
-    // Future new room versions must obviously be added to the constant above,
-    // otherwise the js-sdk will use the old, pre-hydra semantics. At some point
-    // it would make sense to assume hydra for unknown versions but this will break
-    // any rooms using unknown versions, so at hydra switch time we've agreed all
-    // Element clients will only use hydra for the two specific hydra versions.
-    return HYDRA_ROOM_VERSIONS.includes(roomVersion);
+    return !PRE_HYDRA_ROOM_VERSIONS.includes(roomVersion);
 }


### PR DESCRIPTION
This inverts the check for whether to use hydra semantics to only NOT use it for known, old room versions and use hydra for everything else, so rooms with versions we don't know about will use hydra semantics.

This will cause any rooms using old/experimental versions unknown to the js-sdk to break, but will mean that when the next room version comes out, we'll use hydra for it which is, of course, not a given, but is way more likely than going back to the old semantics.

The mobile Element clients currently hardcode hydra versions (ie. as it is without this change, but we expect them to make this same change soon after the hydra release.

We do NOT expect this to land with the hydra release, but target it for the release after.

Reverts 1e5054a8ff87f83b0875916aa16f435853bf165a from https://github.com/matrix-org/matrix-js-sdk/pull/4937

See https://github.com/element-hq/element-meta/issues/2921 for public discussion.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
