### PR TITLE
[js sdk embedded/widget] Fix race where this.syncApi.injectRoomEvents was called before the syncApi is instantiated

### DIFF
--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -212,60 +212,7 @@ export class RoomWidgetClient extends MatrixClient {
               )
             : Promise.resolve();
 
-        // Request capabilities for the functionality this client needs to support
-        if (
-            capabilities.sendEvent?.length ||
-            capabilities.receiveEvent?.length ||
-            capabilities.sendMessage === true ||
-            (Array.isArray(capabilities.sendMessage) && capabilities.sendMessage.length) ||
-            capabilities.receiveMessage === true ||
-            (Array.isArray(capabilities.receiveMessage) && capabilities.receiveMessage.length) ||
-            capabilities.sendState?.length ||
-            capabilities.receiveState?.length
-        ) {
-            widgetApi.requestCapabilityForRoomTimeline(roomId);
-        }
-        capabilities.sendEvent?.forEach((eventType) => widgetApi.requestCapabilityToSendEvent(eventType));
-        capabilities.receiveEvent?.forEach((eventType) => widgetApi.requestCapabilityToReceiveEvent(eventType));
-        if (capabilities.sendMessage === true) {
-            widgetApi.requestCapabilityToSendMessage();
-        } else if (Array.isArray(capabilities.sendMessage)) {
-            capabilities.sendMessage.forEach((msgType) => widgetApi.requestCapabilityToSendMessage(msgType));
-        }
-        if (capabilities.receiveMessage === true) {
-            widgetApi.requestCapabilityToReceiveMessage();
-        } else if (Array.isArray(capabilities.receiveMessage)) {
-            capabilities.receiveMessage.forEach((msgType) => widgetApi.requestCapabilityToReceiveMessage(msgType));
-        }
-        capabilities.sendState?.forEach(({ eventType, stateKey }) =>
-            widgetApi.requestCapabilityToSendState(eventType, stateKey),
-        );
-        capabilities.receiveState?.forEach(({ eventType, stateKey }) =>
-            widgetApi.requestCapabilityToReceiveState(eventType, stateKey),
-        );
-        capabilities.sendToDevice?.forEach((eventType) => widgetApi.requestCapabilityToSendToDevice(eventType));
-        capabilities.receiveToDevice?.forEach((eventType) => widgetApi.requestCapabilityToReceiveToDevice(eventType));
-        if (
-            capabilities.sendDelayedEvents &&
-            (capabilities.sendEvent?.length ||
-                capabilities.sendMessage === true ||
-                (Array.isArray(capabilities.sendMessage) && capabilities.sendMessage.length) ||
-                capabilities.sendState?.length)
-        ) {
-            widgetApi.requestCapability(MatrixCapabilities.MSC4157SendDelayedEvent);
-        }
-        if (capabilities.updateDelayedEvents) {
-            widgetApi.requestCapability(MatrixCapabilities.MSC4157UpdateDelayedEvent);
-        }
-        if (capabilities.sendSticky) {
-            widgetApi.requestCapability(MatrixCapabilities.MSC4407SendStickyEvent);
-        }
-        if (capabilities.receiveSticky) {
-            widgetApi.requestCapability(MatrixCapabilities.MSC4407ReceiveStickyEvent);
-        }
-        if (capabilities.turnServers) {
-            widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
-        }
+        this.requestInitialCapabilities(capabilities, roomId);
 
         widgetApi.on(`action:${WidgetApiToWidgetAction.SendEvent}`, this.onEvent);
         widgetApi.on(`action:${WidgetApiToWidgetAction.SendToDevice}`, this.onToDevice);
@@ -281,11 +228,70 @@ export class RoomWidgetClient extends MatrixClient {
         if (sendContentLoaded) widgetApi.sendContentLoaded();
     }
 
+    private requestInitialCapabilities(capabilities: ICapabilities, roomId: string): void {
+        // Request capabilities for the functionality this client needs to support
+        if (
+            capabilities.sendEvent?.length ||
+            capabilities.receiveEvent?.length ||
+            capabilities.sendMessage === true ||
+            (Array.isArray(capabilities.sendMessage) && capabilities.sendMessage.length) ||
+            capabilities.receiveMessage === true ||
+            (Array.isArray(capabilities.receiveMessage) && capabilities.receiveMessage.length) ||
+            capabilities.sendState?.length ||
+            capabilities.receiveState?.length
+        ) {
+            this.widgetApi.requestCapabilityForRoomTimeline(roomId);
+        }
+        capabilities.sendEvent?.forEach((eventType) => this.widgetApi.requestCapabilityToSendEvent(eventType));
+        capabilities.receiveEvent?.forEach((eventType) => this.widgetApi.requestCapabilityToReceiveEvent(eventType));
+        if (capabilities.sendMessage === true) {
+            this.widgetApi.requestCapabilityToSendMessage();
+        } else if (Array.isArray(capabilities.sendMessage)) {
+            capabilities.sendMessage.forEach((msgType) => this.widgetApi.requestCapabilityToSendMessage(msgType));
+        }
+        if (capabilities.receiveMessage === true) {
+            this.widgetApi.requestCapabilityToReceiveMessage();
+        } else if (Array.isArray(capabilities.receiveMessage)) {
+            capabilities.receiveMessage.forEach((msgType) => this.widgetApi.requestCapabilityToReceiveMessage(msgType));
+        }
+        capabilities.sendState?.forEach(({ eventType, stateKey }) =>
+            this.widgetApi.requestCapabilityToSendState(eventType, stateKey),
+        );
+        capabilities.receiveState?.forEach(({ eventType, stateKey }) =>
+            this.widgetApi.requestCapabilityToReceiveState(eventType, stateKey),
+        );
+        capabilities.sendToDevice?.forEach((eventType) => this.widgetApi.requestCapabilityToSendToDevice(eventType));
+        capabilities.receiveToDevice?.forEach((eventType) =>
+            this.widgetApi.requestCapabilityToReceiveToDevice(eventType),
+        );
+        if (
+            capabilities.sendDelayedEvents &&
+            (capabilities.sendEvent?.length ||
+                capabilities.sendMessage === true ||
+                (Array.isArray(capabilities.sendMessage) && capabilities.sendMessage.length) ||
+                capabilities.sendState?.length)
+        ) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4157SendDelayedEvent);
+        }
+        if (capabilities.updateDelayedEvents) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4157UpdateDelayedEvent);
+        }
+        if (capabilities.sendSticky) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4407SendStickyEvent);
+        }
+        if (capabilities.receiveSticky) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4407ReceiveStickyEvent);
+        }
+        if (capabilities.turnServers) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
+        }
+    }
+
     public async supportUpdateState(): Promise<boolean> {
         return (await this.widgetApi.getClientVersions()).includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
     }
 
-    private syncApiResolver = Promise.withResolvers<void>();
+    private readonly syncApiResolver = Promise.withResolvers<void>();
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {
         this.lifecycle = new AbortController();
 


### PR DESCRIPTION
review commit by commit. (The second commit is only refactor no actual changes.)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
