### PR TITLE
MSC4140: add dedicated endpoint for delayed events

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -808,505 +808,553 @@ describe("MatrixClient", function () {
             await expect(client._unstable_sendScheduledDelayedEvent("anyDelayId")).rejects.toThrow(errorMessage);
         });
 
-        it.each([false, true])("works with null threadId (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
-            httpLookups = [];
+        it.each([false, true])(
+            "works with null threadId (with dedicated endpoint: %s)",
+            async (useDedicatedEndpoint: boolean) => {
+                httpLookups = [];
 
-            const timeoutDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id1" },
-                    expectBody: content,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    data: { delay_id: "id1" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        content,
-                    },
-                });
-            }
+                const timeoutDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id1" },
+                            expectBody: content,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                        data: { delay_id: "id1" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            content,
+                        },
+                    });
+                }
 
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                null,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
+                const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    null,
+                    EventType.RoomMessage,
+                    { ...content },
+                    timeoutDelayTxnId,
+                );
 
-            const actionDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                    data: { delay_id: "id2" },
-                    expectBody: content,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    data: { delay_id: "id2" },
-                    expectBody: {
-                        parent_delay_id: timeoutDelayId,
-                        content,
-                    },
-                });
-            }
+                const actionDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                            expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                            data: { delay_id: "id2" },
+                            expectBody: content,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                        data: { delay_id: "id2" },
+                        expectBody: {
+                            parent_delay_id: timeoutDelayId,
+                            content,
+                        },
+                    });
+                }
 
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                null,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
-            );
-        });
+                await client._unstable_sendDelayedEvent(
+                    roomId,
+                    { parent_delay_id: timeoutDelayId },
+                    null,
+                    EventType.RoomMessage,
+                    { ...content },
+                    actionDelayTxnId,
+                );
+            },
+        );
 
-        it.each([false, true])("works with non-null threadId (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
-            httpLookups = [];
-            const threadId = "$threadId:server";
-            const expectBody = {
-                ...content,
-                "m.relates_to": {
-                    event_id: threadId,
-                    is_falling_back: true,
-                    rel_type: "m.thread",
-                },
-            };
-
-            const timeoutDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id1" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    data: { delay_id: "id1" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        content: expectBody,
-                    },
-                });
-            }
-
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                    data: { delay_id: "id2" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    data: { delay_id: "id2" },
-                    expectBody: {
-                        parent_delay_id: timeoutDelayId,
-                        content: expectBody,
-                    },
-                });
-            }
-
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
-            );
-        });
-
-        it.each([false, true])("should add thread relation if threadId is passed and the relation is missing (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
-            httpLookups = [];
-            const threadId = "$threadId:server";
-            const expectBody = {
-                ...content,
-                "m.relates_to": {
-                    "m.in_reply_to": {
+        it.each([false, true])(
+            "works with non-null threadId (with dedicated endpoint: %s)",
+            async (useDedicatedEndpoint: boolean) => {
+                httpLookups = [];
+                const threadId = "$threadId:server";
+                const expectBody = {
+                    ...content,
+                    "m.relates_to": {
                         event_id: threadId,
+                        is_falling_back: true,
+                        rel_type: "m.thread",
                     },
-                    "event_id": threadId,
-                    "is_falling_back": true,
-                    "rel_type": "m.thread",
-                },
-            };
+                };
 
-            const room = new Room(roomId, client, userId);
-            mocked(store.getRoom).mockReturnValue(room);
+                const timeoutDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id1" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                        data: { delay_id: "id1" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            content: expectBody,
+                        },
+                    });
+                }
 
-            const rootEvent = new MatrixEvent({ event_id: threadId });
-            room.createThread(threadId, rootEvent, [rootEvent], false);
+                const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    timeoutDelayTxnId,
+                );
 
-            const timeoutDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
+                const actionDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                            expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                            data: { delay_id: "id2" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                        data: { delay_id: "id2" },
+                        expectBody: {
+                            parent_delay_id: timeoutDelayId,
+                            content: expectBody,
+                        },
+                    });
+                }
+
+                await client._unstable_sendDelayedEvent(
+                    roomId,
+                    { parent_delay_id: timeoutDelayId },
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    actionDelayTxnId,
+                );
+            },
+        );
+
+        it.each([false, true])(
+            "should add thread relation if threadId is passed and the relation is missing (with dedicated endpoint: %s)",
+            async (useDedicatedEndpoint: boolean) => {
+                httpLookups = [];
+                const threadId = "$threadId:server";
+                const expectBody = {
+                    ...content,
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            event_id: threadId,
+                        },
+                        "event_id": threadId,
+                        "is_falling_back": true,
+                        "rel_type": "m.thread",
                     },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id1" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    data: { delay_id: "id1" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        content: expectBody,
+                };
+
+                const room = new Room(roomId, client, userId);
+                mocked(store.getRoom).mockReturnValue(room);
+
+                const rootEvent = new MatrixEvent({ event_id: threadId });
+                room.createThread(threadId, rootEvent, [rootEvent], false);
+
+                const timeoutDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id1" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                        data: { delay_id: "id1" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            content: expectBody,
+                        },
+                    });
+                }
+
+                const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    timeoutDelayTxnId,
+                );
+
+                const actionDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                            expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                            data: { delay_id: "id2" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                        data: { delay_id: "id2" },
+                        expectBody: {
+                            parent_delay_id: timeoutDelayId,
+                            content: expectBody,
+                        },
+                    });
+                }
+
+                await client._unstable_sendDelayedEvent(
+                    roomId,
+                    { parent_delay_id: timeoutDelayId },
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    actionDelayTxnId,
+                );
+            },
+        );
+
+        it.each([false, true])(
+            "should add thread relation if threadId is passed and the relation is missing with reply (with dedicated endpoint: %s)",
+            async (useDedicatedEndpoint: boolean) => {
+                httpLookups = [];
+                const threadId = "$threadId:server";
+
+                const content = {
+                    body,
+                    "msgtype": MsgType.Text,
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            event_id: "$other:event",
+                        },
                     },
-                });
-            }
-
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
+                } satisfies RoomMessageEventContent;
+                const expectBody = {
+                    ...content,
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            event_id: "$other:event",
+                        },
+                        "event_id": threadId,
+                        "is_falling_back": false,
+                        "rel_type": "m.thread",
                     },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                    data: { delay_id: "id2" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    data: { delay_id: "id2" },
-                    expectBody: {
-                        parent_delay_id: timeoutDelayId,
-                        content: expectBody,
-                    },
-                });
-            }
+                };
 
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
-            );
-        });
+                const room = new Room(roomId, client, userId);
+                mocked(store.getRoom).mockReturnValue(room);
 
-        it.each([false, true])("should add thread relation if threadId is passed and the relation is missing with reply (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
-            httpLookups = [];
-            const threadId = "$threadId:server";
+                const rootEvent = new MatrixEvent({ event_id: threadId });
+                room.createThread(threadId, rootEvent, [rootEvent], false);
 
-            const content = {
-                body,
-                "msgtype": MsgType.Text,
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        event_id: "$other:event",
-                    },
-                },
-            } satisfies RoomMessageEventContent;
-            const expectBody = {
-                ...content,
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        event_id: "$other:event",
-                    },
-                    "event_id": threadId,
-                    "is_falling_back": false,
-                    "rel_type": "m.thread",
-                },
-            };
+                const timeoutDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id1" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                        data: { delay_id: "id1" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            content: expectBody,
+                        },
+                    });
+                }
 
-            const room = new Room(roomId, client, userId);
-            mocked(store.getRoom).mockReturnValue(room);
+                const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    timeoutDelayTxnId,
+                );
 
-            const rootEvent = new MatrixEvent({ event_id: threadId });
-            room.createThread(threadId, rootEvent, [rootEvent], false);
+                const actionDelayTxnId = client.makeTxnId();
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                            expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                            data: { delay_id: "id2" },
+                            expectBody,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                        data: { delay_id: "id2" },
+                        expectBody: {
+                            parent_delay_id: timeoutDelayId,
+                            content: expectBody,
+                        },
+                    });
+                }
 
-            const timeoutDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id1" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
-                    data: { delay_id: "id1" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        content: expectBody,
-                    },
-                });
-            }
+                await client._unstable_sendDelayedEvent(
+                    roomId,
+                    { parent_delay_id: timeoutDelayId },
+                    threadId,
+                    EventType.RoomMessage,
+                    { ...content },
+                    actionDelayTxnId,
+                );
+            },
+        );
 
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
+        it.each([false, true])(
+            "can send a delayed state event (with dedicated endpoint: %s)",
+            async (useDedicatedEndpoint: boolean) => {
+                httpLookups = [];
+                const content = { topic: "The year 2000" };
 
-            const actionDelayTxnId = client.makeTxnId();
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                    data: { delay_id: "id2" },
-                    expectBody,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
-                    data: { delay_id: "id2" },
-                    expectBody: {
-                        parent_delay_id: timeoutDelayId,
-                        content: expectBody,
-                    },
-                });
-            }
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id1" },
+                            expectBody: content,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                        data: { delay_id: "id1" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            state_key: "",
+                            content,
+                        },
+                    });
+                }
 
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
-            );
-        });
+                const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedStateEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    EventType.RoomTopic,
+                    { ...content },
+                );
 
-        it.each([false, true])("can send a delayed state event (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
-            httpLookups = [];
-            const content = { topic: "The year 2000" };
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
+                            expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                            data: { delay_id: "id2" },
+                            expectBody: content,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                        data: { delay_id: "id2" },
+                        expectBody: {
+                            parent_delay_id: timeoutDelayId,
+                            state_key: "",
+                            content,
+                        },
+                    });
+                }
 
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id1" },
-                    expectBody: content,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
-                    data: { delay_id: "id1" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        state_key: "",
-                        content,
-                    }
-                });
-            }
+                await client._unstable_sendDelayedStateEvent(
+                    roomId,
+                    { parent_delay_id: timeoutDelayId },
+                    EventType.RoomTopic,
+                    { ...content },
+                );
 
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedStateEvent(
-                roomId,
-                timeoutDelayOpts,
-                EventType.RoomTopic,
-                { ...content },
-            );
+                if (!useDedicatedEndpoint) {
+                    httpLookups.push(
+                        {
+                            method: "PUT",
+                            prefix: unstableMSC4140Prefix,
+                            path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
+                            error: {
+                                httpStatus: 404,
+                                errcode: "M_UNRECOGNIZED",
+                            },
+                        },
+                        {
+                            method: "PUT",
+                            path: `/rooms/${encodeURIComponent(roomId)}/state/org.example.state/xyz`,
+                            expectQueryParams: timeoutDelayQueryOpts,
+                            data: { delay_id: "id3" },
+                            expectBody: content,
+                        },
+                    );
+                } else {
+                    httpLookups.push({
+                        method: "PUT",
+                        prefix: unstableMSC4140Prefix,
+                        path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
+                        data: { delay_id: "id3" },
+                        expectBody: {
+                            ...timeoutDelayOpts,
+                            state_key: "xyz",
+                            content,
+                        },
+                    });
+                }
 
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                    data: { delay_id: "id2" },
-                    expectBody: content,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
-                    data: { delay_id: "id2" },
-                    expectBody: {
-                        parent_delay_id: timeoutDelayId,
-                        state_key: "",
-                        content,
-                    }
-                });
-            }
-
-            await client._unstable_sendDelayedStateEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                EventType.RoomTopic,
-                { ...content },
-            );
-
-            if (!useDedicatedEndpoint) {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
-                    error: {
-                        httpStatus: 404,
-                        errcode: "M_UNRECOGNIZED",
-                    },
-                }, {
-                    method: "PUT",
-                    path: `/rooms/${encodeURIComponent(roomId)}/state/org.example.state/xyz`,
-                    expectQueryParams: timeoutDelayQueryOpts,
-                    data: { delay_id: "id3" },
-                    expectBody: content,
-                });
-            } else {
-                httpLookups.push({
-                    method: "PUT",
-                    prefix: unstableMSC4140Prefix,
-                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
-                    data: { delay_id: "id3" },
-                    expectBody: {
-                        ...timeoutDelayOpts,
-                        state_key: "xyz",
-                        content,
-                    }
-                });
-            }
-
-            await client._unstable_sendDelayedStateEvent(
-                roomId,
-                timeoutDelayOpts,
-                "org.example.state" as any,
-                { ...content },
-                "xyz",
-            );
-        });
+                await client._unstable_sendDelayedStateEvent(
+                    roomId,
+                    timeoutDelayOpts,
+                    "org.example.state" as any,
+                    { ...content },
+                    "xyz",
+                );
+            },
+        );
 
         describe("lookups", () => {
             const statuses = [undefined, "scheduled" as const, "finalised" as const];

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -770,7 +770,7 @@ describe("MatrixClient", function () {
         const body = "This is the body";
         const content = { body, msgtype: MsgType.Text } satisfies RoomMessageEventContent;
         const timeoutDelayOpts = { delay: 2000 };
-        const realTimeoutDelayOpts = { "org.matrix.msc4140.delay": 2000 };
+        const timeoutDelayQueryOpts = { "org.matrix.msc4140.delay": 2000 };
 
         beforeEach(() => {
             unstableFeatures["org.matrix.msc4140"] = true;
@@ -808,17 +808,38 @@ describe("MatrixClient", function () {
             await expect(client._unstable_sendScheduledDelayedEvent("anyDelayId")).rejects.toThrow(errorMessage);
         });
 
-        it("works with null threadId", async () => {
+        it.each([false, true])("works with null threadId (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
             httpLookups = [];
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody: content,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id1" },
+                    expectBody: content,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    data: { delay_id: "id1" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        content,
+                    },
+                });
+            }
 
             const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
                 roomId,
@@ -830,13 +851,34 @@ describe("MatrixClient", function () {
             );
 
             const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody: content,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                    data: { delay_id: "id2" },
+                    expectBody: content,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    data: { delay_id: "id2" },
+                    expectBody: {
+                        parent_delay_id: timeoutDelayId,
+                        content,
+                    },
+                });
+            }
 
             await client._unstable_sendDelayedEvent(
                 roomId,
@@ -848,7 +890,7 @@ describe("MatrixClient", function () {
             );
         });
 
-        it("works with non-null threadId", async () => {
+        it.each([false, true])("works with non-null threadId (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
             httpLookups = [];
             const threadId = "$threadId:server";
             const expectBody = {
@@ -861,13 +903,34 @@ describe("MatrixClient", function () {
             };
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id1" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    data: { delay_id: "id1" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        content: expectBody,
+                    },
+                });
+            }
 
             const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
                 roomId,
@@ -879,13 +942,34 @@ describe("MatrixClient", function () {
             );
 
             const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                    data: { delay_id: "id2" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    data: { delay_id: "id2" },
+                    expectBody: {
+                        parent_delay_id: timeoutDelayId,
+                        content: expectBody,
+                    },
+                });
+            }
 
             await client._unstable_sendDelayedEvent(
                 roomId,
@@ -897,7 +981,7 @@ describe("MatrixClient", function () {
             );
         });
 
-        it("should add thread relation if threadId is passed and the relation is missing", async () => {
+        it.each([false, true])("should add thread relation if threadId is passed and the relation is missing (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
             httpLookups = [];
             const threadId = "$threadId:server";
             const expectBody = {
@@ -919,13 +1003,34 @@ describe("MatrixClient", function () {
             room.createThread(threadId, rootEvent, [rootEvent], false);
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id1" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    data: { delay_id: "id1" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        content: expectBody,
+                    },
+                });
+            }
 
             const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
                 roomId,
@@ -937,13 +1042,34 @@ describe("MatrixClient", function () {
             );
 
             const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                    data: { delay_id: "id2" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    data: { delay_id: "id2" },
+                    expectBody: {
+                        parent_delay_id: timeoutDelayId,
+                        content: expectBody,
+                    },
+                });
+            }
 
             await client._unstable_sendDelayedEvent(
                 roomId,
@@ -955,7 +1081,7 @@ describe("MatrixClient", function () {
             );
         });
 
-        it("should add thread relation if threadId is passed and the relation is missing with reply", async () => {
+        it.each([false, true])("should add thread relation if threadId is passed and the relation is missing with reply (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
             httpLookups = [];
             const threadId = "$threadId:server";
 
@@ -987,13 +1113,34 @@ describe("MatrixClient", function () {
             room.createThread(threadId, rootEvent, [rootEvent], false);
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id1" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${timeoutDelayTxnId}`,
+                    data: { delay_id: "id1" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        content: expectBody,
+                    },
+                });
+            }
 
             const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
                 roomId,
@@ -1005,13 +1152,34 @@ describe("MatrixClient", function () {
             );
 
             const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
+                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                    data: { delay_id: "id2" },
+                    expectBody,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.message/${actionDelayTxnId}`,
+                    data: { delay_id: "id2" },
+                    expectBody: {
+                        parent_delay_id: timeoutDelayId,
+                        content: expectBody,
+                    },
+                });
+            }
 
             await client._unstable_sendDelayedEvent(
                 roomId,
@@ -1023,17 +1191,39 @@ describe("MatrixClient", function () {
             );
         });
 
-        it("can send a delayed state event", async () => {
+        it.each([false, true])("can send a delayed state event (with dedicated endpoint: %s)", async (useDedicatedEndpoint: boolean) => {
             httpLookups = [];
             const content = { topic: "The year 2000" };
 
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody: content,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id1" },
+                    expectBody: content,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                    data: { delay_id: "id1" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        state_key: "",
+                        content,
+                    }
+                });
+            }
 
             const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedStateEvent(
                 roomId,
@@ -1042,19 +1232,79 @@ describe("MatrixClient", function () {
                 { ...content },
             );
 
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody: content,
-            });
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
+                    expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
+                    data: { delay_id: "id2" },
+                    expectBody: content,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/m.room.topic`,
+                    data: { delay_id: "id2" },
+                    expectBody: {
+                        parent_delay_id: timeoutDelayId,
+                        state_key: "",
+                        content,
+                    }
+                });
+            }
 
             await client._unstable_sendDelayedStateEvent(
                 roomId,
                 { parent_delay_id: timeoutDelayId },
                 EventType.RoomTopic,
                 { ...content },
+            );
+
+            if (!useDedicatedEndpoint) {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
+                    error: {
+                        httpStatus: 404,
+                        errcode: "M_UNRECOGNIZED",
+                    },
+                }, {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/state/org.example.state/xyz`,
+                    expectQueryParams: timeoutDelayQueryOpts,
+                    data: { delay_id: "id3" },
+                    expectBody: content,
+                });
+            } else {
+                httpLookups.push({
+                    method: "PUT",
+                    prefix: unstableMSC4140Prefix,
+                    path: `/rooms/${encodeURIComponent(roomId)}/delayed_event/org.example.state`,
+                    data: { delay_id: "id3" },
+                    expectBody: {
+                        ...timeoutDelayOpts,
+                        state_key: "xyz",
+                        content,
+                    }
+                });
+            }
+
+            await client._unstable_sendDelayedStateEvent(
+                roomId,
+                timeoutDelayOpts,
+                "org.example.state" as any,
+                { ...content },
+                "xyz",
             );
         });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3127,17 +3127,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         if (delayOpts) {
-            return this.http.authedRequest<SendDelayedEventResponse>(
+            return await this.http.authedRequest<SendDelayedEventResponse>(
                 Method.Put,
                 path,
                 { ...getUnstableDelayQueryOpts(delayOpts), ...queryOpts },
                 content,
             );
         } else {
-            return this.http.authedRequest<ISendEventResponse>(Method.Put, path, queryOpts, content).then((res) => {
-                this.logger.debug(`Event sent to ${event.getRoomId()} with event id ${res.event_id}`);
-                return res;
-            });
+            const res = await this.http.authedRequest<ISendEventResponse>(Method.Put, path, queryOpts, content);
+            this.logger.debug(`Event sent to ${event.getRoomId()} with event id ${res.event_id}`);
+            return res;
         }
     }
 
@@ -3608,7 +3607,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             if (!(e instanceof MatrixError && e.errcode === "M_UNRECOGNIZED")) {
                 throw e;
             }
-            return this.http.authedRequest(
+            return await this.http.authedRequest(
                 Method.Put,
                 utils.encodeUri("/rooms/$roomId/state/$eventType/$stateKey", {
                     $stateKey: stateKey,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3057,7 +3057,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         delayOpts: SendDelayedEventRequestOpts,
         queryDict?: QueryDict,
     ): Promise<SendDelayedEventResponse>;
-    private sendEventHttpRequest(
+    private async sendEventHttpRequest(
         event: MatrixEvent,
         queryOrDelayOpts?: SendDelayedEventRequestOpts | QueryDict,
         queryDict?: QueryDict,
@@ -3074,6 +3074,37 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             $stateKey: event.getStateKey()!,
             $txnId: txnId,
         };
+
+        const content = event.getWireContent();
+
+        const delayOpts =
+            queryOrDelayOpts && isSendDelayedEventRequestOpts(queryOrDelayOpts) ? queryOrDelayOpts : undefined;
+        const queryOpts = !delayOpts ? queryOrDelayOpts : queryDict;
+
+        if (delayOpts) {
+            try {
+                return await this.http.authedRequest<SendDelayedEventResponse>(
+                    Method.Put,
+                    utils.encodeUri("/rooms/$roomId/delayed_event/$eventType/$txnId", pathParams),
+                    undefined,
+                    {
+                        ...delayOpts,
+                        ...queryOpts,
+                        ...(event.isState() && { state_key: event.getStateKey()! }),
+                        content,
+                    },
+                    {
+                        prefix: `${ClientPrefix.Unstable}/${UNSTABLE_MSC4140_DELAYED_EVENTS}`,
+                    },
+                );
+            } catch (e) {
+                // For backwards compatibility with implementations of MSC4140 that
+                // do not support a dedicated endpoint for adding delayed events
+                if (!(e instanceof MatrixError && e.errcode === "M_UNRECOGNIZED")) {
+                    throw e;
+                }
+            }
+        }
 
         let path: string;
 
@@ -3093,10 +3124,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             path = utils.encodeUri("/rooms/$roomId/send/$eventType/$txnId", pathParams);
         }
 
-        const delayOpts =
-            queryOrDelayOpts && isSendDelayedEventRequestOpts(queryOrDelayOpts) ? queryOrDelayOpts : undefined;
-        const queryOpts = !delayOpts ? queryOrDelayOpts : queryDict;
-        const content = event.getWireContent();
         if (delayOpts) {
             return this.http.authedRequest<SendDelayedEventResponse>(
                 Method.Put,
@@ -3559,11 +3586,33 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             $eventType: eventType,
             $stateKey: stateKey,
         };
-        let path = utils.encodeUri("/rooms/$roomId/state/$eventType", pathParams);
-        if (stateKey !== undefined) {
-            path = utils.encodeUri(path + "/$stateKey", pathParams);
+        try {
+            return await this.http.authedRequest(
+                Method.Put,
+                utils.encodeUri("/rooms/$roomId/delayed_event/$eventType", pathParams),
+                undefined,
+                {
+                    ...delayOpts,
+                    state_key: stateKey,
+                    content,
+                },
+                {
+                    ...opts,
+                    prefix: `${ClientPrefix.Unstable}/${UNSTABLE_MSC4140_DELAYED_EVENTS}`,
+                },
+            );
+        } catch (e) {
+            // For backwards compatibility with implementations of MSC4140 that
+            // do not support a dedicated endpoint for adding delayed events
+            if (!(e instanceof MatrixError && e.errcode === "M_UNRECOGNIZED")) {
+                throw e;
+            }
+            let path = utils.encodeUri("/rooms/$roomId/state/$eventType", pathParams);
+            if (stateKey !== undefined) {
+                path = utils.encodeUri(path + "/$stateKey", pathParams);
+            }
+            return this.http.authedRequest(Method.Put, path, getUnstableDelayQueryOpts(delayOpts), content as Body, opts);
         }
-        return this.http.authedRequest(Method.Put, path, getUnstableDelayQueryOpts(delayOpts), content as Body, opts);
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -3071,7 +3071,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const pathParams = {
             $roomId: event.getRoomId()!,
             $eventType: event.getWireType(),
-            $stateKey: event.getStateKey()!,
             $txnId: txnId,
         };
 
@@ -3113,7 +3112,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             if (event.getStateKey() && event.getStateKey()!.length > 0) {
                 pathTemplate = "/rooms/$roomId/state/$eventType/$stateKey";
             }
-            path = utils.encodeUri(pathTemplate, pathParams);
+            path = utils.encodeUri(pathTemplate, {
+                $stateKey: event.getStateKey()!,
+                ...pathParams,
+            });
         } else if (event.isRedaction() && event.event.redacts) {
             const pathTemplate = `/rooms/$roomId/redact/$redactsEventId/$txnId`;
             path = utils.encodeUri(pathTemplate, {
@@ -3584,7 +3586,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const pathParams = {
             $roomId: roomId,
             $eventType: eventType,
-            $stateKey: stateKey,
         };
         try {
             return await this.http.authedRequest(
@@ -3607,11 +3608,16 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             if (!(e instanceof MatrixError && e.errcode === "M_UNRECOGNIZED")) {
                 throw e;
             }
-            let path = utils.encodeUri("/rooms/$roomId/state/$eventType", pathParams);
-            if (stateKey !== undefined) {
-                path = utils.encodeUri(path + "/$stateKey", pathParams);
-            }
-            return this.http.authedRequest(Method.Put, path, getUnstableDelayQueryOpts(delayOpts), content as Body, opts);
+            return this.http.authedRequest(
+                Method.Put,
+                utils.encodeUri("/rooms/$roomId/state/$eventType/$stateKey", {
+                    $stateKey: stateKey,
+                    ...pathParams,
+                }),
+                getUnstableDelayQueryOpts(delayOpts),
+                content,
+                opts,
+            );
         }
     }
 


### PR DESCRIPTION
Use a new, dedicated endpoint for scheduling delayed events. This should deprecate the `delay` query parameter on the `/send` and `/state` endpoints.

See:
- https://github.com/matrix-org/matrix-spec-proposals/pull/4140/commits/1618990017ed2c96ebd00b5ce6de7c61333f4bb6
- https://github.com/matrix-org/matrix-spec-proposals/pull/4140/commits/8a98ec46b501001cd859375697851456567497eb

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
