### PR TITLE
Specify `this` type for BaseLogger methods

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,35 +52,35 @@ export interface BaseLogger {
      *
      * @param msg - Data to log.
      */
-    trace(...msg: any[]): void;
+    trace(this: void, ...msg: any[]): void;
 
     /**
      * Output debug message to the logger.
      *
      * @param msg - Data to log.
      */
-    debug(...msg: any[]): void;
+    debug(this: void, ...msg: any[]): void;
 
     /**
      * Output info message to the logger.
      *
      * @param msg - Data to log.
      */
-    info(...msg: any[]): void;
+    info(this: void, ...msg: any[]): void;
 
     /**
      * Output warn message to the logger.
      *
      * @param msg - Data to log.
      */
-    warn(...msg: any[]): void;
+    warn(this: void, ...msg: any[]): void;
 
     /**
      * Output error message to the logger.
      *
      * @param msg - Data to log.
      */
-    error(...msg: any[]): void;
+    error(this: void, ...msg: any[]): void;
 }
 
 // This is to demonstrate, that you can use any namespace you want.


### PR DESCRIPTION
This allows https://typescript-eslint.io/rules/unbound-method/ in consumers to be happy

For https://github.com/element-hq/element-web/pull/32578
