### PR TITLE
Mark `forwardingCurve25519KeyChain` as deprecated

### DIFF
--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -200,8 +200,9 @@ export interface EventDecryptionResult {
      */
     clearEvent: IClearEvent;
     /**
-     * List of curve25519 keys involved in telling us about the senderCurve25519Key and claimedEd25519Key.
+     * No longer used.
      * See {@link MatrixEvent#getForwardingCurve25519KeyChain}.
+     * @deprecated
      */
     forwardingCurve25519KeyChain?: string[];
     /**

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -285,12 +285,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      */
     private claimedEd25519Key: string | null = null;
 
-    /* curve25519 keys of devices involved in telling us about the
-     * senderCurve25519Key and claimedEd25519Key.
-     * See getForwardingCurve25519KeyChain().
-     */
-    private forwardingCurve25519KeyChain: string[] = [];
-
     /* where the decryption key is untrusted
      */
     private untrusted: boolean | null = null;
@@ -1029,7 +1023,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         this.clearEvent = decryptionResult.clearEvent;
         this.senderCurve25519Key = decryptionResult.senderCurve25519Key ?? null;
         this.claimedEd25519Key = decryptionResult.claimedEd25519Key ?? null;
-        this.forwardingCurve25519KeyChain = decryptionResult.forwardingCurve25519KeyChain || [];
         this.untrusted = decryptionResult.untrusted || false;
         this.invalidateExtensibleEvent();
     }
@@ -1049,7 +1042,6 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
         };
         this.senderCurve25519Key = null;
         this.claimedEd25519Key = null;
-        this.forwardingCurve25519KeyChain = [];
         this.untrusted = false;
         this.invalidateExtensibleEvent();
     }
@@ -1120,21 +1112,18 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
     }
 
     /**
-     * Get the curve25519 keys of the devices which were involved in telling us
-     * about the claimedEd25519Key and sender curve25519 key.
+     *  Returns an empty array.
      *
-     * Normally this will be empty, but in the case of a forwarded megolm
-     * session, the sender keys are sent to us by another device (the forwarding
-     * device), which we need to trust to do this. In that case, the result will
-     * be a list consisting of one entry.
+     * Previously, this returned the chain of Curve25519 keys through which
+     * this session was forwarded, via `m.forwarded_room_key` events.
+     * However, that is not cryptographically reliable, and clients should not
+     * be using it.
      *
-     * If the device that sent us the key (A) got it from another device which
-     * it wasn't prepared to vouch for (B), the result will be [A, B]. And so on.
-     *
-     * @returns base64-encoded curve25519 keys, from oldest to newest.
+     * @see https://github.com/matrix-org/matrix-spec/issues/1089
+     * @deprecated
      */
     public getForwardingCurve25519KeyChain(): string[] {
-        return this.forwardingCurve25519KeyChain;
+        return [];
     }
 
     /**

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -2235,7 +2235,6 @@ class EventDecryptor {
                 clearEvent: JSON.parse(res.event),
                 claimedEd25519Key: res.senderClaimedEd25519Key,
                 senderCurve25519Key: res.senderCurve25519Key,
-                forwardingCurve25519KeyChain: res.forwardingCurve25519KeyChain,
             };
         } catch (err) {
             if (err instanceof RustSdkCryptoJs.MegolmDecryptionError) {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -179,7 +179,6 @@ export async function decryptExistingEvent(
             type: opts.plainType,
             content: opts.plainContent,
         },
-        forwardingCurve25519KeyChain: [],
         senderCurve25519Key: "",
         untrusted: false,
     };


### PR DESCRIPTION
The Rust SDK always populates this as an empty array, so we may as well get rid of it.