### PR TITLE
Add more context to HTTPError & MatrixError classes

### DIFF
--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -1347,7 +1347,7 @@ describe("verification", () => {
             await sendBackupGossipAndExpectVersion(
                 requestId!,
                 BACKUP_DECRYPTION_KEY_BASE64,
-                new MatrixError({ errcode: "M_NOT_FOUND", error: "No backup found" }, 404),
+                new MatrixError({ errcode: "M_NOT_FOUND", error: "No backup found" }, { httpStatus: 404 }),
             );
 
             // the backup secret should not be cached

--- a/spec/integ/matrix-client-methods.spec.ts
+++ b/spec/integ/matrix-client-methods.spec.ts
@@ -133,8 +133,9 @@ describe("MatrixClient", function () {
                 },
                 function (error) {
                     expect(error.httpStatus).toEqual(400);
+                    expect(error.method).toEqual("POST");
                     expect(error.errcode).toEqual("M_SNAFU");
-                    expect(error.message).toEqual("MatrixError: [400] broken");
+                    expect(error.message).toEqual("MatrixError: [POST 400] broken");
                 },
             );
 
@@ -380,12 +381,12 @@ describe("MatrixClient", function () {
                 [
                     403,
                     { errcode: "M_FORBIDDEN", error: "You don't have permission to knock" },
-                    "[M_FORBIDDEN: MatrixError: [403] You don't have permission to knock]",
+                    "[M_FORBIDDEN: MatrixError: [POST 403] You don't have permission to knock]",
                 ],
                 [
                     500,
                     { errcode: "INTERNAL_SERVER_ERROR" },
-                    "[INTERNAL_SERVER_ERROR: MatrixError: [500] Unknown message]",
+                    "[INTERNAL_SERVER_ERROR: MatrixError: [POST 500] Unknown message]",
                 ],
             ];
 
@@ -1556,7 +1557,7 @@ describe("MatrixClient", function () {
 
             const prom = client.setPowerLevel("!room_id:server", userId, 42);
             await Promise.all([
-                expect(prom).rejects.toMatchInlineSnapshot(`[ERR_DERP: MatrixError: [500] Unknown message]`),
+                expect(prom).rejects.toMatchInlineSnapshot(`[ERR_DERP: MatrixError: [GET 500] Unknown message]`),
                 httpBackend.flushAllExpected(),
             ]);
         });
@@ -1801,7 +1802,7 @@ describe("MatrixClient", function () {
                 function (error) {
                     expect(error.httpStatus).toEqual(errorUnrecogStatus);
                     expect(error.errcode).toEqual(errorUnrecogBody.errcode);
-                    expect(error.message).toEqual(`MatrixError: [${errorUnrecogStatus}] ${errorUnrecogBody.error}`);
+                    expect(error.message).toEqual(`MatrixError: [GET ${errorUnrecogStatus}] ${errorUnrecogBody.error}`);
                 },
             );
 
@@ -1819,7 +1820,7 @@ describe("MatrixClient", function () {
                 function (error) {
                     expect(error.httpStatus).toEqual(errorBadreqStatus);
                     expect(error.errcode).toEqual(errorBadreqBody.errcode);
-                    expect(error.message).toEqual(`MatrixError: [${errorBadreqStatus}] ${errorBadreqBody.error}`);
+                    expect(error.message).toEqual(`MatrixError: [GET ${errorBadreqStatus}] ${errorBadreqBody.error}`);
                 },
             );
 

--- a/spec/integ/matrix-client-opts.spec.ts
+++ b/spec/integ/matrix-client-opts.spec.ts
@@ -1,7 +1,7 @@
 import HttpBackend from "matrix-mock-request";
 
 import * as utils from "../test-utils/test-utils";
-import { ClientEvent, MatrixClient } from "../../src/matrix";
+import { ClientEvent, MatrixClient, Method } from "../../src/matrix";
 import { MatrixScheduler } from "../../src/scheduler";
 import { MemoryStore } from "../../src/store/memory";
 import { MatrixError } from "../../src/http-api";
@@ -151,15 +151,18 @@ describe("MatrixClient opts", function () {
         it("shouldn't retry sending events", async () => {
             httpBackend.when("PUT", "/txn1").respond(
                 500,
-                new MatrixError({
-                    errcode: "M_SOMETHING",
-                    error: "Ruh roh",
-                }),
+                new MatrixError(
+                    {
+                        errcode: "M_SOMETHING",
+                        error: "Ruh roh",
+                    },
+                    { httpStatus: 500, method: Method.Put },
+                ),
             );
 
             await expect(
                 Promise.all([client.sendTextMessage("!foo:bar", "a body", "txn1"), httpBackend.flush("/txn1", 1)]),
-            ).rejects.toThrow("MatrixError: [500] Ruh roh");
+            ).rejects.toThrow("MatrixError: [PUT 500] Ruh roh");
         });
 
         it("shouldn't queue events", async () => {

--- a/spec/integ/matrix-client-room-timeline.spec.ts
+++ b/spec/integ/matrix-client-room-timeline.spec.ts
@@ -799,12 +799,15 @@ describe("MatrixClient room timelines", function () {
                 })
                 .respond(
                     500,
-                    new MatrixError({
-                        errcode: "TEST_FAKE_ERROR",
-                        error:
-                            "We purposely intercepted this /context request to make it fail " +
-                            "in order to test whether the refresh timeline code is resilient",
-                    }),
+                    new MatrixError(
+                        {
+                            errcode: "TEST_FAKE_ERROR",
+                            error:
+                                "We purposely intercepted this /context request to make it fail " +
+                                "in order to test whether the refresh timeline code is resilient",
+                        },
+                        { httpStatus: 500 },
+                    ),
                 );
 
             // Refresh the timeline and expect it to fail

--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -171,7 +171,9 @@ describe("MSC4108SignInWithQR", () => {
         it("should be able to connect with opponent and share verificationUri", async () => {
             await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
 
-            mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
+            mocked(client.getDevice).mockRejectedValue(
+                new MatrixError({ errcode: "M_NOT_FOUND" }, { httpStatus: 404 }),
+            );
 
             await Promise.all([
                 expect(ourLogin.deviceAuthorizationGrant()).resolves.toEqual({
@@ -280,7 +282,9 @@ describe("MSC4108SignInWithQR", () => {
             await opponentLogin.send({
                 type: PayloadType.Success,
             });
-            mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
+            mocked(client.getDevice).mockRejectedValue(
+                new MatrixError({ errcode: "M_NOT_FOUND" }, { httpStatus: 404 }),
+            );
 
             const ourProm = ourLogin.shareSecrets();
             await expect(ourProm).rejects.toThrow("New device not found");
@@ -298,7 +302,7 @@ describe("MSC4108SignInWithQR", () => {
                 type: PayloadType.Success,
             });
             mocked(client.getDevice).mockRejectedValue(
-                new MatrixError({ errcode: "M_UNKNOWN", error: "The message" }, 500),
+                new MatrixError({ errcode: "M_UNKNOWN", error: "The message" }, { httpStatus: 500 }),
             );
 
             await expect(ourLogin.shareSecrets()).rejects.toThrow("The message");

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -590,10 +590,13 @@ describe("SlidingSyncSdk", () => {
                 SlidingSyncEvent.Lifecycle,
                 SlidingSyncState.RequestFinished,
                 null,
-                new MatrixError({
-                    errcode: "M_UNKNOWN_TOKEN",
-                    message: "Oh no your access token is no longer valid",
-                }),
+                new MatrixError(
+                    {
+                        errcode: "M_UNKNOWN_TOKEN",
+                        message: "Oh no your access token is no longer valid",
+                    },
+                    { httpStatus: 401 },
+                ),
             );
             expect(sdk!.getSyncState()).toEqual(SyncState.Error);
             expect(mockSlidingSync!.stop).toHaveBeenCalled();

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -383,7 +383,7 @@ describe("RoomWidgetClient", () => {
                     response: errorData,
                 },
             });
-            const matrixError = new MatrixError(errorData, errorStatusCode, errorUrl);
+            const matrixError = new MatrixError(errorData, { httpStatus: errorStatusCode, url: errorUrl });
 
             widgetApi.transport.send.mockRejectedValue(widgetError);
 
@@ -994,7 +994,7 @@ describe("RoomWidgetClient", () => {
                     response: errorData,
                 },
             });
-            const matrixError = new MatrixError(errorData, errorStatusCode, errorUrl);
+            const matrixError = new MatrixError(errorData, { httpStatus: errorStatusCode, url: errorUrl });
 
             widgetApi.transport.sendComplete.mockRejectedValue(widgetError);
 

--- a/spec/unit/http-api/errors.spec.ts
+++ b/spec/unit/http-api/errors.spec.ts
@@ -25,8 +25,8 @@ describe("MatrixError", () => {
         headers = new Headers({ "Content-Type": "application/json" });
     });
 
-    function makeMatrixError(httpStatus: number, data: IErrorJson, url?: string): MatrixError {
-        return new MatrixError(data, httpStatus, url, undefined, headers);
+    function makeMatrixError(httpStatus: number, data: IErrorJson, url = "https://default-url"): MatrixError {
+        return new MatrixError(data, { httpStatus, url, httpHeaders: headers });
     }
 
     it("should accept absent retry time from rate-limit error", () => {

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -35,7 +35,10 @@ describe("FetchHttpApi", () => {
     const baseUrl = "http://baseUrl";
     const idBaseUrl = "http://idBaseUrl";
     const prefix = ClientPrefix.V3;
-    const tokenInactiveError = new MatrixError({ errcode: "M_UNKNOWN_TOKEN", error: "Token is not active" }, 401);
+    const tokenInactiveError = new MatrixError(
+        { errcode: "M_UNKNOWN_TOKEN", error: "Token is not active" },
+        { httpStatus: 401 },
+    );
 
     beforeEach(() => {
         jest.useRealTimers();
@@ -322,7 +325,7 @@ describe("FetchHttpApi", () => {
                     error: "Token is not active",
                     soft_logout: false,
                 };
-                const unknownTokenErr = new MatrixError(unknownTokenErrBody, 401);
+                const unknownTokenErr = new MatrixError(unknownTokenErrBody, { httpStatus: 401, method: Method.Post });
                 const unknownTokenResponse = {
                     ok: false,
                     status: 401,

--- a/spec/unit/http-api/utils.spec.ts
+++ b/spec/unit/http-api/utils.spec.ts
@@ -23,6 +23,7 @@ import {
     MatrixError,
     MatrixSafetyError,
     MatrixSafetyErrorCode,
+    Method,
     parseErrorResponse,
     retryNetworkOperation,
     timeoutSignal,
@@ -112,6 +113,7 @@ describe("parseErrorResponse", () => {
                     ...xhrHeaderMethods,
                     status: 500,
                 } as XMLHttpRequest,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(
@@ -119,7 +121,7 @@ describe("parseErrorResponse", () => {
                 {
                     errcode: "TEST",
                 },
-                500,
+                { httpStatus: 500, method: Method.Post },
             ),
         );
     });
@@ -132,6 +134,7 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(
@@ -139,7 +142,7 @@ describe("parseErrorResponse", () => {
                 {
                     errcode: "TEST",
                 },
-                500,
+                { httpStatus: 500, method: Method.Post },
             ),
         );
     });
@@ -153,6 +156,7 @@ describe("parseErrorResponse", () => {
                     ...xhrHeaderMethods,
                     status: 500,
                 } as XMLHttpRequest,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(
@@ -160,8 +164,7 @@ describe("parseErrorResponse", () => {
                 {
                     errcode: "TEST",
                 },
-                500,
-                "https://example.com",
+                { httpStatus: 500, url: "https://example.com", method: Method.Post },
             ),
         );
     });
@@ -175,6 +178,7 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(
@@ -182,8 +186,7 @@ describe("parseErrorResponse", () => {
                 {
                     errcode: "TEST",
                 },
-                500,
-                "https://example.com",
+                { httpStatus: 500, url: "https://example.com", method: Method.Post },
             ),
         );
     });
@@ -210,6 +213,7 @@ describe("parseErrorResponse", () => {
                 headers,
                 status: 400,
             } as Response,
+            Method.Post,
             JSON.stringify(errContent),
         ) as MatrixSafetyError;
         expect(value).toBeInstanceOf(MatrixSafetyError);
@@ -233,20 +237,26 @@ describe("parseErrorResponse", () => {
         it("should resolve HTTP Errors from XHR with headers", () => {
             headers.set("Content-Type", "text/plain");
             addHeaders(headers);
-            const err = parseErrorResponse({
-                ...xhrHeaderMethods,
-                status: 500,
-            } as XMLHttpRequest) as HTTPError;
+            const err = parseErrorResponse(
+                {
+                    ...xhrHeaderMethods,
+                    status: 500,
+                } as XMLHttpRequest,
+                Method.Post,
+            ) as HTTPError;
             compareHeaders(headers, err.httpHeaders);
         });
 
         it("should resolve HTTP Errors from fetch with headers", () => {
             headers.set("Content-Type", "text/plain");
             addHeaders(headers);
-            const err = parseErrorResponse({
-                headers,
-                status: 500,
-            } as Response) as HTTPError;
+            const err = parseErrorResponse(
+                {
+                    headers,
+                    status: 500,
+                } as Response,
+                Method.Post,
+            ) as HTTPError;
             compareHeaders(headers, err.httpHeaders);
         });
 
@@ -258,6 +268,7 @@ describe("parseErrorResponse", () => {
                     ...xhrHeaderMethods,
                     status: 500,
                 } as XMLHttpRequest,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ) as MatrixError;
             compareHeaders(headers, err.httpHeaders);
@@ -271,6 +282,7 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ) as MatrixError;
             compareHeaders(headers, err.httpHeaders);
@@ -294,9 +306,10 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
-        ).toStrictEqual(new HTTPError("Server returned 500 error", 500));
+        ).toStrictEqual(new HTTPError("Server returned 500 error", { httpStatus: 500, method: Method.Post }));
     });
 
     it("should handle empty type gracefully", () => {
@@ -307,6 +320,7 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(new Error("Error parsing Content-Type '': TypeError: argument string is required"));
@@ -320,6 +334,7 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 500,
                 } as Response,
+                Method.Post,
                 '{"errcode": "TEST"}',
             ),
         ).toStrictEqual(new Error("Error parsing Content-Type 'unknown': TypeError: invalid media type"));
@@ -333,9 +348,12 @@ describe("parseErrorResponse", () => {
                     headers,
                     status: 418,
                 } as Response,
+                Method.Post,
                 "I'm a teapot",
             ),
-        ).toStrictEqual(new HTTPError("Server returned 418 error: I'm a teapot", 418));
+        ).toStrictEqual(
+            new HTTPError("Server returned 418 error: I'm a teapot", { httpStatus: 418, method: Method.Post }),
+        );
     });
 });
 

--- a/spec/unit/interactive-auth.spec.ts
+++ b/spec/unit/interactive-auth.spec.ts
@@ -212,7 +212,7 @@ describe("InteractiveAuth", () => {
                         [AuthType.Password]: { param: "aa" },
                     },
                 },
-                401,
+                { httpStatus: 401 },
             );
             throw err;
         });
@@ -274,7 +274,7 @@ describe("InteractiveAuth", () => {
                         [AuthType.Password]: { param: "aa" },
                     },
                 },
-                401,
+                { httpStatus: 401 },
             );
             throw err;
         });
@@ -332,7 +332,7 @@ describe("InteractiveAuth", () => {
                         [AuthType.Password]: { param: "aa" },
                     },
                 },
-                401,
+                { httpStatus: 401 },
             );
             throw err;
         });
@@ -367,7 +367,7 @@ describe("InteractiveAuth", () => {
                     error: "Mock Error 1",
                     errcode: "MOCKERR1",
                 },
-                401,
+                { httpStatus: 401 },
             );
             throw err;
         });
@@ -393,11 +393,11 @@ describe("InteractiveAuth", () => {
         doRequest.mockImplementation((authData) => {
             logger.log("request1", authData);
             expect(authData).toEqual({ session: "sessionId" }); // has existing sessionId
-            const err = new HTTPError("myerror", 401);
+            const err = new HTTPError("myerror", { httpStatus: 401 });
             throw err;
         });
 
-        await expect(ia.attemptAuth.bind(ia)).rejects.toThrow(new Error("myerror"));
+        await expect(ia.attemptAuth.bind(ia)).rejects.toThrow(new HTTPError("myerror", { httpStatus: 401 }));
     });
 
     it("should allow dummy auth", async () => {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -299,7 +299,7 @@ describe("MatrixClient", function () {
                             message: "Expected testing error",
                             data: next.error,
                         },
-                        (<MatrixError>next.error).httpStatus,
+                        <MatrixError>next.error,
                     ),
                 );
             }
@@ -3876,7 +3876,7 @@ describe("MatrixClient", function () {
                 {
                     method: "GET",
                     path: `/auth_metadata`,
-                    error: new MatrixError({ errcode: "M_UNRECOGNIZED" }, 404),
+                    error: new MatrixError({ errcode: "M_UNRECOGNIZED" }, { httpStatus: 404, method: Method.Get }),
                     prefix: "/_matrix/client/unstable/org.matrix.msc2965",
                 },
                 {

--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -220,10 +220,7 @@ describe("MembershipManager", () => {
                     const sendStateEventAttempt = new Promise<void>((resolve) => {
                         const error = new MatrixError(
                             { errcode: "M_LIMIT_EXCEEDED" },
-                            429,
-                            undefined,
-                            undefined,
-                            new Headers({ "Retry-After": "1" }),
+                            { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                         );
                         (client.sendStateEvent as Mock).mockImplementationOnce(() => {
                             resolve();
@@ -308,7 +305,7 @@ describe("MembershipManager", () => {
                 const delayedHandle = createAsyncHandle(client._unstable_sendDelayedStateEvent as Mock);
                 const manager = new MembershipManager({}, room, client, callSession);
                 manager.join([focus]);
-                delayedHandle.reject?.(new HTTPError("rate limited", 429, undefined));
+                delayedHandle.reject?.(new HTTPError("rate limited", { httpStatus: 429 }));
                 await jest.advanceTimersByTimeAsync(5000);
                 expect(client._unstable_sendDelayedStateEvent).toHaveBeenCalledTimes(2);
             });
@@ -632,10 +629,7 @@ describe("MembershipManager", () => {
                 handle.reject?.(
                     new MatrixError(
                         { errcode: "M_LIMIT_EXCEEDED" },
-                        429,
-                        undefined,
-                        undefined,
-                        new Headers({ "Retry-After": "1" }),
+                        { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                     ),
                 );
                 await jest.advanceTimersByTimeAsync(1000);
@@ -646,10 +640,7 @@ describe("MembershipManager", () => {
                 (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(
                     new MatrixError(
                         { errcode: "M_LIMIT_EXCEEDED" },
-                        429,
-                        undefined,
-                        undefined,
-                        new Headers({ "Retry-After": "1" }),
+                        { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                     ),
                 );
                 const manager = new MembershipManager({}, room, client, callSession);
@@ -677,10 +668,7 @@ describe("MembershipManager", () => {
                 handle.reject?.(
                     new MatrixError(
                         { errcode: "M_LIMIT_EXCEEDED" },
-                        429,
-                        undefined,
-                        undefined,
-                        new Headers({ "Retry-After": "1" }),
+                        { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                     ),
                 );
 
@@ -701,10 +689,7 @@ describe("MembershipManager", () => {
                 (client._unstable_restartScheduledDelayedEvent as Mock<any>).mockRejectedValue(
                     new MatrixError(
                         { errcode: "M_LIMIT_EXCEEDED" },
-                        429,
-                        undefined,
-                        undefined,
-                        new Headers({ "Retry-After": "1" }),
+                        { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                     ),
                 );
                 const manager = new MembershipManager({}, room, client, callSession);
@@ -734,10 +719,7 @@ describe("MembershipManager", () => {
             (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(
                 new MatrixError(
                     { errcode: "M_LIMIT_EXCEEDED" },
-                    429,
-                    undefined,
-                    undefined,
-                    new Headers({ "Retry-After": "2" }),
+                    { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "2" }) },
                 ),
             );
             const manager = new MembershipManager({}, room, client, callSession);
@@ -754,10 +736,7 @@ describe("MembershipManager", () => {
             (client._unstable_restartScheduledDelayedEvent as Mock<any>).mockRejectedValue(
                 new MatrixError(
                     { errcode: "M_LIMIT_EXCEEDED" },
-                    429,
-                    undefined,
-                    undefined,
-                    new Headers({ "Retry-After": "1" }),
+                    { httpStatus: 429, httpHeaders: new Headers({ "Retry-After": "1" }) },
                 ),
             );
             const manager = new MembershipManager({}, room, client, callSession);
@@ -770,7 +749,9 @@ describe("MembershipManager", () => {
         });
         it("falls back to using pure state events when some error occurs while sending delayed events", async () => {
             const unrecoverableError = jest.fn();
-            (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(new HTTPError("unknown", 601));
+            (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(
+                new HTTPError("unknown", { httpStatus: 601 }),
+            );
             const manager = new MembershipManager({}, room, client, callSession);
             manager.join([focus], focusActive, unrecoverableError);
             await waitForMockCall(client.sendStateEvent);
@@ -779,7 +760,9 @@ describe("MembershipManager", () => {
         });
         it("retries before failing in case its a network error", async () => {
             const unrecoverableError = jest.fn();
-            (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(new HTTPError("unknown", 501));
+            (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(
+                new HTTPError("unknown", { httpStatus: 501 }),
+            );
             const manager = new MembershipManager(
                 { networkErrorRetryMs: 1000, maximumNetworkErrorRetryCount: 7 },
                 room,

--- a/src/http-api/errors.ts
+++ b/src/http-api/errors.ts
@@ -19,6 +19,7 @@ import { type IMatrixApiError as IWidgetMatrixError } from "matrix-widget-api";
 import { type IUsageLimit } from "../@types/partials.ts";
 import { type MatrixEvent } from "../models/event.ts";
 import { NamespacedValue } from "../NamespacedValue.ts";
+import { type Method } from "./method.ts";
 
 interface IErrorJson extends Partial<IUsageLimit> {
     [key: string]: any; // extensible
@@ -26,20 +27,60 @@ interface IErrorJson extends Partial<IUsageLimit> {
     error?: string;
 }
 
+interface HttpErrorOptions extends ErrorOptions {
+    /**
+     * The URL which returned this error. This should be the final (after redirects) URL.
+     */
+    url?: string;
+    /**
+     * The HTTP method in response to which this error pertains.
+     */
+    method?: Method;
+    /**
+     * The HTTP status encountered alongside the error.
+     */
+    httpStatus?: number;
+    /**
+     * The HTTP headers present in the response alongside the error.
+     */
+    httpHeaders?: Headers;
+}
+
 /**
  * Construct a generic HTTP error. This is a JavaScript Error with additional information
  * specific to HTTP responses.
  * @param msg - The error message to include.
- * @param httpStatus - The HTTP response status code.
- * @param httpHeaders - The HTTP response headers.
+ * @param options - Relevant context surrounding this error.
  */
 export class HTTPError extends Error {
-    public constructor(
-        msg: string,
-        public readonly httpStatus?: number,
-        public readonly httpHeaders?: Headers,
-    ) {
-        super(msg);
+    public readonly url?: string;
+    public readonly method?: Method;
+    public readonly httpStatus?: number;
+    public readonly httpHeaders?: Headers;
+
+    public constructor(msg: string, options: HttpErrorOptions = {}) {
+        const details: string[] = [];
+        if (options.method) {
+            details.push(options.method);
+        }
+        if (options.httpStatus !== undefined) {
+            details.push("" + options.httpStatus);
+        }
+
+        let message = msg || "Unknown message";
+        if (details.length) {
+            message = `[${details.join(" ")}] ${message}`;
+        }
+        if (options.url) {
+            message += ` (${options.url})`;
+        }
+
+        super(`HTTPError: ${message}`, { cause: options?.cause });
+
+        this.url = options.url;
+        this.method = options.method;
+        this.httpStatus = options.httpStatus;
+        this.httpHeaders = options.httpHeaders;
     }
 
     /**
@@ -80,6 +121,13 @@ export class HTTPError extends Error {
     }
 }
 
+interface MatrixErrorOptions extends HttpErrorOptions {
+    /**
+     * The MatrixEvent to which this error relates.
+     */
+    event?: MatrixEvent;
+}
+
 export class MatrixError extends HTTPError {
     // The Matrix 'errcode' value, e.g. "M_FORBIDDEN".
     public readonly errcode?: string;
@@ -87,29 +135,21 @@ export class MatrixError extends HTTPError {
     public readonly error?: string;
     // The raw Matrix error JSON used to construct this object.
     public data: IErrorJson;
+    // The MatrixEvent to which this error relates.
+    public event?: MatrixEvent;
 
     /**
      * Construct a Matrix error. This is a JavaScript Error with additional
      * information specific to the standard Matrix error response.
      * @param errorJson - The Matrix error JSON returned from the homeserver.
-     * @param httpStatus - The numeric HTTP status code given
-     * @param httpHeaders - The HTTP response headers given
+     * @param options - Relevant context surrounding this error.
      */
-    public constructor(
-        errorJson: IErrorJson = {},
-        httpStatus?: number,
-        public url?: string,
-        public event?: MatrixEvent,
-        httpHeaders?: Headers,
-    ) {
-        let message = errorJson.error || "Unknown message";
-        if (httpStatus) {
-            message = `[${httpStatus}] ${message}`;
-        }
-        if (url) {
-            message = `${message} (${url})`;
-        }
-        super(`MatrixError: ${message}`, httpStatus, httpHeaders);
+    public constructor(errorJson: IErrorJson = {}, options: MatrixErrorOptions = {}) {
+        const { event, ...otherOptions } = options;
+        super(errorJson.error || "Unknown message", otherOptions);
+        this.message = this.message.replace("HTTPError: ", "MatrixError: ");
+
+        this.event = event;
         this.errcode = errorJson.errcode;
         this.error = errorJson.error;
         this.name = errorJson.errcode || "Unknown error code";
@@ -166,7 +206,11 @@ export class MatrixError extends HTTPError {
      * received from Widget API error responses.
      */
     public static fromWidgetApiErrorData(data: IWidgetMatrixError): MatrixError {
-        return new MatrixError(data.response, data.http_status, data.url, undefined, new Headers(data.http_headers));
+        return new MatrixError(data.response, {
+            httpStatus: data.http_status,
+            url: data.url,
+            httpHeaders: new Headers(data.http_headers),
+        });
     }
 }
 

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -318,7 +318,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         }
 
         if (!res.ok) {
-            throw parseErrorResponse(res, await res.text());
+            throw parseErrorResponse(res, method, await res.text());
         }
 
         if (opts.rawResponseBody) {

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -69,6 +69,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
 
         if (globalThis.XMLHttpRequest) {
             const xhr = new globalThis.XMLHttpRequest();
+            const method = Method.Post;
 
             const timeoutFn = function (): void {
                 xhr.abort();
@@ -91,7 +92,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
                             }
 
                             if (xhr.status >= 400) {
-                                uploadResolvers.reject(parseErrorResponse(xhr, xhr.responseText));
+                                uploadResolvers.reject(parseErrorResponse(xhr, method, xhr.responseText));
                             } else {
                                 uploadResolvers.resolve(JSON.parse(xhr.responseText));
                             }
@@ -127,7 +128,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
                 url.searchParams.set("access_token", encodeURIComponent(this.opts.accessToken));
             }
 
-            xhr.open(Method.Post, url.href);
+            xhr.open(method, url.href);
             if (this.opts.useAuthorizationHeader && this.opts.accessToken) {
                 xhr.setRequestHeader("Authorization", "Bearer " + this.opts.accessToken);
             }

--- a/src/http-api/utils.ts
+++ b/src/http-api/utils.ts
@@ -26,6 +26,7 @@ import {
     MatrixSafetyErrorCode,
     safeGetRetryAfterMs,
 } from "./errors.ts";
+import { Method } from "./method.ts";
 
 // Ponyfill for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout
 export function timeoutSignal(ms: number): AbortSignal {
@@ -75,11 +76,14 @@ export function anySignal(signals: AbortSignal[]): {
  * we return a generic Error.
  *
  * @param response - response object
+ * @param method - the HTTP method used in the request resulting in this response
  * @param body - raw body of the response
  * @returns
  */
-export function parseErrorResponse(response: XMLHttpRequest | Response, body?: string): Error {
-    const httpHeaders = isXhr(response)
+export function parseErrorResponse(response: XMLHttpRequest | Response, method: Method, body?: string): Error {
+    const responseIsXhr = isXhr(response);
+    const url = responseIsXhr ? response.responseURL : response.url;
+    const httpHeaders = responseIsXhr
         ? new Headers(
               response
                   .getAllResponseHeaders()
@@ -98,29 +102,19 @@ export function parseErrorResponse(response: XMLHttpRequest | Response, body?: s
     } catch (e) {
         return <Error>e;
     }
+
+    const errorContext = { httpStatus: response.status, url, httpHeaders, method };
     if (contentType?.type === "application/json" && body) {
         const errorBody = JSON.parse(body);
         if (errorBody.errcode && MatrixSafetyErrorCode.matches(errorBody.errcode)) {
-            return new MatrixSafetyError(
-                errorBody,
-                response.status,
-                isXhr(response) ? response.responseURL : response.url,
-                undefined,
-                httpHeaders,
-            );
+            return new MatrixSafetyError(errorBody, errorContext);
         }
-        return new MatrixError(
-            errorBody,
-            response.status,
-            isXhr(response) ? response.responseURL : response.url,
-            undefined,
-            httpHeaders,
-        );
+        return new MatrixError(errorBody, errorContext);
     }
     if (contentType?.type === "text/plain") {
-        return new HTTPError(`Server returned ${response.status} error: ${body}`, response.status, httpHeaders);
+        return new HTTPError(`Server returned ${response.status} error: ${body}`, errorContext);
     }
-    return new HTTPError(`Server returned ${response.status} error`, response.status, httpHeaders);
+    return new HTTPError(`Server returned ${response.status} error`, errorContext);
 }
 
 function isXhr(response: XMLHttpRequest | Response): response is XMLHttpRequest {

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -19,7 +19,7 @@ import { type MatrixClient } from "./client.ts";
 import { type IRoomEvent, type IStateEvent } from "./sync-accumulator.ts";
 import { TypedEventEmitter } from "./models/typed-event-emitter.ts";
 import { sleep } from "./utils.ts";
-import { type HTTPError } from "./http-api/index.ts";
+import { HTTPError } from "./http-api/index.ts";
 
 // /sync requests allow you to set a timeout= but the request may continue
 // beyond that and wedge forever, so we need to track how long we are willing
@@ -634,9 +634,9 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
                 });
                 this.invokeLifecycleListeners(SlidingSyncState.RequestFinished, resp);
             } catch (err) {
-                if ((<HTTPError>err).httpStatus) {
-                    this.invokeLifecycleListeners(SlidingSyncState.RequestFinished, null, <Error>err);
-                    if ((<HTTPError>err).httpStatus === 400) {
+                if (err instanceof HTTPError) {
+                    this.invokeLifecycleListeners(SlidingSyncState.RequestFinished, null, err);
+                    if (err.httpStatus === 400) {
                         // session probably expired TODO: assign an errcode
                         // so drop state and re-request
                         this.resetup();


### PR DESCRIPTION
This helps debugging both for tests & making sense of client error logs

Split out from https://github.com/matrix-org/matrix-js-sdk/pull/5136