### PR TITLE
Toger5/refactor-session-manager-based-on-sticky-events

### DIFF
--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -14,12 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EventEmitter } from "stream";
 import { type Mocked } from "jest-mock";
 
-import { EventType, type Room, RoomEvent, type MatrixClient, type MatrixEvent } from "../../../src";
+import {
+    EventType,
+    type Room,
+    RoomEvent,
+    type MatrixClient,
+    type MatrixEvent,
+    Direction,
+    TypedEventEmitter,
+} from "../../../src";
 import { CallMembership, type SessionMembershipData } from "../../../src/matrixrtc/CallMembership";
 import { secureRandomString } from "../../../src/randomstring";
+import { type StickyMatrixEvent } from "../../../src/models/room-sticky-events";
 
 export type MembershipData = (SessionMembershipData | {}) & { user_id: string };
 
@@ -81,7 +89,7 @@ export function makeMockRoom(
     // Caching roomState here so it does not get recreated when calling `getLiveTimeline.getState()`
     const roomState = makeMockRoomState(useStickyEvents ? [] : membershipData, roomId);
     const ts = Date.now();
-    const room = Object.assign(new EventEmitter(), {
+    const room = Object.assign(new TypedEventEmitter(), {
         roomId: roomId,
         hasMembershipState: jest.fn().mockReturnValue(true),
         getLiveTimeline: jest.fn().mockReturnValue({
@@ -102,14 +110,13 @@ export function makeMockRoom(
 
 function makeMockRoomState(membershipData: MembershipData[], roomId: string) {
     const events = membershipData.map((m) => mockRTCEvent(m, roomId));
+
     const keysAndEvents = events.map((e) => {
         const data = e.getContent() as SessionMembershipData;
         return [`_${e.sender?.userId}_${data.device_id}`];
     });
 
-    return {
-        on: jest.fn(),
-        off: jest.fn(),
+    return Object.assign(new TypedEventEmitter(), {
         getStateEvents: (_: string, stateKey: string) => {
             if (stateKey !== undefined) return keysAndEvents.find(([k]) => k === stateKey)?.[1];
             return events;
@@ -128,11 +135,17 @@ function makeMockRoomState(membershipData: MembershipData[], roomId: string) {
                           },
                       ],
                   ]),
-    };
+    });
 }
 
 export function mockRoomState(room: Room, membershipData: MembershipData[]): void {
-    room.getLiveTimeline().getState = jest.fn().mockReturnValue(makeMockRoomState(membershipData, room.roomId));
+    const prevState = room.getLiveTimeline().getState(Direction.Forward)!;
+    const newState = makeMockRoomState(membershipData, room.roomId);
+    room.getLiveTimeline().getState = jest
+        .fn()
+        .mockReturnValue(
+            Object.assign(prevState, { events: newState.events, getStateEvents: newState.getStateEvents }),
+        );
 }
 
 export function makeMockEvent(
@@ -160,7 +173,7 @@ export function mockRTCEvent(
     roomId: string,
     stickyDuration?: number,
     timestamp?: number,
-): MatrixEvent {
+): StickyMatrixEvent {
     return {
         ...makeMockEvent(
             stickyDuration !== undefined ? EventType.RTCMembership : EventType.GroupCallMemberPrefix,
@@ -171,7 +184,7 @@ export function mockRTCEvent(
             !stickyDuration && "device_id" in membershipData ? `_${sender}_${membershipData.device_id}` : "",
         ),
         unstableStickyExpiresAt: stickyDuration,
-    } as unknown as MatrixEvent;
+    } as unknown as StickyMatrixEvent;
 }
 
 export function mockCallMembership(membershipData: MembershipData, roomId: string): CallMembership {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -775,7 +775,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
         }
 
         if (soonestExpiry != undefined) {
-            this.expiryTimeout = setTimeout(this.onRTCSessionMemberUpdate, soonestExpiry);
+            this.expiryTimeout = setTimeout(this.recalculateSessionMembers, soonestExpiry);
         }
     }
 
@@ -868,12 +868,12 @@ export class MatrixRTCSession extends TypedEventEmitter<
         this.recalculateSessionMembers();
     };
 
-    /**
-     * Call this when something changed that may impacts the current MatrixRTC members in this session.
-     */
-    public onRTCSessionMemberUpdate = (): void => {
-        this.recalculateSessionMembers();
-    };
+    // /**
+    //  * Call this when something changed that may impacts the current MatrixRTC members in this session.
+    //  */
+    // public onRTCSessionMemberUpdate = (): void => {
+    //     this.recalculateSessionMembers();
+    // };
 
     /**
      * Call this when anything that could impact rtc memberships has changed: Room Members or RTC members.

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -1062,12 +1062,12 @@ export class StickyEventMembershipManager extends MembershipManager {
         );
     };
 
+    private static nameMap = new Map([
+        ["sendStateEvent", "_unstable_sendStickyEvent"],
+        ["sendDelayedStateEvent", "_unstable_sendStickyDelayedEvent"],
+    ]);
     protected actionUpdateFromErrors(e: unknown, t: MembershipActionType, m: string): ActionUpdate | undefined {
-        const mappedMethod = new Map([
-            ["sendStateEvent", "_unstable_sendStickyEvent"],
-            ["_unstable_sendDelayedStateEvent", "_unstable_sendStickyDelayedEvent"],
-        ]).get(m);
-        return super.actionUpdateFromErrors(e, t, mappedMethod ?? "unknown method");
+        return super.actionUpdateFromErrors(e, t, StickyEventMembershipManager.nameMap.get(m) ?? "unknown");
     }
 
     protected makeMyMembership(expires: number): SessionMembershipData | RtcMembershipData {

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -1062,12 +1062,12 @@ export class StickyEventMembershipManager extends MembershipManager {
         );
     };
 
-    private static nameMap = new Map([
-        ["sendStateEvent", "_unstable_sendStickyEvent"],
-        ["sendDelayedStateEvent", "_unstable_sendStickyDelayedEvent"],
-    ]);
     protected actionUpdateFromErrors(e: unknown, t: MembershipActionType, m: string): ActionUpdate | undefined {
-        return super.actionUpdateFromErrors(e, t, StickyEventMembershipManager.nameMap.get(m) ?? "unknown");
+        const mappedMethod = new Map([
+            ["sendStateEvent", "_unstable_sendStickyEvent"],
+            ["_unstable_sendDelayedStateEvent", "_unstable_sendStickyDelayedEvent"],
+        ]).get(m);
+        return super.actionUpdateFromErrors(e, t, mappedMethod ?? "unknown method");
     }
 
     protected makeMyMembership(expires: number): SessionMembershipData | RtcMembershipData {


### PR DESCRIPTION
This PR changes the responsibitiy of the SessionManager.

 - before: it was listeinging to all state event updates and called recalculate members on effected rtc sessions. This resulted in a couple of duplicated member recalculations because the session itself also listened to the same events.
  - now: The SessionManager is ONLY responsible for starting a session. So it will only listen to the events required to find out if a new sessins just started. All event listener setup is done inside the MatrixRTC session itself. This also makes the RTCSession easier to read since we do not call `recalculateSessionMembers` externally which cannot be seen when just looking at the MatrixRTC session.
  
Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
