### PR TITLE
MSC4140: remove parent delay IDs

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -73,8 +73,8 @@ class MockWidgetApi extends EventEmitter {
     public requestCapabilityToSendToDevice = vi.fn().mockResolvedValue(undefined);
     public requestCapabilityToReceiveToDevice = vi.fn().mockResolvedValue(undefined);
     public sendRoomEvent = vi.fn(
-        async (eventType: string, content: unknown, roomId?: string, delay?: number, parentDelayId?: string) =>
-            delay === undefined && parentDelayId === undefined
+        async (eventType: string, content: unknown, roomId?: string, delay?: number) =>
+            delay === undefined
                 ? { event_id: `$${Math.random()}` }
                 : { delay_id: `id-${Math.random()}` },
     );
@@ -85,9 +85,8 @@ class MockWidgetApi extends EventEmitter {
             content: unknown,
             roomId?: string,
             delay?: number,
-            parentDelayId?: string,
         ) =>
-            delay === undefined && parentDelayId === undefined
+            delay === undefined
                 ? { event_id: `$${Math.random()}` }
                 : { delay_id: `id-${Math.random()}` },
     );
@@ -176,7 +175,6 @@ describe("RoomWidgetClient", () => {
                 "org.matrix.rageshake_request",
                 { request_id: 123 },
                 "!1:example.org",
-                undefined,
                 undefined,
                 undefined,
             );
@@ -434,28 +432,6 @@ describe("RoomWidgetClient", () => {
                     "!1:example.org",
                     2000,
                     undefined,
-                    undefined,
-                );
-            });
-
-            it("sends child action delayed message events", async () => {
-                await makeClient({ sendDelayedEvents: true, sendEvent: ["org.matrix.rageshake_request"] });
-                expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4157SendDelayedEvent);
-                const parentDelayId = `id-${Math.random()}`;
-                await client._unstable_sendDelayedEvent(
-                    "!1:example.org",
-                    { parent_delay_id: parentDelayId },
-                    null,
-                    "org.matrix.rageshake_request",
-                    { request_id: 123 },
-                );
-                expect(widgetApi.sendRoomEvent).toHaveBeenCalledWith(
-                    "org.matrix.rageshake_request",
-                    { request_id: 123 },
-                    "!1:example.org",
-                    undefined,
-                    parentDelayId,
-                    undefined,
                 );
             });
 
@@ -478,31 +454,6 @@ describe("RoomWidgetClient", () => {
                     { hello: "world" },
                     "!1:example.org",
                     2000,
-                    undefined,
-                );
-            });
-
-            it("sends child action delayed state events", async () => {
-                await makeClient({
-                    sendDelayedEvents: true,
-                    sendState: [{ eventType: "org.example.foo", stateKey: "bar" }],
-                });
-                expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4157SendDelayedEvent);
-                const parentDelayId = `fg-${Math.random()}`;
-                await client._unstable_sendDelayedStateEvent(
-                    "!1:example.org",
-                    { parent_delay_id: parentDelayId },
-                    "org.example.foo",
-                    { hello: "world" },
-                    "bar",
-                );
-                expect(widgetApi.sendStateEvent).toHaveBeenCalledWith(
-                    "org.example.foo",
-                    "bar",
-                    { hello: "world" },
-                    "!1:example.org",
-                    undefined,
-                    parentDelayId,
                 );
             });
 
@@ -909,7 +860,6 @@ describe("RoomWidgetClient", () => {
                     EventType.RTCMembership,
                     { msc4354_sticky_key: "test" },
                     "!1:example.org",
-                    undefined,
                     undefined,
                     2000,
                 );

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -72,23 +72,12 @@ class MockWidgetApi extends EventEmitter {
     public requestCapabilityToReceiveState = vi.fn().mockResolvedValue(undefined);
     public requestCapabilityToSendToDevice = vi.fn().mockResolvedValue(undefined);
     public requestCapabilityToReceiveToDevice = vi.fn().mockResolvedValue(undefined);
-    public sendRoomEvent = vi.fn(
-        async (eventType: string, content: unknown, roomId?: string, delay?: number) =>
-            delay === undefined
-                ? { event_id: `$${Math.random()}` }
-                : { delay_id: `id-${Math.random()}` },
+    public sendRoomEvent = vi.fn(async (eventType: string, content: unknown, roomId?: string, delay?: number) =>
+        delay === undefined ? { event_id: `$${Math.random()}` } : { delay_id: `id-${Math.random()}` },
     );
     public sendStateEvent = vi.fn(
-        async (
-            eventType: string,
-            stateKey: string,
-            content: unknown,
-            roomId?: string,
-            delay?: number,
-        ) =>
-            delay === undefined
-                ? { event_id: `$${Math.random()}` }
-                : { delay_id: `id-${Math.random()}` },
+        async (eventType: string, stateKey: string, content: unknown, roomId?: string, delay?: number) =>
+            delay === undefined ? { event_id: `$${Math.random()}` } : { delay_id: `id-${Math.random()}` },
     );
     public cancelScheduledDelayedEvent = vi.fn().mockResolvedValue(undefined);
     public restartScheduledDelayedEvent = vi.fn().mockResolvedValue(undefined);

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -987,12 +987,7 @@ describe("MatrixClient", function () {
                 },
             ];
 
-            await client._unstable_sendDelayedStateEvent(
-                roomId,
-                delayOpts,
-                EventType.RoomTopic,
-                { ...content },
-            );
+            await client._unstable_sendDelayedStateEvent(roomId, delayOpts, EventType.RoomTopic, { ...content });
         });
 
         describe("lookups", () => {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -781,8 +781,9 @@ describe("MatrixClient", function () {
         const roomId = "!room:example.org";
         const body = "This is the body";
         const content = { body, msgtype: MsgType.Text } satisfies RoomMessageEventContent;
-        const timeoutDelayOpts = { delay: 2000 };
-        const realTimeoutDelayOpts = { "org.matrix.msc4140.delay": 2000 };
+        const delayOpts = { delay: 2000 };
+        const realDelayOpts = { "org.matrix.msc4140.delay": 2000 };
+        const delayData = { delay_id: "did" };
 
         beforeEach(() => {
             unstableFeatures["org.matrix.msc4140"] = true;
@@ -795,7 +796,7 @@ describe("MatrixClient", function () {
             await expect(
                 client._unstable_sendDelayedEvent(
                     roomId,
-                    timeoutDelayOpts,
+                    delayOpts,
                     null,
                     EventType.RoomMessage,
                     { ...content },
@@ -804,7 +805,7 @@ describe("MatrixClient", function () {
             ).rejects.toThrow(errorMessage);
 
             await expect(
-                client._unstable_sendDelayedStateEvent(roomId, timeoutDelayOpts, EventType.RoomTopic, {
+                client._unstable_sendDelayedStateEvent(roomId, delayOpts, EventType.RoomTopic, {
                     topic: "topic",
                 }),
             ).rejects.toThrow(errorMessage);
@@ -822,48 +823,29 @@ describe("MatrixClient", function () {
 
         // eslint-disable-next-line @vitest/expect-expect
         it("works with null threadId", async () => {
-            httpLookups = [];
-
-            const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody: content,
-            });
-
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                null,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody: content,
-            });
+            const txnId = client.makeTxnId();
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txnId}`,
+                    data: delayData,
+                    expectQueryParams: realDelayOpts,
+                    expectBody: content,
+                },
+            ];
 
             await client._unstable_sendDelayedEvent(
                 roomId,
-                { parent_delay_id: timeoutDelayId },
+                delayOpts,
                 null,
                 EventType.RoomMessage,
                 { ...content },
-                actionDelayTxnId,
+                txnId,
             );
         });
 
         // eslint-disable-next-line @vitest/expect-expect
         it("works with non-null threadId", async () => {
-            httpLookups = [];
             const threadId = "$threadId:server";
             const expectBody = {
                 ...content,
@@ -874,46 +856,29 @@ describe("MatrixClient", function () {
                 },
             };
 
-            const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
-
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
-                roomId,
-                timeoutDelayOpts,
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
+            const txnId = client.makeTxnId();
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txnId}`,
+                    data: delayData,
+                    expectQueryParams: realDelayOpts,
+                    expectBody,
+                },
+            ];
 
             await client._unstable_sendDelayedEvent(
                 roomId,
-                { parent_delay_id: timeoutDelayId },
+                delayOpts,
                 threadId,
                 EventType.RoomMessage,
                 { ...content },
-                actionDelayTxnId,
+                txnId,
             );
         });
 
         // eslint-disable-next-line @vitest/expect-expect
         it("should add thread relation if threadId is passed and the relation is missing", async () => {
-            httpLookups = [];
             const threadId = "$threadId:server";
             const expectBody = {
                 ...content,
@@ -934,39 +899,23 @@ describe("MatrixClient", function () {
             room.createThread(threadId, rootEvent, [rootEvent], false);
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    data: delayData,
+                    expectQueryParams: realDelayOpts,
+                    expectBody,
+                },
+            ];
 
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+            await client._unstable_sendDelayedEvent(
                 roomId,
-                timeoutDelayOpts,
+                delayOpts,
                 threadId,
                 EventType.RoomMessage,
                 { ...content },
                 timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
-
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
             );
         });
 
@@ -1003,39 +952,23 @@ describe("MatrixClient", function () {
             room.createThread(threadId, rootEvent, [rootEvent], false);
 
             const timeoutDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody,
-            });
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${timeoutDelayTxnId}`,
+                    data: delayData,
+                    expectQueryParams: realDelayOpts,
+                    expectBody,
+                },
+            ];
 
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedEvent(
+            await client._unstable_sendDelayedEvent(
                 roomId,
-                timeoutDelayOpts,
+                delayOpts,
                 threadId,
                 EventType.RoomMessage,
                 { ...content },
                 timeoutDelayTxnId,
-            );
-
-            const actionDelayTxnId = client.makeTxnId();
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${actionDelayTxnId}`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody,
-            });
-
-            await client._unstable_sendDelayedEvent(
-                roomId,
-                { parent_delay_id: timeoutDelayId },
-                threadId,
-                EventType.RoomMessage,
-                { ...content },
-                actionDelayTxnId,
             );
         });
 
@@ -1044,32 +977,19 @@ describe("MatrixClient", function () {
             httpLookups = [];
             const content = { topic: "The year 2000" };
 
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                expectQueryParams: realTimeoutDelayOpts,
-                data: { delay_id: "id1" },
-                expectBody: content,
-            });
-
-            const { delay_id: timeoutDelayId } = await client._unstable_sendDelayedStateEvent(
-                roomId,
-                timeoutDelayOpts,
-                EventType.RoomTopic,
-                { ...content },
-            );
-
-            httpLookups.push({
-                method: "PUT",
-                path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
-                expectQueryParams: { "org.matrix.msc4140.parent_delay_id": timeoutDelayId },
-                data: { delay_id: "id2" },
-                expectBody: content,
-            });
+            httpLookups = [
+                {
+                    method: "PUT",
+                    path: `/rooms/${encodeURIComponent(roomId)}/state/m.room.topic/`,
+                    data: delayData,
+                    expectQueryParams: realDelayOpts,
+                    expectBody: content,
+                },
+            ];
 
             await client._unstable_sendDelayedStateEvent(
                 roomId,
-                { parent_delay_id: timeoutDelayId },
+                delayOpts,
                 EventType.RoomTopic,
                 { ...content },
             );

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -97,20 +97,14 @@ export interface ISendEventResponse {
     event_id: string;
 }
 
-export type SendDelayedEventRequestOpts = { parent_delay_id: string } | { delay: number; parent_delay_id?: string };
+export type SendDelayedEventRequestOpts = {
+    delay: number;
+};
 
 export function isSendDelayedEventRequestOpts(opts: object): opts is SendDelayedEventRequestOpts {
-    if ("parent_delay_id" in opts && typeof opts.parent_delay_id !== "string") {
-        // Invalid type, reject
-        return false;
-    }
-    if ("delay" in opts && typeof opts.delay !== "number") {
-        // Invalid type, reject.
-        return true;
-    }
-    // At least one of these fields must be specified.
-    return "delay" in opts || "parent_delay_id" in opts;
+    return "delay" in opts && typeof opts.delay === "number";
 }
+
 export type SendDelayedEventResponse = {
     delay_id: string;
 };

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -425,8 +425,7 @@ export class RoomWidgetClient extends MatrixClient {
                     event.getType(),
                     content,
                     room.roomId,
-                    "delay" in delayOpts ? delayOpts.delay : undefined,
-                    "parent_delay_id" in delayOpts ? delayOpts.parent_delay_id : undefined,
+                    delayOpts.delay,
                     stickyDurationMsAsNumber,
                 )
                 .catch(timeoutToConnectionError);
@@ -440,7 +439,7 @@ export class RoomWidgetClient extends MatrixClient {
         let response: ISendEventFromWidgetResponseData;
         try {
             response = await this.widgetApi
-                .sendRoomEvent(event.getType(), content, room.roomId, undefined, undefined, stickyDurationMsAsNumber)
+                .sendRoomEvent(event.getType(), content, room.roomId, undefined, stickyDurationMsAsNumber)
                 .catch(timeoutToConnectionError);
         } catch (e) {
             this.updatePendingEventStatus(room, event, EventStatus.NOT_SENT);
@@ -497,8 +496,7 @@ export class RoomWidgetClient extends MatrixClient {
                 stateKey,
                 content,
                 roomId,
-                "delay" in delayOpts ? delayOpts.delay : undefined,
-                "parent_delay_id" in delayOpts ? delayOpts.parent_delay_id : undefined,
+                delayOpts.delay,
             )
             .catch(timeoutToConnectionError);
         return this.validateSendDelayedEventResponse(response);

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -421,13 +421,7 @@ export class RoomWidgetClient extends MatrixClient {
         if (delayOpts) {
             // TODO: updatePendingEvent for delayed events?
             const response = await this.widgetApi
-                .sendRoomEvent(
-                    event.getType(),
-                    content,
-                    room.roomId,
-                    delayOpts.delay,
-                    stickyDurationMsAsNumber,
-                )
+                .sendRoomEvent(event.getType(), content, room.roomId, delayOpts.delay, stickyDurationMsAsNumber)
                 .catch(timeoutToConnectionError);
             return this.validateSendDelayedEventResponse(response);
         }
@@ -491,13 +485,7 @@ export class RoomWidgetClient extends MatrixClient {
         }
 
         const response = await this.widgetApi
-            .sendStateEvent(
-                eventType,
-                stateKey,
-                content,
-                roomId,
-                delayOpts.delay,
-            )
+            .sendStateEvent(eventType, stateKey, content, roomId, delayOpts.delay)
             .catch(timeoutToConnectionError);
         return this.validateSendDelayedEventResponse(response);
     }


### PR DESCRIPTION
Drop support for sending delayed events that are sent upon the scheduled sending of another delayed event.  This feature has been absent from the delayed event MSC for some time now, and is not known to have been implemented in any server.

Depends on matrix-org/matrix-widget-api#162

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
