### PR TITLE
Fix `m.topic` format

### DIFF
--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -215,11 +215,11 @@ describe("Topic content helpers", () => {
         it("creates an empty event when the topic is falsey", () => {
             expect(makeTopicContent(undefined)).toEqual({
                 topic: undefined,
-                [M_TOPIC.name]: {"m.text": []},
+                [M_TOPIC.name]: { "m.text": [] },
             });
             expect(makeTopicContent(null)).toEqual({
                 topic: null,
-                [M_TOPIC.name]: {"m.text": []},
+                [M_TOPIC.name]: { "m.text": [] },
             });
         });
     });

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -289,7 +289,25 @@ describe("Topic content helpers", () => {
             });
         });
 
-        it("uses legacy event content when new topic key is invalid", () => {
+        // TODO delete this test and re-enable the next one after support for the invalid form is removed
+        //      https://github.com/matrix-org/matrix-js-sdk/pull/4984#pullrequestreview-3174251065
+        it("parses malformed event content with html topic", () => {
+            expect(
+                parseTopicContent({
+                    "topic": "pizza",
+                    "m.topic": [
+                        {
+                            body: "<b>pizza</b>",
+                            mimetype: "text/html",
+                        },
+                    ] as any,
+                }),
+            ).toEqual({
+                text: "pizza",
+                html: "<b>pizza</b>",
+            });
+        });
+        it.skip("uses legacy event content when new topic key is invalid", () => {
             expect(
                 parseTopicContent({
                     "topic": "pizza",

--- a/spec/unit/content-helpers.spec.ts
+++ b/spec/unit/content-helpers.spec.ts
@@ -183,39 +183,43 @@ describe("Topic content helpers", () => {
         it("creates fully defined event content without html", () => {
             expect(makeTopicContent("pizza")).toEqual({
                 topic: "pizza",
-                [M_TOPIC.name]: [
-                    {
-                        body: "pizza",
-                        mimetype: "text/plain",
-                    },
-                ],
+                [M_TOPIC.name]: {
+                    "m.text": [
+                        {
+                            body: "pizza",
+                            mimetype: "text/plain",
+                        },
+                    ],
+                },
             });
         });
 
         it("creates fully defined event content with html", () => {
             expect(makeTopicContent("pizza", "<b>pizza</b>")).toEqual({
                 topic: "pizza",
-                [M_TOPIC.name]: [
-                    {
-                        body: "<b>pizza</b>",
-                        mimetype: "text/html",
-                    },
-                    {
-                        body: "pizza",
-                        mimetype: "text/plain",
-                    },
-                ],
+                [M_TOPIC.name]: {
+                    "m.text": [
+                        {
+                            body: "<b>pizza</b>",
+                            mimetype: "text/html",
+                        },
+                        {
+                            body: "pizza",
+                            mimetype: "text/plain",
+                        },
+                    ],
+                },
             });
         });
 
         it("creates an empty event when the topic is falsey", () => {
             expect(makeTopicContent(undefined)).toEqual({
                 topic: undefined,
-                [M_TOPIC.name]: [],
+                [M_TOPIC.name]: {"m.text": []},
             });
             expect(makeTopicContent(null)).toEqual({
                 topic: null,
-                [M_TOPIC.name]: [],
+                [M_TOPIC.name]: {"m.text": []},
             });
         });
     });
@@ -225,11 +229,13 @@ describe("Topic content helpers", () => {
             expect(
                 parseTopicContent({
                     topic: "pizza",
-                    [M_TOPIC.name]: [
-                        {
-                            body: "pizza",
-                        },
-                    ],
+                    [M_TOPIC.name]: {
+                        "m.text": [
+                            {
+                                body: "pizza",
+                            },
+                        ],
+                    },
                 }),
             ).toEqual({
                 text: "pizza",
@@ -240,12 +246,14 @@ describe("Topic content helpers", () => {
             expect(
                 parseTopicContent({
                     topic: "pizza",
-                    [M_TOPIC.name]: [
-                        {
-                            body: "pizza",
-                            mimetype: "text/plain",
-                        },
-                    ],
+                    [M_TOPIC.name]: {
+                        "m.text": [
+                            {
+                                body: "pizza",
+                                mimetype: "text/plain",
+                            },
+                        ],
+                    },
                 }),
             ).toEqual({
                 text: "pizza",
@@ -256,12 +264,14 @@ describe("Topic content helpers", () => {
             expect(
                 parseTopicContent({
                     topic: "pizza",
-                    [M_TOPIC.name]: [
-                        {
-                            body: "<b>pizza</b>",
-                            mimetype: "text/html",
-                        },
-                    ],
+                    [M_TOPIC.name]: {
+                        "m.text": [
+                            {
+                                body: "<b>pizza</b>",
+                                mimetype: "text/html",
+                            },
+                        ],
+                    },
                 }),
             ).toEqual({
                 text: "pizza",
@@ -283,7 +293,12 @@ describe("Topic content helpers", () => {
             expect(
                 parseTopicContent({
                     "topic": "pizza",
-                    "m.topic": {} as any,
+                    "m.topic": [
+                        {
+                            body: "<b>pizza</b>",
+                            mimetype: "text/html",
+                        },
+                    ] as any,
                 }),
             ).toEqual({
                 text: "pizza",

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -50,9 +50,16 @@ export const M_TOPIC = new NamespacedValue("m.topic");
 export type MTopicContent = { "m.text": IMessageRendering[] };
 
 /**
+ * A previous incorrect form of m.topic used by matrix-js-sdk
+ * TODO remove this after a few releases
+ *      https://github.com/matrix-org/matrix-js-sdk/pull/4984#pullrequestreview-3174251065
+ */
+export type MalformedMTopicEvent = { "m.topic": IMessageRendering[] };
+
+/**
  * The event definition for an m.topic event (in content)
  */
-export type MTopicEvent = { "m.topic": MTopicContent };
+export type MTopicEvent = { "m.topic": MTopicContent } | MalformedMTopicEvent;
 
 /**
  * The event content for an m.room.topic event

--- a/src/@types/topic.ts
+++ b/src/@types/topic.ts
@@ -47,7 +47,7 @@ export const M_TOPIC = new NamespacedValue("m.topic");
 /**
  * The event content for an m.topic event (in content)
  */
-export type MTopicContent = IMessageRendering[];
+export type MTopicContent = { "m.text": IMessageRendering[] };
 
 /**
  * The event definition for an m.topic event (in content)

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -197,7 +197,7 @@ export const makeTopicContent: MakeTopicContent = (topic, htmlTopic) => {
     if (isProvided(topic)) {
         renderings.push({ body: topic, mimetype: "text/plain" });
     }
-    return { topic, [M_TOPIC.name]: renderings };
+    return { topic, [M_TOPIC.name]: { "m.text": renderings } };
 };
 
 export type TopicState = {
@@ -206,7 +206,7 @@ export type TopicState = {
 };
 
 export const parseTopicContent = (content: MRoomTopicEventContent): TopicState => {
-    const mtopic = M_TOPIC.findIn<MTopicContent>(content);
+    const mtopic = M_TOPIC.findIn<MTopicContent>(content)?.["m.text"];
     if (!Array.isArray(mtopic)) {
         return { text: content.topic ?? undefined };
     }

--- a/src/content-helpers.ts
+++ b/src/content-helpers.ts
@@ -206,7 +206,11 @@ export type TopicState = {
 };
 
 export const parseTopicContent = (content: MRoomTopicEventContent): TopicState => {
-    const mtopic = M_TOPIC.findIn<MTopicContent>(content)?.["m.text"];
+    const mtopicParent = M_TOPIC.findIn<MTopicContent>(content);
+    const mtopic = Array.isArray(mtopicParent) ? mtopicParent : mtopicParent?.["m.text"];
+    // TODO remove support for the old malformed m.topic arrays after a few releases (only allow array in m.text)
+    //      https://github.com/matrix-org/matrix-js-sdk/pull/4984#pullrequestreview-3174251065
+    //const mtopic = M_TOPIC.findIn<MTopicContent>(content)?.["m.text"];
     if (!Array.isArray(mtopic)) {
         return { text: content.topic ?? undefined };
     }


### PR DESCRIPTION
Fixes #4902

I don't think any kind of backwards compatibility makes sense. The existing topics are malformed and if rooms have such topics, it's better that they notice the formatting disappears and fix it. An automatic migration would probably also be too invasive (it'd require sending events as the user)