### PR TITLE
[MatrixRTC] Remove sending of deprecated `notify` event (we now use `m.rtc.notification`)

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -620,9 +620,7 @@ describe("MatrixRTCSession", () => {
         it("sends a notification when starting a call and emit DidSendCallNotification", async () => {
             // Simulate a join, including the update to the room state
             // Ensure sendEvent returns event IDs so the DidSendCallNotification payload includes them
-            sendEventMock
-                .mockResolvedValueOnce({ event_id: "legacy-evt" })
-                .mockResolvedValueOnce({ event_id: "new-evt" });
+            sendEventMock.mockResolvedValueOnce({ event_id: "new-evt" });
             const didSendEventFn = vi.fn();
             sess!.once(MatrixRTCSessionEvent.DidSendCallNotification, didSendEventFn);
             // Create an additional listener to create a promise that resolves after the emission.
@@ -647,43 +645,25 @@ describe("MatrixRTCSession", () => {
                 "sender_ts": expect.any(Number),
             });
 
-            // Check if deprecated notify event is also sent.
-            expect(client.sendEvent).toHaveBeenCalledWith(mockRoom!.roomId, EventType.CallNotify, {
-                "application": "m.call",
-                "m.mentions": { user_ids: [], room: true },
-                "notify_type": "ring",
-                "call_id": "",
-            });
             await didSendNotification;
             // And ensure we emitted the DidSendCallNotification event with both payloads
-            expect(didSendEventFn).toHaveBeenCalledWith(
-                {
-                    "event_id": "new-evt",
-                    "lifetime": 30000,
-                    "m.mentions": { room: true, user_ids: [] },
-                    "m.relates_to": {
-                        event_id: expect.any(String),
-                        rel_type: "m.reference",
-                    },
-                    "notification_type": "ring",
-                    "sender_ts": expect.any(Number),
+            expect(didSendEventFn).toHaveBeenCalledWith({
+                "event_id": "new-evt",
+                "lifetime": 30000,
+                "m.mentions": { room: true, user_ids: [] },
+                "m.relates_to": {
+                    event_id: expect.any(String),
+                    rel_type: "m.reference",
                 },
-                {
-                    "application": "m.call",
-                    "call_id": "",
-                    "event_id": "legacy-evt",
-                    "m.mentions": { room: true, user_ids: [] },
-                    "notify_type": "ring",
-                },
-            );
+                "notification_type": "ring",
+                "sender_ts": expect.any(Number),
+            });
         });
 
         it("sends a notification with a intent when starting a call and emits DidSendCallNotification", async () => {
             // Simulate a join, including the update to the room state
             // Ensure sendEvent returns event IDs so the DidSendCallNotification payload includes them
-            sendEventMock
-                .mockResolvedValueOnce({ event_id: "legacy-evt" })
-                .mockResolvedValueOnce({ event_id: "new-evt" });
+            sendEventMock.mockResolvedValueOnce({ event_id: "new-evt" });
             const didSendEventFn = vi.fn();
             sess!.once(MatrixRTCSessionEvent.DidSendCallNotification, didSendEventFn);
             // Create an additional listener to create a promise that resolves after the emission.
@@ -707,7 +687,7 @@ describe("MatrixRTCSession", () => {
             ]);
 
             await sess!._onRTCSessionMemberUpdate();
-            const ownMembershipId = sess?.memberships[0].eventId;
+            const ownMembershipEventId = sess?.memberships[0].eventId;
             expect(sess!.getConsensusCallIntent()).toEqual("audio");
 
             expect(client.sendEvent).toHaveBeenCalledWith(mockRoom!.roomId, EventType.RTCNotification, {
@@ -715,43 +695,27 @@ describe("MatrixRTCSession", () => {
                 "notification_type": "ring",
                 "m.call.intent": "audio",
                 "m.relates_to": {
-                    event_id: ownMembershipId,
+                    event_id: ownMembershipEventId,
                     rel_type: "m.reference",
                 },
                 "lifetime": 30000,
                 "sender_ts": expect.any(Number),
             });
 
-            // Check if deprecated notify event is also sent.
-            expect(client.sendEvent).toHaveBeenCalledWith(mockRoom!.roomId, EventType.CallNotify, {
-                "application": "m.call",
-                "m.mentions": { user_ids: [], room: true },
-                "notify_type": "ring",
-                "call_id": "",
-            });
             await didSendNotification;
             // And ensure we emitted the DidSendCallNotification event with both payloads
-            expect(didSendEventFn).toHaveBeenCalledWith(
-                {
-                    "event_id": "new-evt",
-                    "lifetime": 30000,
-                    "m.mentions": { room: true, user_ids: [] },
-                    "m.relates_to": {
-                        event_id: expect.any(String),
-                        rel_type: "m.reference",
-                    },
-                    "notification_type": "ring",
-                    "m.call.intent": "audio",
-                    "sender_ts": expect.any(Number),
+            expect(didSendEventFn).toHaveBeenCalledWith({
+                "event_id": "new-evt",
+                "lifetime": 30000,
+                "m.mentions": { room: true, user_ids: [] },
+                "m.relates_to": {
+                    event_id: expect.any(String),
+                    rel_type: "m.reference",
                 },
-                {
-                    "application": "m.call",
-                    "call_id": "",
-                    "event_id": "legacy-evt",
-                    "m.mentions": { room: true, user_ids: [] },
-                    "notify_type": "ring",
-                },
-            );
+                "notification_type": "ring",
+                "m.call.intent": "audio",
+                "sender_ts": expect.any(Number),
+            });
         });
 
         it("doesn't send a notification when joining an existing call", async () => {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -32,7 +32,6 @@ import type {
     RTCNotificationType,
     Status,
     IRTCNotificationContent,
-    ICallNotifyContent,
     RTCCallIntent,
     Transport,
 } from "./types.ts";
@@ -81,7 +80,6 @@ export type MatrixRTCSessionEventHandlerMap = {
     [MatrixRTCSessionEvent.MembershipManagerError]: (error: unknown) => void;
     [MatrixRTCSessionEvent.DidSendCallNotification]: (
         notificationContentNew: { event_id: string } & IRTCNotificationContent,
-        notificationContentLegacy: { event_id: string } & ICallNotifyContent,
     ) => void;
 };
 
@@ -713,20 +711,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
         notificationType: RTCNotificationType,
         callIntent?: RTCCallIntent,
     ): void {
-        const sendLegacyNotificationEvent = async (): Promise<{
-            response: ISendEventResponse;
-            content: ICallNotifyContent;
-        }> => {
-            const content: ICallNotifyContent = {
-                "application": "m.call",
-                "m.mentions": { user_ids: [], room: true },
-                "notify_type": notificationType === "notification" ? "notify" : notificationType,
-                "call_id": this.callId!,
-            };
-            const response = await this.client.sendEvent(this.roomSubset.roomId, EventType.CallNotify, content);
-            return { response, content };
-        };
-        const sendNewNotificationEvent = async (): Promise<{
+        const sendNotificationEvent = async (): Promise<{
             response: ISendEventResponse;
             content: IRTCNotificationContent;
         }> => {
@@ -747,12 +732,11 @@ export class MatrixRTCSession extends TypedEventEmitter<
             return { response, content };
         };
 
-        void Promise.all([sendLegacyNotificationEvent(), sendNewNotificationEvent()])
-            .then(([legacy, newNotification]) => {
+        void sendNotificationEvent()
+            .then((notification) => {
                 // Join event_id and origin event content
-                const legacyResult = { ...legacy.response, ...legacy.content };
-                const newResult = { ...newNotification.response, ...newNotification.content };
-                this.emit(MatrixRTCSessionEvent.DidSendCallNotification, newResult, legacyResult);
+                const newResult = { ...notification.response, ...notification.content };
+                this.emit(MatrixRTCSessionEvent.DidSendCallNotification, newResult);
             })
             .catch(([errorLegacy, errorNew]) =>
                 this.logger.error("Failed to send call notification", errorLegacy, errorNew),


### PR DESCRIPTION
This is now part of the rust sdk and EX (and also EW since a really long time) So no need for the double sending anymore.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
