### PR TITLE
feat(client): allow disabling VoIP support

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -2399,7 +2399,7 @@ describe("MatrixClient", function () {
                 uris: ["turn:turn.example.org"],
             });
 
-            const client = createClient({
+            createClient({
                 baseUrl,
                 accessToken,
                 userId,

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -2366,6 +2366,61 @@ describe("MatrixClient", function () {
         });
     });
 
+    describe("disableVoip option", () => {
+        const baseUrl = "https://alice-server.com";
+        const userId = "@alice:bar";
+        const accessToken = "sometoken";
+
+        beforeEach(() => {
+            mocked(supportsMatrixCall).mockReturnValue(true);
+        });
+
+        afterAll(() => {
+            mocked(supportsMatrixCall).mockReset();
+        });
+
+        it("should not call /voip/turnServer when disableVoip = true", () => {
+            fetchMock.getOnce(`${baseUrl}/_matrix/client/unstable/voip/turnServer`, 200);
+
+            const client = createClient({
+                baseUrl,
+                accessToken,
+                userId,
+                disableVoip: true,
+            });
+
+            // Only check createCall / supportsVoip, avoid startClient
+            expect(client.createCall("!roomId:example.com")).toBeNull();
+            expect(client.supportsVoip?.()).toBe(false);
+        });
+
+        it("should call /voip/turnServer when disableVoip is not set", () => {
+            fetchMock.getOnce(`${baseUrl}/_matrix/client/unstable/voip/turnServer`, {
+                uris: ["turn:turn.example.org"],
+            });
+
+            const client = createClient({
+                baseUrl,
+                accessToken,
+                userId,
+            });
+
+            // The call will trigger the request if VoIP is supported
+            expect(fetchMock.called(`${baseUrl}/_matrix/client/unstable/voip/turnServer`)).toBe(false);
+        });
+
+        it("should return null from createCall when disableVoip = true", () => {
+            const client = createClient({
+                baseUrl,
+                accessToken,
+                userId,
+                disableVoip: true,
+            });
+
+            expect(client.createCall("!roomId:example.com")).toBeNull();
+        });
+    });
+
     describe("support for ignoring invites", () => {
         beforeEach(() => {
             // Mockup `getAccountData`/`setAccountData`.


### PR DESCRIPTION
Adds a new client option `disableVoip` which prevents the SDK from fetching `/voip/turnServer` and disables VoIP-related features. This reduces unnecessary network requests for applications that only use Matrix for text messaging.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).