### PR TITLE
Make MatrixRTC encryption key types narrower for TS 5.9 compatibility

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -62,6 +62,6 @@ declare global {
 
     interface Uint8ArrayConstructor {
         // https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.frombase64
-        fromBase64?(base64: string, options?: Uint8ArrayFromBase64Options): Uint8Array;
+        fromBase64?(base64: string, options?: Uint8ArrayFromBase64Options): Uint8Array<ArrayBuffer>;
     }
 }

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -64,7 +64,7 @@ export function encodeUnpaddedBase64Url(uint8Array: Uint8Array): string {
     return toBase64(uint8Array, { alphabet: "base64url", omitPadding: true });
 }
 
-function fromBase64(base64: string, options: Uint8ArrayFromBase64Options): Uint8Array {
+function fromBase64(base64: string, options: Uint8ArrayFromBase64Options): Uint8Array<ArrayBuffer> {
     if (typeof Uint8Array.fromBase64 === "function") {
         // Currently this is only supported in Firefox,
         // but we match the options in the hope in the future we can rely on it for all environments.
@@ -80,7 +80,7 @@ function fromBase64(base64: string, options: Uint8ArrayFromBase64Options): Uint8
  * @param base64 - The base64 to decode.
  * @returns The decoded data.
  */
-export function decodeBase64(base64: string): Uint8Array {
+export function decodeBase64(base64: string): Uint8Array<ArrayBuffer> {
     // The function requires us to select an alphabet, but we don't know if base64url was used so we convert.
     return fromBase64(base64.replace(/-/g, "+").replace(/_/g, "/"), { alphabet: "base64", lastChunkHandling: "loose" });
 }

--- a/src/matrixrtc/EncryptionManager.ts
+++ b/src/matrixrtc/EncryptionManager.ts
@@ -38,7 +38,7 @@ export interface IEncryptionManager {
      *
      * @returns A map of participant IDs to their encryption keys.
      */
-    getEncryptionKeys(): ReadonlyMap<ParticipantId, ReadonlyArray<{ key: Uint8Array; keyIndex: number }>>;
+    getEncryptionKeys(): ReadonlyMap<ParticipantId, ReadonlyArray<{ key: Uint8Array<ArrayBuffer>; keyIndex: number }>>;
 }
 
 /**
@@ -67,7 +67,7 @@ export class EncryptionManager implements IEncryptionManager {
         return this.joinConfig?.useKeyDelay ?? 5_000;
     }
 
-    private encryptionKeys = new Map<string, Array<{ key: Uint8Array; timestamp: number }>>();
+    private encryptionKeys = new Map<string, Array<{ key: Uint8Array<ArrayBuffer>; timestamp: number }>>();
     private lastEncryptionKeyUpdateRequest?: number;
 
     // We use this to store the last membership fingerprints we saw, so we can proactively re-send encryption keys
@@ -85,7 +85,7 @@ export class EncryptionManager implements IEncryptionManager {
         private transport: IKeyTransport,
         private statistics: Statistics,
         private onEncryptionKeysChanged: (
-            keyBin: Uint8Array,
+            keyBin: Uint8Array<ArrayBuffer>,
             encryptionKeyIndex: number,
             participantId: string,
         ) => void,
@@ -94,8 +94,11 @@ export class EncryptionManager implements IEncryptionManager {
         this.logger = (parentLogger ?? rootLogger).getChild(`[EncryptionManager]`);
     }
 
-    public getEncryptionKeys(): ReadonlyMap<ParticipantId, ReadonlyArray<{ key: Uint8Array; keyIndex: number }>> {
-        const keysMap = new Map<ParticipantId, ReadonlyArray<{ key: Uint8Array; keyIndex: number }>>();
+    public getEncryptionKeys(): ReadonlyMap<
+        ParticipantId,
+        ReadonlyArray<{ key: Uint8Array<ArrayBuffer>; keyIndex: number }>
+    > {
+        const keysMap = new Map<ParticipantId, ReadonlyArray<{ key: Uint8Array<ArrayBuffer>; keyIndex: number }>>();
         for (const [userId, userKeys] of this.encryptionKeys) {
             const keys = userKeys.map((entry, index) => ({
                 key: entry.key,
@@ -244,7 +247,7 @@ export class EncryptionManager implements IEncryptionManager {
      * @param deviceId the device ID of the participant
      * @returns The encryption keys for the given participant, or undefined if they are not known.
      */
-    private getKeysForParticipant(userId: string, deviceId: string): Array<Uint8Array> | undefined {
+    private getKeysForParticipant(userId: string, deviceId: string): Array<Uint8Array<ArrayBuffer>> | undefined {
         return this.encryptionKeys.get(getParticipantId(userId, deviceId))?.map((entry) => entry.key);
     }
 

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -73,7 +73,7 @@ export type MatrixRTCSessionEventHandlerMap = {
     ) => void;
     [MatrixRTCSessionEvent.JoinStateChanged]: (isJoined: boolean) => void;
     [MatrixRTCSessionEvent.EncryptionKeyChanged]: (
-        key: Uint8Array,
+        key: Uint8Array<ArrayBuffer>,
         encryptionKeyIndex: number,
         participantId: string,
     ) => void;
@@ -626,7 +626,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
                     () => this.memberships,
                     transport,
                     this.statistics,
-                    (keyBin: Uint8Array, encryptionKeyIndex: number, participantId: string) => {
+                    (keyBin: Uint8Array<ArrayBuffer>, encryptionKeyIndex: number, participantId: string) => {
                         this.emit(
                             MatrixRTCSessionEvent.EncryptionKeyChanged,
                             keyBin,
@@ -644,7 +644,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
                     () => this.memberships,
                     transport,
                     this.statistics,
-                    (keyBin: Uint8Array, encryptionKeyIndex: number, participantId: string) => {
+                    (keyBin: Uint8Array<ArrayBuffer>, encryptionKeyIndex: number, participantId: string) => {
                         this.emit(
                             MatrixRTCSessionEvent.EncryptionKeyChanged,
                             keyBin,

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -51,7 +51,7 @@ export class RTCEncryptionManager implements IEncryptionManager {
      * The encryption manager stores the keys because the application layer might not be ready yet to handle the keys.
      * The keys are stored and can be retrieved later when the application layer is ready {@link RTCEncryptionManager#getEncryptionKeys}.
      */
-    private participantKeyRings = new Map<ParticipantId, Array<{ key: Uint8Array; keyIndex: number }>>();
+    private participantKeyRings = new Map<ParticipantId, Array<{ key: Uint8Array<ArrayBuffer>; keyIndex: number }>>();
 
     // The current per-sender media key for this device
     private outboundSession: OutboundEncryptionSession | null = null;
@@ -104,7 +104,7 @@ export class RTCEncryptionManager implements IEncryptionManager {
         private statistics: Statistics,
         // Callback to notify the media layer of new keys
         private onEncryptionKeysChanged: (
-            keyBin: Uint8Array,
+            keyBin: Uint8Array<ArrayBuffer>,
             encryptionKeyIndex: number,
             participantId: ParticipantId,
         ) => void,
@@ -113,11 +113,14 @@ export class RTCEncryptionManager implements IEncryptionManager {
         this.logger = parentLogger?.getChild(`[EncryptionManager]`);
     }
 
-    public getEncryptionKeys(): ReadonlyMap<ParticipantId, ReadonlyArray<{ key: Uint8Array; keyIndex: number }>> {
+    public getEncryptionKeys(): ReadonlyMap<
+        ParticipantId,
+        ReadonlyArray<{ key: Uint8Array<ArrayBuffer>; keyIndex: number }>
+    > {
         return new Map(this.participantKeyRings);
     }
 
-    private addKeyToParticipant(key: Uint8Array, keyIndex: number, participantId: ParticipantId): void {
+    private addKeyToParticipant(key: Uint8Array<ArrayBuffer>, keyIndex: number, participantId: ParticipantId): void {
         if (!this.participantKeyRings.has(participantId)) {
             this.participantKeyRings.set(participantId, []);
         }
@@ -354,7 +357,7 @@ export class RTCEncryptionManager implements IEncryptionManager {
         return 0;
     }
 
-    private generateRandomKey(): Uint8Array {
+    private generateRandomKey(): Uint8Array<ArrayBuffer> {
         const key = new Uint8Array(16);
         globalThis.crypto.getRandomValues(key);
         return key;

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -37,7 +37,7 @@ export type ParticipantDeviceInfo = {
  * A type representing the information needed to decrypt video streams.
  */
 export type InboundEncryptionSession = {
-    key: Uint8Array;
+    key: Uint8Array<ArrayBuffer>;
     participantId: ParticipantId;
     keyIndex: number;
     creationTS: number;
@@ -47,7 +47,7 @@ export type InboundEncryptionSession = {
  * The information about the key used to encrypt video streams.
  */
 export type OutboundEncryptionSession = {
-    key: Uint8Array;
+    key: Uint8Array<ArrayBuffer>;
     creationTS: number;
     // The devices that this key is shared with.
     sharedWith: Array<ParticipantDeviceInfo>;


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes

TypeScript 5.9 changes some things about the `ArrayBuffer` type and makes a number of DOM types, including the subtle crypto APIs, require a narrower buffer type as their input. For example if you wanted to use `crypto.subtle.importKey` to convert a MatrixRTC encryption key buffer given by matrix-js-sdk to a `CryptoKey`, you would run into a type error with TS 5.9. Specifying the type parameter of `Uint8Array` everywhere around the MatrixRTC files fixes this breakage.