### PR TITLE
Fix coverage reports clobbering each other

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -63,7 +63,6 @@ jobs:
                   run-id: ${{ github.event.workflow_run.id }}
                   pattern: coverage-*
                   path: coverage
-                  merge-multiple: true
             - name: Check coverage artifact
               run: |
                   if [ ! -d coverage ]; then


### PR DESCRIPTION
merge-multiple would silently drop files with clashing names - it ultimately isn't necessary given the `find` command will happily find them in nested subdirs
