### PR TITLE
Fix npm publish script

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -36,7 +36,10 @@ jobs:
               run: "yarn install --frozen-lockfile"
 
             - name: 🚀 Publish to npm
-              run: npm publish --provenance --access public --tag "$TAG"
+              id: npm-publish
+              run: |
+                  npm publish --provenance --access public --tag "$TAG"
+                  release=$(jq -r '"\(.name)@\(.version)"' package.json)
+                  echo "id=$release" >> $GITHUB_OUTPUT
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   TAG: ${{ contains(steps.npm-publish.outputs.id, '-rc.') && 'next' || 'latest' }}


### PR DESCRIPTION
The `id` is also an output from this workflow so needs re-adding, not sure how the token stuck around, I thought I removed that
