### PR TITLE
Unit tests for OutgoingRequestsManager not repeating failed requests

### DIFF
--- a/spec/unit/rust-crypto/OutgoingRequestsManager.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestsManager.spec.ts
@@ -236,4 +236,105 @@ describe("OutgoingRequestsManager", () => {
             expect(processor.makeOutgoingRequest).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("Repeated processing of outgoing requests", () => {
+        it("Processes any requests still in the queue after processing", async () => {
+            // Given that the first time we call outgoingRequests we get back
+            // requests 1 and 2, but the second time, we get request 3
+            const [request1, request2, request3] = setupOutgoingTwoRequestsThenOne();
+
+            // (And requests finish immediately)
+            processor.makeOutgoingRequest.mockImplementation(async () => {
+                return;
+            });
+
+            // When we ask a manager to process the requests
+            await manager.doProcessOutgoingRequests();
+
+            // Then all three are processed because we re-call outgoingRequests
+            // to check for more
+            await vi.waitFor(() => expect(olmMachine.outgoingRequests).toHaveBeenCalledTimes(3));
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledTimes(3);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request1);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request2);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request3);
+        });
+
+        it("Does reprocess if any request succeeded, even if some failed", async () => {
+            // Given that the first time we call outgoingRequests we get back
+            // requests 1 and 2, but the second time, we get request 3
+            const [request1, request2, request3] = setupOutgoingTwoRequestsThenOne();
+
+            // And the first request fails, but subsequent ones pass
+            processor.makeOutgoingRequest
+                .mockImplementationOnce(async () => {
+                    throw new Error("This request failed!");
+                })
+                .mockImplementation(async () => {
+                    return;
+                });
+
+            // When we ask a manager to process the requests
+            await manager.doProcessOutgoingRequests();
+
+            // Then all three are processed because we re-call outgoingRequests
+            // to check for more, even though one failed
+            await vi.waitFor(() => expect(olmMachine.outgoingRequests).toHaveBeenCalledTimes(3));
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledTimes(3);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request1);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request2);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request3);
+        });
+
+        it("Does not reprocess if all requests failed", async () => {
+            // Given that the first time we call outgoingRequests we get back
+            // requests 1 and 2, but the second time, we get request 3
+            const [request1, request2, request3] = setupOutgoingTwoRequestsThenOne();
+
+            // And the first two requests fail, but subsequent ones pass
+            processor.makeOutgoingRequest
+                .mockImplementationOnce(async () => {
+                    throw new Error("Request 1 failed!");
+                })
+                .mockImplementationOnce(async () => {
+                    throw new Error("Request 2 failed!");
+                })
+                .mockImplementation(async () => {
+                    return;
+                });
+
+            // When we ask a manager to process the requests
+            await manager.doProcessOutgoingRequests();
+
+            // Then only the first two requests are processed, because since
+            // they both failed we stop retrying
+            await vi.waitFor(() => expect(olmMachine.outgoingRequests).toHaveBeenCalledTimes(1));
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledTimes(2);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request1);
+            expect(processor.makeOutgoingRequest).toHaveBeenCalledWith(request2);
+            expect(processor.makeOutgoingRequest).not.toHaveBeenCalledWith(request3);
+        });
+
+        /// Mock calls to olmMachine.outgoingRequests. The first time it is
+        // called, return two requests and the second time return a third one.
+        //
+        // Returns the three returned requests.
+        function setupOutgoingTwoRequestsThenOne(): [OutgoingRequest, OutgoingRequest, OutgoingRequest] {
+            const request1 = new RustSdkCryptoJs.KeysQueryRequest("1", "{}");
+            const request2 = new RustSdkCryptoJs.KeysUploadRequest("2", "{}");
+            const request3 = new RustSdkCryptoJs.KeysUploadRequest("3", "{}");
+
+            // Given that the first time we call outgoingRequests we get back
+            // requests 1 and 2, but the second time, we get request 3
+            olmMachine.outgoingRequests
+                .mockImplementationOnce(async (): Promise<OutgoingRequest[]> => {
+                    return [request1, request2];
+                })
+                .mockImplementationOnce(async (): Promise<OutgoingRequest[]> => {
+                    return [request3];
+                });
+
+            return [request1, request2, request3];
+        }
+    });
 });


### PR DESCRIPTION
Part of the fix for https://github.com/element-hq/element-web/issues/31790 , following on from https://github.com/matrix-org/matrix-js-sdk/pull/5146