### PR TITLE
Expose `UserVerificationStatus.known` flag

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -2064,6 +2064,7 @@ describe("crypto", () => {
             expect(hasCrossSigningKeysForUser).toBe(true);
 
             const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(BOB_TEST_USER_ID);
+            expect(verificationStatus.known).toBe(false); // We haven't actually stashed a copy of Alice's identity
             expect(verificationStatus.isVerified()).toBe(false);
             expect(verificationStatus.isCrossSigningVerified()).toBe(false);
             expect(verificationStatus.wasCrossSigningVerified()).toBe(false);
@@ -2078,7 +2079,8 @@ describe("crypto", () => {
             const hasCrossSigningKeysForUser = await aliceClient.getCrypto()!.userHasCrossSigningKeys(TEST_USER_ID);
             expect(hasCrossSigningKeysForUser).toBe(true);
 
-            const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(BOB_TEST_USER_ID);
+            const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(TEST_USER_ID);
+            expect(verificationStatus.known).toBe(true);
             expect(verificationStatus.isVerified()).toBe(false);
             expect(verificationStatus.isCrossSigningVerified()).toBe(false);
             expect(verificationStatus.wasCrossSigningVerified()).toBe(false);
@@ -2089,7 +2091,8 @@ describe("crypto", () => {
             const hasCrossSigningKeysForUser = await aliceClient.getCrypto()!.userHasCrossSigningKeys("@unknown:xyz");
             expect(hasCrossSigningKeysForUser).toBe(false);
 
-            const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(BOB_TEST_USER_ID);
+            const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus("@unknown:xyz");
+            expect(verificationStatus.known).toBe(false);
             expect(verificationStatus.isVerified()).toBe(false);
             expect(verificationStatus.isCrossSigningVerified()).toBe(false);
             expect(verificationStatus.wasCrossSigningVerified()).toBe(false);
@@ -2119,6 +2122,7 @@ describe("crypto", () => {
 
             {
                 const verificationStatus = await aliceClient.getCrypto()!.getUserVerificationStatus(BOB_TEST_USER_ID);
+                expect(verificationStatus.known).toBe(true);
                 expect(verificationStatus.isVerified()).toBe(false);
                 expect(verificationStatus.isCrossSigningVerified()).toBe(false);
                 expect(verificationStatus.wasCrossSigningVerified()).toBe(false);

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1526,6 +1526,7 @@ describe("RustCrypto", () => {
 
         it("returns an unverified UserVerificationStatus when there is no UserIdentity", async () => {
             const userVerificationStatus = await rustCrypto.getUserVerificationStatus(testData.TEST_USER_ID);
+            expect(userVerificationStatus.known).toBe(false);
             expect(userVerificationStatus.isVerified()).toBeFalsy();
             expect(userVerificationStatus.isTofu()).toBeFalsy();
             expect(userVerificationStatus.isCrossSigningVerified()).toBeFalsy();
@@ -1540,6 +1541,7 @@ describe("RustCrypto", () => {
             } as unknown as OtherUserIdentity);
 
             const userVerificationStatus = await rustCrypto.getUserVerificationStatus(testData.TEST_USER_ID);
+            expect(userVerificationStatus.known).toBe(true);
             expect(userVerificationStatus.isVerified()).toBeTruthy();
             expect(userVerificationStatus.isTofu()).toBeFalsy();
             expect(userVerificationStatus.isCrossSigningVerified()).toBeTruthy();

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -858,6 +858,25 @@ export interface BootstrapCrossSigningOpts {
  */
 export class UserVerificationStatus {
     /**
+     * Indicates if we have saved a known identity for this user. Typically, this means that we share a
+     * room with them (or have done in the past).
+     *
+     * If this is `false`, then the other flags ({@link isCrossSigningVerified}, {@link wasCrossSigningVerified},
+     * {@link needsUserApproval}) will also be `false`. This means that we haven't seen this user before.
+     *
+     * If this is `true`, then there are further possibilities:
+     *
+     *  - If {@link isCrossSigningVerified} returns `true`, then we have cryptographically verified the current
+     *    identity of this user: that is the highest form of trust we have.
+     *
+     *  - If {@link needsUserApproval} is `true`, that means that the user has changed their identity.
+     *
+     *  - Otherwise, the user is "TOFU trusted": we have a record of their identity, and, typically, will share
+     *    encrypted content with them as long as they retain that identity.
+     */
+    public readonly known: boolean;
+
+    /**
      * Indicates if the identity has changed in a way that needs user approval.
      *
      * This happens if the identity has changed since we first saw it, *unless* the new identity has also been verified
@@ -872,12 +891,14 @@ export class UserVerificationStatus {
      */
     public readonly needsUserApproval: boolean;
 
+    /** @internal */
     public constructor(
         private readonly crossSigningVerified: boolean,
         private readonly crossSigningVerifiedBefore: boolean,
-        private readonly tofu: boolean,
+        known: boolean,
         needsUserApproval: boolean = false,
     ) {
+        this.known = known;
         this.needsUserApproval = needsUserApproval;
     }
 
@@ -909,7 +930,7 @@ export class UserVerificationStatus {
      * @deprecated No longer supported, with the Rust crypto stack.
      */
     public isTofu(): boolean {
-        return this.tofu;
+        return false;
     }
 }
 

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -736,7 +736,7 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
                 ? userIdentity.identityNeedsUserApproval()
                 : false;
         userIdentity.free();
-        return new UserVerificationStatus(verified, wasVerified, false, needsUserApproval);
+        return new UserVerificationStatus(verified, wasVerified, true, needsUserApproval);
     }
 
     /**


### PR DESCRIPTION
Indicate whether we have a record of this user's identity.

In support of https://github.com/element-hq/element-meta/issues/3163.