### PR TITLE
Implement MSC4429: Profile Updates for Legacy Sync

### DIFF
--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -2549,6 +2549,47 @@ describe("MatrixClient syncing", () => {
         });
     });
 
+    describe("user profiles", () => {
+        const TEST_STATUS_UPDATE = {
+            text: "Swimming in the Great Lakes!",
+            emoji: "🏊️",
+        };
+
+        beforeEach(() => {
+            vi.spyOn(client!, "doesServerSupportExtendedProfiles").mockResolvedValue(true);
+        });
+
+        it("should consume user profile updates from the sync response", async () => {
+            const fn = vi.fn();
+            client!.on(ClientEvent.UserProfileUpdate, fn);
+
+            httpBackend!.when("GET", "/sync").respond(200, {
+                next_batch: "batch_token",
+                rooms: {},
+                presence: {},
+                users: {
+                    ["@alice:localhost"]: {
+                        profile_updates: {
+                            ["m.status"]: TEST_STATUS_UPDATE,
+                        },
+                    },
+                },
+            });
+
+            await Promise.all([client!.startClient(), httpBackend!.flushAllExpected()]);
+
+            expect(await client!.getExtendedProfileProperty("@alice:localhost", "m.status")).toEqual(
+                TEST_STATUS_UPDATE,
+            );
+
+            expect(fn).toHaveBeenCalledWith("@alice:localhost", {
+                "m.status": TEST_STATUS_UPDATE,
+            });
+
+            client!.off(ClientEvent.UserProfileUpdate, fn);
+        });
+    });
+
     /**
      * waits for the MatrixClient to emit one or more 'sync' events.
      *

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -2563,6 +2563,20 @@ describe("MatrixClient syncing", () => {
             const fn = vi.fn();
             client!.on(ClientEvent.UserProfileUpdate, fn);
 
+            httpBackend!.expectedRequests = [];
+            httpBackend!.when("GET", "/versions").respond(200, {});
+            httpBackend!.when("GET", "/pushrules").respond(200, {});
+            httpBackend!
+                .when("POST", "/filter")
+                .check((req) => {
+                    expect(req.data).toEqual({
+                        "org.matrix.msc4429.profile_fields": {
+                            ids: ["m.status"],
+                        },
+                    });
+                })
+                .respond(200, { filter_id: "a filter id" });
+
             httpBackend!.when("GET", "/sync").respond(200, {
                 next_batch: "batch_token",
                 rooms: {},
@@ -2576,7 +2590,10 @@ describe("MatrixClient syncing", () => {
                 },
             });
 
-            await Promise.all([client!.startClient(), httpBackend!.flushAllExpected()]);
+            await Promise.all([
+                client!.startClient({ unstableMSC4429SyncUserProfileFields: ["m.status"] }),
+                httpBackend!.flushAllExpected(),
+            ]);
 
             expect(await client!.getExtendedProfileProperty("@alice:localhost", "m.status")).toEqual(
                 TEST_STATUS_UPDATE,

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -375,6 +375,7 @@ describe("MatrixClient", function () {
                 "startup",
                 "deleteAllData",
                 "setUserCreator",
+                "storeUserProfiles",
             ] as const
         ).reduce((r, k) => {
             r[k] = vi.fn();

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -19,7 +19,7 @@ limitations under the License.
  */
 
 import fetchMock from "@fetch-mock/vitest";
-import { type Mocked } from "vitest";
+import { type MockedObject, type Mocked } from "vitest";
 
 import { logger } from "../../src/logger";
 import {
@@ -89,6 +89,7 @@ import { type CryptoBackend } from "../../src/common-crypto/CryptoBackend";
 import { SyncResponder } from "../test-utils/SyncResponder.ts";
 import { mockInitialApiRequests } from "../test-utils/mockEndpoints.ts";
 import { type Transport } from "../../src/matrixrtc/index.ts";
+import { type IStore } from "../../src/store/index.ts";
 
 vi.useFakeTimers();
 
@@ -385,6 +386,7 @@ describe("MatrixClient", function () {
         store.getClientOptions = vi.fn().mockReturnValue(Promise.resolve(null));
         store.storeClientOptions = vi.fn().mockReturnValue(Promise.resolve(null));
         store.isNewlyCreated = vi.fn().mockReturnValue(Promise.resolve(true));
+        store.getUserProfile = vi.fn().mockReturnValue(undefined);
 
         // set unstableFeatures to a defined state before each test
         unstableFeatures = {
@@ -1323,6 +1325,18 @@ describe("MatrixClient", function () {
             ];
             await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");
             expect(httpLookups).toHaveLength(0);
+        });
+
+        it("can fetch a property from a extended user profile with a cached profile", async () => {
+            const testProfile = {
+                test_key: "foo",
+            };
+            (client.store as MockedObject<IStore>).getUserProfile.mockImplementation((requestedUserId) => {
+                expect(requestedUserId).toEqual(userId);
+                expect("test_key").toEqual("test_key");
+                return testProfile;
+            });
+            await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");
         });
 
         it("can set a property in our extended profile", async () => {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1331,7 +1331,7 @@ describe("MatrixClient", function () {
             const testProfile = {
                 test_key: "foo",
             };
-            (client.store as MockedObject<IStore>).getUserProfile.mockImplementation((requestedUserId) => {
+            (client.store as MockedObject<IStore>).getUserProfile.mockImplementation(async (requestedUserId) => {
                 expect(requestedUserId).toEqual(userId);
                 expect("test_key").toEqual("test_key");
                 return testProfile;

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1327,13 +1327,12 @@ describe("MatrixClient", function () {
             expect(httpLookups).toHaveLength(0);
         });
 
-        it("can fetch a property from a extended user profile with a cached profile", async () => {
+        it("can fetch a property from an extended user profile with a cached profile", async () => {
             const testProfile = {
                 test_key: "foo",
             };
             (client.store as MockedObject<IStore>).getUserProfile.mockImplementation(async (requestedUserId) => {
                 expect(requestedUserId).toEqual(userId);
-                expect("test_key").toEqual("test_key");
                 return testProfile;
             });
             await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");

--- a/spec/unit/store/indexeddb-local-backend.spec.ts
+++ b/spec/unit/store/indexeddb-local-backend.spec.ts
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "fake-indexeddb/auto";
+
+import { LocalIndexedDBStoreBackend } from "../../../src/store/indexeddb-local-backend";
+import type { SyncUserProfile } from "../../../src/models/user";
+
+describe("LocalIndexedDBStoreBackend", () => {
+    let backend: LocalIndexedDBStoreBackend;
+
+    beforeEach(async () => {
+        backend = new LocalIndexedDBStoreBackend(indexedDB, `get-user-profile-${Date.now()}-${Math.random()}`);
+        await backend.connect();
+    });
+
+    afterEach(async () => {
+        await backend.clearDatabase();
+    });
+
+    it("stores and retrieves a user profile for the given user ID", async () => {
+        const userId = "@alice:example.org";
+        const profile: SyncUserProfile = {
+            displayname: "Alice",
+            avatar_url: "mxc://example.org/avatar",
+        };
+
+        await backend.storeUserProfiles([[userId, profile]]);
+
+        await expect(backend.getUserProfile(userId)).resolves.toEqual(profile);
+    });
+
+    it("returns undefined for a missing user profile", async () => {
+        await expect(backend.getUserProfile("@missing:example.org")).resolves.toBeUndefined();
+    });
+
+    it("returns undefined once a user profile has been removed", async () => {
+        const userId = "@alice:example.org";
+        const profile: SyncUserProfile = {
+            displayname: "Alice",
+            avatar_url: "mxc://example.org/avatar",
+        };
+
+        await backend.storeUserProfiles([[userId, profile]]);
+
+        await expect(backend.getUserProfile(userId)).resolves.toEqual(profile);
+        backend.removeUserProfiles([userId]);
+        await expect(backend.getUserProfile(userId)).resolves.toBeUndefined();
+    });
+});

--- a/spec/unit/store/indexeddb-local-backend.spec.ts
+++ b/spec/unit/store/indexeddb-local-backend.spec.ts
@@ -38,7 +38,7 @@ describe("LocalIndexedDBStoreBackend", () => {
             avatar_url: "mxc://example.org/avatar",
         };
 
-        await backend.storeUserProfiles([[userId, profile]]);
+        await backend.storeUserProfiles(new Map([[userId, profile]]));
 
         await expect(backend.getUserProfile(userId)).resolves.toEqual(profile);
     });
@@ -54,7 +54,7 @@ describe("LocalIndexedDBStoreBackend", () => {
             avatar_url: "mxc://example.org/avatar",
         };
 
-        await backend.storeUserProfiles([[userId, profile]]);
+        await backend.storeUserProfiles(new Map([[userId, profile]]));
 
         await expect(backend.getUserProfile(userId)).resolves.toEqual(profile);
         backend.removeUserProfiles([userId]);

--- a/spec/unit/store/indexeddb-remote-backend.spec.ts
+++ b/spec/unit/store/indexeddb-remote-backend.spec.ts
@@ -1,0 +1,372 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RemoteIndexedDBStoreBackend } from "../../../src/store/indexeddb-remote-backend";
+
+describe("RemoteIndexedDBStoreBackend", () => {
+    let mockPostMessage: ReturnType<typeof vi.fn>;
+    let mockTerminate: ReturnType<typeof vi.fn>;
+    let workerMessageHandler: ((ev: MessageEvent) => void) | undefined;
+    let backend: RemoteIndexedDBStoreBackend;
+
+    function simulateWorkerMessage(data: object): void {
+        workerMessageHandler?.({ data } as MessageEvent);
+    }
+
+    /** Override the next postMessage reply to return a specific result. */
+    function stubNextResult(result: unknown): void {
+        mockPostMessage.mockImplementationOnce((msg: { seq: number }) => {
+            Promise.resolve().then(() => {
+                simulateWorkerMessage({ command: "cmd_success", seq: msg.seq, result });
+            });
+        });
+    }
+
+    /** Override the next postMessage reply to return a cmd_fail. */
+    function stubNextError(error: { message: string; name: string }): void {
+        mockPostMessage.mockImplementationOnce((msg: { seq: number }) => {
+            Promise.resolve().then(() => {
+                simulateWorkerMessage({ command: "cmd_fail", seq: msg.seq, error });
+            });
+        });
+    }
+
+    beforeEach(() => {
+        workerMessageHandler = undefined;
+
+        // Auto-reply with cmd_success to every worker message by default.
+        mockPostMessage = vi.fn().mockImplementation((msg: { seq: number }) => {
+            Promise.resolve().then(() => {
+                simulateWorkerMessage({ command: "cmd_success", seq: msg.seq, result: undefined });
+            });
+        });
+        mockTerminate = vi.fn();
+
+        backend = new RemoteIndexedDBStoreBackend(
+            () =>
+                ({
+                    postMessage: mockPostMessage,
+                    terminate: mockTerminate,
+                    get onmessage() {
+                        return workerMessageHandler ?? null;
+                    },
+                    set onmessage(fn: ((ev: MessageEvent) => void) | null) {
+                        workerMessageHandler = fn ?? undefined;
+                    },
+                }) as unknown as Worker,
+            "test-db",
+        );
+    });
+
+    /**
+     * Connect the backend (drives setupWorker + connect replies via the auto-mock),
+     * then clear the postMessage call log so tests only see the calls they trigger.
+     */
+    async function start(): Promise<void> {
+        await backend.connect();
+        mockPostMessage.mockClear();
+    }
+
+    describe("connect()", () => {
+        it("sends setupWorker with the database name and then a connect command", async () => {
+            await backend.connect();
+
+            expect(mockPostMessage).toHaveBeenCalledWith({ command: "setupWorker", seq: 0, args: ["test-db"] });
+            expect(mockPostMessage).toHaveBeenCalledWith({ command: "connect", seq: 1, args: undefined });
+        });
+
+        it("calls the worker factory only once across multiple connect() calls", async () => {
+            const factory = vi.fn().mockReturnValue({
+                postMessage: mockPostMessage,
+                terminate: mockTerminate,
+                get onmessage() {
+                    return workerMessageHandler ?? null;
+                },
+                set onmessage(fn: ((ev: MessageEvent) => void) | null) {
+                    workerMessageHandler = fn ?? undefined;
+                },
+            } as unknown as Worker);
+            backend = new RemoteIndexedDBStoreBackend(factory, "test-db");
+
+            await backend.connect();
+            await backend.connect();
+
+            expect(factory).toHaveBeenCalledTimes(1);
+        });
+
+        it("calls the onClose callback when the worker sends a closed message", async () => {
+            const onClose = vi.fn();
+            await backend.connect(onClose);
+
+            simulateWorkerMessage({ command: "closed" });
+
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("clearDatabase()", () => {
+        it("starts the worker if not yet started and sends clearDatabase", async () => {
+            await backend.clearDatabase();
+
+            expect(mockPostMessage).toHaveBeenCalledWith({ command: "setupWorker", seq: 0, args: ["test-db"] });
+            expect(mockPostMessage).toHaveBeenCalledWith({ command: "clearDatabase", seq: 1, args: undefined });
+        });
+    });
+
+    describe("commands (after connect)", () => {
+        beforeEach(start);
+
+        it("isNewlyCreated sends the command and returns the result", async () => {
+            stubNextResult(true);
+
+            const result = await backend.isNewlyCreated();
+
+            expect(result).toBe(true);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "isNewlyCreated",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("getSavedSync sends the command and returns the result", async () => {
+            const savedSync = { nextBatch: "tok", roomsMap: {} };
+            stubNextResult(savedSync);
+
+            const result = await backend.getSavedSync();
+
+            expect(result).toBe(savedSync);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getSavedSync",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("getNextBatchToken sends the command and returns the token", async () => {
+            stubNextResult("s1234_5678");
+
+            const result = await backend.getNextBatchToken();
+
+            expect(result).toBe("s1234_5678");
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getNextBatchToken",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("setSyncData sends the command with sync data as args", async () => {
+            const syncData = { next_batch: "tok" } as any;
+
+            await backend.setSyncData(syncData);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "setSyncData",
+                seq: expect.any(Number),
+                args: [syncData],
+            });
+        });
+
+        it("syncToDatabase sends the command with userTuples as args", async () => {
+            const userTuples = [["@alice:example.org", { type: "m.presence" }]] as any;
+
+            await backend.syncToDatabase(userTuples);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "syncToDatabase",
+                seq: expect.any(Number),
+                args: [userTuples],
+            });
+        });
+
+        it("getUserPresenceEvents sends the command and returns the result", async () => {
+            const events = [["@alice:example.org", { type: "m.presence" }]] as any;
+            stubNextResult(events);
+
+            const result = await backend.getUserPresenceEvents();
+
+            expect(result).toBe(events);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getUserPresenceEvents",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("getOutOfBandMembers sends the command with roomId and returns the result", async () => {
+            const members = [{ type: "m.room.member", room_id: "!room:example.org" }] as any;
+            stubNextResult(members);
+
+            const result = await backend.getOutOfBandMembers("!room:example.org");
+
+            expect(result).toBe(members);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getOutOfBandMembers",
+                seq: expect.any(Number),
+                args: ["!room:example.org"],
+            });
+        });
+
+        it("setOutOfBandMembers sends the command with roomId and events as args", async () => {
+            const events = [{ type: "m.room.member" }] as any;
+
+            await backend.setOutOfBandMembers("!room:example.org", events);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "setOutOfBandMembers",
+                seq: expect.any(Number),
+                args: ["!room:example.org", events],
+            });
+        });
+
+        it("clearOutOfBandMembers sends the command with roomId as args", async () => {
+            await backend.clearOutOfBandMembers("!room:example.org");
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "clearOutOfBandMembers",
+                seq: expect.any(Number),
+                args: ["!room:example.org"],
+            });
+        });
+
+        it("getClientOptions sends the command and returns the result", async () => {
+            const opts = { lazyLoadMembers: true };
+            stubNextResult(opts);
+
+            const result = await backend.getClientOptions();
+
+            expect(result).toEqual(opts);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getClientOptions",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("storeClientOptions sends the command with options as args", async () => {
+            const opts = { lazyLoadMembers: true } as any;
+
+            await backend.storeClientOptions(opts);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "storeClientOptions",
+                seq: expect.any(Number),
+                args: [opts],
+            });
+        });
+
+        it("saveToDeviceBatches sends the command with batches as args", async () => {
+            const batches = [{ eventType: "m.room_key_request", txnId: "txn", batch: [] }] as any;
+
+            await backend.saveToDeviceBatches(batches);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "saveToDeviceBatches",
+                seq: expect.any(Number),
+                args: [batches],
+            });
+        });
+
+        it("getOldestToDeviceBatch sends the command and returns the result", async () => {
+            const batch = { id: 1, eventType: "m.room_key_request", txnId: "txn", events: [] };
+            stubNextResult(batch);
+
+            const result = await backend.getOldestToDeviceBatch();
+
+            expect(result).toBe(batch);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getOldestToDeviceBatch",
+                seq: expect.any(Number),
+                args: undefined,
+            });
+        });
+
+        it("removeToDeviceBatch sends the command with the batch id as args", async () => {
+            await backend.removeToDeviceBatch(42);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "removeToDeviceBatch",
+                seq: expect.any(Number),
+                args: [42],
+            });
+        });
+
+        it("getUserProfile sends the command with the userId and returns the result", async () => {
+            const profile = { displayname: "Alice", avatar_url: "mxc://example.org/alice" };
+            stubNextResult(profile);
+
+            const result = await backend.getUserProfile("@alice:example.org");
+
+            expect(result).toEqual(profile);
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "getUserProfile",
+                seq: expect.any(Number),
+                args: ["@alice:example.org"],
+            });
+        });
+
+        it("storeUserProfiles sends the command with profile tuples as args", async () => {
+            const tuples: [string, { displayname: string }][] = [["@alice:example.org", { displayname: "Alice" }]];
+
+            await backend.storeUserProfiles(tuples as any);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "storeUserProfiles",
+                seq: expect.any(Number),
+                args: [tuples],
+            });
+        });
+
+        it("removeUserProfiles sends the 'removeUserProfile' command with user IDs as args", async () => {
+            await backend.removeUserProfiles(["@alice:example.org"]);
+
+            expect(mockPostMessage).toHaveBeenCalledWith({
+                command: "removeUserProfiles",
+                seq: expect.any(Number),
+                args: [["@alice:example.org"]],
+            });
+        });
+    });
+
+    describe("worker message handling", () => {
+        beforeEach(start);
+
+        it("rejects the in-flight promise when cmd_fail is received", async () => {
+            stubNextError({ message: "disk full", name: "QuotaExceededError" });
+
+            await expect(backend.getNextBatchToken()).rejects.toMatchObject({
+                message: "disk full",
+                name: "QuotaExceededError",
+            });
+        });
+    });
+
+    describe("destroy()", () => {
+        it("terminates the worker", async () => {
+            await start();
+            await backend.destroy();
+
+            expect(mockTerminate).toHaveBeenCalledTimes(1);
+        });
+
+        it("does nothing if the worker was never started", async () => {
+            await backend.destroy();
+
+            expect(mockTerminate).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/spec/unit/store/indexeddb-store-worker.spec.ts
+++ b/spec/unit/store/indexeddb-store-worker.spec.ts
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { type LocalIndexedDBStoreBackend } from "../../../src/store/indexeddb-local-backend";
+import { IndexedDBStoreWorker } from "../../../src/store/indexeddb-store-worker";
+import "fake-indexeddb/auto";
+import { waitFor } from "../../test-utils/test-utils";
+
+const { backendFactoryMock } = vi.hoisted(() => ({
+    backendFactoryMock: vi.fn(),
+}));
+
+vi.mock("../../../src/store/indexeddb-local-backend", () => ({
+    LocalIndexedDBStoreBackend: function (...args: any[]) {
+        return backendFactoryMock(...args);
+    },
+}));
+
+describe("IndexedDBStoreWorker", () => {
+    let mockBackend: LocalIndexedDBStoreBackend;
+    let worker: IndexedDBStoreWorker;
+    const postMessage = vi.fn();
+
+    beforeEach(async () => {
+        backendFactoryMock.mockReset();
+        mockBackend = {} as LocalIndexedDBStoreBackend;
+        backendFactoryMock.mockReturnValue(mockBackend);
+
+        worker = new IndexedDBStoreWorker(postMessage);
+
+        worker.onMessage({
+            data: { command: "setupWorker", seq: 1, args: ["worker-db"] },
+        } as MessageEvent);
+
+        await waitFor(() =>
+            expect(postMessage).toHaveBeenCalledWith({ command: "cmd_success", seq: 1, result: undefined }),
+        );
+
+        postMessage.mockReset();
+    });
+
+    it("reports an unrecognised command", () => {
+        worker.onMessage({
+            data: { command: "notACommand", seq: 7, args: [] },
+        } as MessageEvent);
+
+        expect(postMessage).toHaveBeenCalledWith({
+            command: "cmd_fail",
+            seq: 7,
+            error: "Unrecognised command",
+        });
+    });
+
+    it("responds to getUserProfile", async () => {
+        mockBackend.getUserProfile = vi.fn().mockResolvedValue({ displayname: "Alice" });
+
+        worker.onMessage({ data: { command: "getUserProfile", seq: 2, args: ["alice"] } } as MessageEvent);
+
+        expect(mockBackend.getUserProfile).toHaveBeenCalledWith("alice");
+
+        await waitFor(() =>
+            expect(postMessage).toHaveBeenCalledWith({
+                command: "cmd_success",
+                seq: 2,
+                result: { displayname: "Alice" },
+            }),
+        );
+    });
+
+    it("responds to storeUserProfiles", async () => {
+        mockBackend.storeUserProfiles = vi.fn().mockResolvedValue(undefined);
+
+        worker.onMessage({ data: { command: "storeUserProfiles", seq: 2, args: [[]] } } as MessageEvent);
+
+        expect(mockBackend.storeUserProfiles).toHaveBeenCalledWith([]);
+
+        await waitFor(() =>
+            expect(postMessage).toHaveBeenCalledWith({
+                command: "cmd_success",
+                seq: 2,
+                result: undefined,
+            }),
+        );
+    });
+
+    it("responds to removeUserProfiles", async () => {
+        mockBackend.removeUserProfiles = vi.fn().mockResolvedValue(undefined);
+
+        worker.onMessage({ data: { command: "removeUserProfiles", seq: 2, args: [[]] } } as MessageEvent);
+
+        expect(mockBackend.removeUserProfiles).toHaveBeenCalledWith([]);
+
+        await waitFor(() =>
+            expect(postMessage).toHaveBeenCalledWith({
+                command: "cmd_success",
+                seq: 2,
+                result: undefined,
+            }),
+        );
+    });
+});

--- a/src/@types/json.ts
+++ b/src/@types/json.ts
@@ -1,0 +1,16 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// Types for JSON and JSON objects, copied from element-web (left in both places as I don't think we
+// want this as a part of js-sdk's interface and I don't think it's worth it being its own package)
+
+export type JsonValue = null | string | number | boolean;
+export type JsonArray = Array<JsonValue | JsonObject | JsonArray>;
+export interface JsonObject {
+    [key: string]: JsonObject | JsonArray | JsonValue;
+}
+export type Json = JsonArray | JsonObject;

--- a/src/client.ts
+++ b/src/client.ts
@@ -7407,7 +7407,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Fetch a specific key from the user's *extended* profile.
+     * Fetch a specific key from the user's *extended* profile by checking local cache (which is updated from
+     * the sync) and querying the server if no data is cached locally.
      *
      * @see https://github.com/tcpipuk/matrix-spec-proposals/blob/main/proposals/4133-extended-profiles.md
      * @param userId The user ID to fetch the profile of.
@@ -7436,6 +7437,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 prefix: await this.getExtendedProfileRequestPrefix(),
             },
         )) as Record<string, unknown>;
+
+        // write through to the cache
+        await this.store.storeUserProfiles([[userId, profile]]);
+
         return profile[key];
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -7439,7 +7439,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         )) as Record<string, unknown>;
 
         // write through to the cache
-        await this.store.storeUserProfiles([[userId, profile]]);
+        await this.store.storeUserProfiles(new Map([[userId, profile]]));
 
         return profile[key];
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -539,6 +539,12 @@ export interface IStartClientOpts {
      * @experimental
      */
     slidingSync?: SlidingSync;
+
+    /**
+     * Include user profiles in sync responses.
+     * Will only work if the server supports MSC4429.
+     */
+    unstableMSC4429SyncUserProfileFields?: string[];
 }
 
 export interface IStoredClientOpts extends IStartClientOpts {}
@@ -1102,6 +1108,7 @@ export enum ClientEvent {
     ReceivedVoipEvent = "received_voip_event",
     TurnServers = "turnServers",
     TurnServersError = "turnServers.error",
+    UserProfileUpdate = "userProfileUpdate",
 }
 
 type RoomEvents =
@@ -1172,6 +1179,7 @@ export type ClientEventHandlerMap = {
     [ClientEvent.ReceivedVoipEvent]: (event: MatrixEvent) => void;
     [ClientEvent.TurnServers]: (servers: ITurnServer[]) => void;
     [ClientEvent.TurnServersError]: (error: Error, fatal: boolean) => void;
+    [ClientEvent.UserProfileUpdate]: (userId: string, profile: Record<string, unknown>) => void;
 } & RoomEventHandlerMap &
     RoomStateEventHandlerMap &
     CryptoEventHandlerMap &
@@ -7401,6 +7409,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public async getExtendedProfileProperty(userId: string, key: string): Promise<unknown> {
         if (!(await this.doesServerSupportExtendedProfiles())) {
             throw new Error("Server does not support extended profiles");
+        }
+        const storedProfile = this.store.getUserProfile(userId);
+        if (storedProfile?.[key] !== undefined) {
+            return storedProfile[key];
         }
         const profile = (await this.http.authedRequest(
             Method.Get,

--- a/src/client.ts
+++ b/src/client.ts
@@ -78,7 +78,7 @@ import {
     type UploadOpts,
     type UploadResponse,
 } from "./http-api/index.ts";
-import { User, UserEvent, type UserEventHandlerMap } from "./models/user.ts";
+import { type SyncUserProfile, User, UserEvent, type UserEventHandlerMap } from "./models/user.ts";
 import { getHttpUriForMxc } from "./content-repo.ts";
 import { SearchResult } from "./models/search-result.ts";
 import { type IIdentityServerProvider } from "./@types/IIdentityServerProvider.ts";
@@ -7436,7 +7436,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             {
                 prefix: await this.getExtendedProfileRequestPrefix(),
             },
-        )) as Record<string, unknown>;
+        )) as SyncUserProfile;
 
         // write through to the cache
         await this.store.storeUserProfiles(new Map([[userId, profile]]));

--- a/src/client.ts
+++ b/src/client.ts
@@ -1181,9 +1181,8 @@ export type ClientEventHandlerMap = {
     [ClientEvent.TurnServersError]: (error: Error, fatal: boolean) => void;
     /**
      *
-     * @param userId
-     * @param profile
-     * @returns
+     * @param userId - the user ID of the profile which was updated
+     * @param profile - the updated profile information
      */
     [ClientEvent.UserProfileUpdate]: (userId: string, profile: Record<string, unknown> | null) => void;
 } & RoomEventHandlerMap &

--- a/src/client.ts
+++ b/src/client.ts
@@ -7410,6 +7410,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (!(await this.doesServerSupportExtendedProfiles())) {
             throw new Error("Server does not support extended profiles");
         }
+        // NOTE: We only read individual keys from a cached profile as we don't have the full profile
+        // cached, only the keys that the user has configured via their sync filter.
         const storedProfile = this.store.getUserProfile(userId);
         if (storedProfile?.[key] !== undefined) {
             return storedProfile[key];

--- a/src/client.ts
+++ b/src/client.ts
@@ -7377,6 +7377,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     /**
      * Fetch a user's *extended* profile, which may include additional keys.
+     * Always returns all available profile fields, irrespective of what profile fields are set
+     * in the sync filter.
      *
      * @see https://github.com/tcpipuk/matrix-spec-proposals/blob/main/proposals/4133-extended-profiles.md
      * @param userId The user ID to fetch the profile of.
@@ -7389,6 +7391,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (!(await this.doesServerSupportExtendedProfiles())) {
             throw new Error("Server does not support extended profiles");
         }
+
+        // Note that this does not look at the profile cache as this will only contain keys
+        // that we included in the sync filter and this function's purpose is to return the whole profile.
+
         return this.http.authedRequest(
             Method.Get,
             utils.encodeUri("/profile/$userId", { $userId: userId }),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1179,7 +1179,13 @@ export type ClientEventHandlerMap = {
     [ClientEvent.ReceivedVoipEvent]: (event: MatrixEvent) => void;
     [ClientEvent.TurnServers]: (servers: ITurnServer[]) => void;
     [ClientEvent.TurnServersError]: (error: Error, fatal: boolean) => void;
-    [ClientEvent.UserProfileUpdate]: (userId: string, profile: Record<string, unknown>) => void;
+    /**
+     *
+     * @param userId
+     * @param profile
+     * @returns
+     */
+    [ClientEvent.UserProfileUpdate]: (userId: string, profile: Record<string, unknown> | null) => void;
 } & RoomEventHandlerMap &
     RoomStateEventHandlerMap &
     CryptoEventHandlerMap &
@@ -7412,7 +7418,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
         // NOTE: We only read individual keys from a cached profile as we don't have the full profile
         // cached, only the keys that the user has configured via their sync filter.
-        const storedProfile = this.store.getUserProfile(userId);
+        const storedProfile = await this.store.getUserProfile(userId);
         if (storedProfile?.[key] !== undefined) {
             return storedProfile[key];
         }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -43,8 +43,8 @@ export interface IFilterDefinition {
     "presence"?: IFilterComponent;
     "account_data"?: IFilterComponent;
     "room"?: IRoomFilter;
-    "profile_fields"?: IProfileFieldsFilter;
-    "org.matrix.msc4429.profile_fields"?: IProfileFieldsFilter;
+    "profile_fields"?: ProfileFieldsFilter;
+    "org.matrix.msc4429.profile_fields"?: ProfileFieldsFilter;
 }
 
 export interface IRoomEventFilter extends IFilterComponent {
@@ -73,7 +73,10 @@ interface IRoomFilter {
     account_data?: IRoomEventFilter;
 }
 
-interface IProfileFieldsFilter {
+/**
+ * Filter section used for requesting a set of extended profile fields that will be sent down the sync stream.
+ */
+interface ProfileFieldsFilter {
     ids: string[];
 }
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -18,6 +18,9 @@ import { type EventType, type RelationType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { FilterComponent, type IFilterComponent } from "./filter-component.ts";
 import { type MatrixEvent } from "./models/event.ts";
+import { NamespacedValue } from "./NamespacedValue.ts";
+
+const profileFieldsFilterName = new NamespacedValue("profile_fields", "org.matrix.msc4429.profile_fields");
 
 /**
  */
@@ -35,11 +38,13 @@ function setProp(obj: Record<string, any>, keyNesting: string, val: any): void {
 
 /* eslint-disable camelcase */
 export interface IFilterDefinition {
-    event_fields?: string[];
-    event_format?: "client" | "federation";
-    presence?: IFilterComponent;
-    account_data?: IFilterComponent;
-    room?: IRoomFilter;
+    "event_fields"?: string[];
+    "event_format"?: "client" | "federation";
+    "presence"?: IFilterComponent;
+    "account_data"?: IFilterComponent;
+    "room"?: IRoomFilter;
+    "profile_fields"?: IProfileFieldsFilter;
+    "org.matrix.msc4429.profile_fields"?: IProfileFieldsFilter;
 }
 
 export interface IRoomEventFilter extends IFilterComponent {
@@ -67,6 +72,11 @@ interface IRoomFilter {
     timeline?: IRoomEventFilter;
     account_data?: IRoomEventFilter;
 }
+
+interface IProfileFieldsFilter {
+    ids: string[];
+}
+
 /* eslint-enable camelcase */
 
 export class Filter {
@@ -241,5 +251,17 @@ export class Filter {
      */
     public setIncludeLeaveRooms(includeLeave: boolean): void {
         setProp(this.definition, "room.include_leave", includeLeave);
+    }
+
+    /**
+     * @param ids The field IDs to sync.
+     * @param stable Whether to use the stable or unstable versions of this filter.
+     * @experimental
+     */
+    public setUnstableMSC4429SyncUserProfiles(ids: string[], stable: boolean): void {
+        const field = stable
+            ? profileFieldsFilterName.name
+            : (profileFieldsFilterName.unstable ?? profileFieldsFilterName.name);
+        this.definition[field] = { ids };
     }
 }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -257,6 +257,7 @@ export class Filter {
     }
 
     /**
+     * Set the list of fields to be included in the profile information sent down the sync stream.
      * @param ids The field IDs to sync.
      * @param stable Whether to use the stable or unstable versions of this filter.
      * @experimental

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -26,6 +26,8 @@ export enum UserEvent {
     LastPresenceTs = "User.lastPresenceTs",
 }
 
+export type SyncUserProfile = Record<string, unknown>;
+
 export type UserEventHandlerMap = {
     /**
      * Fires whenever any user's display name changes.

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -26,6 +26,9 @@ export enum UserEvent {
     LastPresenceTs = "User.lastPresenceTs",
 }
 
+/**
+ * An object of extended profile attributes for a user as it arrives down the sync stream.
+ */
 export type SyncUserProfile = Record<string, unknown>;
 
 export type UserEventHandlerMap = {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { type Json, type JsonValue } from "../@types/json.ts";
 import { type MatrixClient } from "../matrix.ts";
 import { type MatrixEvent } from "./event.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
@@ -29,7 +30,7 @@ export enum UserEvent {
 /**
  * An object of extended profile attributes for a user as it arrives down the sync stream.
  */
-export type SyncUserProfile = Record<string, unknown>;
+export type SyncUserProfile = Record<string, Json | JsonValue>;
 
 export type UserEventHandlerMap = {
     /**

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { SyncUserProfile, type User } from "../models/user.ts";
+import { type SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type Filter } from "../filter.ts";
 import { type RoomSummary } from "../models/room-summary.ts";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { type User } from "../models/user.ts";
+import { SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type Filter } from "../filter.ts";
 import { type RoomSummary } from "../models/room-summary.ts";
@@ -159,6 +159,25 @@ export interface IStore {
      * @param events - The events to store.
      */
     storeAccountDataEvents(events: MatrixEvent[]): void;
+
+    /**
+     * Store user profile details from a sync. Existing profiles will be overwritten.
+     * @param userId - The user's ID.
+     * @param fullUserProfile - The full user profile.
+     */
+    storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void;
+
+    /**
+     * Delete a user profile based on a sync response.
+     * @param userId - The user's ID.
+     */
+    removeUserProfile(userId: string): void;
+
+    /**
+     * Delete a user profile based on a sync response.
+     * @param userId - The user's ID.
+     */
+    getUserProfile(userId: string): SyncUserProfile | undefined;
 
     /**
      * Get account data event by event type

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -161,25 +161,6 @@ export interface IStore {
     storeAccountDataEvents(events: MatrixEvent[]): void;
 
     /**
-     * Store user profile details from a sync. Existing profiles will be overwritten.
-     * @param userId - The user's ID.
-     * @param fullUserProfile - The full user profile.
-     */
-    storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void;
-
-    /**
-     * Delete a user profile based on a sync response.
-     * @param userId - The user's ID.
-     */
-    removeUserProfile(userId: string): void;
-
-    /**
-     * Delete a user profile based on a sync response.
-     * @param userId - The user's ID.
-     */
-    getUserProfile(userId: string): SyncUserProfile | undefined;
-
-    /**
      * Get account data event by event type
      * @param eventType - The event type being queried
      */
@@ -272,6 +253,22 @@ export interface IStore {
      * Removes a specific batch of to-device messages from the queue
      */
     removeToDeviceBatch(id: number): Promise<void>;
+
+    /**
+     * Store user profile details from a sync. Existing profiles will be overwritten.
+     * @param userProfileTuples - A set of userIds to profiles.
+     */
+    storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void>;
+
+    /**
+     * Delete stored profiles for the given users.
+     */
+    removeUserProfiles(userIds: string[]): Promise<void>;
+
+    /**
+     * Delete a user profile based on a sync response.
+     */
+    getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
 
     /**
      * Stop the store and perform any appropriate cleanup

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -262,11 +262,14 @@ export interface IStore {
 
     /**
      * Delete stored profiles for the given users.
+     * @param userIds - The user IDs whose profiles should be deleted.
      */
     removeUserProfiles(userIds: string[]): Promise<void>;
 
     /**
-     * Delete a user profile based on a sync response.
+     * Retrieve a stored user profile for the given user ID, if it exists.
+     * @param userId - The user ID to retrieve the profile for.
+     * @returns The stored profile, or undefined if no profile is stored for this user ID.
      */
     getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -256,9 +256,9 @@ export interface IStore {
 
     /**
      * Store user profile details from a sync. Existing profiles will be overwritten.
-     * @param userProfileTuples - A set of userIds to profiles.
+     * @param userProfiles - A map of userIds to profiles.
      */
-    storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void>;
+    storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void>;
 
     /**
      * Delete stored profiles for the given users.

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -37,7 +37,7 @@ export interface IIndexedDBBackend {
     getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch | null>;
     removeToDeviceBatch(id: number): Promise<void>;
     getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
-    storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void>;
+    storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void>;
     removeUserProfiles(userIds: string[]): Promise<void>;
     destroy(): Promise<void>;
 }

--- a/src/store/indexeddb-backend.ts
+++ b/src/store/indexeddb-backend.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { type ISavedSync } from "./index.ts";
 import { type IEvent, type IStateEventWithRoomId, type IStoredClientOpts, type ISyncResponse } from "../matrix.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type SyncUserProfile } from "../models/user.ts";
 
 export interface IIndexedDBBackend {
     connect(onClose?: () => void): Promise<void>;
@@ -35,6 +36,9 @@ export interface IIndexedDBBackend {
     saveToDeviceBatches(batches: ToDeviceBatchWithTxnId[]): Promise<void>;
     getOldestToDeviceBatch(): Promise<IndexedToDeviceBatch | null>;
     removeToDeviceBatch(id: number): Promise<void>;
+    getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
+    storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void>;
+    removeUserProfiles(userIds: string[]): Promise<void>;
     destroy(): Promise<void>;
 }
 

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -614,10 +614,10 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         });
     }
 
-    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
+    public async storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void> {
         const txn = this.db!.transaction(["user_profile"], "readwrite");
         const store = txn.objectStore("user_profile");
-        for (const [userId, profile] of userProfileTuples) {
+        for (const [userId, profile] of userProfiles.entries()) {
             store.put({ profile, userId });
         }
         await txnAsPromise(txn);

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -51,10 +51,6 @@ const DB_MIGRATIONS: DbMigration[] = [
     (db): void => {
         db.createObjectStore("user_profile", { keyPath: ["userId"] });
     },
-    (db): void => {
-        db.deleteObjectStore("userProfile");
-        db.createObjectStore("user_profile", { keyPath: ["userId"] });
-    },
     // Expand as needed.
 ];
 const VERSION = DB_MIGRATIONS.length;

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -18,7 +18,7 @@ import { type IMinimalEvent, type ISyncData, type ISyncResponse, SyncAccumulator
 import { deepCopy, promiseTry } from "../utils.ts";
 import { exists as idbExists } from "../indexeddb-helpers.ts";
 import { logger } from "../logger.ts";
-import { type IStateEventWithRoomId, type IStoredClientOpts } from "../matrix.ts";
+import type { IUserUpdate, SyncUserProfile, IStateEventWithRoomId, IStoredClientOpts } from "../matrix.ts";
 import { type ISavedSync } from "./index.ts";
 import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
@@ -47,6 +47,13 @@ const DB_MIGRATIONS: DbMigration[] = [
     },
     (db): void => {
         db.createObjectStore("to_device_queue", { autoIncrement: true });
+    },
+    (db): void => {
+        db.createObjectStore("user_profile", { keyPath: ["userId"] });
+    },
+    (db): void => {
+        db.deleteObjectStore("userProfile");
+        db.createObjectStore("user_profile", { keyPath: ["userId"] });
     },
     // Expand as needed.
 ];
@@ -118,6 +125,8 @@ function reqAsPromise(req: IDBRequest): Promise<IDBRequest> {
 function reqAsCursorPromise<T>(req: IDBRequest<T>): Promise<T> {
     return reqAsEventPromise(req).then((event) => req.result);
 }
+
+type StoredSyncUserProfile = { userId: string; profile: SyncUserProfile };
 
 export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     public static exists(indexedDB: IDBFactory, dbName: string): Promise<boolean> {
@@ -215,19 +224,24 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
      * @returns Promise which resolves on success
      */
     private init(): Promise<unknown> {
-        return Promise.all([this.loadAccountData(), this.loadSyncData()]).then(([accountData, syncData]) => {
-            logger.log(`LocalIndexedDBStoreBackend: loaded initial data`);
-            this.syncAccumulator.accumulate(
-                {
-                    next_batch: syncData.nextBatch,
-                    rooms: syncData.roomsData,
-                    account_data: {
-                        events: accountData,
+        return Promise.all([this.loadAccountData(), this.loadUserProfiles(), this.loadSyncData()]).then(
+            ([accountData, userProfiles, syncData]) => {
+                logger.log(`LocalIndexedDBStoreBackend: loaded initial data`);
+                this.syncAccumulator.accumulate(
+                    {
+                        "next_batch": syncData.nextBatch,
+                        "rooms": syncData.roomsData,
+                        "account_data": {
+                            events: accountData,
+                        },
+                        "org.matrix.msc4429.users": Object.fromEntries(
+                            userProfiles.map((o) => [o.userId, { profile_updates: o.profile }]),
+                        ),
                     },
-                },
-                true,
-            );
-        });
+                    true,
+                );
+            },
+        );
     }
 
     /**
@@ -426,6 +440,7 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             await Promise.all([
                 this.persistUserPresenceEvents(userTuples),
                 this.persistAccountData(syncData.accountData),
+                this.persistUserProfiles(syncData.userProfiles ?? {}),
                 this.persistSyncData(syncData.nextBatch, syncData.roomsData),
             ]);
         } finally {
@@ -467,6 +482,29 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             const store = txn.objectStore("accountData");
             for (const event of accountData) {
                 store.put(event); // put == UPSERT
+            }
+            return txnAsPromise(txn).then();
+        });
+    }
+
+    /**
+     * Persist a list of user profiles. Events with the same 'type' will
+     * be replaced.
+     * @param accountData - An array of raw user-scoped account data events
+     * @returns Promise which resolves if the events were persisted.
+     */
+    private persistUserProfiles(profileUpdate: IUserUpdate): Promise<void> {
+        return promiseTry<void>(() => {
+            const txn = this.db!.transaction(["user_profile"], "readwrite");
+            const store = txn.objectStore("user_profile");
+            for (const [userId, profile] of Object.entries(profileUpdate)) {
+                if (Object.keys(profile).length === 0) {
+                    store.delete(userId);
+                } else {
+                    // Merge
+                    const existingProfile = store.get(userId).result;
+                    store.put({ userId, profile: { ...existingProfile, ...profile } } satisfies StoredSyncUserProfile);
+                }
             }
             return txnAsPromise(txn).then();
         });
@@ -523,6 +561,24 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
                 return cursor.value;
             }).then((result: IMinimalEvent[]) => {
                 logger.log(`LocalIndexedDBStoreBackend: loaded account data`);
+                return result;
+            });
+        });
+    }
+
+    /**
+     * Load all the account data events from the database. This is not cached.
+     * @returns A list of raw global account events.
+     */
+    private loadUserProfiles(): Promise<StoredSyncUserProfile[]> {
+        logger.log(`LocalIndexedDBStoreBackend: loading synced user profiles...`);
+        return promiseTry<StoredSyncUserProfile[]>(() => {
+            const txn = this.db!.transaction(["user_profile"], "readonly");
+            const store = txn.objectStore("user_profile");
+            return selectQuery(store, undefined, (cursor) => {
+                return cursor.value;
+            }).then((result: StoredSyncUserProfile[]) => {
+                logger.log(`LocalIndexedDBStoreBackend: loading synced user profiles`);
                 return result;
             });
         });

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -18,7 +18,7 @@ import { type IMinimalEvent, type ISyncData, type ISyncResponse, SyncAccumulator
 import { deepCopy, promiseTry } from "../utils.ts";
 import { exists as idbExists } from "../indexeddb-helpers.ts";
 import { logger } from "../logger.ts";
-import type { IUserUpdate, SyncUserProfile, IStateEventWithRoomId, IStoredClientOpts } from "../matrix.ts";
+import type { SyncUserProfile, IStateEventWithRoomId, IStoredClientOpts } from "../matrix.ts";
 import { type ISavedSync } from "./index.ts";
 import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
@@ -122,8 +122,6 @@ function reqAsCursorPromise<T>(req: IDBRequest<T>): Promise<T> {
     return reqAsEventPromise(req).then((event) => req.result);
 }
 
-type StoredSyncUserProfile = { userId: string; profile: SyncUserProfile };
-
 export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
     public static exists(indexedDB: IDBFactory, dbName: string): Promise<boolean> {
         dbName = "matrix-js-sdk:" + (dbName || "default");
@@ -220,24 +218,19 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
      * @returns Promise which resolves on success
      */
     private init(): Promise<unknown> {
-        return Promise.all([this.loadAccountData(), this.loadUserProfiles(), this.loadSyncData()]).then(
-            ([accountData, userProfiles, syncData]) => {
-                logger.log(`LocalIndexedDBStoreBackend: loaded initial data`);
-                this.syncAccumulator.accumulate(
-                    {
-                        "next_batch": syncData.nextBatch,
-                        "rooms": syncData.roomsData,
-                        "account_data": {
-                            events: accountData,
-                        },
-                        "org.matrix.msc4429.users": Object.fromEntries(
-                            userProfiles.map((o) => [o.userId, { profile_updates: o.profile }]),
-                        ),
+        return Promise.all([this.loadAccountData(), this.loadSyncData()]).then(([accountData, syncData]) => {
+            logger.log(`LocalIndexedDBStoreBackend: loaded initial data`);
+            this.syncAccumulator.accumulate(
+                {
+                    next_batch: syncData.nextBatch,
+                    rooms: syncData.roomsData,
+                    account_data: {
+                        events: accountData,
                     },
-                    true,
-                );
-            },
-        );
+                },
+                true,
+            );
+        });
     }
 
     /**
@@ -436,7 +429,6 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             await Promise.all([
                 this.persistUserPresenceEvents(userTuples),
                 this.persistAccountData(syncData.accountData),
-                this.persistUserProfiles(syncData.userProfiles ?? {}),
                 this.persistSyncData(syncData.nextBatch, syncData.roomsData),
             ]);
         } finally {
@@ -478,29 +470,6 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
             const store = txn.objectStore("accountData");
             for (const event of accountData) {
                 store.put(event); // put == UPSERT
-            }
-            return txnAsPromise(txn).then();
-        });
-    }
-
-    /**
-     * Persist a list of user profiles. Events with the same 'type' will
-     * be replaced.
-     * @param accountData - An array of raw user-scoped account data events
-     * @returns Promise which resolves if the events were persisted.
-     */
-    private persistUserProfiles(profileUpdate: IUserUpdate): Promise<void> {
-        return promiseTry<void>(() => {
-            const txn = this.db!.transaction(["user_profile"], "readwrite");
-            const store = txn.objectStore("user_profile");
-            for (const [userId, profile] of Object.entries(profileUpdate)) {
-                if (Object.keys(profile).length === 0) {
-                    store.delete(userId);
-                } else {
-                    // Merge
-                    const existingProfile = store.get(userId).result;
-                    store.put({ userId, profile: { ...existingProfile, ...profile } } satisfies StoredSyncUserProfile);
-                }
             }
             return txnAsPromise(txn).then();
         });
@@ -557,24 +526,6 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
                 return cursor.value;
             }).then((result: IMinimalEvent[]) => {
                 logger.log(`LocalIndexedDBStoreBackend: loaded account data`);
-                return result;
-            });
-        });
-    }
-
-    /**
-     * Load all the account data events from the database. This is not cached.
-     * @returns A list of raw global account events.
-     */
-    private loadUserProfiles(): Promise<StoredSyncUserProfile[]> {
-        logger.log(`LocalIndexedDBStoreBackend: loading synced user profiles...`);
-        return promiseTry<StoredSyncUserProfile[]>(() => {
-            const txn = this.db!.transaction(["user_profile"], "readonly");
-            const store = txn.objectStore("user_profile");
-            return selectQuery(store, undefined, (cursor) => {
-                return cursor.value;
-            }).then((result: StoredSyncUserProfile[]) => {
-                logger.log(`LocalIndexedDBStoreBackend: loading synced user profiles`);
                 return result;
             });
         });
@@ -650,6 +601,34 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         const txn = this.db!.transaction(["to_device_queue"], "readwrite");
         const store = txn.objectStore("to_device_queue");
         store.delete(id);
+        await txnAsPromise(txn);
+    }
+
+    public async getUserProfile(userId: string): Promise<SyncUserProfile | undefined> {
+        return Promise.resolve().then(() => {
+            const txn = this.db!.transaction(["user_profile"], "readonly");
+            const store = txn.objectStore("user_profile");
+            return selectQuery(store, userId, (cursor) => {
+                return cursor.value?.profile;
+            }).then((results) => results[0]);
+        });
+    }
+
+    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
+        const txn = this.db!.transaction(["user_profile"], "readwrite");
+        const store = txn.objectStore("user_profile");
+        for (const [userId, profile] of userProfileTuples) {
+            store.put({ profile, userId });
+        }
+        await txnAsPromise(txn);
+    }
+
+    public async removeUserProfiles(userIds: string[]): Promise<void> {
+        const txn = this.db!.transaction(["user_profile"], "readwrite");
+        const store = txn.objectStore("user_profile");
+        for (const userId of userIds) {
+            store.delete(userId);
+        }
         await txnAsPromise(txn);
     }
 

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -608,7 +608,7 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         return Promise.resolve().then(() => {
             const txn = this.db!.transaction(["user_profile"], "readonly");
             const store = txn.objectStore("user_profile");
-            return selectQuery(store, userId, (cursor) => {
+            return selectQuery(store, [userId], (cursor) => {
                 return cursor.value?.profile;
             }).then((results) => results[0]);
         });
@@ -627,7 +627,7 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         const txn = this.db!.transaction(["user_profile"], "readwrite");
         const store = txn.objectStore("user_profile");
         for (const userId of userIds) {
-            store.delete(userId);
+            store.delete([userId]);
         }
         await txnAsPromise(txn);
     }

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -20,6 +20,7 @@ import { type IStoredClientOpts } from "../client.ts";
 import { type IStateEventWithRoomId, type ISyncResponse } from "../matrix.ts";
 import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
+import { type SyncUserProfile } from "../models/user.ts";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     private worker?: Worker;
@@ -143,6 +144,18 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
 
     public async removeToDeviceBatch(id: number): Promise<void> {
         return this.doCmd("removeToDeviceBatch", [id]);
+    }
+
+    public async getUserProfile(userId: string): Promise<SyncUserProfile | undefined> {
+        return this.doCmd("getUserProfile", [userId]);
+    }
+
+    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
+        await this.doCmd("storeUserProfiles", [userProfileTuples]);
+    }
+
+    public async removeUserProfiles(userIds: string[]): Promise<void> {
+        await this.doCmd("removeUserProfile", [userIds]);
     }
 
     private ensureStarted(): Promise<void> {

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -155,7 +155,7 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     }
 
     public async removeUserProfiles(userIds: string[]): Promise<void> {
-        await this.doCmd("removeUserProfile", [userIds]);
+        await this.doCmd("removeUserProfiles", [userIds]);
     }
 
     private ensureStarted(): Promise<void> {

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -150,8 +150,8 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
         return this.doCmd("getUserProfile", [userId]);
     }
 
-    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
-        await this.doCmd("storeUserProfiles", [userProfileTuples]);
+    public async storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void> {
+        await this.doCmd("storeUserProfiles", [userProfiles]);
     }
 
     public async removeUserProfiles(userIds: string[]): Promise<void> {

--- a/src/store/indexeddb-store-worker.ts
+++ b/src/store/indexeddb-store-worker.ts
@@ -120,6 +120,15 @@ export class IndexedDBStoreWorker {
             case "removeToDeviceBatch":
                 prom = this.backend?.removeToDeviceBatch(msg.args[0]);
                 break;
+            case "getUserProfile":
+                prom = this.backend?.getUserProfile(msg.args[0]);
+                break;
+            case "storeUserProfiles":
+                prom = this.backend?.storeUserProfiles(msg.args[0]);
+                break;
+            case "removeUserProfiles":
+                prom = this.backend?.removeUserProfiles(msg.args[0]);
+                break;
         }
 
         if (prom === undefined) {

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -390,8 +390,8 @@ export class IndexedDBStore extends MemoryStore {
         return this.backend.getUserProfile(userId);
     }
 
-    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
-        return this.backend.storeUserProfiles(userProfileTuples);
+    public async storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void> {
+        return this.backend.storeUserProfiles(userProfiles);
     }
 
     public async removeUserProfiles(userIds: string[]): Promise<void> {

--- a/src/store/indexeddb.ts
+++ b/src/store/indexeddb.ts
@@ -28,6 +28,7 @@ import { type EventEmitterEvents, TypedEventEmitter } from "../models/typed-even
 import { type IStateEventWithRoomId } from "../@types/search.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
 import { type IStoredClientOpts } from "../client.ts";
+import { type SyncUserProfile } from "../models/user.ts";
 
 /**
  * This is an internal module. See {@link IndexedDBStore} for the public class.
@@ -383,6 +384,18 @@ export class IndexedDBStore extends MemoryStore {
 
     public removeToDeviceBatch(id: number): Promise<void> {
         return this.backend.removeToDeviceBatch(id);
+    }
+
+    public async getUserProfile(userId: string): Promise<SyncUserProfile | undefined> {
+        return this.backend.getUserProfile(userId);
+    }
+
+    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
+        return this.backend.storeUserProfiles(userProfileTuples);
+    }
+
+    public async removeUserProfiles(userIds: string[]): Promise<void> {
+        return this.backend.removeUserProfiles(userIds);
     }
 }
 

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { SyncUserProfile, type User } from "../models/user.ts";
+import { type SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
 import { type RoomMember } from "../models/room-member.ts";

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -443,16 +443,16 @@ export class MemoryStore implements IStore {
         return Promise.resolve();
     }
 
-    public getUserProfile(userId: string): SyncUserProfile | undefined {
+    public async getUserProfile(userId: string): Promise<SyncUserProfile | undefined> {
         return this.userProfiles.get(userId);
     }
 
-    public storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void {
-        this.userProfiles.set(userId, fullUserProfile);
+    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
+        userProfileTuples.forEach(([userId, profile]) => this.userProfiles.set(userId, profile));
     }
 
-    public removeUserProfile(userId: string): void {
-        this.userProfiles.delete(userId);
+    public async removeUserProfiles(userIds: string[]): Promise<void> {
+        userIds.forEach((userId) => this.userProfiles.delete(userId));
     }
 
     public async destroy(): Promise<void> {

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { type User } from "../models/user.ts";
+import { SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type RoomState, RoomStateEvent } from "../models/room-state.ts";
 import { type RoomMember } from "../models/room-member.ts";
@@ -65,6 +65,7 @@ export class MemoryStore implements IStore {
     private pendingToDeviceBatches: IndexedToDeviceBatch[] = [];
     private nextToDeviceBatchId = 0;
     protected createUser?: UserCreator;
+    public readonly userProfiles = new Map<string, SyncUserProfile>();
 
     /**
      * Construct a new in-memory data store for the Matrix Client.
@@ -440,6 +441,18 @@ export class MemoryStore implements IStore {
     public removeToDeviceBatch(id: number): Promise<void> {
         this.pendingToDeviceBatches = this.pendingToDeviceBatches.filter((batch) => batch.id !== id);
         return Promise.resolve();
+    }
+
+    public getUserProfile(userId: string): SyncUserProfile | undefined {
+        return this.userProfiles.get(userId);
+    }
+
+    public storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void {
+        this.userProfiles.set(userId, fullUserProfile);
+    }
+
+    public removeUserProfile(userId: string): void {
+        this.userProfiles.delete(userId);
     }
 
     public async destroy(): Promise<void> {

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -447,8 +447,8 @@ export class MemoryStore implements IStore {
         return this.userProfiles.get(userId);
     }
 
-    public async storeUserProfiles(userProfileTuples: Array<[string, SyncUserProfile]>): Promise<void> {
-        userProfileTuples.forEach(([userId, profile]) => this.userProfiles.set(userId, profile));
+    public async storeUserProfiles(userProfiles: Map<string, SyncUserProfile>): Promise<void> {
+        userProfiles.forEach((profile, userId) => this.userProfiles.set(userId, profile));
     }
 
     public async removeUserProfiles(userIds: string[]): Promise<void> {

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { SyncUserProfile, type User } from "../models/user.ts";
+import { type SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type Filter } from "../filter.ts";
 import { type ISavedSync, type IStore, type UserCreator } from "./index.ts";

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { type User } from "../models/user.ts";
+import { SyncUserProfile, type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type Filter } from "../filter.ts";
 import { type ISavedSync, type IStore, type UserCreator } from "./index.ts";
@@ -272,6 +272,18 @@ export class StubStore implements IStore {
 
     public async removeToDeviceBatch(id: number): Promise<void> {
         return Promise.resolve();
+    }
+
+    public getUserProfile(userId: string): undefined {
+        return undefined;
+    }
+
+    public storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void {
+        return;
+    }
+
+    public removeUserProfile(userId: string): void {
+        return;
     }
 
     public async destroy(): Promise<void> {

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { type EventType } from "../@types/event.ts";
 import { type Room } from "../models/room.ts";
-import { type SyncUserProfile, type User } from "../models/user.ts";
+import { type User } from "../models/user.ts";
 import { type IEvent, type MatrixEvent } from "../models/event.ts";
 import { type Filter } from "../filter.ts";
 import { type ISavedSync, type IStore, type UserCreator } from "./index.ts";
@@ -274,15 +274,15 @@ export class StubStore implements IStore {
         return Promise.resolve();
     }
 
-    public getUserProfile(userId: string): undefined {
+    public async getUserProfile(): Promise<undefined> {
         return undefined;
     }
 
-    public storeUserProfile(userId: string, fullUserProfile: SyncUserProfile): void {
+    public async storeUserProfiles(): Promise<void> {
         return;
     }
 
-    public removeUserProfile(userId: string): void {
+    public async removeUserProfiles(): Promise<void> {
         return;
     }
 

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -26,6 +26,10 @@ import { type EventType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { ReceiptAccumulator } from "./receipt-accumulator.ts";
 import { type OlmEncryptionInfo } from "./crypto-api/index.ts";
+import { NamespacedValue } from "./NamespacedValue.ts";
+import { SyncUserProfile } from "./matrix.ts";
+
+const profileFieldsFilterName = new NamespacedValue("users", "org.matrix.msc4429.users");
 
 interface IOpts {
     /**
@@ -36,6 +40,10 @@ interface IOpts {
      * Default: 50.
      */
     maxTimelineEntries?: number;
+    /**
+     * Whether to use the stable or unstable fields for user profiles.
+     */
+    profileFieldsStable?: boolean;
 }
 
 export interface IMinimalEvent {
@@ -183,6 +191,12 @@ export interface IDeviceLists {
     left?: string[];
 }
 
+export interface IUserUpdate {
+    [userId: string]: {
+        profile_updates?: Record<string, unknown>;
+    };
+}
+
 export interface ISyncResponse {
     "next_batch": string;
     "rooms": IRooms;
@@ -191,7 +205,8 @@ export interface ISyncResponse {
     "to_device"?: IToDevice;
     "device_lists"?: IDeviceLists;
     "device_one_time_keys_count"?: Record<string, number>;
-
+    "users"?: IUserUpdate;
+    "org.matrix.msc4429.users"?: IUserUpdate;
     "device_unused_fallback_key_types"?: string[];
     "org.matrix.msc2732.device_unused_fallback_key_types"?: string[];
 }
@@ -229,6 +244,7 @@ export interface ISyncData {
     nextBatch: string;
     accountData: IMinimalEvent[];
     roomsData: IRooms;
+    userProfiles?: IUserUpdate;
 }
 
 type TaggedEvent = IRoomEvent & { _localTs?: number };
@@ -249,6 +265,7 @@ function isTaggedEvent(event: IRoomEvent): event is TaggedEvent {
  */
 export class SyncAccumulator {
     private accountData: Record<string, IMinimalEvent> = {}; // $event_type: Object
+    private userProfiles: Record<string, SyncUserProfile> = {}; // userId: Object
     private inviteRooms: Record<string, IInvitedRoom> = {}; // $roomId: { ... sync 'invite' json data ... }
     private knockRooms: Record<string, IKnockedRoom> = {}; // $roomId: { ... sync 'knock' json data ... }
     private joinRooms: { [roomId: string]: IRoom } = {};
@@ -265,6 +282,7 @@ export class SyncAccumulator {
     public accumulate(syncResponse: ISyncResponse, fromDatabase = false): void {
         this.accumulateRooms(syncResponse, fromDatabase);
         this.accumulateAccountData(syncResponse);
+        this.accumulateProfileInfo(syncResponse);
         this.nextBatch = syncResponse.next_batch;
     }
 
@@ -275,6 +293,29 @@ export class SyncAccumulator {
         // Clobbers based on event type.
         syncResponse.account_data.events.forEach((e) => {
             this.accountData[e.type] = e;
+        });
+    }
+
+    private accumulateProfileInfo(syncResponse: ISyncResponse): void {
+        let data: IUserUpdate;
+        if (this.opts.profileFieldsStable && syncResponse[profileFieldsFilterName.name]) {
+            data = syncResponse.users ?? {};
+        } else if (this.opts.profileFieldsStable === false && syncResponse[profileFieldsFilterName.unstable!]) {
+            data = syncResponse["org.matrix.msc4429.users"] ?? {};
+        } else {
+            return;
+        }
+        // Clobbers based on event type.
+        Object.entries(data).forEach(([userId, userData]) => {
+            if (!userData.profile_updates) {
+                return;
+            }
+            if (Object.keys(userData.profile_updates).length === 0) {
+                // Keep the object size down.
+                delete this.userProfiles[userId];
+            } else {
+                this.userProfiles[userId] = { ...this.userProfiles[userId], ...userData.profile_updates };
+            }
         });
     }
 
@@ -760,6 +801,9 @@ export class SyncAccumulator {
             nextBatch: this.nextBatch!,
             roomsData: data,
             accountData: accData,
+            userProfiles: Object.fromEntries(
+                Object.entries(this.userProfiles).map(([userId, profile]) => [userId, { profile_updates: profile }]),
+            ),
         };
     }
 

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -27,7 +27,7 @@ import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { ReceiptAccumulator } from "./receipt-accumulator.ts";
 import { type OlmEncryptionInfo } from "./crypto-api/index.ts";
 import { NamespacedValue } from "./NamespacedValue.ts";
-import { SyncUserProfile } from "./matrix.ts";
+import { type SyncUserProfile } from "./matrix.ts";
 
 const profileFieldsFilterName = new NamespacedValue("users", "org.matrix.msc4429.users");
 

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -187,7 +187,10 @@ export interface IDeviceLists {
     left?: string[];
 }
 
-export interface IUserUpdate {
+/**
+ * The "users" section of the sync update which contains extended profile updates.
+ */
+export interface UsersUpdate {
     [userId: string]: {
         profile_updates?: Record<string, unknown> | null;
     };
@@ -201,8 +204,8 @@ export interface ISyncResponse {
     "to_device"?: IToDevice;
     "device_lists"?: IDeviceLists;
     "device_one_time_keys_count"?: Record<string, number>;
-    "users"?: IUserUpdate;
-    "org.matrix.msc4429.users"?: IUserUpdate;
+    "users"?: UsersUpdate;
+    "org.matrix.msc4429.users"?: UsersUpdate;
     "device_unused_fallback_key_types"?: string[];
     "org.matrix.msc2732.device_unused_fallback_key_types"?: string[];
 }

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -260,7 +260,6 @@ function isTaggedEvent(event: IRoomEvent): event is TaggedEvent {
  */
 export class SyncAccumulator {
     private accountData: Record<string, IMinimalEvent> = {}; // $event_type: Object
-
     private inviteRooms: Record<string, IInvitedRoom> = {}; // $roomId: { ... sync 'invite' json data ... }
     private knockRooms: Record<string, IKnockedRoom> = {}; // $roomId: { ... sync 'knock' json data ... }
     private joinRooms: { [roomId: string]: IRoom } = {};

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -26,10 +26,6 @@ import { type EventType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { ReceiptAccumulator } from "./receipt-accumulator.ts";
 import { type OlmEncryptionInfo } from "./crypto-api/index.ts";
-import { NamespacedValue } from "./NamespacedValue.ts";
-import { type SyncUserProfile } from "./matrix.ts";
-
-const profileFieldsFilterName = new NamespacedValue("users", "org.matrix.msc4429.users");
 
 interface IOpts {
     /**
@@ -193,7 +189,7 @@ export interface IDeviceLists {
 
 export interface IUserUpdate {
     [userId: string]: {
-        profile_updates?: Record<string, unknown>;
+        profile_updates?: Record<string, unknown> | null;
     };
 }
 
@@ -244,7 +240,6 @@ export interface ISyncData {
     nextBatch: string;
     accountData: IMinimalEvent[];
     roomsData: IRooms;
-    userProfiles?: IUserUpdate;
 }
 
 type TaggedEvent = IRoomEvent & { _localTs?: number };
@@ -265,7 +260,7 @@ function isTaggedEvent(event: IRoomEvent): event is TaggedEvent {
  */
 export class SyncAccumulator {
     private accountData: Record<string, IMinimalEvent> = {}; // $event_type: Object
-    private userProfiles: Record<string, SyncUserProfile> = {}; // userId: Object
+
     private inviteRooms: Record<string, IInvitedRoom> = {}; // $roomId: { ... sync 'invite' json data ... }
     private knockRooms: Record<string, IKnockedRoom> = {}; // $roomId: { ... sync 'knock' json data ... }
     private joinRooms: { [roomId: string]: IRoom } = {};
@@ -282,7 +277,6 @@ export class SyncAccumulator {
     public accumulate(syncResponse: ISyncResponse, fromDatabase = false): void {
         this.accumulateRooms(syncResponse, fromDatabase);
         this.accumulateAccountData(syncResponse);
-        this.accumulateProfileInfo(syncResponse);
         this.nextBatch = syncResponse.next_batch;
     }
 
@@ -293,29 +287,6 @@ export class SyncAccumulator {
         // Clobbers based on event type.
         syncResponse.account_data.events.forEach((e) => {
             this.accountData[e.type] = e;
-        });
-    }
-
-    private accumulateProfileInfo(syncResponse: ISyncResponse): void {
-        let data: IUserUpdate;
-        if (this.opts.profileFieldsStable && syncResponse[profileFieldsFilterName.name]) {
-            data = syncResponse.users ?? {};
-        } else if (this.opts.profileFieldsStable === false && syncResponse[profileFieldsFilterName.unstable!]) {
-            data = syncResponse["org.matrix.msc4429.users"] ?? {};
-        } else {
-            return;
-        }
-        // Clobbers based on event type.
-        Object.entries(data).forEach(([userId, userData]) => {
-            if (!userData.profile_updates) {
-                return;
-            }
-            if (Object.keys(userData.profile_updates).length === 0) {
-                // Keep the object size down.
-                delete this.userProfiles[userId];
-            } else {
-                this.userProfiles[userId] = { ...this.userProfiles[userId], ...userData.profile_updates };
-            }
         });
     }
 
@@ -801,9 +772,6 @@ export class SyncAccumulator {
             nextBatch: this.nextBatch!,
             roomsData: data,
             accountData: accData,
-            userProfiles: Object.fromEntries(
-                Object.entries(this.userProfiles).map(([userId, profile]) => [userId, { profile_updates: profile }]),
-            ),
         };
     }
 

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -26,6 +26,7 @@ import { type EventType } from "./@types/event.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { ReceiptAccumulator } from "./receipt-accumulator.ts";
 import { type OlmEncryptionInfo } from "./crypto-api/index.ts";
+import { type SyncUserProfile } from "./matrix.ts";
 
 interface IOpts {
     /**
@@ -192,7 +193,7 @@ export interface IDeviceLists {
  */
 export interface UsersUpdate {
     [userId: string]: {
-        profile_updates?: Record<string, unknown> | null;
+        profile_updates?: SyncUserProfile | null;
     };
 }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -634,6 +634,17 @@ export class SyncApi {
             }
             this.opts.filter.setLazyLoadMembers(true);
         }
+        // I feel like this is the wrong home for this.
+        if (this.opts.unstableMSC4429SyncUserProfileFields?.length) {
+            this.syncOpts.logger.debug("Enabling EXPERIMENTAL user profiles on sync filter...");
+            if (!this.opts.filter) {
+                this.opts.filter = this.buildDefaultFilter();
+            }
+            this.opts.filter.setUnstableMSC4429SyncUserProfiles(
+                this.opts.unstableMSC4429SyncUserProfileFields,
+                await this.client.doesServerSupportUnstableFeature("org.matrix.msc4429.stable"),
+            );
+        }
     };
 
     private storeClientOptions = async (): Promise<void> => {
@@ -1136,6 +1147,17 @@ export class SyncApi {
                 client.emit(ClientEvent.AccountData, accountDataEvent, prevEvent);
                 return accountDataEvent;
             });
+        }
+
+        const userUpdate = data["users"] ?? data["org.matrix.msc4429.users"];
+        if (typeof userUpdate === "object" && userUpdate !== null) {
+            for (const [userId, userData] of Object.entries(userUpdate)) {
+                if (userData.profile_updates) {
+                    client.emit(ClientEvent.UserProfileUpdate, userId, userData.profile_updates);
+                    const existingProfile = client.store.getUserProfile(userId);
+                    client.store.storeUserProfile(userId, { ...existingProfile, ...userData.profile_updates });
+                }
+            }
         }
 
         // handle to-device events

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -24,7 +24,7 @@ limitations under the License.
  */
 
 import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.ts";
-import { SyncUserProfile, User } from "./models/user.ts";
+import { type SyncUserProfile, User } from "./models/user.ts";
 import { NotificationCountType, Room, RoomEvent } from "./models/room.ts";
 import { deepCopy, noUnsafeEventProps, unsafeProp } from "./utils.ts";
 import { Filter } from "./filter.ts";

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -24,12 +24,12 @@ limitations under the License.
  */
 
 import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.ts";
-import { User } from "./models/user.ts";
+import { SyncUserProfile, User } from "./models/user.ts";
 import { NotificationCountType, Room, RoomEvent } from "./models/room.ts";
 import { deepCopy, noUnsafeEventProps, unsafeProp } from "./utils.ts";
 import { Filter } from "./filter.ts";
 import { EventTimeline } from "./models/event-timeline.ts";
-import { type Logger } from "./logger.ts";
+import { logger, type Logger } from "./logger.ts";
 import {
     ClientEvent,
     type IStoredClientOpts,
@@ -1151,12 +1151,23 @@ export class SyncApi {
 
         const userUpdate = data["users"] ?? data["org.matrix.msc4429.users"];
         if (typeof userUpdate === "object" && userUpdate !== null) {
+            const usersToRemove = [];
+            const profilesToAmend: Array<[string, SyncUserProfile]> = [];
             for (const [userId, userData] of Object.entries(userUpdate)) {
+                logger.info(`Storing user profile ${userId}`, userData);
                 if (userData.profile_updates) {
                     client.emit(ClientEvent.UserProfileUpdate, userId, userData.profile_updates);
                     const existingProfile = client.store.getUserProfile(userId);
-                    client.store.storeUserProfile(userId, { ...existingProfile, ...userData.profile_updates });
+                    profilesToAmend.push([userId, { ...existingProfile, ...userData.profile_updates }]);
+                } else if (userData.profile_updates === null) {
+                    usersToRemove.push(userId);
                 }
+            }
+            if (usersToRemove.length) {
+                await client.store.removeUserProfiles(usersToRemove);
+            }
+            if (profilesToAmend) {
+                await client.store.storeUserProfiles(profilesToAmend);
             }
         }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1168,7 +1168,7 @@ export class SyncApi {
                 logger.info(`Storing user profile ${userId}`, userData);
                 if (userData.profile_updates) {
                     client.emit(ClientEvent.UserProfileUpdate, userId, userData.profile_updates);
-                    const existingProfile = client.store.getUserProfile(userId);
+                    const existingProfile = await client.store.getUserProfile(userId);
                     profilesToAmend.push([userId, { ...existingProfile, ...userData.profile_updates }]);
                 } else if (userData.profile_updates === null) {
                     usersToRemove.push(userId);
@@ -1177,7 +1177,7 @@ export class SyncApi {
             if (usersToRemove.length) {
                 await client.store.removeUserProfiles(usersToRemove);
             }
-            if (profilesToAmend) {
+            if (profilesToAmend.length) {
                 await client.store.storeUserProfiles(profilesToAmend);
             }
         }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -622,7 +622,11 @@ export class SyncApi {
         return filter;
     };
 
-    private prepareLazyLoadingForSync = async (): Promise<void> => {
+    /**
+     * Sets up the sync filter options for lazy loading if enabled,
+     * (or force-disables lazy loading entirely if we're a guest).
+     */
+    private prepareSyncFilterLazyLoading = (): void => {
         this.syncOpts.logger.debug("Prepare lazy loading for sync...");
         if (this.client.isGuest()) {
             this.opts.lazyLoadMembers = false;
@@ -634,7 +638,12 @@ export class SyncApi {
             }
             this.opts.filter.setLazyLoadMembers(true);
         }
-        // I feel like this is the wrong home for this.
+    };
+
+    /**
+     * Preare sync filter options for the unstable MSC4429 user profile fields if enabled.
+     */
+    private prepareSyncFilterUserProfiles = async (): Promise<void> => {
         if (this.opts.unstableMSC4429SyncUserProfileFields?.length) {
             this.syncOpts.logger.debug("Enabling EXPERIMENTAL user profiles on sync filter...");
             if (!this.opts.filter) {
@@ -734,7 +743,8 @@ export class SyncApi {
         // take a while so if we set it going now, we can wait for it
         // to finish while we process our saved sync data.
         await this.getPushRules();
-        await this.prepareLazyLoadingForSync();
+        this.prepareSyncFilterLazyLoading();
+        await this.prepareSyncFilterUserProfiles();
         await this.storeClientOptions();
 
         const { filterId, filter } = await this.getFilter();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1159,6 +1159,7 @@ export class SyncApi {
             });
         }
 
+        // handle user profile updates (MSC4429)
         const userUpdate = data["users"] ?? data["org.matrix.msc4429.users"];
         if (typeof userUpdate === "object" && userUpdate !== null) {
             const usersToRemove = [];

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1162,7 +1162,7 @@ export class SyncApi {
         // handle user profile updates (MSC4429)
         const userUpdate = data["users"] ?? data["org.matrix.msc4429.users"];
         if (typeof userUpdate === "object" && userUpdate !== null) {
-            const usersToRemove = [];
+            const usersToRemove: string[] = [];
             const profilesToAmend: Array<[string, SyncUserProfile]> = [];
             for (const [userId, userData] of Object.entries(userUpdate)) {
                 logger.info(`Storing user profile ${userId}`, userData);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1163,13 +1163,13 @@ export class SyncApi {
         const userUpdate = data["users"] ?? data["org.matrix.msc4429.users"];
         if (typeof userUpdate === "object" && userUpdate !== null) {
             const usersToRemove: string[] = [];
-            const profilesToAmend: Array<[string, SyncUserProfile]> = [];
+            const profilesToAmend: Map<string, SyncUserProfile> = new Map();
             for (const [userId, userData] of Object.entries(userUpdate)) {
                 logger.info(`Storing user profile ${userId}`, userData);
                 if (userData.profile_updates) {
                     client.emit(ClientEvent.UserProfileUpdate, userId, userData.profile_updates);
                     const existingProfile = await client.store.getUserProfile(userId);
-                    profilesToAmend.push([userId, { ...existingProfile, ...userData.profile_updates }]);
+                    profilesToAmend.set(userId, { ...existingProfile, ...userData.profile_updates });
                 } else if (userData.profile_updates === null) {
                     usersToRemove.push(userId);
                 }
@@ -1177,7 +1177,7 @@ export class SyncApi {
             if (usersToRemove.length) {
                 await client.store.removeUserProfiles(usersToRemove);
             }
-            if (profilesToAmend.length) {
+            if (profilesToAmend.size) {
                 await client.store.storeUserProfiles(profilesToAmend);
             }
         }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/pull/4429

This implements half functional support for profile updates over legacy sync. <del>It does not yet fully support storing them over sessions, but does handle updates.</del>

Now stores updates in indexeddb with write-through caching on the get API so they'll eventually all be stored in the database even if you turn the feature flag on after your initial sync.

Closes https://github.com/element-hq/wat-internal/issues/464

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
