### PR TITLE
Exclude cancelled requests from in-progress lists

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1040,7 +1040,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             new RustSdkCryptoJs.UserId(userId),
         );
         return requests
-            .filter((request) => request.roomId === undefined)
+            .filter((request) => request.roomId === undefined && !request.isCancelled())
             .map((request) => this.makeVerificationRequest(request));
     }
 
@@ -1063,7 +1063,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         );
 
         // Search for the verification request for the given room id
-        const request = requests.find((request) => request.roomId?.toString() === roomId);
+        const request = requests.find((request) => request.roomId?.toString() === roomId && !request.isCancelled());
 
         if (request) {
             return this.makeVerificationRequest(request);


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/29882

When we ask for the in-progress verification requests, exclude requests that have been cancelled. This means that we don't erroneously tell the user that the new request they are about to create has been cancelled.

A higher-level test for this bug is introduced in https://github.com/element-hq/element-web/pull/30835