### PR TITLE
Fix thread edit aggregation race condition

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -778,18 +778,20 @@ describe("Thread", () => {
                 // This test reproduces the race condition bug from https://github.com/element-hq/element-web/issues/30617
                 // The bug occurs when edits arrive while the thread is not initialized,
                 // causing aggregation to fail because the target event isn't in the timeline yet
-                
+
                 // Given a thread exists with server-side support enabled
                 const myUserId = "@alice:example.org";
-                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, { timelineSupport: false });
+                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, {
+                    timelineSupport: false,
+                });
                 const client = testClient.client;
                 client.supportsThreads = jest.fn().mockReturnValue(true);
-                
+
                 const room = new Room("!room:z", client, myUserId, {
                     pendingEventOrdering: PendingEventOrdering.Detached,
                 });
                 jest.spyOn(client, "getRoom").mockReturnValue(room);
-                
+
                 // Create a root event
                 const rootEvent = mkMessage({
                     room: room.roomId,
@@ -797,88 +799,88 @@ describe("Thread", () => {
                     msg: "Root message",
                     event: true,
                 });
-                
+
                 // Create thread manually - starts with initialEventsFetched = false
                 const thread = new Thread(rootEvent.getId()!, rootEvent, {
                     room: room,
                     client: client,
                     pendingEventOrdering: PendingEventOrdering.Detached,
                 });
-                
+
                 // The thread is NOT initialized - this is the key to reproducing the bug!
                 expect(thread.initialEventsFetched).toBe(false);
-                
+
                 // Create a message that will be edited
                 const originalMessage = mkMessage({
                     room: room.roomId,
                     user: myUserId,
                     msg: "Original message in thread",
                     relatesTo: {
-                        rel_type: THREAD_RELATION_TYPE.name,
-                        event_id: thread.id,
+                        "rel_type": THREAD_RELATION_TYPE.name,
+                        "event_id": thread.id,
                         "m.in_reply_to": {
                             event_id: thread.id,
-                        }
+                        },
                     },
                     event: true,
                 });
-                
+
                 // Create edit events BEFORE the original message is in the timeline
                 const edit1 = mkEdit(originalMessage, client, myUserId, room.roomId, "Edit 1");
-                const edit2 = mkEdit(originalMessage, client, myUserId, room.roomId, "Edit 2"); 
+                const edit2 = mkEdit(originalMessage, client, myUserId, room.roomId, "Edit 2");
                 const edit3 = mkEdit(originalMessage, client, myUserId, room.roomId, "Final edit");
 
                 // CRITICAL: Add edits while thread is NOT initialized
                 // They will be queued in replayEvents and aggregation will be attempted but fail
                 await thread.addEvent(edit1, false);
-                
+
                 // Check the aggregation state after adding first edit
                 // With our fix: edits should NOT be aggregated yet (thread not initialized)
                 // Without fix: edits would be aggregated but fail to link to target
                 const relationsAfterFirstEdit = thread.timelineSet.relations?.getChildEventsForEvent(
                     originalMessage.getId()!,
                     RelationType.Replace,
-                    EventType.RoomMessage
+                    EventType.RoomMessage,
                 );
-                
+
                 // With the fix, no aggregation happens yet (which is correct)
                 // Without the fix, aggregation would happen but fail silently
                 expect(relationsAfterFirstEdit).toBeUndefined();
-                
+
                 // Add remaining edits
                 await thread.addEvent(edit2, false);
                 await thread.addEvent(edit3, false);
-                
+
                 // Check that edits went to replayEvents
                 expect(thread.replayEvents).toHaveLength(3);
-                
+
                 // Now initialize the thread and add the original message
                 thread.initialEventsFetched = true;
-                
+
                 // Clear replayEvents and add the original message
                 const replayEvents = [...(thread.replayEvents || [])];
                 thread.replayEvents = [];
-                
+
                 // Add original message first
                 await thread.addEvent(originalMessage, false);
-                
+
                 // At this point, the original message should NOT have the edits aggregated yet
                 // because they were attempted when the target wasn't in timeline
                 const replacingEventBeforeReplay = originalMessage.replacingEvent();
                 // With the fix, edits should not be aggregated yet (pre-init)
                 expect(replacingEventBeforeReplay).toBeNull();
-                
+
                 // Then replay the edits
                 for (const event of replayEvents) {
                     await thread.addEvent(event, false);
                 }
-                
+
                 // After replay, check aggregation
                 const replacingEvent = originalMessage.replacingEvent();
-                
+
                 // This should now work because edits were re-aggregated when replayed
                 expect(replacingEvent).toBe(edit3);
-                
+
                 // The content should also be updated
                 expect(originalMessage.getContent().body).toBe("Final edit");
 
@@ -897,7 +899,9 @@ describe("Thread", () => {
 
             it("Reactions aggregate pre-init and remain idempotent on replay", async () => {
                 const myUserId = "@alice:example.org";
-                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, { timelineSupport: false });
+                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, {
+                    timelineSupport: false,
+                });
                 const client = testClient.client;
                 client.supportsThreads = jest.fn().mockReturnValue(true);
 
@@ -927,8 +931,8 @@ describe("Thread", () => {
                         user: myUserId,
                         msg: "Thread message",
                         relatesTo: {
-                            rel_type: THREAD_RELATION_TYPE.name,
-                            event_id: thread.id,
+                            "rel_type": THREAD_RELATION_TYPE.name,
+                            "event_id": thread.id,
                             "m.in_reply_to": { event_id: thread.id },
                         },
                         event: true,

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -440,8 +440,9 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
              */
             this.replayEvents?.push(event);
 
-            // For annotations (reactions), aggregate immediately (pre-init)
-            // Only aggregate as child: parent aggregation is unnecessary here
+            // For annotations (reactions), aggregate immediately (pre-init) to keep
+            // reaction counts/summary visible while the thread is still initialising.
+            // Only aggregate as child: parent aggregation is unnecessary here.
             if (event.isRelation(RelationType.Annotation)) {
                 this.timelineSet.relations?.aggregateChildEvent(event, this.timelineSet);
             }


### PR DESCRIPTION
## Summary

Fixes a race condition where message edits in threads fail to display correctly when they arrive before thread initialization completes. This resolves the issue where Element Web shows the original message instead of the edited version in approximately 10% of cases.

**Fixes**: https://github.com/element-hq/element-web/issues/30617

## The Problem

When edit events arrive while a thread is not yet initialized (`initialEventsFetched = false`), the aggregation system attempts to link the edit to its target message. However, since the thread isn't initialized, the target message may not be in the timeline yet, causing the aggregation to fail silently.

The bug manifests as:
- Edit events are stored in the Relations container
- BUT the `targetEvent` remains `null` because the original message wasn't findable
- Element Web's `replacingEvent()` returns null even though edits exist
- Users see the original message instead of the edited version

## The Solution

Defer aggregation for edits until after the event is in the timeline and the thread is initialized, while allowing reactions to aggregate immediately. Concretely:
1. Edits (`RelationType.Replace`): do not aggregate before initialization; queue in `replayEvents` and aggregate after adding to the timeline post-init.
2. Reactions (`RelationType.Annotation`): aggregate immediately even before initialization to keep reaction summaries available; they will be re-aggregated safely on replay (idempotent).

This prevents premature aggregation of edits that creates broken Relations with `targetEvent: null`, while preserving the existing behavior for reactions.

## Technical Details

### Root Cause
`addRelatedThreadEvent()` aggregated relations even when `initialEventsFetched = false`. If the target message wasn’t yet present in the thread timeline, Replace aggregation created a relations container with no `targetEvent`, so the edit did not apply.

### The Fix
Defer Replace aggregation until the thread is initialized and the event has been added to the thread timeline. Keep Annotation aggregation pre‑init to preserve reaction summaries; replay is safe because aggregation is idempotent. Also removed redundant manual aggregation in the post‑init path since timeline insertion already aggregates.

### Why This Works
- Edits that arrive before initialization are queued in `replayEvents` and aggregated only after the target is present in the timeline.
- Reactions aggregate immediately so reaction summaries remain available pre-init; during replay, re-aggregation is a no-op due to deduplication.
- On replay, the thread is initialized and edit aggregation succeeds with proper target linking.

### Idempotence and Deduplication
- `Relations.addEvent` tracks relation event IDs and ignores duplicates, so re-aggregating reactions on replay does not double-count.
- `EventTimelineSet.addEventToTimeline`/`insertEventIntoTimeline` also short-circuit on already-known events, avoiding duplicate timeline entries.

## Testing

Added tests to cover both the regression and behavior guarantees:
- Edit race regression: create a thread with `initialEventsFetched = false`, add edits before the original message, then initialize and replay. Without the fix, Replace relations aggregate prematurely and fail to link; with the fix, edits apply after replay.
- Reaction idempotence: reactions aggregate pre‑init for visibility and remain deduplicated after replay (no double counting).

## Impact

- **Bug frequency**: Affected ~10% of edited messages in threads (*in my application that edits messages many times*)
- **User impact**: Messages appeared unedited when they should show edits
- **Scope**: Only affects threads with server-side support enabled
- **Risk**: Low — edit aggregation is delayed to a safe point; reaction behavior is preserved and duplicate aggregation is idempotent.

## Notes for Reviewers

The key insight is that edit aggregation must not happen until the thread is initialized and events are in the timeline. The bug was subtle because:
1. It only occurred with specific timing (edits arriving during initialization)
2. The aggregation appeared to work (Relations object created) but was broken internally
3. The 90% success rate made it seem intermittent

The fix ensures edits only aggregate when they can succeed, preventing broken Relations objects. Reactions (e.g. 👍) still aggregate immediately; re-aggregation on replay is safe due to deduplication.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
