### PR TITLE
Only process MatrixRTC sessions associated with calls for `callMembershipsForRoom`

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -59,6 +59,25 @@ describe("MatrixRTCSession", () => {
             expect(sess?.callId).toEqual("");
         });
 
+        it("ignores memberships where application is not m.call", () => {
+            const testMembership = Object.assign({}, membershipTemplate, {
+            application: "not-m.call",
+            });
+            const mockRoom = makeMockRoom([testMembership]);
+            const sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
+            expect(sess?.memberships).toHaveLength(0);
+        });
+
+        it("ignores memberships where callId is not empty", () => {
+            const testMembership = Object.assign({}, membershipTemplate, {
+            call_id: "not-empty",
+            scope: "m.room",
+            });
+            const mockRoom = makeMockRoom([testMembership]);
+            const sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
+            expect(sess?.memberships).toHaveLength(0);
+        });
+
         it("ignores expired memberships events", () => {
             jest.useFakeTimers();
             const expiredMembership = Object.assign({}, membershipTemplate);

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -61,7 +61,7 @@ describe("MatrixRTCSession", () => {
 
         it("ignores memberships where application is not m.call", () => {
             const testMembership = Object.assign({}, membershipTemplate, {
-            application: "not-m.call",
+                application: "not-m.call",
             });
             const mockRoom = makeMockRoom([testMembership]);
             const sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);
@@ -70,8 +70,8 @@ describe("MatrixRTCSession", () => {
 
         it("ignores memberships where callId is not empty", () => {
             const testMembership = Object.assign({}, membershipTemplate, {
-            call_id: "not-empty",
-            scope: "m.room",
+                call_id: "not-empty",
+                scope: "m.room",
             });
             const mockRoom = makeMockRoom([testMembership]);
             const sess = MatrixRTCSession.roomSessionForRoom(client, mockRoom);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -290,6 +290,12 @@ export class MatrixRTCSession extends TypedEventEmitter<
                 try {
                     const membership = new CallMembership(memberEvent, membershipData);
 
+                    if (membership.application !== "m.call") {
+                        // Only process MatrixRTC sessions associated with calls
+                        logger.info("Skipping non-call MatrixRTC session");
+                        continue;
+                    }
+
                     if (membership.callId !== "" || membership.scope !== "m.room") {
                         // for now, just ignore anything that isn't a room scope call
                         logger.info(`Ignoring user-scoped call`);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
