### PR TITLE
Remove knocked room when membership changes to join

### DIFF
--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -317,7 +317,10 @@ export class SyncAccumulator {
                 break;
 
             case Category.Join:
-                if (this.inviteRooms[roomId]) {
+                if (this.knockRooms[roomId]) {
+                    // delete knock state on join
+                    delete this.knockRooms[roomId];
+                } else if (this.inviteRooms[roomId]) {
                     // (1)
                     // was previously invite, now join. We expect /sync to give
                     // the entire state and timeline on 'join', so delete previous


### PR DESCRIPTION
Signed-off-by: Svajunas Budrys <svajunas.budrys.sb@gmail.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

PR suggests removing a knocked room on join, which happens in this scenario (also video attached)

- User A: knock on the room
- User A: reload
- User B: approve user A
- User A: join the room
- User A: reload a few times
- User A: sees "Request to join sent" view, but he has joined the room already

Used https://github.com/matrix-org/matrix-js-sdk/pull/3729 as a reference

https://github.com/user-attachments/assets/78499bdd-24ff-4da4-9fbc-77ff3e80521e

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
