### PR TITLE
Fetch the user's device info before processing a verification request

### DIFF
--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -2062,7 +2062,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             `Incoming verification event ${event.getId()} type ${event.getType()} from ${event.getSender()}`,
         );
 
-        await this.olmMachine.receiveVerificationEvent(
+        await this.getOlmMachineOrThrow().receiveVerificationEvent(
             JSON.stringify({
                 event_id: event.getId(),
                 type: event.getType(),


### PR DESCRIPTION
If we don't have the device info for a user when we receive their verification request, we ignore it. This change gives us the best possible chance of having the right device data before we try to process the verification.
    
* Fixes [#30693](https://github.com/element-hq/element-web/issues/30693)
* Fixes [#27819](https://github.com/element-hq/element-web/issues/27819)
