### PR TITLE
Rotate the current room key when we see a member leave

### DIFF
--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -68,6 +68,7 @@ afterEach(() => {
 const ROOM_ID = "!room:example.com";
 const ALICE_HOMESERVER_URL = "https://alice-server.com";
 const BOB_HOMESERVER_URL = "https://bob-server.com";
+const CHARLIE_HOMESERVER_URL = "https://charlie-server.com";
 
 async function createAndInitClient(homeserverUrl: string, userId: string, setupNewCrossSigning = true) {
     mockInitialApiRequests(homeserverUrl, userId);
@@ -91,6 +92,8 @@ describe("History Sharing", () => {
     let aliceSyncResponder: SyncResponder;
     let bobClient: MatrixClient;
     let bobSyncResponder: SyncResponder;
+    let charlieClient: MatrixClient;
+    let charlieSyncResponder: SyncResponder;
 
     beforeEach(async () => {
         // anything that we don't have a specific matcher for silently returns a 404
@@ -100,6 +103,7 @@ describe("History Sharing", () => {
 
         const aliceId = TEST_USER_ID;
         const bobId = "@bob:xyz";
+        const charlieId = "@charlie:zyx";
 
         const aliceKeyReceiver = new E2EKeyReceiver(ALICE_HOMESERVER_URL, "alice-");
         const aliceKeyResponder = new E2EKeyResponder(ALICE_HOMESERVER_URL);
@@ -108,23 +112,39 @@ describe("History Sharing", () => {
 
         const bobKeyReceiver = new E2EKeyReceiver(BOB_HOMESERVER_URL, "bob-");
         const bobKeyResponder = new E2EKeyResponder(BOB_HOMESERVER_URL);
+        const bobKeyClaimResponder = new E2EOTKClaimResponder(BOB_HOMESERVER_URL);
         bobSyncResponder = new SyncResponder(BOB_HOMESERVER_URL);
+
+        const charlieKeyReceiver = new E2EKeyReceiver(CHARLIE_HOMESERVER_URL, "charlie-");
+        const charlieKeyResponder = new E2EKeyResponder(CHARLIE_HOMESERVER_URL);
+        charlieSyncResponder = new SyncResponder(CHARLIE_HOMESERVER_URL);
 
         aliceKeyResponder.addKeyReceiver(aliceId, aliceKeyReceiver);
         aliceKeyResponder.addKeyReceiver(bobId, bobKeyReceiver);
+        aliceKeyResponder.addKeyReceiver(charlieId, charlieKeyReceiver);
         bobKeyResponder.addKeyReceiver(aliceId, aliceKeyReceiver);
         bobKeyResponder.addKeyReceiver(bobId, bobKeyReceiver);
+        bobKeyResponder.addKeyReceiver(charlieId, charlieKeyReceiver);
+        charlieKeyResponder.addKeyReceiver(aliceId, aliceKeyReceiver);
+        charlieKeyResponder.addKeyReceiver(bobId, bobKeyReceiver);
+        charlieKeyResponder.addKeyReceiver(charlieId, charlieKeyReceiver);
 
         aliceClient = await createAndInitClient(ALICE_HOMESERVER_URL, aliceId);
         bobClient = await createAndInitClient(BOB_HOMESERVER_URL, bobId);
+        charlieClient = await createAndInitClient(CHARLIE_HOMESERVER_URL, charlieId);
 
         aliceKeyClaimResponder.addKeyReceiver(bobId, bobClient.deviceId!, bobKeyReceiver);
+        aliceKeyClaimResponder.addKeyReceiver(charlieId, charlieClient.deviceId!, charlieKeyReceiver);
+        bobKeyClaimResponder.addKeyReceiver(aliceId, aliceClient.deviceId!, aliceKeyReceiver);
 
         aliceSyncResponder.sendOrQueueSyncResponse({});
         await syncPromise(aliceClient);
 
         bobSyncResponder.sendOrQueueSyncResponse({});
         await syncPromise(bobClient);
+
+        charlieSyncResponder.sendOrQueueSyncResponse({});
+        await syncPromise(charlieClient);
     });
 
     test("Room keys are successfully shared on invite", async () => {
@@ -675,6 +695,258 @@ describe("History Sharing", () => {
             ),
         ).toBeFalsy();
     });
+
+    test("Room key is rotated after a member joins and leaves the room", async () => {
+        // Alice and Bob are in an encrypted room
+        let syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
+
+        await syncPromise(aliceClient);
+        await syncPromise(bobClient);
+
+        // Bob sends a message M1, which both he and Alice receive.
+        let msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
+        let toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
+        await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
+            msgtype: MsgType.Text,
+            body: "Charlie should be able to read",
+        });
+        const bobEventM1Content = await msgProm;
+        let sentToDeviceRequest = await toDeviceMessageProm;
+        expect(sentToDeviceRequest).toBeDefined();
+        let aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
+
+        // Alice receives the message down sync.
+        syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+            mkEventCustom({
+                type: "m.room.encrypted",
+                sender: bobClient.getSafeUserId(),
+                content: bobEventM1Content,
+                event_id: "$event_id_m1",
+            }) as any,
+        );
+        syncResponse.to_device = {
+            events: [
+                {
+                    type: "m.room.encrypted",
+                    sender: bobClient.getSafeUserId(),
+                    content: aliceToDeviceMessage,
+                },
+            ],
+        };
+        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        await syncPromise(aliceClient);
+
+        // Alice checks she can read M1.
+        const aliceRoom = aliceClient.getRoom(ROOM_ID);
+        const aliceM1 = aliceRoom!.getLastLiveEvent()!;
+        await aliceM1.getDecryptionPromise();
+        expect(aliceM1.getType()).toEqual("m.room.message");
+        expect(aliceM1.getContent().body).toEqual("Charlie should be able to read");
+
+        // Alice invites and sends a key bundle to Charlie
+        const uploadProm = expectUploadRequest();
+        toDeviceMessageProm = expectSendToDeviceMessage(ALICE_HOMESERVER_URL, "m.room.encrypted");
+        fetchMock.postOnce(`${ALICE_HOMESERVER_URL}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
+        await aliceClient.invite(ROOM_ID, charlieClient.getSafeUserId(), { shareEncryptedHistory: true });
+        const uploadedBlob = await uploadProm;
+        sentToDeviceRequest = await toDeviceMessageProm;
+        debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
+        const charlieToDeviceMessage = sentToDeviceRequest[charlieClient.getSafeUserId()][charlieClient.deviceId!];
+        expect(charlieToDeviceMessage).toBeDefined();
+
+        /// Charlie receives the invite ...
+        const inviteEvent = mkInviteEvent(aliceClient, charlieClient);
+        charlieSyncResponder.sendOrQueueSyncResponse({
+            rooms: { invite: { [ROOM_ID]: { invite_state: { events: [inviteEvent] } } } },
+            to_device: {
+                events: [
+                    {
+                        type: "m.room.encrypted",
+                        sender: aliceClient.getSafeUserId(),
+                        content: charlieToDeviceMessage,
+                    },
+                ],
+            },
+        });
+        await syncPromise(charlieClient);
+
+        const charlieRoom = charlieClient.getRoom(ROOM_ID);
+        expect(charlieRoom).toBeTruthy();
+        expect(charlieRoom?.getMyMembership()).toEqual(KnownMembership.Invite);
+
+        // ... and subsequently joins.
+        fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
+            room_id: ROOM_ID,
+        });
+        fetchMock.getOnce(`begin:${CHARLIE_HOMESERVER_URL}/_matrix/client/v1/media/download/alice-server/here`, {
+            body: uploadedBlob,
+        });
+        await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+
+        // Charlie syncs to receive M1 and ensure he can read it.
+        syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+            mkEventCustom({
+                type: "m.room.encrypted",
+                sender: bobClient.getSafeUserId(),
+                content: bobEventM1Content,
+                event_id: "$event_id_m1",
+            }) as any,
+        );
+        charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        await syncPromise(charlieClient);
+
+        const charlieEventM1 = charlieRoom!
+            .getLiveTimeline()
+            .getEvents()
+            .find((e) => e.getId() === "$event_id_m1");
+
+        await charlieEventM1!.getDecryptionPromise();
+        expect(charlieEventM1!.getType()).toEqual("m.room.message");
+        expect(charlieEventM1!.getContent().body).toEqual("Charlie should be able to read");
+
+        // Charlie then immediately leaves.
+        const charlieSyncResponse = {
+            next_batch: "1",
+            rooms: {
+                leave: {
+                    [ROOM_ID]: {
+                        state: { events: [] },
+                        timeline: {
+                            events: [
+                                mkEventCustom({
+                                    content: { membership: KnownMembership.Leave },
+                                    type: EventType.RoomMember,
+                                    sender: charlieClient.getSafeUserId(),
+                                    state_key: charlieClient.getSafeUserId(),
+                                }),
+                            ],
+                            prev_batch: "",
+                        },
+                        account_data: { events: [] },
+                    },
+                },
+                invite: {},
+                join: {},
+                knock: {},
+            },
+            account_data: { events: [] },
+        };
+        charlieSyncResponder.sendOrQueueSyncResponse(charlieSyncResponse);
+        await syncPromise(charlieClient);
+
+        // Bob syncs to learn about Charlie's joining and leaving.
+        syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+            mkEventCustom({
+                content: { membership: KnownMembership.Leave },
+                type: EventType.RoomMember,
+                sender: charlieClient.getSafeUserId(),
+                state_key: charlieClient.getSafeUserId(),
+            }),
+        );
+        bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        await syncPromise(bobClient);
+
+        // Bob then sends M2, sharing a new room key with Alice.
+        msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
+        toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
+        await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
+            msgtype: MsgType.Text,
+            body: "Charlie should not be able to read",
+        });
+        const bobEventM2Content = await msgProm;
+        sentToDeviceRequest = await toDeviceMessageProm;
+        expect(sentToDeviceRequest).toBeDefined();
+        aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
+
+        // Charlie should not receive the room key
+        expect(sentToDeviceRequest[charlieClient.getSafeUserId()]).toBeUndefined();
+
+        debug(`Bob sent encrypted room event: ${JSON.stringify(bobEventM2Content)}`);
+
+        // Sync the message to Alice along with the to-device message, and check she can decrypt it.
+        syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+            mkEventCustom({
+                type: "m.room.encrypted",
+                sender: bobClient.getSafeUserId(),
+                content: bobEventM2Content,
+                event_id: "$event_id_m2",
+            }) as any,
+        );
+        syncResponse.to_device = {
+            events: [
+                {
+                    type: "m.room.encrypted",
+                    sender: bobClient.getSafeUserId(),
+                    content: aliceToDeviceMessage,
+                },
+            ],
+        };
+        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        await syncPromise(aliceClient);
+
+        const aliceEventM2 = aliceRoom!.getLastLiveEvent()!;
+        await aliceEventM2.getDecryptionPromise();
+        expect(aliceEventM2.getType()).toEqual("m.room.message");
+        expect(aliceEventM2.getContent().body).toEqual("Charlie should not be able to read");
+
+        // Charlie rejoins the room by ID, receives M2, which he should not be able to decrypt.
+        fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
+            room_id: ROOM_ID,
+        });
+        await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        syncResponse = getSyncResponse(
+            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+            HistoryVisibility.Shared,
+            ROOM_ID,
+        );
+        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+            mkEventCustom({
+                type: "m.room.encrypted",
+                sender: bobClient.getSafeUserId(),
+                content: bobEventM2Content,
+                event_id: "$event_id_m2",
+            }) as any,
+        );
+        charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
+        await syncPromise(charlieClient);
+
+        const events = charlieRoom!.getLiveTimeline().getEvents();
+        expect(events.length).toBeGreaterThanOrEqual(2);
+
+        const charlieM2 = charlieRoom!
+            .getLiveTimeline()
+            .getEvents()
+            .find((e) => e.getId() === "$event_id_m2");
+
+        await charlieM2!.getDecryptionPromise();
+        expect(charlieM2!.isDecryptionFailure()).toBeTruthy();
+    }, 60e3);
 
     afterEach(async () => {
         vitest.useRealTimers();

--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -855,12 +855,19 @@ describe("History Sharing", () => {
             charlieSyncResponder.sendOrQueueSyncResponse(charlieSyncResponse);
             await syncPromise(charlieClient);
 
+            syncResponse = {
+                next_batch: "2",
+                rooms: {
+                    join: {
+                        [ROOM_ID]: {
+                            timeline: {
+                                events: [],
+                            },
+                        },
+                    },
+                },
+            } as any;
             if (gappySync) {
-                syncResponse = getSyncResponse(
-                    [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
-                    HistoryVisibility.Shared,
-                    ROOM_ID,
-                );
                 // In case of a gappy sync, the timeline is limited and we only see the leave event.
                 syncResponse.rooms.join[ROOM_ID].timeline.limited = true;
                 syncResponse.rooms.join[ROOM_ID].state = {
@@ -874,18 +881,19 @@ describe("History Sharing", () => {
                     ],
                 };
             } else {
-                syncResponse = getSyncResponse(
-                    [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
-                    HistoryVisibility.Shared,
-                    ROOM_ID,
-                );
                 syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                    mkEventCustom({
+                        content: { membership: KnownMembership.Join },
+                        type: EventType.RoomMember,
+                        sender: charlieClient.getSafeUserId(),
+                        state_key: charlieClient.getSafeUserId(),
+                    }) as any,
                     mkEventCustom({
                         content: { membership: KnownMembership.Leave },
                         type: EventType.RoomMember,
                         sender: charlieClient.getSafeUserId(),
                         state_key: charlieClient.getSafeUserId(),
-                    }),
+                    }) as any,
                 );
             }
             // Bob syncs to learn about Charlie's leaving (and joining if non-gappy).
@@ -910,28 +918,34 @@ describe("History Sharing", () => {
             debug(`Bob sent encrypted room event: ${JSON.stringify(bobEventM2Content)}`);
 
             // Sync the message to Alice along with the to-device message, and check she can decrypt it.
-            syncResponse = getSyncResponse(
-                [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
-                HistoryVisibility.Shared,
-                ROOM_ID,
-            );
-            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-                mkEventCustom({
-                    type: "m.room.encrypted",
-                    sender: bobClient.getSafeUserId(),
-                    content: bobEventM2Content,
-                    event_id: "$event_id_m2",
-                }) as any,
-            );
-            syncResponse.to_device = {
-                events: [
-                    {
-                        type: "m.room.encrypted",
-                        sender: bobClient.getSafeUserId(),
-                        content: aliceToDeviceMessage,
+            syncResponse = {
+                next_batch: "3",
+                rooms: {
+                    join: {
+                        [ROOM_ID]: {
+                            timeline: {
+                                events: [
+                                    mkEventCustom({
+                                        type: "m.room.encrypted",
+                                        sender: bobClient.getSafeUserId(),
+                                        content: bobEventM2Content,
+                                        event_id: "$event_id_m2",
+                                    }) as any,
+                                ],
+                            },
+                        },
                     },
-                ],
-            };
+                },
+                to_device: {
+                    events: [
+                        {
+                            type: "m.room.encrypted",
+                            sender: bobClient.getSafeUserId(),
+                            content: aliceToDeviceMessage,
+                        },
+                    ],
+                },
+            } as any;
             aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
             await syncPromise(aliceClient);
 
@@ -945,19 +959,25 @@ describe("History Sharing", () => {
                 room_id: ROOM_ID,
             });
             await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
-            syncResponse = getSyncResponse(
-                [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
-                HistoryVisibility.Shared,
-                ROOM_ID,
-            );
-            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-                mkEventCustom({
-                    type: "m.room.encrypted",
-                    sender: bobClient.getSafeUserId(),
-                    content: bobEventM2Content,
-                    event_id: "$event_id_m2",
-                }) as any,
-            );
+            syncResponse = {
+                next_batch: "4",
+                rooms: {
+                    join: {
+                        [ROOM_ID]: {
+                            timeline: {
+                                events: [
+                                    mkEventCustom({
+                                        type: "m.room.encrypted",
+                                        sender: bobClient.getSafeUserId(),
+                                        content: bobEventM2Content,
+                                        event_id: "$event_id_m2",
+                                    }) as any,
+                                ],
+                            },
+                        },
+                    },
+                },
+            } as any;
             charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
             await syncPromise(charlieClient);
 

--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -696,257 +696,284 @@ describe("History Sharing", () => {
         ).toBeFalsy();
     });
 
-    test("Room key is rotated after a member joins and leaves the room", async () => {
-        // Alice and Bob are in an encrypted room
-        let syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
+    test.each([false, true])(
+        "Room key is rotated after a member joins and leaves the room (gappy sync = %s)",
+        async (gappySync) => {
+            // Alice and Bob are in an encrypted room
+            let syncResponse = getSyncResponse(
+                [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+                HistoryVisibility.Shared,
+                ROOM_ID,
+            );
+            aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
 
-        await syncPromise(aliceClient);
-        await syncPromise(bobClient);
+            await syncPromise(aliceClient);
+            await syncPromise(bobClient);
 
-        // Bob sends a message M1, which both he and Alice receive.
-        let msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
-        let toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
-        await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
-            msgtype: MsgType.Text,
-            body: "Charlie should be able to read",
-        });
-        const bobEventM1Content = await msgProm;
-        let sentToDeviceRequest = await toDeviceMessageProm;
-        expect(sentToDeviceRequest).toBeDefined();
-        let aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
+            // Bob sends a message M1, which both he and Alice receive.
+            let msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
+            let toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
+            await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
+                msgtype: MsgType.Text,
+                body: "Charlie should be able to read",
+            });
+            const bobEventM1Content = await msgProm;
+            let sentToDeviceRequest = await toDeviceMessageProm;
+            expect(sentToDeviceRequest).toBeDefined();
+            let aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
 
-        // Alice receives the message down sync.
-        syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-            mkEventCustom({
-                type: "m.room.encrypted",
-                sender: bobClient.getSafeUserId(),
-                content: bobEventM1Content,
-                event_id: "$event_id_m1",
-            }) as any,
-        );
-        syncResponse.to_device = {
-            events: [
-                {
+            // Alice receives the message down sync.
+            syncResponse = getSyncResponse(
+                [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+                HistoryVisibility.Shared,
+                ROOM_ID,
+            );
+            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                mkEventCustom({
                     type: "m.room.encrypted",
                     sender: bobClient.getSafeUserId(),
-                    content: aliceToDeviceMessage,
-                },
-            ],
-        };
-        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        await syncPromise(aliceClient);
-
-        // Alice checks she can read M1.
-        const aliceRoom = aliceClient.getRoom(ROOM_ID);
-        const aliceM1 = aliceRoom!.getLastLiveEvent()!;
-        await aliceM1.getDecryptionPromise();
-        expect(aliceM1.getType()).toEqual("m.room.message");
-        expect(aliceM1.getContent().body).toEqual("Charlie should be able to read");
-
-        // Alice invites and sends a key bundle to Charlie
-        const uploadProm = expectUploadRequest();
-        toDeviceMessageProm = expectSendToDeviceMessage(ALICE_HOMESERVER_URL, "m.room.encrypted");
-        fetchMock.postOnce(`${ALICE_HOMESERVER_URL}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, charlieClient.getSafeUserId(), { shareEncryptedHistory: true });
-        const uploadedBlob = await uploadProm;
-        sentToDeviceRequest = await toDeviceMessageProm;
-        debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
-        const charlieToDeviceMessage = sentToDeviceRequest[charlieClient.getSafeUserId()][charlieClient.deviceId!];
-        expect(charlieToDeviceMessage).toBeDefined();
-
-        /// Charlie receives the invite ...
-        const inviteEvent = mkInviteEvent(aliceClient, charlieClient);
-        charlieSyncResponder.sendOrQueueSyncResponse({
-            rooms: { invite: { [ROOM_ID]: { invite_state: { events: [inviteEvent] } } } },
-            to_device: {
+                    content: bobEventM1Content,
+                    event_id: "$event_id_m1",
+                }) as any,
+            );
+            syncResponse.to_device = {
                 events: [
                     {
                         type: "m.room.encrypted",
-                        sender: aliceClient.getSafeUserId(),
-                        content: charlieToDeviceMessage,
+                        sender: bobClient.getSafeUserId(),
+                        content: aliceToDeviceMessage,
                     },
                 ],
-            },
-        });
-        await syncPromise(charlieClient);
+            };
+            aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            await syncPromise(aliceClient);
 
-        const charlieRoom = charlieClient.getRoom(ROOM_ID);
-        expect(charlieRoom).toBeTruthy();
-        expect(charlieRoom?.getMyMembership()).toEqual(KnownMembership.Invite);
+            // Alice checks she can read M1.
+            const aliceRoom = aliceClient.getRoom(ROOM_ID);
+            const aliceM1 = aliceRoom!.getLastLiveEvent()!;
+            await aliceM1.getDecryptionPromise();
+            expect(aliceM1.getType()).toEqual("m.room.message");
+            expect(aliceM1.getContent().body).toEqual("Charlie should be able to read");
 
-        // ... and subsequently joins.
-        fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
-            room_id: ROOM_ID,
-        });
-        fetchMock.getOnce(`begin:${CHARLIE_HOMESERVER_URL}/_matrix/client/v1/media/download/alice-server/here`, {
-            body: uploadedBlob,
-        });
-        await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+            // Alice invites and sends a key bundle to Charlie
+            const uploadProm = expectUploadRequest();
+            toDeviceMessageProm = expectSendToDeviceMessage(ALICE_HOMESERVER_URL, "m.room.encrypted");
+            fetchMock.postOnce(
+                `${ALICE_HOMESERVER_URL}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`,
+                {},
+            );
+            await aliceClient.invite(ROOM_ID, charlieClient.getSafeUserId(), { shareEncryptedHistory: true });
+            const uploadedBlob = await uploadProm;
+            sentToDeviceRequest = await toDeviceMessageProm;
+            debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
+            const charlieToDeviceMessage = sentToDeviceRequest[charlieClient.getSafeUserId()][charlieClient.deviceId!];
+            expect(charlieToDeviceMessage).toBeDefined();
 
-        // Charlie syncs to receive M1 and ensure he can read it.
-        syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-            mkEventCustom({
-                type: "m.room.encrypted",
-                sender: bobClient.getSafeUserId(),
-                content: bobEventM1Content,
-                event_id: "$event_id_m1",
-            }) as any,
-        );
-        charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        await syncPromise(charlieClient);
-
-        const charlieEventM1 = charlieRoom!
-            .getLiveTimeline()
-            .getEvents()
-            .find((e) => e.getId() === "$event_id_m1");
-
-        await charlieEventM1!.getDecryptionPromise();
-        expect(charlieEventM1!.getType()).toEqual("m.room.message");
-        expect(charlieEventM1!.getContent().body).toEqual("Charlie should be able to read");
-
-        // Charlie then immediately leaves.
-        const charlieSyncResponse = {
-            next_batch: "1",
-            rooms: {
-                leave: {
-                    [ROOM_ID]: {
-                        state: { events: [] },
-                        timeline: {
-                            events: [
-                                mkEventCustom({
-                                    content: { membership: KnownMembership.Leave },
-                                    type: EventType.RoomMember,
-                                    sender: charlieClient.getSafeUserId(),
-                                    state_key: charlieClient.getSafeUserId(),
-                                }),
-                            ],
-                            prev_batch: "",
+            /// Charlie receives the invite ...
+            const inviteEvent = mkInviteEvent(aliceClient, charlieClient);
+            charlieSyncResponder.sendOrQueueSyncResponse({
+                rooms: { invite: { [ROOM_ID]: { invite_state: { events: [inviteEvent] } } } },
+                to_device: {
+                    events: [
+                        {
+                            type: "m.room.encrypted",
+                            sender: aliceClient.getSafeUserId(),
+                            content: charlieToDeviceMessage,
                         },
-                        account_data: { events: [] },
-                    },
+                    ],
                 },
-                invite: {},
-                join: {},
-                knock: {},
-            },
-            account_data: { events: [] },
-        };
-        charlieSyncResponder.sendOrQueueSyncResponse(charlieSyncResponse);
-        await syncPromise(charlieClient);
+            });
+            await syncPromise(charlieClient);
 
-        // Bob syncs to learn about Charlie's joining and leaving.
-        syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-            mkEventCustom({
-                content: { membership: KnownMembership.Leave },
-                type: EventType.RoomMember,
-                sender: charlieClient.getSafeUserId(),
-                state_key: charlieClient.getSafeUserId(),
-            }),
-        );
-        bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        await syncPromise(bobClient);
+            const charlieRoom = charlieClient.getRoom(ROOM_ID);
+            expect(charlieRoom).toBeTruthy();
+            expect(charlieRoom?.getMyMembership()).toEqual(KnownMembership.Invite);
 
-        // Bob then sends M2, sharing a new room key with Alice.
-        msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
-        toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
-        await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
-            msgtype: MsgType.Text,
-            body: "Charlie should not be able to read",
-        });
-        const bobEventM2Content = await msgProm;
-        sentToDeviceRequest = await toDeviceMessageProm;
-        expect(sentToDeviceRequest).toBeDefined();
-        aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
+            // ... and subsequently joins.
+            fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
+                room_id: ROOM_ID,
+            });
+            fetchMock.getOnce(`begin:${CHARLIE_HOMESERVER_URL}/_matrix/client/v1/media/download/alice-server/here`, {
+                body: uploadedBlob,
+            });
+            await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
 
-        // Charlie should not receive the room key
-        expect(sentToDeviceRequest[charlieClient.getSafeUserId()]).toBeUndefined();
-
-        debug(`Bob sent encrypted room event: ${JSON.stringify(bobEventM2Content)}`);
-
-        // Sync the message to Alice along with the to-device message, and check she can decrypt it.
-        syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-            mkEventCustom({
-                type: "m.room.encrypted",
-                sender: bobClient.getSafeUserId(),
-                content: bobEventM2Content,
-                event_id: "$event_id_m2",
-            }) as any,
-        );
-        syncResponse.to_device = {
-            events: [
-                {
+            // Charlie syncs to receive M1 and ensure he can read it.
+            syncResponse = getSyncResponse(
+                [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+                HistoryVisibility.Shared,
+                ROOM_ID,
+            );
+            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                mkEventCustom({
                     type: "m.room.encrypted",
                     sender: bobClient.getSafeUserId(),
-                    content: aliceToDeviceMessage,
+                    content: bobEventM1Content,
+                    event_id: "$event_id_m1",
+                }) as any,
+            );
+            charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            await syncPromise(charlieClient);
+
+            const charlieEventM1 = charlieRoom!
+                .getLiveTimeline()
+                .getEvents()
+                .find((e) => e.getId() === "$event_id_m1");
+
+            await charlieEventM1!.getDecryptionPromise();
+            expect(charlieEventM1!.getType()).toEqual("m.room.message");
+            expect(charlieEventM1!.getContent().body).toEqual("Charlie should be able to read");
+
+            // Charlie then immediately leaves.
+            const charlieSyncResponse = {
+                next_batch: "1",
+                rooms: {
+                    leave: {
+                        [ROOM_ID]: {
+                            state: { events: [] },
+                            timeline: {
+                                events: [
+                                    mkEventCustom({
+                                        content: { membership: KnownMembership.Leave },
+                                        type: EventType.RoomMember,
+                                        sender: charlieClient.getSafeUserId(),
+                                        state_key: charlieClient.getSafeUserId(),
+                                    }),
+                                ],
+                                prev_batch: "",
+                            },
+                            account_data: { events: [] },
+                        },
+                    },
+                    invite: {},
+                    join: {},
+                    knock: {},
                 },
-            ],
-        };
-        aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        await syncPromise(aliceClient);
+                account_data: { events: [] },
+            };
+            charlieSyncResponder.sendOrQueueSyncResponse(charlieSyncResponse);
+            await syncPromise(charlieClient);
 
-        const aliceEventM2 = aliceRoom!.getLastLiveEvent()!;
-        await aliceEventM2.getDecryptionPromise();
-        expect(aliceEventM2.getType()).toEqual("m.room.message");
-        expect(aliceEventM2.getContent().body).toEqual("Charlie should not be able to read");
+            if (gappySync) {
+                syncResponse = getSyncResponse(
+                    [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+                    HistoryVisibility.Shared,
+                    ROOM_ID,
+                );
+                // In case of a gappy sync, the timeline is limited and we only see the leave event.
+                syncResponse.rooms.join[ROOM_ID].timeline.limited = true;
+                syncResponse.rooms.join[ROOM_ID].state = {
+                    events: [
+                        mkEventCustom({
+                            content: { membership: KnownMembership.Leave },
+                            type: EventType.RoomMember,
+                            sender: charlieClient.getSafeUserId(),
+                            state_key: charlieClient.getSafeUserId(),
+                        }) as any,
+                    ],
+                };
+            } else {
+                syncResponse = getSyncResponse(
+                    [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+                    HistoryVisibility.Shared,
+                    ROOM_ID,
+                );
+                syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                    mkEventCustom({
+                        content: { membership: KnownMembership.Leave },
+                        type: EventType.RoomMember,
+                        sender: charlieClient.getSafeUserId(),
+                        state_key: charlieClient.getSafeUserId(),
+                    }),
+                );
+            }
+            // Bob syncs to learn about Charlie's leaving (and joining if non-gappy).
+            bobSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            await syncPromise(bobClient);
 
-        // Charlie rejoins the room by ID, receives M2, which he should not be able to decrypt.
-        fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
-            room_id: ROOM_ID,
-        });
-        await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
-        syncResponse = getSyncResponse(
-            [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
-            HistoryVisibility.Shared,
-            ROOM_ID,
-        );
-        syncResponse.rooms.join[ROOM_ID].timeline.events.push(
-            mkEventCustom({
-                type: "m.room.encrypted",
-                sender: bobClient.getSafeUserId(),
-                content: bobEventM2Content,
-                event_id: "$event_id_m2",
-            }) as any,
-        );
-        charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
-        await syncPromise(charlieClient);
+            // Bob then sends M2, sharing a new room key with Alice.
+            msgProm = expectSendRoomEvent(BOB_HOMESERVER_URL, "m.room.encrypted");
+            toDeviceMessageProm = expectSendToDeviceMessage(BOB_HOMESERVER_URL, "m.room.encrypted");
+            await bobClient.sendEvent(ROOM_ID, EventType.RoomMessage, {
+                msgtype: MsgType.Text,
+                body: "Charlie should not be able to read",
+            });
+            const bobEventM2Content = await msgProm;
+            sentToDeviceRequest = await toDeviceMessageProm;
+            expect(sentToDeviceRequest).toBeDefined();
+            aliceToDeviceMessage = sentToDeviceRequest[aliceClient.getSafeUserId()][aliceClient.deviceId!];
 
-        const events = charlieRoom!.getLiveTimeline().getEvents();
-        expect(events.length).toBeGreaterThanOrEqual(2);
+            // Charlie should not receive the room key
+            expect(sentToDeviceRequest[charlieClient.getSafeUserId()]).toBeUndefined();
 
-        const charlieM2 = charlieRoom!
-            .getLiveTimeline()
-            .getEvents()
-            .find((e) => e.getId() === "$event_id_m2");
+            debug(`Bob sent encrypted room event: ${JSON.stringify(bobEventM2Content)}`);
 
-        await charlieM2!.getDecryptionPromise();
-        expect(charlieM2!.isDecryptionFailure()).toBeTruthy();
-    }, 60e3);
+            // Sync the message to Alice along with the to-device message, and check she can decrypt it.
+            syncResponse = getSyncResponse(
+                [aliceClient.getSafeUserId(), bobClient.getSafeUserId()],
+                HistoryVisibility.Shared,
+                ROOM_ID,
+            );
+            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                mkEventCustom({
+                    type: "m.room.encrypted",
+                    sender: bobClient.getSafeUserId(),
+                    content: bobEventM2Content,
+                    event_id: "$event_id_m2",
+                }) as any,
+            );
+            syncResponse.to_device = {
+                events: [
+                    {
+                        type: "m.room.encrypted",
+                        sender: bobClient.getSafeUserId(),
+                        content: aliceToDeviceMessage,
+                    },
+                ],
+            };
+            aliceSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            await syncPromise(aliceClient);
+
+            const aliceEventM2 = aliceRoom!.getLastLiveEvent()!;
+            await aliceEventM2.getDecryptionPromise();
+            expect(aliceEventM2.getType()).toEqual("m.room.message");
+            expect(aliceEventM2.getContent().body).toEqual("Charlie should not be able to read");
+
+            // Charlie rejoins the room by ID, receives M2, which he should not be able to decrypt.
+            fetchMock.postOnce(`${CHARLIE_HOMESERVER_URL}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
+                room_id: ROOM_ID,
+            });
+            await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+            syncResponse = getSyncResponse(
+                [aliceClient.getSafeUserId(), bobClient.getSafeUserId(), charlieClient.getSafeUserId()],
+                HistoryVisibility.Shared,
+                ROOM_ID,
+            );
+            syncResponse.rooms.join[ROOM_ID].timeline.events.push(
+                mkEventCustom({
+                    type: "m.room.encrypted",
+                    sender: bobClient.getSafeUserId(),
+                    content: bobEventM2Content,
+                    event_id: "$event_id_m2",
+                }) as any,
+            );
+            charlieSyncResponder.sendOrQueueSyncResponse(syncResponse);
+            await syncPromise(charlieClient);
+
+            const events = charlieRoom!.getLiveTimeline().getEvents();
+            expect(events.length).toBeGreaterThanOrEqual(2);
+
+            const charlieM2 = charlieRoom!
+                .getLiveTimeline()
+                .getEvents()
+                .find((e) => e.getId() === "$event_id_m2");
+
+            await charlieM2!.getDecryptionPromise();
+            expect(charlieM2!.isDecryptionFailure()).toBeTruthy();
+        },
+        60e3,
+    );
 
     afterEach(async () => {
         vitest.useRealTimers();

--- a/src/client.ts
+++ b/src/client.ts
@@ -101,7 +101,7 @@ import {
     type RoomNameState,
 } from "./models/room.ts";
 import { RoomMemberEvent, type RoomMemberEventHandlerMap } from "./models/room-member.ts";
-import { type IPowerLevelsContent, type RoomStateEvent, type RoomStateEventHandlerMap } from "./models/room-state.ts";
+import { RoomStateEvent, type IPowerLevelsContent, type RoomStateEventHandlerMap } from "./models/room-state.ts";
 import {
     isSendDelayedEventRequestOpts,
     UpdateDelayedEventAction,
@@ -2027,6 +2027,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         // attach the event listeners needed by RustCrypto
         this.on(RoomMemberEvent.Membership, rustCrypto.onRoomMembership.bind(rustCrypto));
+        this.on(RoomStateEvent.Events, rustCrypto.onRoomStateEvent.bind(rustCrypto));
         this.on(ClientEvent.Event, (event) => {
             rustCrypto.onLiveEventFromSync(event);
         });

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1947,7 +1947,23 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             });
         }
 
-        // If it's not our membership, and it was a leave event, rotate the room key.
+        /**
+         * Previously, it was sufficient to check if we need to rotate the room key
+         * prior to sending a message. However, the history sharing feature
+         * (MSC4268) breaks this logic:
+         *
+         * 1. Alice sends a message M1 in room X;
+         * 2. Bob invites Charlie, who joins and immediately leaves the room;
+         * 3. Alice sends another message M2 in room X.
+         *
+         * Under the old logic, Alice would not rotate her key after Charlie
+         * leaves, resulting in M2 being encrypted with the same session as M1.
+         * This would allow Charlie to decrypt M2 if he ever gains access to
+         * the event.
+         *
+         * This conditional discards the current room key if the membership event
+         * is a `leave` event.
+         */
         if (member.userId !== this.olmMachine.userId.toString() && member.membership === KnownMembership.Leave) {
             this.logger.info(`Rotating session for room ${roomId} due to member leaving the room`);
             this.forceDiscardSession(member.roomId);

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -98,6 +98,7 @@ import { VerificationMethod } from "../types.ts";
 import { keyFromAuthData } from "../common-crypto/key-passphrase.ts";
 import { type UIAuthCallback } from "../interactive-auth.ts";
 import { getHttpUriForMxc } from "../content-repo.ts";
+import { type RoomState } from "../matrix.ts";
 
 const ALL_VERIFICATION_METHODS = [
     VerificationMethod.Sas,
@@ -1947,6 +1948,20 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             });
         }
 
+        const enc = this.roomEncryptors[roomId];
+        if (!enc) {
+            // not encrypting in this room
+            return;
+        }
+        enc.onRoomMembership(member);
+    }
+
+    public onRoomStateEvent(event: MatrixEvent, state: RoomState, prevEvent: MatrixEvent | null): void {
+        if (event.getType() != EventType.RoomMember) {
+            // Ignore all events that aren't member updates.
+            return;
+        }
+
         /**
          * Previously, it was sufficient to check if we need to rotate the room key
          * prior to sending a message. However, the history sharing feature
@@ -1964,17 +1979,13 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
          * This conditional discards the current room key if the membership event
          * is a `leave` event.
          */
-        if (member.userId !== this.olmMachine.userId.toString() && member.membership === KnownMembership.Leave) {
-            this.logger.info(`Rotating session for room ${roomId} due to member leaving the room`);
-            this.forceDiscardSession(member.roomId);
+        if (
+            event.getStateKey()! !== this.olmMachine.userId.toString() &&
+            event.getContent().membership === KnownMembership.Leave
+        ) {
+            this.logger.info(`Rotating session for room ${event.getRoomId()} due to member leaving the room`);
+            this.forceDiscardSession(event.getRoomId()!);
         }
-
-        const enc = this.roomEncryptors[roomId];
-        if (!enc) {
-            // not encrypting in this room
-            return;
-        }
-        enc.onRoomMembership(member);
     }
 
     /** Callback for OlmMachine.registerRoomKeyUpdatedCallback

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1956,29 +1956,34 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         enc.onRoomMembership(member);
     }
 
+    /**
+     * Previously, it was sufficient to check if we need to rotate the room key
+     * prior to sending a message. However, the history sharing feature
+     * (MSC4268) breaks this logic:
+     *
+     * 1. Alice sends a message M1 in room X;
+     * 2. Bob invites Charlie, who joins and immediately leaves the room;
+     * 3. Alice sends another message M2 in room X.
+     *
+     * Under the old logic, Alice would not rotate her key after Charlie
+     * leaves, resulting in M2 being encrypted with the same session as M1.
+     * This would allow Charlie to decrypt M2 if he ever gains access to
+     * the event.
+     *
+     * To counter this, we proactively discard any active outgoing Megolm
+     * session when we see a `leave` event. Note that we have to do this in
+     * `onRoomStateEvent` rather than `onRoomMembership`, because
+     * `onRoomMembership` is only called when we see a *change* in membership.
+     * In the case of a gappy sync, we might miss Charlie's invite and join,
+     * and only see the final `leave` event (sohis membership goes from `leave`
+     * to `leave`).
+     */
     public onRoomStateEvent(event: MatrixEvent, state: RoomState, prevEvent: MatrixEvent | null): void {
         if (event.getType() != EventType.RoomMember) {
             // Ignore all events that aren't member updates.
             return;
         }
 
-        /**
-         * Previously, it was sufficient to check if we need to rotate the room key
-         * prior to sending a message. However, the history sharing feature
-         * (MSC4268) breaks this logic:
-         *
-         * 1. Alice sends a message M1 in room X;
-         * 2. Bob invites Charlie, who joins and immediately leaves the room;
-         * 3. Alice sends another message M2 in room X.
-         *
-         * Under the old logic, Alice would not rotate her key after Charlie
-         * leaves, resulting in M2 being encrypted with the same session as M1.
-         * This would allow Charlie to decrypt M2 if he ever gains access to
-         * the event.
-         *
-         * This conditionally discards the current room key if the membership event
-         * is a `leave` event.
-         */
         if (
             event.getStateKey()! !== this.olmMachine.userId.toString() &&
             event.getContent().membership === KnownMembership.Leave

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1947,6 +1947,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
             });
         }
 
+        // If it's not our membership, and it was a leave event, rotate the room key.
+        if (member.userId !== this.olmMachine.userId.toString() && member.membership === KnownMembership.Leave) {
+            this.logger.info(`Rotating session for room ${roomId} due to member leaving the room`);
+            this.forceDiscardSession(member.roomId);
+        }
+
         const enc = this.roomEncryptors[roomId];
         if (!enc) {
             // not encrypting in this room

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1976,7 +1976,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
          * This would allow Charlie to decrypt M2 if he ever gains access to
          * the event.
          *
-         * This conditional discards the current room key if the membership event
+         * This conditionally discards the current room key if the membership event
          * is a `leave` event.
          */
         if (


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
This PR adds logic to the `RustCrypto.onRoomMembership` event handler that discards (and hence rotates) the current session whenever we see an event `leave` membership.

Part of https://github.com/element-hq/element-meta/issues/3078

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
