### PR TITLE
Re-enable Complement Crypto tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
 
     complement-crypto:
         name: "Run Complement Crypto tests"
-        if: false # disabled due to flakiness
+        if: github.event_name == 'merge_group'
         permissions: read-all # zizmor: ignore[excessive-permissions]
         uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@main # zizmor: ignore[unpinned-uses]
         with:


### PR DESCRIPTION
Since https://github.com/matrix-org/complement-crypto/pull/235 these should be more reliable.

This reverts commit 4d592915382ddff5d62e33b515ad0169f0d26d30.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
