### PR TITLE
Implement _unstable_getRTCTransports for MSC4143

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -84,6 +84,7 @@ import { mockOpenIdConfiguration } from "../test-utils/oidc.ts";
 import { type CryptoBackend } from "../../src/common-crypto/CryptoBackend";
 import { SyncResponder } from "../test-utils/SyncResponder.ts";
 import { mockInitialApiRequests } from "../test-utils/mockEndpoints.ts";
+import { type Transport } from "src/matrixrtc/index.ts";
 
 jest.useFakeTimers();
 
@@ -3933,6 +3934,25 @@ describe("MatrixClient", function () {
 
             expect(lookupResult).toHaveLength(1);
             expect(lookupResult[0]).toEqual({ address: "bob@email.dummy", mxid: "@bob:homeserver.dummy" });
+        });
+    });
+
+    describe("_unstable_getRTCTransports", () => {
+        it("makes a well-formed request", async () => {
+            httpLookups = [
+                {
+                    method: "GET",
+                    path: `/rtc/transports`,
+                    data: { rtc_transports: [{ type: "livekit", extra_field: "foobar" }] satisfies Transport[] },
+                    prefix: "/_matrix/client/unstable/org.matrix.msc4143",
+                },
+            ];
+            expect(await client._unstable_getRTCTransports()).toEqual([
+                {
+                    type: "livekit",
+                    extra_field: "foobar",
+                },
+            ]);
         });
     });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -246,6 +246,7 @@ import {
 } from "./oidc/index.ts";
 import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
+import { type Transport } from "./matrixrtc/index.ts";
 
 export type Store = IStore;
 
@@ -6078,6 +6079,23 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         } while (token != null);
 
         return rooms;
+    }
+
+    /**
+     * Returns a set of configured RTC transports supported by the homeserver.
+     * Requires homeserver support for MSC4143.
+     * @throws A M_NOT_FOUND error if not supported by the homeserver.
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public async _unstable_getRTCTransports(): Promise<Transport[]> {
+        // There is no /versions endpoint to check for support, so we just have to attempt a request.
+        return (
+            await this.http.authedRequest<{
+                rtc_transports: Transport[];
+            }>(Method.Get, "/rtc/transports", undefined, undefined, {
+                prefix: `${ClientPrefix.Unstable}/org.matrix.msc4143`,
+            })
+        ).rtc_transports;
     }
 
     /**


### PR DESCRIPTION
MSC4143 - [Relevant section](https://github.com/matrix-org/matrix-spec-proposals/blob/toger5/matrixRTC/proposals/4143-matrix-rtc.md#discovery-of-rtc-transports)

This adds a support for fetching the RTCTransports via the homeserver, which supersedes the legacy mechanism of going vla well-known (in a previous iteration of MSC4143).

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
