### PR TITLE
[MatrixRTC] Add extensible event fallback for call notifications.

### DIFF
--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import type { IMentions } from "../matrix.ts";
+import type { IMentions, M_HTML, M_TEXT } from "../matrix.ts";
 import type { RelationEvent } from "../types.ts";
 import type { CallMembership } from "./CallMembership.ts";
 
@@ -112,6 +112,8 @@ export interface IRTCNotificationContent extends RelationEvent {
     "m.call.intent"?: RTCCallIntent;
     "sender_ts": number;
     "lifetime": number;
+    // Extensible event types
+    [M_TEXT.name]: {body: string, mimetype?: string}[];
 }
 
 /**


### PR DESCRIPTION
This allows unsupporting clients to be aware when a call is started, and additionally allows passing in a guest URL when the caller's infrastructure provides one.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
