### PR TITLE
Remove custom `org.matrix.msc4075.rtc.notification.parent` relation type

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -355,7 +355,7 @@ describe("MatrixRTCSession", () => {
                     "m.mentions": { room: true, user_ids: [] },
                     "m.relates_to": {
                         event_id: expect.any(String),
-                        rel_type: "org.matrix.msc4075.rtc.notification.parent",
+                        rel_type: "m.reference",
                     },
                     "notification_type": "ring",
                     "sender_ts": expect.any(Number),

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -333,7 +333,7 @@ describe("MatrixRTCSession", () => {
                 "notification_type": "ring",
                 "m.relates_to": {
                     event_id: ownMembershipId,
-                    rel_type: "org.matrix.msc4075.rtc.notification.parent",
+                    rel_type: "m.reference",
                 },
                 "lifetime": 30000,
                 "sender_ts": expect.any(Number),

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -165,7 +165,6 @@ export enum RelationType {
     // moreover, our tests currently use the unstable prefix. Use THREAD_RELATION_TYPE.name.
     // Once we support *only* the stable prefix, THREAD_RELATION_TYPE can die and we can switch to this.
     Thread = "m.thread",
-    unstable_RTCNotificationParent = "org.matrix.msc4075.rtc.notification.parent",
 }
 
 export enum MsgType {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -690,7 +690,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
                 "notification_type": notificationType,
                 "m.relates_to": {
                     event_id: parentEventId,
-                    rel_type: RelationType.unstable_RTCNotificationParent,
+                    rel_type: RelationType.Reference,
                 },
                 "sender_ts": Date.now(),
                 "lifetime": 30_000, // 30 seconds


### PR DESCRIPTION
The MSC4075 now uses `m.reference` instead
Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
