### PR TITLE
Implement Sticky Events MSC4354

### DIFF
--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -616,12 +616,17 @@ describe("MatrixEvent", () => {
         };
         try {
             jest.useFakeTimers();
-            jest.setSystemTime(0);
+            jest.setSystemTime(50);
             // Prefer unsigned
-            expect(new MatrixEvent({ ...evData } satisfies IStickyEvent).unstableStickyExpiresAt).toEqual(5000);
+            expect(new MatrixEvent({ ...evData } satisfies IStickyEvent).unstableStickyExpiresAt).toEqual(5050);
             // Fall back to `duration_ms`
             expect(
                 new MatrixEvent({ ...evData, unsigned: undefined } satisfies IStickyEvent).unstableStickyExpiresAt,
+            ).toEqual(1050);
+            // Prefer current time if `origin_server_ts` is more recent.
+            expect(
+                new MatrixEvent({ ...evData, unsigned: undefined, origin_server_ts: 5000 } satisfies IStickyEvent)
+                    .unstableStickyExpiresAt,
             ).toEqual(1050);
         } finally {
             jest.useRealTimers();

--- a/spec/unit/models/event.spec.ts
+++ b/spec/unit/models/event.spec.ts
@@ -20,6 +20,7 @@ import { type IContent, MatrixEvent, MatrixEventEvent } from "../../../src/model
 import { emitPromise } from "../../test-utils/test-utils";
 import {
     type IAnnotatedPushRule,
+    type IStickyEvent,
     type MatrixClient,
     PushRuleActionName,
     Room,
@@ -597,6 +598,34 @@ describe("MatrixEvent", () => {
 
         expect(stateEvent.isState()).toBeTruthy();
         expect(stateEvent.threadRootId).toBeUndefined();
+    });
+
+    it("should calculate sticky duration correctly", async () => {
+        const evData: IStickyEvent = {
+            event_id: "$event_id",
+            type: "some_state_event",
+            content: {},
+            sender: "@alice:example.org",
+            origin_server_ts: 50,
+            msc4354_sticky: {
+                duration_ms: 1000,
+            },
+            unsigned: {
+                msc4354_sticky_duration_ttl_ms: 5000,
+            },
+        };
+        try {
+            jest.useFakeTimers();
+            jest.setSystemTime(0);
+            // Prefer unsigned
+            expect(new MatrixEvent({ ...evData } satisfies IStickyEvent).unstableStickyExpiresAt).toEqual(5000);
+            // Fall back to `duration_ms`
+            expect(
+                new MatrixEvent({ ...evData, unsigned: undefined } satisfies IStickyEvent).unstableStickyExpiresAt,
+            ).toEqual(1050);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });
 

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -76,6 +76,15 @@ describe("RoomStickyEvents", () => {
             ]);
             expect([...stickyEvents.getStickyEvents()]).toEqual([originalEv]);
         });
+        it("should allow multiple events with the same sticky key for different event types", () => {
+            const originalEv = new MatrixEvent({ ...stickyEvent });
+            const anotherEv = new MatrixEvent({
+                ...stickyEvent,
+                type: "org.example.another_type",
+            });
+            stickyEvents.addStickyEvents([originalEv, anotherEv]);
+            expect([...stickyEvents.getStickyEvents()]).toEqual([originalEv, anotherEv]);
+        });
     });
 
     describe("_unstable_addStickyEvents(", () => {

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -28,26 +28,26 @@ describe("RoomStickyEvents", () => {
 
     describe("addStickyEvents", () => {
         it("should allow adding an event without a msc4354_sticky_key", () => {
-            stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, content: {} }));
+            stickyEvents._unstable_addStickyEvent(new MatrixEvent({ ...stickyEvent, content: {} }));
         });
         it("should not allow adding an event without a msc4354_sticky property", () => {
             expect(() =>
-                stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, msc4354_sticky: undefined })),
+                stickyEvents._unstable_addStickyEvent(new MatrixEvent({ ...stickyEvent, msc4354_sticky: undefined })),
             ).toThrow(`${stickyEvent.event_id} is missing msc4354_sticky.duration_ms`);
             expect(() =>
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({ ...stickyEvent, msc4354_sticky: { duration_ms: undefined } as any }),
                 ),
             ).toThrow(`${stickyEvent.event_id} is missing msc4354_sticky.duration_ms`);
         });
         it("should not allow adding an event without a sender", () => {
             expect(() =>
-                stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, sender: undefined })),
+                stickyEvents._unstable_addStickyEvent(new MatrixEvent({ ...stickyEvent, sender: undefined })),
             ).toThrow(`${stickyEvent.event_id} is missing a sender`);
         });
         it("should ignore old events", () => {
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                         origin_server_ts: 0,
@@ -60,14 +60,14 @@ describe("RoomStickyEvents", () => {
         });
         it("should not replace newer events", () => {
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                     }),
                 ),
             ).toEqual({ added: true });
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                         origin_server_ts: 1,
@@ -77,14 +77,14 @@ describe("RoomStickyEvents", () => {
         });
         it("should not replace events on ID tie break", () => {
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                     }),
                 ),
             ).toEqual({ added: true });
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                         event_id: "$abc:bar",
@@ -94,7 +94,7 @@ describe("RoomStickyEvents", () => {
         });
         it("should be able to just add an event", () => {
             expect(
-                stickyEvents.unstableAddStickyEvent(
+                stickyEvents._unstable_addStickyEvent(
                     new MatrixEvent({
                         ...stickyEvent,
                     }),
@@ -103,14 +103,14 @@ describe("RoomStickyEvents", () => {
         });
     });
 
-    describe("unstableAddStickyEvents", () => {
+    describe("_unstable_addStickyEvents(", () => {
         it("should emit when a new sticky event is added", () => {
             const emitSpy = jest.fn();
             stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
             const ev = new MatrixEvent({
                 ...stickyEvent,
             });
-            stickyEvents.unstableAddStickyEvents([ev]);
+            stickyEvents._unstable_addStickyEvents(([ev]));
             expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
             expect(emitSpy).toHaveBeenCalledWith([ev], []);
         });
@@ -121,7 +121,7 @@ describe("RoomStickyEvents", () => {
                 ...stickyEvent,
                 content: {},
             });
-            stickyEvents.unstableAddStickyEvents([ev]);
+            stickyEvents._unstable_addStickyEvents(([ev]));
             expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
             expect(emitSpy).toHaveBeenCalledWith([ev], []);
         });
@@ -135,7 +135,7 @@ describe("RoomStickyEvents", () => {
             const ev = new MatrixEvent({
                 ...stickyEvent,
             });
-            stickyEvents.unstableAddStickyEvent(
+            stickyEvents._unstable_addStickyEvent(
                 new MatrixEvent({
                     ...stickyEvent,
                 }),
@@ -153,8 +153,8 @@ describe("RoomStickyEvents", () => {
                     msc4354_sticky_key: "bibble",
                 },
             });
-            stickyEvents.unstableAddStickyEvent(ev);
-            stickyEvents.unstableAddStickyEvent(ev2);
+            stickyEvents._unstable_addStickyEvent(ev);
+            stickyEvents._unstable_addStickyEvent(ev2);
             expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev, ev2]);
         });
     });
@@ -175,7 +175,7 @@ describe("RoomStickyEvents", () => {
                 ...stickyEvent,
                 origin_server_ts: Date.now(),
             });
-            stickyEvents.unstableAddStickyEvent(ev);
+            stickyEvents._unstable_addStickyEvent(ev);
             jest.setSystemTime(15000);
             jest.advanceTimersByTime(15000);
             expect(emitSpy).toHaveBeenCalledWith([], [ev]);
@@ -197,7 +197,7 @@ describe("RoomStickyEvents", () => {
                 },
                 origin_server_ts: 0,
             });
-            stickyEvents.unstableAddStickyEvents([ev1, ev2]);
+            stickyEvents._unstable_addStickyEvents(([ev1, ev2]));
             expect(emitSpy).toHaveBeenCalledWith([ev1, ev2], []);
             jest.setSystemTime(15000);
             jest.advanceTimersByTime(15000);
@@ -212,7 +212,7 @@ describe("RoomStickyEvents", () => {
                 content: {},
                 origin_server_ts: Date.now(),
             });
-            stickyEvents.unstableAddStickyEvent(ev);
+            stickyEvents._unstable_addStickyEvent(ev);
             jest.setSystemTime(15000);
             jest.advanceTimersByTime(15000);
             expect(emitSpy).toHaveBeenCalledWith([], [ev]);

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -110,7 +110,7 @@ describe("RoomStickyEvents", () => {
             const ev = new MatrixEvent({
                 ...stickyEvent,
             });
-            stickyEvents._unstable_addStickyEvents(([ev]));
+            stickyEvents._unstable_addStickyEvents([ev]);
             expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
             expect(emitSpy).toHaveBeenCalledWith([ev], []);
         });
@@ -121,7 +121,7 @@ describe("RoomStickyEvents", () => {
                 ...stickyEvent,
                 content: {},
             });
-            stickyEvents._unstable_addStickyEvents(([ev]));
+            stickyEvents._unstable_addStickyEvents([ev]);
             expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
             expect(emitSpy).toHaveBeenCalledWith([ev], []);
         });
@@ -197,7 +197,7 @@ describe("RoomStickyEvents", () => {
                 },
                 origin_server_ts: 0,
             });
-            stickyEvents._unstable_addStickyEvents(([ev1, ev2]));
+            stickyEvents._unstable_addStickyEvents([ev1, ev2]);
             expect(emitSpy).toHaveBeenCalledWith([ev1, ev2], []);
             jest.setSystemTime(15000);
             jest.advanceTimersByTime(15000);

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -203,16 +203,16 @@ describe("RoomStickyEvents", () => {
         });
 
         it("should emit when a sticky event expires", () => {
-            jest.setSystemTime(0);
+            jest.setSystemTime(1000);
             const ev = new MatrixEvent({
                 ...stickyEvent,
-                origin_server_ts: Date.now(),
+                origin_server_ts: 0,
             });
             const evLater = new MatrixEvent({
                 ...stickyEvent,
                 event_id: "$baz:bar",
                 sender: "@bob:example.org",
-                origin_server_ts: Date.now() + 1000,
+                origin_server_ts: 1000,
             });
             stickyEvents.addStickyEvents([ev, evLater]);
             const emitSpy = jest.fn();

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -1,0 +1,221 @@
+import { type IEvent, MatrixEvent } from "../../../src";
+import { RoomStickyEvents, RoomStickyEventsEvent } from "../../../src/models/room-sticky-events";
+
+describe("RoomStickyEvents", () => {
+    let stickyEvents: RoomStickyEvents;
+    const stickyEvent: IEvent = {
+        event_id: "$foo:bar",
+        room_id: "!roomId",
+        type: "org.example.any_type",
+        msc4354_sticky: {
+            duration_ms: 15000,
+        },
+        content: {
+            msc4354_sticky_key: "foobar",
+        },
+        sender: "@alice:example.org",
+        origin_server_ts: Date.now(),
+        unsigned: {},
+    };
+
+    beforeEach(() => {
+        stickyEvents = new RoomStickyEvents();
+    });
+
+    afterEach(() => {
+        stickyEvents?.clear();
+    });
+
+    describe("addStickyEvents", () => {
+        it("should allow adding an event without a msc4354_sticky_key", () => {
+            stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, content: {} }));
+        });
+        it("should not allow adding an event without a msc4354_sticky property", () => {
+            expect(() =>
+                stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, msc4354_sticky: undefined })),
+            ).toThrow(`${stickyEvent.event_id} is missing msc4354_sticky.duration_ms`);
+            expect(() =>
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({ ...stickyEvent, msc4354_sticky: { duration_ms: undefined } as any }),
+                ),
+            ).toThrow(`${stickyEvent.event_id} is missing msc4354_sticky.duration_ms`);
+        });
+        it("should not allow adding an event without a sender", () => {
+            expect(() =>
+                stickyEvents.unstableAddStickyEvent(new MatrixEvent({ ...stickyEvent, sender: undefined })),
+            ).toThrow(`${stickyEvent.event_id} is missing a sender`);
+        });
+        it("should ignore old events", () => {
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                        origin_server_ts: 0,
+                        msc4354_sticky: {
+                            duration_ms: 1,
+                        },
+                    }),
+                ),
+            ).toEqual({ added: false });
+        });
+        it("should not replace newer events", () => {
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                    }),
+                ),
+            ).toEqual({ added: true });
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                        origin_server_ts: 1,
+                    }),
+                ),
+            ).toEqual({ added: false });
+        });
+        it("should not replace events on ID tie break", () => {
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                    }),
+                ),
+            ).toEqual({ added: true });
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                        event_id: "$abc:bar",
+                    }),
+                ),
+            ).toEqual({ added: false });
+        });
+        it("should be able to just add an event", () => {
+            expect(
+                stickyEvents.unstableAddStickyEvent(
+                    new MatrixEvent({
+                        ...stickyEvent,
+                    }),
+                ),
+            ).toEqual({ added: true });
+        });
+    });
+
+    describe("unstableAddStickyEvents", () => {
+        it("should emit when a new sticky event is added", () => {
+            const emitSpy = jest.fn();
+            stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+            });
+            stickyEvents.unstableAddStickyEvents([ev]);
+            expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
+            expect(emitSpy).toHaveBeenCalledWith([ev], []);
+        });
+        it("should emit when a new unketed sticky event is added", () => {
+            const emitSpy = jest.fn();
+            stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+                content: {},
+            });
+            stickyEvents.unstableAddStickyEvents([ev]);
+            expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
+            expect(emitSpy).toHaveBeenCalledWith([ev], []);
+        });
+    });
+
+    describe("getStickyEvents", () => {
+        it("should have zero sticky events", () => {
+            expect([...stickyEvents._unstable_getStickyEvents()]).toHaveLength(0);
+        });
+        it("should contain a sticky event", () => {
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+            });
+            stickyEvents.unstableAddStickyEvent(
+                new MatrixEvent({
+                    ...stickyEvent,
+                }),
+            );
+            expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev]);
+        });
+        it("should contain two sticky events", () => {
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+            });
+            const ev2 = new MatrixEvent({
+                ...stickyEvent,
+                sender: "@fibble:bobble",
+                content: {
+                    msc4354_sticky_key: "bibble",
+                },
+            });
+            stickyEvents.unstableAddStickyEvent(ev);
+            stickyEvents.unstableAddStickyEvent(ev2);
+            expect([...stickyEvents._unstable_getStickyEvents()]).toEqual([ev, ev2]);
+        });
+    });
+
+    describe("cleanExpiredStickyEvents", () => {
+        beforeAll(() => {
+            jest.useFakeTimers();
+        });
+        afterAll(() => {
+            jest.useRealTimers();
+        });
+
+        it("should emit when a sticky event expires", () => {
+            const emitSpy = jest.fn();
+            stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
+            jest.setSystemTime(0);
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+                origin_server_ts: Date.now(),
+            });
+            stickyEvents.unstableAddStickyEvent(ev);
+            jest.setSystemTime(15000);
+            jest.advanceTimersByTime(15000);
+            expect(emitSpy).toHaveBeenCalledWith([], [ev]);
+        });
+        it("should emit two events when both expire at the same time", () => {
+            const emitSpy = jest.fn();
+            stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
+            jest.setSystemTime(0);
+            const ev1 = new MatrixEvent({
+                ...stickyEvent,
+                event_id: "$eventA",
+                origin_server_ts: 0,
+            });
+            const ev2 = new MatrixEvent({
+                ...stickyEvent,
+                event_id: "$eventB",
+                content: {
+                    msc4354_sticky_key: "key_2",
+                },
+                origin_server_ts: 0,
+            });
+            stickyEvents.unstableAddStickyEvents([ev1, ev2]);
+            expect(emitSpy).toHaveBeenCalledWith([ev1, ev2], []);
+            jest.setSystemTime(15000);
+            jest.advanceTimersByTime(15000);
+            expect(emitSpy).toHaveBeenCalledWith([], [ev1, ev2]);
+        });
+        it("should emit when a unkeyed sticky event expires", () => {
+            const emitSpy = jest.fn();
+            stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
+            jest.setSystemTime(0);
+            const ev = new MatrixEvent({
+                ...stickyEvent,
+                content: {},
+                origin_server_ts: Date.now(),
+            });
+            stickyEvents.unstableAddStickyEvent(ev);
+            jest.setSystemTime(15000);
+            jest.advanceTimersByTime(15000);
+            expect(emitSpy).toHaveBeenCalledWith([], [ev]);
+        });
+    });
+});

--- a/spec/unit/sync-accumulator.spec.ts
+++ b/spec/unit/sync-accumulator.spec.ts
@@ -1101,13 +1101,13 @@ describe("SyncAccumulator", function () {
             );
             expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toEqual([ev]);
         });
-        it("should clear stale sticky events", () => {
+        it.only("should clear stale sticky events", () => {
             jest.setSystemTime(1000);
             const ev = stickyEvent(1000);
             sa.accumulate(
                 syncSkeleton({
                     msc4354_sticky: {
-                        events: [ev, stickyEvent(0)],
+                        events: [ev],
                     },
                 }),
             );

--- a/spec/unit/sync-accumulator.spec.ts
+++ b/spec/unit/sync-accumulator.spec.ts
@@ -1116,6 +1116,18 @@ describe("SyncAccumulator", function () {
             sa.accumulate(syncSkeleton({}));
             expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toBeUndefined();
         });
+
+        it("clears stale sticky events that pretend to be from the distant future", () => {
+            jest.setSystemTime(0);
+            const eventFarInTheFuture = stickyEvent(999999999999);
+            sa.accumulate(syncSkeleton({ msc4354_sticky: { events: [eventFarInTheFuture] } }));
+            expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toEqual([
+                eventFarInTheFuture,
+            ]);
+            jest.setSystemTime(1000); // Expire the event
+            sa.accumulate(syncSkeleton({}));
+            expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toBeUndefined();
+        });
     });
 });
 

--- a/spec/unit/sync-accumulator.spec.ts
+++ b/spec/unit/sync-accumulator.spec.ts
@@ -1101,7 +1101,7 @@ describe("SyncAccumulator", function () {
             );
             expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toEqual([ev]);
         });
-        it.only("should clear stale sticky events", () => {
+        it("should clear stale sticky events", () => {
             jest.setSystemTime(1000);
             const ev = stickyEvent(1000);
             sa.accumulate(

--- a/spec/unit/sync-accumulator.spec.ts
+++ b/spec/unit/sync-accumulator.spec.ts
@@ -26,6 +26,7 @@ import {
     type ILeftRoom,
     type IRoomEvent,
     type IStateEvent,
+    type IStickyEvent,
     type IStrippedState,
     type ISyncResponse,
     SyncAccumulator,
@@ -1065,6 +1066,55 @@ describe("SyncAccumulator", function () {
             expect(roomData.timeline?.events.find((e) => e.type === "m.room.member")?.content.membership).toEqual(
                 KnownMembership.Join,
             );
+        });
+    });
+
+    describe("MSC4354 sticky events", () => {
+        function stickyEvent(ts = 0): IStickyEvent {
+            const msgData = msg("test", "test text");
+            return {
+                ...msgData,
+                msc4354_sticky: {
+                    duration_ms: 1000,
+                },
+                origin_server_ts: ts,
+            };
+        }
+
+        beforeAll(() => {
+            jest.useFakeTimers();
+        });
+
+        afterAll(() => {
+            jest.useRealTimers();
+        });
+
+        it("should accumulate sticky events", () => {
+            jest.setSystemTime(0);
+            const ev = stickyEvent();
+            sa.accumulate(
+                syncSkeleton({
+                    msc4354_sticky: {
+                        events: [ev],
+                    },
+                }),
+            );
+            expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toEqual([ev]);
+        });
+        it("should clear stale sticky events", () => {
+            jest.setSystemTime(1000);
+            const ev = stickyEvent(1000);
+            sa.accumulate(
+                syncSkeleton({
+                    msc4354_sticky: {
+                        events: [ev, stickyEvent(0)],
+                    },
+                }),
+            );
+            expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toEqual([ev]);
+            jest.setSystemTime(2000); // Expire the event
+            sa.accumulate(syncSkeleton({}));
+            expect(sa.getJSON().roomsData[Category.Join]["!foo:bar"].msc4354_sticky?.events).toBeUndefined();
         });
     });
 });

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -107,6 +107,9 @@ export type SendActionDelayedEventRequestOpts = ParentDelayId;
 
 export type SendDelayedEventRequestOpts = SendTimeoutDelayedEventRequestOpts | SendActionDelayedEventRequestOpts;
 
+export function isSendDelayedEventRequestOpts(opts: object): opts is SendDelayedEventRequestOpts {
+    return (opts as TimeoutDelay).delay !== undefined || (opts as ParentDelayId).parent_delay_id !== undefined;
+}
 export type SendDelayedEventResponse = {
     delay_id: string;
 };

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -94,21 +94,19 @@ export interface ISendEventResponse {
     event_id: string;
 }
 
-export type TimeoutDelay = {
-    delay: number;
-};
-
-export type ParentDelayId = {
-    parent_delay_id: string;
-};
-
-export type SendTimeoutDelayedEventRequestOpts = TimeoutDelay & Partial<ParentDelayId>;
-export type SendActionDelayedEventRequestOpts = ParentDelayId;
-
-export type SendDelayedEventRequestOpts = SendTimeoutDelayedEventRequestOpts | SendActionDelayedEventRequestOpts;
+export type SendDelayedEventRequestOpts = { parent_delay_id: string } | { delay: number; parent_delay_id?: string };
 
 export function isSendDelayedEventRequestOpts(opts: object): opts is SendDelayedEventRequestOpts {
-    return (opts as TimeoutDelay).delay !== undefined || (opts as ParentDelayId).parent_delay_id !== undefined;
+    if ("parent_delay_id" in opts && typeof opts.parent_delay_id !== "string") {
+        // Invalid type, reject
+        return false;
+    }
+    if ("delay" in opts && typeof opts.delay !== "number") {
+        // Invalid type, reject.
+        return true;
+    }
+    // At least one of these fields must be specified.
+    return "delay" in opts || "parent_delay_id" in opts;
 }
 export type SendDelayedEventResponse = {
     delay_id: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -3419,10 +3419,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Send a delayed timeline event.
+     * Send a delayed sticky timeline event.
      *
      * Note: This endpoint is unstable, and can throw an `Error`.
-     *   Check progress on [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) for more details.
+     *   Check progress on [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) and
+     *   [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) for more details.
      */
     // eslint-disable-next-line
     public async _unstable_sendStickyDelayedEvent<K extends keyof TimelineEvents>(
@@ -3434,6 +3435,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         content: TimelineEvents[K] & { msc4354_sticky_key: string },
         txnId?: string,
     ): Promise<SendDelayedEventResponse> {
+        if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4140_DELAYED_EVENTS))) {
+            throw new UnsupportedDelayedEventsEndpointError(
+                "Server does not support the delayed events API",
+                "getDelayedEvents",
+            );
+        }
         if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4354_STICKY_EVENTS))) {
             throw new UnsupportedStickyEventsEndpointError(
                 "Server does not support the sticky events",
@@ -3446,7 +3453,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             roomId,
             threadId,
             eventObject: { type: eventType, content },
-            queryDict: { msc4354_stick_duration_ms: stickDuration },
+            queryDict: { "org.matrix.msc4354.sticky_duration_ms": stickDuration },
             delayOpts,
             txnId,
         });
@@ -3487,10 +3494,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Send a delayed timeline event.
+     * Send a sticky timeline event.
      *
      * Note: This endpoint is unstable, and can throw an `Error`.
-     *   Check progress on [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) for more details.
+     *   Check progress on [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) for more details.
      */
     // eslint-disable-next-line
     public async _unstable_sendStickyEvent<K extends keyof TimelineEvents>(
@@ -3513,7 +3520,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             roomId,
             threadId,
             eventObject: { type: eventType, content },
-            queryDict: { msc4354_stick_duration_ms: stickDuration },
+            queryDict: { "org.matrix.msc4354.sticky_duration_ms": stickDuration },
             txnId,
         });
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -105,6 +105,7 @@ import {
 import { RoomMemberEvent, type RoomMemberEventHandlerMap } from "./models/room-member.ts";
 import { type IPowerLevelsContent, type RoomStateEvent, type RoomStateEventHandlerMap } from "./models/room-state.ts";
 import {
+    isSendDelayedEventRequestOpts,
     type DelayedEventInfo,
     type IAddThreePidOnlyBody,
     type IBindThreePidBody,
@@ -246,7 +247,7 @@ import {
     validateAuthMetadataAndKeys,
 } from "./oidc/index.ts";
 import { type EmptyObject } from "./@types/common.ts";
-import { UnsupportedDelayedEventsEndpointError } from "./errors.ts";
+import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
 
 export type Store = IStore;
 
@@ -545,6 +546,7 @@ export const UNSTABLE_MSC2666_MUTUAL_ROOMS = "uk.half-shot.msc2666.mutual_rooms"
 export const UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_mutual_rooms";
 
 export const UNSTABLE_MSC4140_DELAYED_EVENTS = "org.matrix.msc4140";
+export const UNSTABLE_MSC4354_STICKY_EVENTS = "org.matrix.msc4354";
 
 export const UNSTABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133";
 export const STABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133.stable";
@@ -2672,7 +2674,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         this.addThreadRelationIfNeeded(content, threadId, roomId);
-        return this.sendCompleteEvent(roomId, threadId, { type: eventType, content }, txnId);
+        return this.sendCompleteEvent({ roomId, threadId, eventObject: { type: eventType, content }, txnId });
     }
 
     /**
@@ -2709,12 +2711,13 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: to an empty object `{}`
      * @returns Rejects: with an error response.
      */
-    private sendCompleteEvent(
-        roomId: string,
-        threadId: string | null,
-        eventObject: Partial<IEvent>,
-        txnId?: string,
-    ): Promise<ISendEventResponse>;
+    private sendCompleteEvent(params: {
+        roomId: string;
+        threadId: string | null;
+        eventObject: Partial<IEvent>;
+        queryDict?: QueryDict;
+        txnId?: string;
+    }): Promise<ISendEventResponse>;
     /**
      * Sends a delayed event (MSC4140).
      * @param eventObject - An object with the partial structure of an event, to which event_id, user_id, room_id and origin_server_ts will be added.
@@ -2723,29 +2726,29 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise which resolves: to an empty object `{}`
      * @returns Rejects: with an error response.
      */
-    private sendCompleteEvent(
-        roomId: string,
-        threadId: string | null,
-        eventObject: Partial<IEvent>,
-        delayOpts: SendDelayedEventRequestOpts,
-        txnId?: string,
-    ): Promise<SendDelayedEventResponse>;
-    private sendCompleteEvent(
-        roomId: string,
-        threadId: string | null,
-        eventObject: Partial<IEvent>,
-        delayOptsOrTxnId?: SendDelayedEventRequestOpts | string,
-        txnIdOrVoid?: string,
-    ): Promise<ISendEventResponse | SendDelayedEventResponse> {
-        let delayOpts: SendDelayedEventRequestOpts | undefined;
-        let txnId: string | undefined;
-        if (typeof delayOptsOrTxnId === "string") {
-            txnId = delayOptsOrTxnId;
-        } else {
-            delayOpts = delayOptsOrTxnId;
-            txnId = txnIdOrVoid;
-        }
-
+    private sendCompleteEvent(params: {
+        roomId: string;
+        threadId: string | null;
+        eventObject: Partial<IEvent>;
+        delayOpts: SendDelayedEventRequestOpts;
+        queryDict?: QueryDict;
+        txnId?: string;
+    }): Promise<SendDelayedEventResponse>;
+    private sendCompleteEvent({
+        roomId,
+        threadId,
+        eventObject,
+        delayOpts,
+        queryDict,
+        txnId,
+    }: {
+        roomId: string;
+        threadId: string | null;
+        eventObject: Partial<IEvent>;
+        delayOpts?: SendDelayedEventRequestOpts;
+        queryDict?: QueryDict;
+        txnId?: string;
+    }): Promise<SendDelayedEventResponse | ISendEventResponse> {
         if (!txnId) {
             txnId = this.makeTxnId();
         }
@@ -2788,7 +2791,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         const type = localEvent.getType();
         this.logger.debug(
-            `sendEvent of type ${type} in ${roomId} with txnId ${txnId}${delayOpts ? " (delayed event)" : ""}`,
+            `sendEvent of type ${type} in ${roomId} with txnId ${txnId}${delayOpts ? " (delayed event)" : ""}${queryDict ? " query params: " + JSON.stringify(queryDict) : ""}`,
         );
 
         localEvent.setTxnId(txnId);
@@ -2806,9 +2809,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 return Promise.reject(new Error("Event blocked by other events not yet sent"));
             }
 
-            return this.encryptAndSendEvent(room, localEvent);
+            return this.encryptAndSendEvent(room, localEvent, queryDict);
         } else {
-            return this.encryptAndSendEvent(room, localEvent, delayOpts);
+            return this.encryptAndSendEvent(room, localEvent, delayOpts, queryDict);
         }
     }
 
@@ -2816,7 +2819,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * encrypts the event if necessary; adds the event to the queue, or sends it; marks the event as sent/unsent
      * @returns returns a promise which resolves with the result of the send request
      */
-    protected async encryptAndSendEvent(room: Room | null, event: MatrixEvent): Promise<ISendEventResponse>;
+    protected async encryptAndSendEvent(
+        room: Room | null,
+        event: MatrixEvent,
+        queryDict?: QueryDict,
+    ): Promise<ISendEventResponse>;
     /**
      * Simply sends a delayed event without encrypting it.
      * TODO: Allow encrypted delayed events, and encrypt them properly
@@ -2827,16 +2834,20 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         room: Room | null,
         event: MatrixEvent,
         delayOpts: SendDelayedEventRequestOpts,
-    ): Promise<SendDelayedEventResponse>;
+        queryDict?: QueryDict,
+    ): Promise<ISendEventResponse>;
     protected async encryptAndSendEvent(
         room: Room | null,
         event: MatrixEvent,
-        delayOpts?: SendDelayedEventRequestOpts,
+        delayOptsOrQuery?: SendDelayedEventRequestOpts | QueryDict,
+        queryDict?: QueryDict,
     ): Promise<ISendEventResponse | SendDelayedEventResponse> {
-        if (delayOpts) {
-            return this.sendEventHttpRequest(event, delayOpts);
+        let queryOpts = queryDict;
+        if (delayOptsOrQuery && isSendDelayedEventRequestOpts(delayOptsOrQuery)) {
+            return this.sendEventHttpRequest(event, delayOptsOrQuery, queryOpts);
+        } else if (!queryOpts) {
+            queryOpts = delayOptsOrQuery;
         }
-
         try {
             let cancelled: boolean;
             this.eventsBeingEncrypted.add(event.getId()!);
@@ -2872,7 +2883,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             }
 
             if (!promise) {
-                promise = this.sendEventHttpRequest(event);
+                promise = this.sendEventHttpRequest(event, queryOpts);
                 if (room) {
                     promise = promise.then((res) => {
                         room.updatePendingEvent(event, EventStatus.SENT, res["event_id"]);
@@ -2987,14 +2998,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
     }
 
-    private sendEventHttpRequest(event: MatrixEvent): Promise<ISendEventResponse>;
+    private sendEventHttpRequest(event: MatrixEvent, queryDict?: QueryDict): Promise<ISendEventResponse>;
     private sendEventHttpRequest(
         event: MatrixEvent,
         delayOpts: SendDelayedEventRequestOpts,
+        queryDict?: QueryDict,
     ): Promise<SendDelayedEventResponse>;
     private sendEventHttpRequest(
         event: MatrixEvent,
-        delayOpts?: SendDelayedEventRequestOpts,
+        queryOrDelayOpts?: SendDelayedEventRequestOpts | QueryDict,
+        queryDict?: QueryDict,
     ): Promise<ISendEventResponse | SendDelayedEventResponse> {
         let txnId = event.getTxnId();
         if (!txnId) {
@@ -3027,19 +3040,22 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             path = utils.encodeUri("/rooms/$roomId/send/$eventType/$txnId", pathParams);
         }
 
+        const delayOpts =
+            queryOrDelayOpts && isSendDelayedEventRequestOpts(queryOrDelayOpts) ? queryOrDelayOpts : undefined;
+        const queryOpts = !delayOpts ? queryOrDelayOpts : queryDict;
         const content = event.getWireContent();
-        if (!delayOpts) {
-            return this.http.authedRequest<ISendEventResponse>(Method.Put, path, undefined, content).then((res) => {
-                this.logger.debug(`Event sent to ${event.getRoomId()} with event id ${res.event_id}`);
-                return res;
-            });
-        } else {
+        if (delayOpts) {
             return this.http.authedRequest<SendDelayedEventResponse>(
                 Method.Put,
                 path,
-                getUnstableDelayQueryOpts(delayOpts),
+                { ...getUnstableDelayQueryOpts(delayOpts), ...queryOpts },
                 content,
             );
+        } else {
+            return this.http.authedRequest<ISendEventResponse>(Method.Put, path, queryOpts, content).then((res) => {
+                this.logger.debug(`Event sent to ${event.getRoomId()} with event id ${res.event_id}`);
+                return res;
+            });
         }
     }
 
@@ -3096,16 +3112,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             content[withRelTypesPropName] = opts.with_rel_types;
         }
 
-        return this.sendCompleteEvent(
+        return this.sendCompleteEvent({
             roomId,
             threadId,
-            {
+            eventObject: {
                 type: EventType.RoomRedaction,
                 content,
                 redacts: eventId,
             },
-            txnId as string,
-        );
+            txnId: txnId as string,
+        });
     }
 
     /**
@@ -3393,7 +3409,47 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         this.addThreadRelationIfNeeded(content, threadId, roomId);
-        return this.sendCompleteEvent(roomId, threadId, { type: eventType, content }, delayOpts, txnId);
+        return this.sendCompleteEvent({
+            roomId,
+            threadId,
+            eventObject: { type: eventType, content },
+            delayOpts,
+            txnId,
+        });
+    }
+
+    /**
+     * Send a delayed timeline event.
+     *
+     * Note: This endpoint is unstable, and can throw an `Error`.
+     *   Check progress on [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) for more details.
+     */
+    // eslint-disable-next-line
+    public async _unstable_sendStickyDelayedEvent<K extends keyof TimelineEvents>(
+        roomId: string,
+        stickDuration: number,
+        delayOpts: SendDelayedEventRequestOpts,
+        threadId: string | null,
+        eventType: K,
+        content: TimelineEvents[K] & { msc4354_sticky_key: string },
+        txnId?: string,
+    ): Promise<SendDelayedEventResponse> {
+        if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4354_STICKY_EVENTS))) {
+            throw new UnsupportedStickyEventsEndpointError(
+                "Server does not support the sticky events",
+                "sendStickyEvent",
+            );
+        }
+
+        this.addThreadRelationIfNeeded(content, threadId, roomId);
+        return this.sendCompleteEvent({
+            roomId,
+            threadId,
+            eventObject: { type: eventType, content },
+            queryDict: { msc4354_stick_duration_ms: stickDuration },
+            delayOpts,
+            txnId,
+        });
     }
 
     /**
@@ -3428,6 +3484,38 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             path = utils.encodeUri(path + "/$stateKey", pathParams);
         }
         return this.http.authedRequest(Method.Put, path, getUnstableDelayQueryOpts(delayOpts), content as Body, opts);
+    }
+
+    /**
+     * Send a delayed timeline event.
+     *
+     * Note: This endpoint is unstable, and can throw an `Error`.
+     *   Check progress on [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) for more details.
+     */
+    // eslint-disable-next-line
+    public async _unstable_sendStickyEvent<K extends keyof TimelineEvents>(
+        roomId: string,
+        stickDuration: number,
+        threadId: string | null,
+        eventType: K,
+        content: TimelineEvents[K] & { msc4354_sticky_key: string },
+        txnId?: string,
+    ): Promise<ISendEventResponse> {
+        if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4354_STICKY_EVENTS))) {
+            throw new UnsupportedStickyEventsEndpointError(
+                "Server does not support the sticky events",
+                "sendStickyEvent",
+            );
+        }
+
+        this.addThreadRelationIfNeeded(content, threadId, roomId);
+        return this.sendCompleteEvent({
+            roomId,
+            threadId,
+            eventObject: { type: eventType, content },
+            queryDict: { msc4354_stick_duration_ms: stickDuration },
+            txnId,
+        });
     }
 
     /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -54,7 +54,7 @@ export class ClientStoppedError extends Error {
 }
 
 /**
- * This error is thrown when the Homeserver does not support the delayed events enpdpoints.
+ * This error is thrown when the Homeserver does not support the delayed events endpoints.
  */
 export class UnsupportedDelayedEventsEndpointError extends Error {
     public constructor(
@@ -63,5 +63,18 @@ export class UnsupportedDelayedEventsEndpointError extends Error {
     ) {
         super(message);
         this.name = "UnsupportedDelayedEventsEndpointError";
+    }
+}
+
+/**
+ * This error is thrown when the Homeserver does not support the sticky events endpoints.
+ */
+export class UnsupportedStickyEventsEndpointError extends Error {
+    public constructor(
+        message: string,
+        public clientEndpoint: "sendStickyEvent" | "sendStickyStateEvent",
+    ) {
+        super(message);
+        this.name = "UnsupportedStickyEventsEndpointError";
     }
 }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -460,11 +460,11 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         const age = this.getAge();
         this.localTimestamp = age !== undefined ? Date.now() - age : (this.getTs() ?? Date.now());
         this.reEmitter = new TypedReEmitter(this);
-        if (this.unstableStickyContent) {
-            if (this.unstableStickyContent.duration_ttl_ms) {
-                this.unstableStickyExpiresAt = Date.now() + this.unstableStickyContent.duration_ttl_ms;
+        if (this.unstableStickyInfo) {
+            if (this.unstableStickyInfo.duration_ttl_ms) {
+                this.unstableStickyExpiresAt = Date.now() + this.unstableStickyInfo.duration_ttl_ms;
             } else {
-                this.unstableStickyExpiresAt = this.getTs() + this.unstableStickyContent.duration_ms;
+                this.unstableStickyExpiresAt = this.getTs() + this.unstableStickyInfo.duration_ms;
             }
         }
     }
@@ -1763,7 +1763,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      * If the event is not a sticky event (or not supported by the server),
      * then this returns `undefined`.
      */
-    public get unstableStickyContent(): { duration_ms: number; duration_ttl_ms?: number } | undefined {
+    public get unstableStickyInfo(): { duration_ms: number; duration_ttl_ms?: number } | undefined {
         if (!this.event.msc4354_sticky?.duration_ms) {
             return undefined;
         }

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -41,7 +41,6 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
      * Get all sticky events that are currently active.
      * @returns An iterable set of events.
      */
-    // eslint-disable-next-line
     public *getStickyEvents(): Iterable<MatrixEvent> {
         yield* this.unkeyedStickyEvents;
         for (const innerMap of this.stickyEventsMap.values()) {
@@ -57,7 +56,7 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
      * @returns A matching active sticky event, or undefined.
      */
     public getStickyEvent(sender: string, stickyKey: string, type: string): MatrixEvent | undefined {
-        return this.stickyEventsMap.get("type")?.get(`${stickyKey}${sender}`);
+        return this.stickyEventsMap.get(type)?.get(`${stickyKey}${sender}`);
     }
 
     /**
@@ -70,7 +69,6 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
      * @returns An object describing whether the event was added to the map,
      *          and the previous event it may have replaced.
      */
-    // eslint-disable-next-line
     private addStickyEvent(event: MatrixEvent): { added: true; prevEvent?: MatrixEvent } | { added: false } {
         const stickyKey = event.getContent().msc4354_sticky_key;
         if (typeof stickyKey !== "string" && stickyKey !== undefined) {
@@ -139,7 +137,6 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
      * changes were made.
      * @param events A set of new sticky events.
      */
-    // eslint-disable-next-line
     public addStickyEvents(events: MatrixEvent[]): void {
         const added = [];
         const removed = [];

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -24,7 +24,6 @@ export type RoomStickyEventsMap = {
     ) => void;
 };
 
-
 /**
  * Tracks sticky events on behalf of one room, and fires an event
  * whenever a sticky event is updated or replaced.
@@ -208,6 +207,7 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
                     );
                 }
             }
+            // Clean up map after use.
             if (this.stickyEventsMap.get(eventType)?.size === 0) {
                 this.stickyEventsMap.delete(eventType);
             }

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -32,7 +32,7 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
     private readonly stickyEventsMap = new Map<string, Map<string, StickyMatrixEvent>>(); // (type -> stickyKey+userId) -> event
     private readonly unkeyedStickyEvents = new Set<StickyMatrixEvent>();
 
-    private stickyEventTimer?: NodeJS.Timeout;
+    private stickyEventTimer?: ReturnType<typeof setTimeout>;
     private nextStickyEventExpiryTs: number = Number.MAX_SAFE_INTEGER;
 
     /**

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -123,7 +123,7 @@ export class RoomStickyEvents extends TypedEventEmitter<RoomStickyEventsEvent, R
      * @param events A set of new sticky events.
      */
     // eslint-disable-next-line
-    public _unstable_AddStickyEvents(events: MatrixEvent[]): void {
+    public _unstable_addStickyEvents(events: MatrixEvent[]): void {
         const added = [];
         const removed = [];
         for (const e of events) {

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3454,8 +3454,26 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @returns A matching active sticky event, or undefined.
      */
     // eslint-disable-next-line
-    public _unstable_getStickyEvent(sender: string, stickyKey: string, type: string): ReturnType<RoomStickyEventsStore["getStickyEvent"]> {
-        return this.stickyEvents.getStickyEvent(sender, stickyKey, type);
+    public _unstable_getKeyedStickyEvent(
+        sender: string,
+        type: string,
+        stickyKey: string,
+    ): ReturnType<RoomStickyEventsStore["getKeyedStickyEvent"]> {
+        return this.stickyEvents.getKeyedStickyEvent(sender, type, stickyKey);
+    }
+
+    /**
+     * Get an active sticky events that match the given `type` and `sender`.
+     * @param type The event `type`.
+     * @param sender The sender of the sticky event.
+     * @returns An array of matching sticky events.
+     */
+    // eslint-disable-next-line
+    public _unstable_getUnkeyedStickyEvent(
+        sender: string,
+        type: string,
+    ): ReturnType<RoomStickyEventsStore["getUnkeyedStickyEvent"]> {
+        return this.stickyEvents.getUnkeyedStickyEvent(sender, type);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -500,7 +500,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         // Listen to our own receipt event as a more modular way of processing our own
         // receipts. No need to remove the listener: it's on ourself anyway.
         this.on(RoomEvent.Receipt, this.onReceipt);
-        this.reEmitter.reEmit(this.stickyEvents, [RoomStickyEventsEvent.Update])
+        this.reEmitter.reEmit(this.stickyEvents, [RoomStickyEventsEvent.Update]);
 
         // all our per-room timeline sets. the first one is the unfiltered ones;
         // the subsequent ones are the filtered ones in no particular order.

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -77,7 +77,7 @@ import { compareEventOrdering } from "./compare-event-ordering.ts";
 import { KnownMembership, type Membership } from "../@types/membership.ts";
 import { type Capabilities, type IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities.ts";
 import { type MSC4186Hero } from "../sliding-sync.ts";
-import { RoomStickyEvents, RoomStickyEventsEvent } from "./room-sticky-events.ts";
+import { RoomStickyEventsStore, RoomStickyEventsEvent } from "./room-sticky-events.ts";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -464,7 +464,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     /**
      * Stores and tracks sticky events
      */
-    private stickyEvents = new RoomStickyEvents();
+    private stickyEvents = new RoomStickyEventsStore();
 
     /**
      * Construct a new Room.
@@ -3442,8 +3442,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * Get an iterator of currently active sticky events.
      */
     // eslint-disable-next-line
-    public _unstable_getStickyEvents(): ReturnType<RoomStickyEvents["_unstable_getStickyEvents"]> {
-        return this.stickyEvents._unstable_getStickyEvents();
+    public _unstable_getStickyEvents(): ReturnType<RoomStickyEventsStore["getStickyEvents"]> {
+        return this.stickyEvents.getStickyEvents();
     }
 
     /**
@@ -3452,8 +3452,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @param events A set of new sticky events.
      */
     // eslint-disable-next-line
-    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEvents["_unstable_addStickyEvents"]> {
-        return this.stickyEvents._unstable_addStickyEvents(events);
+    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEventsStore["addStickyEvents"]> {
+        return this.stickyEvents.addStickyEvents(events);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3452,8 +3452,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @param events A set of new sticky events.
      */
     // eslint-disable-next-line
-    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEvents["_unstable_AddStickyEvents"]> {
-        return this.stickyEvents._unstable_AddStickyEvents(events);
+    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEvents["_unstable_addStickyEvents"]> {
+        return this.stickyEvents._unstable_addStickyEvents(events);
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3447,6 +3447,18 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     /**
+     * Get a sticky event that match the given `type`, `sender`, and `stickyKey`
+     * @param type The event `type`.
+     * @param sender The sender of the sticky event.
+     * @param stickyKey The sticky key used by the event.
+     * @returns A matching active sticky event, or undefined.
+     */
+    // eslint-disable-next-line
+    public _unstable_getStickyEvent(sender: string, stickyKey: string, type: string): ReturnType<RoomStickyEventsStore["getStickyEvent"]> {
+        return this.stickyEvents.getStickyEvent(sender, stickyKey, type);
+    }
+
+    /**
      * Add a series of sticky events, emitting `RoomEvent.StickyEvents` if any
      * changes were made.
      * @param events A set of new sticky events.

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -558,7 +558,7 @@ export class SyncAccumulator {
         // Prune out any events in our stores that have since expired, do this before we
         // insert new events.
         currentData._stickyEvents = currentData._stickyEvents.filter((ev) => {
-            return Date.now() < ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
+            return Date.now() > ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
         });
 
         // We want this to be fast, so don't worry about duplicate events here. The RoomStickyEventsStore will

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -555,14 +555,17 @@ export class SyncAccumulator {
             });
         });
 
-        // We want this to be fast, so don't worry about clobbering events here.
-        if (data.msc4354_sticky?.events) {
-            currentData._stickyEvents = currentData._stickyEvents.concat(data.msc4354_sticky?.events);
-        }
-        // But always prune any stale events, as we don't need to keep those in storage.
+        // Prune out any events in our stores that have since expired, do this before we
+        // insert new events.
         currentData._stickyEvents = currentData._stickyEvents.filter((ev) => {
             return Date.now() < ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
         });
+
+        // We want this to be fast, so don't worry about duplicate events here. The RoomStickyEventsStore will
+        // process these events into the correct mapped order.
+        if (data.msc4354_sticky?.events) {
+            currentData._stickyEvents = currentData._stickyEvents.concat(data.msc4354_sticky?.events);
+        }
 
         // attempt to prune the timeline by jumping between events which have
         // pagination tokens.

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -78,7 +78,7 @@ export interface ITimeline {
 
 type StickyEventFields = {
     msc4354_sticky: { duration_ms: number };
-    content: IRoomEvent["content"] & { msc4354_sticky_key?: string };
+    content: { msc4354_sticky_key?: string };
 };
 
 export type IStickyEvent = IRoomEvent & StickyEventFields;
@@ -558,8 +558,10 @@ export class SyncAccumulator {
 
         // Prune out any events in our stores that have since expired, do this before we
         // insert new events.
+        const now = Date.now();
         currentData._stickyEvents = currentData._stickyEvents.filter((ev) => {
-            return Date.now() < ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
+            // If `origin_server_ts` claims to have been from the future, we still bound it to now.
+            return now < ev.msc4354_sticky.duration_ms + Math.min(now, ev.origin_server_ts);
         });
 
         // We want this to be fast, so don't worry about duplicate events here. The RoomStickyEventsStore will

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -558,7 +558,7 @@ export class SyncAccumulator {
         // Prune out any events in our stores that have since expired, do this before we
         // insert new events.
         currentData._stickyEvents = currentData._stickyEvents.filter((ev) => {
-            return Date.now() > ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
+            return Date.now() < ev.msc4354_sticky.duration_ms + ev.origin_server_ts;
         });
 
         // We want this to be fast, so don't worry about duplicate events here. The RoomStickyEventsStore will

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -76,13 +76,14 @@ export interface ITimeline {
     prev_batch: string | null;
 }
 
-export interface IStickyEvent extends IRoomEvent {
+type StickyEventFields = {
     msc4354_sticky: { duration_ms: number };
-}
+    content: IRoomEvent["content"] & { msc4354_sticky_key?: string };
+};
 
-export interface IStickyStateEvent extends IStateEvent {
-    msc4354_sticky: { duration_ms: number };
-}
+export type IStickyEvent = IRoomEvent & StickyEventFields;
+
+export type IStickyStateEvent = IStateEvent & StickyEventFields;
 
 export interface ISticky {
     events: Array<IStickyEvent | IStickyStateEvent>;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1409,7 +1409,7 @@ export class SyncApi {
             // hence we consider them as older.
             // and we add the events from the timeline at the end (newer)
             const stickyEventsAndStickyEventsFromTheTimeline = stickyEvents.concat(
-                timelineEvents.filter((e) => e.unstableStickyContent !== undefined),
+                timelineEvents.filter((e) => e.unstableStickyInfo !== undefined),
             );
             room._unstable_addStickyEvents(stickyEventsAndStickyEventsFromTheTimeline);
 


### PR DESCRIPTION
Split out from https://github.com/matrix-org/matrix-js-sdk/pull/5017 to allow for easy reviewing. Implements https://github.com/matrix-org/matrix-spec-proposals/pull/4354

As a brief overview of the MSC (though please do at least skim the MSC): This allows any member in a room to mark an event as "sticky" and ensure it gets delivered to other users *even* in the case of a gappy sync. This is useful for things like RTC where you want call member events to always reach clients, without having to bloat the room with state events that will contribute to overall DAG bloat. 

This implementation also deals with ensuring that some events will replace predecessors that share the same "sticky key", and emit the appropriate notices to users of the API.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
