### PR TITLE
do not set cache in authenticated fetch

### DIFF
--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -279,6 +279,13 @@ export class FetchHttpApi<O extends IHttpOpts> {
 
         const { signal, cleanup } = anySignal(signals);
 
+        // Set cache mode based on presence of Authorization header.
+        // Proxies do not cache responses to requests with Authorization headers.
+        // So specifying "no-cache" is redundant, and actually prevents caching
+        // of preflight requests in CORS scenarios. As such, we only set "no-cache"
+        // when there is no Authorization header.
+        const cacheMode = "Authorization" in headers ? undefined : "no-cache";
+
         let res: Response;
         const start = Date.now();
         try {
@@ -291,7 +298,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
                 redirect: "follow",
                 referrer: "",
                 referrerPolicy: "no-referrer",
-                cache: "no-cache",
+                cache: cacheMode,
                 credentials: "omit", // we send credentials via headers
                 keepalive: keepAlive,
                 priority: opts.priority,


### PR DESCRIPTION
Fix for issue https://github.com/matrix-org/matrix-js-sdk/issues/5019

In practice, there is no need to set the cache property in `fetch()`, but this PR removes it only when the `Authorization` header is present.
