### PR TITLE
Allow oidc jwks_uri to be omitted

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -3940,6 +3940,31 @@ describe("MatrixClient", function () {
             });
             expect(httpLookups.length).toEqual(0);
         });
+
+        it("should handle no jwks_uri", async () => {
+            const { jwks_uri: _, ...metadata } = mockOpenIdConfiguration();
+            httpLookups = [
+                {
+                    method: "GET",
+                    path: `/auth_metadata`,
+                    error: new MatrixError({ errcode: "M_UNRECOGNIZED" }, 404),
+                    prefix: "/_matrix/client/unstable/org.matrix.msc2965",
+                },
+                {
+                    method: "GET",
+                    path: `/auth_issuer`,
+                    data: { issuer: metadata.issuer },
+                    prefix: "/_matrix/client/unstable/org.matrix.msc2965",
+                },
+            ];
+            fetchMock.get("https://auth.org/.well-known/openid-configuration", metadata);
+
+            await expect(client.getAuthMetadata()).resolves.toEqual({
+                ...metadata,
+                signingKeys: null,
+            });
+            expect(httpLookups.length).toEqual(0);
+        });
     });
 
     describe("identityHashedLookup", () => {

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -62,6 +62,6 @@ export const validateAuthMetadataAndKeys = async (authMetadata: unknown): Promis
 
     return {
         ...validatedIssuerConfig,
-        signingKeys: await metadataService.getSigningKeys(),
+        signingKeys: validatedIssuerConfig.jwks_uri ? await metadataService.getSigningKeys() : null,
     };
 };


### PR DESCRIPTION
As signing keys are seemingly not (yet?) in the spec

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/5270
