### PR TITLE
Make a MatrixRTCSession emit once the RTCNotification is sent

### DIFF
--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -78,8 +78,8 @@ export type MatrixRTCSessionEventHandlerMap = {
     ) => void;
     [MatrixRTCSessionEvent.MembershipManagerError]: (error: unknown) => void;
     [MatrixRTCSessionEvent.DidSendCallNotification]: (
-        notificationContentNew: IRTCNotificationContent,
-        notificationContentLegacy: ICallNotifyContent,
+        notificationContentNew: { event_id: string } & IRTCNotificationContent,
+        notificationContentLegacy: { event_id: string } & ICallNotifyContent,
     ) => void;
 };
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -20,10 +20,11 @@ import { EventTimeline } from "../models/event-timeline.ts";
 import { type Room } from "../models/room.ts";
 import { type MatrixClient } from "../client.ts";
 import { EventType, RelationType } from "../@types/event.ts";
+import { KnownMembership } from "../@types/membership.ts";
+import { type ISendEventResponse } from "../@types/requests.ts";
 import { CallMembership } from "./CallMembership.ts";
 import { RoomStateEvent } from "../models/room-state.ts";
 import { type Focus } from "./focus.ts";
-import { KnownMembership } from "../@types/membership.ts";
 import { MembershipManager } from "./MembershipManager.ts";
 import { EncryptionManager, type IEncryptionManager } from "./EncryptionManager.ts";
 import { deepCompare, logDurationSync } from "../utils.ts";
@@ -48,8 +49,10 @@ import {
 } from "./RoomAndToDeviceKeyTransport.ts";
 import { TypedReEmitter } from "../ReEmitter.ts";
 import { ToDeviceKeyTransport } from "./ToDeviceKeyTransport.ts";
-import { type ISendEventResponse } from "src/matrix.ts";
 
+/**
+ * Events emitted by MatrixRTCSession
+ */
 export enum MatrixRTCSessionEvent {
     // A member joined, left, or updated a property of their membership.
     MembershipsChanged = "memberships_changed",


### PR DESCRIPTION
This PR adds a new event to the MatrixRTC session. An event that is emitted once the session has taken over its responsibilty of sending the notification event.

Context:
Element call now sends the notificaition event (the matrix event that makes other clients ring) instead of the client that encapsuls element call.

In element call we need to know if the js-sdk decided to actually send this notification or not. One example why it might not send it is: There is already someone in the call -> we are not the call starter -> we will not send a ring notification.

If it did send the notification (ring) and this new event emits it allows EC to build a ux around it. Commuication to the user that they are in "waiting for other participants to join" state.

Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
