### PR TITLE
Fix stable-suffixed MSC4133 support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6916,8 +6916,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      */
     public async doesServerSupportExtendedProfiles(): Promise<boolean> {
         return (
-            this.doesServerSupportUnstableFeature(UNSTABLE_MSC4133_EXTENDED_PROFILES) ||
-            this.doesServerSupportUnstableFeature(STABLE_MSC4133_EXTENDED_PROFILES)
+            (await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4133_EXTENDED_PROFILES)) ||
+            (await this.doesServerSupportUnstableFeature(STABLE_MSC4133_EXTENDED_PROFILES))
         );
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -542,6 +542,7 @@ export const UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_m
 export const UNSTABLE_MSC4140_DELAYED_EVENTS = "org.matrix.msc4140";
 
 export const UNSTABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133";
+export const STABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133.stable";
 
 enum CrossSigningKeyType {
     MasterKey = "master_key",
@@ -6914,7 +6915,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns `true` if supported, otherwise `false`
      */
     public async doesServerSupportExtendedProfiles(): Promise<boolean> {
-        return this.doesServerSupportUnstableFeature(UNSTABLE_MSC4133_EXTENDED_PROFILES);
+        return (
+            this.doesServerSupportUnstableFeature(UNSTABLE_MSC4133_EXTENDED_PROFILES) ||
+            this.doesServerSupportUnstableFeature(STABLE_MSC4133_EXTENDED_PROFILES)
+        );
     }
 
     /**


### PR DESCRIPTION
It looked for the ".stable" suffixed feature to work out what URL to use but not to see whether the server supported it.

This will only be relevant until the next spec release but may as well fix it.

See also https://github.com/element-hq/element-web/pull/30649

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
