### PR TITLE
Make the enableEncryptedStateEvents property on MatrixClient public

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1219,7 +1219,21 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     private cryptoBackend?: CryptoBackend; // one of crypto or rustCrypto
 
     /**
-     * Support MSC4362: Simplified Encrypted State Events
+     * Support MSC4362: Simplified Encrypted State Events.
+     *
+     * The client must be recreated for changes to this setting to take effect
+     * reliably.
+     *
+     * When this setting is true, if we find a state event that is encrypted
+     * (within a room that supports encrypted state), we will attempt to decrypt
+     * it as specified in MSC4362. If the user was in the room at the time an
+     * encrypted state event was received (meaning we have the key), even if
+     * this setting was set to false at the time it was received, recreating the
+     * client with this setting set to true will allow decrypting that event.
+     *
+     * When this setting is false, any state event that is encrypted will not be
+     * decrypted, meaning it will have no effect. This matched the behaviour of
+     * a client that does not support MSC4362.
      */
     public enableEncryptedStateEvents: boolean;
 


### PR DESCRIPTION
This supports https://github.com/element-hq/element-web/pull/31513 which is part of https://github.com/matrix-org/matrix-rust-sdk/issues/5397