### PR TITLE
Update sticky events to use NamespacedValue for later stable support.

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -315,6 +315,28 @@ export const UNSIGNED_THREAD_ID_FIELD = new UnstableValue("thread_id", "org.matr
  */
 export const UNSIGNED_MEMBERSHIP_FIELD = new NamespacedValue("membership", "io.element.msc4115.membership");
 
+
+/**
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+ *
+ * @experimental
+ */
+export const STICKY_EVENT_FIELD = new NamespacedValue(null, "msc4354_sticky");
+
+/**
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+ *
+ * @experimental
+ */
+export const STICKY_EVENT_KEY_FIELD = new NamespacedValue(null, "msc4354_sticky_key");
+
+/**
+ * https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+ *
+ * @experimental
+ */
+export const STICKY_EVENT_DURATION_TTL_MS = new NamespacedValue(null, "msc4354_sticky_duration_ttl_ms")
+
 /**
  * Mapped type from event type to content type for all specified non-state room events.
  */

--- a/src/client.ts
+++ b/src/client.ts
@@ -143,6 +143,7 @@ import {
     RoomCreateTypeField,
     RoomType,
     type StateEvents,
+    STICKY_EVENT_KEY_FIELD,
     type TimelineEvents,
     UNSTABLE_MSC3088_ENABLED,
     UNSTABLE_MSC3088_PURPOSE,
@@ -3443,7 +3444,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         delayOpts: SendDelayedEventRequestOpts,
         threadId: string | null,
         eventType: K,
-        content: TimelineEvents[K] & { msc4354_sticky_key: string },
+        content: TimelineEvents[K] & { [STICKY_EVENT_KEY_FIELD.name]: string },
         txnId?: string,
     ): Promise<SendDelayedEventResponse> {
         if (!(await this.doesServerSupportUnstableFeature(UNSTABLE_MSC4140_DELAYED_EVENTS))) {

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -20,7 +20,7 @@ import { type LivekitFocusSelection } from "./LivekitTransport.ts";
 import { slotDescriptionToId, slotIdToDescription, type SlotDescription } from "./MatrixRTCSession.ts";
 import type { RTCCallIntent, Transport } from "./types.ts";
 import { type IContent, type MatrixEvent } from "../models/event.ts";
-import { type RelationType } from "../@types/event.ts";
+import { STICKY_EVENT_KEY_FIELD, type RelationType } from "../@types/event.ts";
 import { logger } from "../logger.ts";
 
 /**
@@ -47,7 +47,7 @@ export interface RtcMembershipData {
     };
     "rtc_transports": Transport[];
     "versions": string[];
-    "msc4354_sticky_key"?: string;
+    [STICKY_EVENT_KEY_FIELD.name]?: string;
     "sticky_key"?: string;
 }
 

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -1,3 +1,4 @@
+import { STICKY_EVENT_KEY_FIELD } from "src/matrix.ts";
 import { logger as loggerInstance } from "../logger.ts";
 import { type MatrixEvent } from "./event.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
@@ -78,14 +79,14 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
      *          and the previous event it may have replaced.
      */
     private addStickyEvent(event: MatrixEvent): { added: true; prevEvent?: StickyMatrixEvent } | { added: false } {
-        const stickyKey = event.getContent().msc4354_sticky_key;
+        const stickyKey = event.getContent()[STICKY_EVENT_KEY_FIELD.name] ?? event.getContent()[STICKY_EVENT_KEY_FIELD.unstable!];
         if (typeof stickyKey !== "string" && stickyKey !== undefined) {
-            throw new Error(`${event.getId()} is missing msc4354_sticky_key`);
+            throw new Error(`${event.getId()} is missing ${STICKY_EVENT_KEY_FIELD.name}`);
         }
 
         // With this we have the guarantee, that all events in stickyEventsMap are correctly formatted
         if (event.unstableStickyExpiresAt === undefined) {
-            throw new Error(`${event.getId()} is missing msc4354_sticky.duration_ms`);
+            throw new Error(`${event.getId()} is missing ${STICKY_EVENT_KEY_FIELD.name}.duration_ms`);
         }
         const sender = event.getSender();
         const type = event.getType();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -40,6 +40,7 @@ import {
     type ResetTimelineCallback,
 } from "./client.ts";
 import {
+    ISticky,
     type IEphemeral,
     type IInvitedRoom,
     type IInviteState,
@@ -58,7 +59,7 @@ import {
 import { MatrixEvent } from "./models/event.ts";
 import { type MatrixError, Method } from "./http-api/index.ts";
 import { type ISavedSync } from "./store/index.ts";
-import { EventType } from "./@types/event.ts";
+import { EventType, STICKY_EVENT_FIELD } from "./@types/event.ts";
 import { type IPushRules } from "./@types/PushRules.ts";
 import { type IMarkerFoundOptions, RoomStateEvent } from "./models/room-state.ts";
 import { RoomMemberEvent } from "./models/room-member.ts";
@@ -1221,7 +1222,7 @@ export class SyncApi {
             const timelineEvents = this.mapSyncEventsFormat(joinObj.timeline, room, false);
             const ephemeralEvents = this.mapSyncEventsFormat(joinObj.ephemeral);
             const accountDataEvents = this.mapSyncEventsFormat(joinObj.account_data);
-            const stickyEvents = this.mapSyncEventsFormat(joinObj.msc4354_sticky);
+            const stickyEvents = this.mapSyncEventsFormat((joinObj[STICKY_EVENT_FIELD.name] ?? joinObj[STICKY_EVENT_FIELD.unstable!]) as ISticky);
 
             // If state_after is present, this is the events that form the state at the end of the timeline block and
             // regular timeline events do *not* count towards state. If it's not present, then the state is formed by


### PR DESCRIPTION
Based on https://github.com/matrix-org/matrix-js-sdk/pull/5017#discussion_r2425707918

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
