### PR TITLE
Use normal base64 encoding for RTC backend identities

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -394,4 +394,20 @@ describe("CallMembership", () => {
             expect(membership.getMsUntilExpiry()).toEqual(DEFAULT_EXPIRE_DURATION - 1000);
         });
     });
+
+    it("uses unpadded base64 for RTC backend identities", async () => {
+        expect(
+            await CallMembership.computeRtcBackendIdentity(makeMockEvent(), {
+                kind: "rtc",
+                data: {
+                    slot_id: "m.call#",
+                    application: { "type": "m.call", "m.call.id": "", "m.call.intent": "voice" },
+                    member: { user_id: "@alice:example.org", device_id: "AAAAAAA", id: "xyzRANDOMxyz" },
+                    rtc_transports: [{ type: "livekit" }],
+                    versions: [],
+                    msc4354_sticky_key: "abc123",
+                },
+            }),
+        ).toBe("2+h2ELE1XY/NsuveToZOekORCoyQMO6V0W7XZUWk5Q4");
+    });
 });

--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -339,6 +339,20 @@ describe("MatrixRTCSession", () => {
                 );
                 expect(sess.memberships).toHaveLength(0);
             });
+
+            it("assigns RTC backend identities to memberships", async () => {
+                const mockRoom = makeMockRoom([membershipTemplate], testConfig.testCreateSticky);
+                sess = MatrixRTCSession.sessionForSlot(
+                    client,
+                    mockRoom,
+                    callSession,
+                    testConfig.createWithDefaults ? undefined : testConfig,
+                );
+                await flushPromises();
+                expect(sess?.memberships.length).toEqual(1);
+                // Backend identity is expected to not be hashed with a legacy (session) membership
+                expect(sess?.memberships[0].rtcBackendIdentity).toEqual("@mock:user.example:AAAAAAA");
+            });
         },
     );
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -322,10 +322,7 @@ export class CallMembership {
     }
 
     public static async computeRtcIdentityRaw(userId: string, deviceId: string, memberId: string): Promise<string> {
-        const hashInput = `${userId}|${deviceId}|${memberId}`;
-        const hashBuffer = await sha256(hashInput);
-        const hashedString = encodeUnpaddedBase64(hashBuffer);
-        return hashedString;
+        return encodeUnpaddedBase64(await sha256(`${userId}|${deviceId}|${memberId}`));
     }
 
     public static membershipDataFromMatrixEvent(matrixEvent: MatrixEvent): MembershipData {


### PR DESCRIPTION
MSC4195 [has been updated](https://github.com/matrix-org/matrix-spec-proposals/pull/4195/commits/a9fa0092c76e654709ee0d4d54d0129d1676ff25) to specify that normal (non-URL-safe) base64 is the correct encoding for LiveKit participant identities.