### PR TITLE
fix(relations): prevent stale m.replace from overriding newer edits

### DIFF
--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -275,6 +275,108 @@ describe("Relations", function () {
         expect(badlyEditedTopic.getContent().topic).toBe("topic");
     });
 
+    describe("m.replace async ordering", () => {
+        const userId = "@bob:example.com";
+        const roomId = "!room:example.com";
+        const targetEventId = "$target";
+
+        function makeEditEvent(eventId: string, ts: number): MatrixEvent {
+            return new MatrixEvent({
+                sender: userId,
+                type: "m.room.message",
+                event_id: eventId,
+                room_id: roomId,
+                origin_server_ts: ts,
+                content: {
+                    "body": `edited ${eventId}`,
+                    "msgtype": "m.text",
+                    "m.new_content": {
+                        body: `edited ${eventId}`,
+                        msgtype: "m.text",
+                    },
+                    "m.relates_to": {
+                        event_id: targetEventId,
+                        rel_type: "m.replace",
+                    },
+                },
+            });
+        }
+
+        it("should not let a slow-decrypting older edit overwrite a newer one", async () => {
+            const room = new Room(roomId, new TestClient(userId).client, userId);
+            const relations = new Relations("m.replace", "m.room.message", room);
+
+            const targetEvent = new MatrixEvent({
+                sender: userId,
+                type: "m.room.message",
+                event_id: targetEventId,
+                room_id: roomId,
+                origin_server_ts: 1000,
+                content: { body: "original", msgtype: "m.text" },
+            });
+
+            await relations.setTargetEvent(targetEvent);
+
+            // Create two edits: edit1 is older (ts=2000), edit2 is newer (ts=3000).
+            const edit1 = makeEditEvent("$edit1", 2000);
+            const edit2 = makeEditEvent("$edit2", 3000);
+
+            // Simulate edit1 being in the process of decryption: isBeingDecrypted()
+            // returns true and getDecryptionPromise() returns a deferred promise.
+            let resolveEdit1Decryption!: () => void;
+            const edit1DecryptionPromise = new Promise<void>((resolve) => {
+                resolveEdit1Decryption = resolve;
+            });
+            vi.spyOn(edit1, "isBeingDecrypted").mockReturnValue(true);
+            vi.spyOn(edit1, "getDecryptionPromise").mockReturnValue(edit1DecryptionPromise);
+            vi.spyOn(edit1, "shouldAttemptDecryption").mockReturnValue(false);
+
+            // edit2 is already decrypted.
+            vi.spyOn(edit2, "isBeingDecrypted").mockReturnValue(false);
+            vi.spyOn(edit2, "shouldAttemptDecryption").mockReturnValue(false);
+
+            // Add edit1 first (it will block on decryption).
+            const addEdit1Promise = relations.addEvent(edit1);
+
+            // While edit1 is still decrypting, add edit2 (resolves immediately).
+            await relations.addEvent(edit2);
+
+            // edit2 should be applied as the replacement (it's newer).
+            expect(targetEvent.replacingEvent()).toBe(edit2);
+
+            // Now resolve edit1's decryption — the stale result must NOT overwrite edit2.
+            resolveEdit1Decryption();
+            await addEdit1Promise;
+
+            // edit2 must still be the replacing event, not edit1.
+            expect(targetEvent.replacingEvent()).toBe(edit2);
+        });
+
+        it("should apply an edit correctly when there is no concurrency", async () => {
+            const room = new Room(roomId, new TestClient(userId).client, userId);
+            const relations = new Relations("m.replace", "m.room.message", room);
+
+            const targetEvent = new MatrixEvent({
+                sender: userId,
+                type: "m.room.message",
+                event_id: targetEventId,
+                room_id: roomId,
+                origin_server_ts: 1000,
+                content: { body: "original", msgtype: "m.text" },
+            });
+
+            await relations.setTargetEvent(targetEvent);
+
+            const edit = makeEditEvent("$edit1", 2000);
+            vi.spyOn(edit, "isBeingDecrypted").mockReturnValue(false);
+            vi.spyOn(edit, "shouldAttemptDecryption").mockReturnValue(false);
+
+            await relations.addEvent(edit);
+
+            expect(targetEvent.replacingEvent()).toBe(edit);
+        });
+    });
+
     it("getSortedAnnotationsByKey should return null for non-annotation relations", async () => {
         const userId = "@user:server";
         const room = new Room("room123", new TestClient(userId).client, userId);

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -53,6 +53,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
     private sortedAnnotationsByKey: [string, Set<MatrixEvent>][] = [];
     private targetEvent: MatrixEvent | null = null;
     private creationEmitted = false;
+    private replacementUpdateId = 0;
     private readonly client: MatrixClient;
 
     /**
@@ -106,9 +107,8 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
 
         if (this.relationType === RelationType.Annotation) {
             this.addAnnotationToAggregation(event);
-        } else if (this.relationType === RelationType.Replace && this.targetEvent && !this.targetEvent.isState()) {
-            const lastReplacement = await this.getLastReplacement();
-            this.targetEvent.makeReplaced(lastReplacement!);
+        } else if (this.relationType === RelationType.Replace) {
+            await this.updateTargetEventReplacement();
         }
 
         event.on(MatrixEventEvent.BeforeRedaction, this.onBeforeRedaction);
@@ -132,9 +132,8 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
 
         if (this.relationType === RelationType.Annotation) {
             this.removeAnnotationFromAggregation(event);
-        } else if (this.relationType === RelationType.Replace && this.targetEvent && !this.targetEvent.isState()) {
-            const lastReplacement = await this.getLastReplacement();
-            this.targetEvent.makeReplaced(lastReplacement!);
+        } else if (this.relationType === RelationType.Replace) {
+            await this.updateTargetEventReplacement();
         }
 
         this.emit(RelationsEvent.Remove, event);
@@ -243,9 +242,8 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
         if (this.relationType === RelationType.Annotation) {
             // Remove the redacted annotation from aggregation by key
             this.removeAnnotationFromAggregation(redactedEvent);
-        } else if (this.relationType === RelationType.Replace && this.targetEvent && !this.targetEvent.isState()) {
-            const lastReplacement = await this.getLastReplacement();
-            this.targetEvent.makeReplaced(lastReplacement!);
+        } else if (this.relationType === RelationType.Replace) {
+            await this.updateTargetEventReplacement();
         }
 
         redactedEvent.removeListener(MatrixEventEvent.BeforeRedaction, this.onBeforeRedaction);
@@ -343,16 +341,40 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
         }
         this.targetEvent = event;
 
-        if (this.relationType === RelationType.Replace && !this.targetEvent.isState()) {
-            const replacement = await this.getLastReplacement();
-            // this is the initial update, so only call it if we already have something
-            // to not emit Event.replaced needlessly
-            if (replacement) {
-                this.targetEvent.makeReplaced(replacement);
-            }
+        if (this.relationType === RelationType.Replace) {
+            await this.updateTargetEventReplacement();
         }
 
         this.maybeEmitCreated();
+    }
+
+    /**
+     * Updates the target event with the latest replacement.
+     *
+     * Multiple replacement updates can be triggered concurrently (for example
+     * while edits are still being decrypted). A monotonic update counter guards
+     * against older async resolutions overriding newer replacement selections.
+     */
+    private async updateTargetEventReplacement(): Promise<void> {
+        if (!this.targetEvent || this.targetEvent.isState()) {
+            return;
+        }
+
+        const targetEvent = this.targetEvent;
+        const updateId = ++this.replacementUpdateId;
+        const lastReplacement = await this.getLastReplacement();
+
+        // If a newer update started while we were awaiting, discard this stale result.
+        if (updateId !== this.replacementUpdateId || this.targetEvent !== targetEvent) {
+            return;
+        }
+
+        // Avoid emitting Event.replaced when there is no replacement and none currently set.
+        if (!lastReplacement && !targetEvent.replacingEvent()) {
+            return;
+        }
+
+        targetEvent.makeReplaced(lastReplacement ?? undefined);
     }
 
     private maybeEmitCreated(): void {


### PR DESCRIPTION
I discovered this bug while building [Mindroom](https://github.com/mindroom-ai), an AI agent platform (like OpenClaw but built on top of Matrix) that lives inside Matrix as a regular bot. When Mindroom streams a response, it rapidly edits the same message ~20 times as tokens arrive — similar to how you'd see a ChatGPT-style response being typed out in real time.

The symptom: after streaming completes, the message would frequently snap back to its original (pre-edit) content and stay there until a page reload. In encrypted rooms, this happened even more often.

### Root cause

In `Relations`, every method that processes `m.replace` events (`addEvent`, `removeEvent`, `onBeforeRedaction`, `setTargetEvent`) follows the same pattern:

```ts
const lastReplacement = await this.getLastReplacement();
this.targetEvent.makeReplaced(lastReplacement!);
```

`getLastReplacement()` is async because it may need to decrypt the replacement event. With rapid edits, multiple calls overlap:

1. Edit A arrives → `getLastReplacement()` blocks on decryption
2. Edit B (newer) arrives → resolves immediately, correctly applies B
3. Edit A's decryption finishes → its stale `getLastReplacement()` result overwrites the target, reverting to A

There is no guard against out-of-order async completion, so promise resolution order — not event timestamp — determines which edit wins.

### Fix

A monotonic counter (`replacementUpdateId`) is incremented before each `await`. After the await, if the counter has moved on, the result is discarded. All four call sites are consolidated into a single `updateTargetEventReplacement()` method.

I've been running this fix in [my Element fork](https://github.com/mindroom-ai/mindroom-element) (as a `patch-package` patch) without issues.

### Relation to #4980

PR #4980 fixed a different race: edits arriving before thread initialization, where `targetEvent` is still `null`. That fix lives in `thread.ts`. This bug is in `relations.ts` itself and affects all rooms — threaded or not — whenever multiple edits are in-flight concurrently.

### Tests

- Regression test: simulates a slow-decrypting older edit racing against a newer one, asserts the newer edit is preserved
- All existing `relations.spec.ts` tests pass
- Type checking passes