### PR TITLE
Mark `IEventDecryptionResult` as deprecated

### DIFF
--- a/src/@types/crypto.ts
+++ b/src/@types/crypto.ts
@@ -15,9 +15,12 @@ limitations under the License.
 */
 
 import type { ISignatures } from "./signed.ts";
+import type { EventDecryptionResult } from "../common-crypto/CryptoBackend.ts";
 
 // Backwards compatible re-export
-export type { EventDecryptionResult as IEventDecryptionResult } from "../common-crypto/CryptoBackend.ts";
+/** @deprecated This is an internal type and should not be used. */
+type IEventDecryptionResult = EventDecryptionResult;
+export type { IEventDecryptionResult };
 
 interface Extensible {
     [key: string]: any;

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -21,7 +21,6 @@ limitations under the License.
 
 import { type ExtensibleEvent, ExtensibleEvents } from "matrix-events-sdk";
 
-import type { IEventDecryptionResult } from "../@types/crypto.ts";
 import { logger } from "../logger.ts";
 import {
     EVENT_VISIBILITY_CHANGE_TYPE,
@@ -40,7 +39,7 @@ import { TypedReEmitter } from "../ReEmitter.ts";
 import { type MatrixError } from "../http-api/index.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 import { type EventStatus } from "./event-status.ts";
-import { type CryptoBackend, DecryptionError } from "../common-crypto/CryptoBackend.ts";
+import { type CryptoBackend, DecryptionError, type EventDecryptionResult } from "../common-crypto/CryptoBackend.ts";
 import { type IAnnotatedPushRule } from "../@types/PushRules.ts";
 import { type Room } from "./room.ts";
 import { EventTimeline } from "./event-timeline.ts";
@@ -1025,7 +1024,7 @@ export class MatrixEvent extends TypedEventEmitter<MatrixEventEmittedEvents, Mat
      *
      * @param decryptionResult - the decryption result, including the plaintext and some key info
      */
-    private setClearData(decryptionResult: IEventDecryptionResult): void {
+    private setClearData(decryptionResult: EventDecryptionResult): void {
         this.clearEvent = decryptionResult.clearEvent;
         this.senderCurve25519Key = decryptionResult.senderCurve25519Key ?? null;
         this.claimedEd25519Key = decryptionResult.claimedEd25519Key ?? null;

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import anotherjson from "another-json";
 import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
-import type { IEventDecryptionResult, IMegolmSessionData } from "../@types/crypto.ts";
+import type { IMegolmSessionData } from "../@types/crypto.ts";
 import { KnownMembership } from "../@types/membership.ts";
 import { type IDeviceLists, type IToDeviceEvent, type ReceivedToDeviceMessage } from "../sync-accumulator.ts";
 import type { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
@@ -28,6 +28,7 @@ import {
     type BackupDecryptor,
     type CryptoBackend,
     DecryptionError,
+    type EventDecryptionResult,
     type OnSyncCompletedData,
 } from "../common-crypto/CryptoBackend.ts";
 import { type Logger, LogSpan } from "../logger.ts";
@@ -285,7 +286,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         await encryptor.encryptEvent(event, this.globalBlacklistUnverifiedDevices, this.deviceIsolationMode);
     }
 
-    public async decryptEvent(event: MatrixEvent): Promise<IEventDecryptionResult> {
+    public async decryptEvent(event: MatrixEvent): Promise<EventDecryptionResult> {
         const roomId = event.getRoomId();
         if (!roomId) {
             // presumably, a to-device message. These are normally decrypted in preprocessToDeviceMessages
@@ -2202,7 +2203,7 @@ class EventDecryptor {
     public async attemptEventDecryption(
         event: MatrixEvent,
         isolationMode: DeviceIsolationMode,
-    ): Promise<IEventDecryptionResult> {
+    ): Promise<EventDecryptionResult> {
         // add the event to the pending list *before* attempting to decrypt.
         // then, if the key turns up while decryption is in progress (and
         // decryption fails), we will schedule a retry.


### PR DESCRIPTION
This is supposed to be js-sdk-internal.