### PR TITLE
MSC4108v2024 iteration and support for sign in on new device

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,12 @@ client.startClient();
 As well as the primary entry point (`matrix-js-sdk`), there are several other entry points which may be useful:
 
 | Entry point                    | Description                                                                                         |
-| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+|--------------------------------|-----------------------------------------------------------------------------------------------------|
 | `matrix-js-sdk`                | Primary entry point. High-level functionality, and lots of historical clutter in need of a cleanup. |
 | `matrix-js-sdk/lib/crypto-api` | Cryptography functionality.                                                                         |
 | `matrix-js-sdk/lib/types`      | Low-level types, reflecting data structures defined in the Matrix spec.                             |
 | `matrix-js-sdk/lib/testing`    | Test utilities, which may be useful in test code but should not be used in production code.         |
+| `matrix-js-sdk/lib/rendezvous` | Utilities around MSC4108 QR code login and rendezvous servers.                                      |
 | `matrix-js-sdk/lib/utils/*.js` | A set of modules exporting standalone functions (and their types).                                  |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ client.startClient();
 As well as the primary entry point (`matrix-js-sdk`), there are several other entry points which may be useful:
 
 | Entry point                    | Description                                                                                         |
-|--------------------------------|-----------------------------------------------------------------------------------------------------|
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
 | `matrix-js-sdk`                | Primary entry point. High-level functionality, and lots of historical clutter in need of a cleanup. |
 | `matrix-js-sdk/lib/crypto-api` | Cryptography functionality.                                                                         |
 | `matrix-js-sdk/lib/types`      | Low-level types, reflecting data structures defined in the Matrix spec.                             |

--- a/knip.ts
+++ b/knip.ts
@@ -7,6 +7,7 @@ export default {
         "src/browser-index.ts",
         "src/indexeddb-worker.ts",
         "src/crypto-api/index.ts",
+        "src/rendezvous/index.ts",
         "src/testing.ts",
         "src/matrix.ts",
         "src/utils.ts", // not really an entrypoint but we have deprecated `defer` there
@@ -17,7 +18,6 @@ export default {
         "src/sliding-sync.ts",
         "src/webrtc/groupCall.ts",
         "src/webrtc/stats/media/mediaTrackStats.ts",
-        "src/rendezvous/RendezvousChannel.ts",
     ],
     project: ["**/*.{js,ts}"],
     ignore: ["examples/**"],

--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -428,5 +428,39 @@ describe("MSC4108SignInWithQR", () => {
                 expect(opponentLogin.deviceAuthorizationGrant()).rejects.toThrow("Specified device ID already exists"),
             ]);
         });
+
+        it("should abort on declined login", async () => {
+            await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
+
+            vi.mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
+            fetchMock.post(metadata.device_authorization_endpoint!, {
+                device_code: "test",
+                verification_uri: verificationUriComplete,
+            });
+
+            await Promise.all([
+                ourLogin.deviceAuthorizationGrant({
+                    clientId,
+                    deviceId,
+                    metadata,
+                }),
+                opponentLogin.deviceAuthorizationGrant(),
+            ]);
+
+            const secrets = {
+                cross_signing: { master_key: "mk", user_signing_key: "usk", self_signing_key: "ssk" },
+            };
+            client.getCrypto()!.exportSecretsBundle = vi.fn().mockResolvedValue(secrets);
+
+            fetchMock.postOnce(metadata.token_endpoint, { error: "access_denied" });
+
+            const ourProm = ourLogin.completeLoginOnNewDevice({ clientId });
+            const opponentProm = opponentLogin.shareSecrets();
+
+            await expect(ourProm).resolves.toBeUndefined();
+            await expect(opponentProm).rejects.toThrow(
+                new RendezvousError("Failed", MSC4108FailureReason.UserCancelled),
+            );
+        });
     });
 });

--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -216,31 +216,41 @@ describe("MSC4108SignInWithQR", () => {
         it("should be able to connect with opponent and share secrets", async () => {
             await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
 
-            // We don't have the new device side of this flow implemented at this time so mock it
-            // @ts-ignore
-            ourLogin.expectingNewDeviceId = "DEADB33F";
+            vi.mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
+            fetchMock.post(metadata.device_authorization_endpoint!, {
+                device_code: "test",
+                verification_uri: verificationUriComplete,
+            });
 
-            const ourProm = ourLogin.shareSecrets();
-
-            // Consume the ProtocolAccepted message which would normally be handled by step 4 which we do not have here
-            // @ts-ignore
-            await opponentLogin.receive();
-
-            vi.mocked(client.getDevice).mockResolvedValue({} as IMyDevice);
+            await Promise.all([
+                ourLogin.deviceAuthorizationGrant(),
+                opponentLogin.deviceAuthorizationGrant({
+                    clientId,
+                    deviceId,
+                    metadata,
+                }),
+            ]);
 
             const secrets = {
                 cross_signing: { master_key: "mk", user_signing_key: "usk", self_signing_key: "ssk" },
             };
             client.getCrypto()!.exportSecretsBundle = vi.fn().mockResolvedValue(secrets);
 
+            // simulate IdP issuing a token from the device_code flow
+            fetchMock.postOnce(metadata.token_endpoint, { access_token: "test", token_type: "Bearer" });
+            vi.mocked(client.getDevice).mockResolvedValue({} as IMyDevice);
+
+            const ourProm = ourLogin.shareSecrets();
+            const opponentProm = opponentLogin
+                .completeLoginOnNewDevice({ clientId })
+                .then(() => opponentLogin.shareSecrets());
+
             const payload = {
                 secrets: expect.objectContaining(secrets),
             };
-            await Promise.all([
-                expect(ourProm).resolves.toEqual(payload),
-                expect(opponentLogin.shareSecrets()).resolves.toEqual(payload),
-            ]);
-        });
+            await expect(ourProm).resolves.toEqual(payload);
+            await expect(opponentProm).resolves.toEqual(payload);
+        }, 20000);
 
         it("should abort if device doesn't come up by timeout", async () => {
             vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
@@ -310,10 +320,6 @@ describe("MSC4108SignInWithQR", () => {
 
             const ourProm = ourLogin.shareSecrets();
             const opponentProm = opponentLogin.shareSecrets();
-
-            // Consume the ProtocolAccepted message which would normally be handled by step 4 which we do not have here
-            // @ts-ignore
-            await opponentLogin.receive();
 
             const deviceResolvers = Promise.withResolvers<IMyDevice>();
             vi.mocked(client.getDevice).mockReturnValue(deviceResolvers.promise);

--- a/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
+++ b/spec/integ/rendezvous/MSC4108SignInWithQR.spec.ts
@@ -34,7 +34,7 @@ import {
     MatrixError,
     MatrixHttpApi,
 } from "../../../src";
-import { makeDelegatedAuthConfig } from "../../test-utils/oidc";
+import { makeDelegatedAuthConfig, mockOpenIdConfiguration } from "../../test-utils/oidc";
 
 function makeMockClient(opts: { userId: string; deviceId: string; msc4108Enabled: boolean }): MatrixClient {
     const baseUrl = "https://example.com";
@@ -80,6 +80,8 @@ describe("MSC4108SignInWithQR", () => {
     const deviceId = "DEADB33F";
     const verificationUri = "https://example.com/verify";
     const verificationUriComplete = "https://example.com/verify/complete";
+    const metadata = mockOpenIdConfiguration();
+    const clientId = "oidc-client-id";
 
     it("should generate qr code data as expected", async () => {
         const session = new MSC4108RendezvousSession({
@@ -164,6 +166,10 @@ describe("MSC4108SignInWithQR", () => {
         });
 
         it("should be able to connect with opponent and share verificationUri", async () => {
+            fetchMock.post(metadata.device_authorization_endpoint!, {
+                device_code: "test",
+                verification_uri: verificationUriComplete,
+            });
             await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
 
             vi.mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
@@ -172,37 +178,19 @@ describe("MSC4108SignInWithQR", () => {
                 expect(ourLogin.deviceAuthorizationGrant()).resolves.toEqual({
                     verificationUri: verificationUriComplete,
                 }),
-                // We don't have the new device side of this flow implemented at this time so mock it
-                // @ts-ignore
-                opponentLogin.send({
-                    type: PayloadType.Protocol,
-                    protocol: "device_authorization_grant",
-                    device_authorization_grant: {
-                        verification_uri: verificationUri,
-                        verification_uri_complete: verificationUriComplete,
-                    },
-                    device_id: deviceId,
-                }),
+                opponentLogin.deviceAuthorizationGrant({ clientId, deviceId, metadata }),
             ]);
         });
 
         it("should abort if device already exists", async () => {
+            fetchMock.post(metadata.device_authorization_endpoint!, { device_code: "test" });
             await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
 
             vi.mocked(client.getDevice).mockResolvedValue({} as IMyDevice);
 
             await Promise.all([
                 expect(ourLogin.deviceAuthorizationGrant()).rejects.toThrow("Specified device ID already exists"),
-                // We don't have the new device side of this flow implemented at this time so mock it
-                // @ts-ignore
-                opponentLogin.send({
-                    type: PayloadType.Protocol,
-                    protocol: "device_authorization_grant",
-                    device_authorization_grant: {
-                        verification_uri: verificationUri,
-                    },
-                    device_id: deviceId,
-                }),
+                opponentLogin.deviceAuthorizationGrant({ clientId, deviceId, metadata }),
             ]);
         });
 
@@ -213,7 +201,6 @@ describe("MSC4108SignInWithQR", () => {
                 expect(ourLogin.deviceAuthorizationGrant()).rejects.toThrow(
                     "Received a request for an unsupported protocol",
                 ),
-                // We don't have the new device side of this flow implemented at this time so mock it
                 // @ts-ignore
                 opponentLogin.send({
                     type: PayloadType.Protocol,
@@ -342,6 +329,97 @@ describe("MSC4108SignInWithQR", () => {
             await Promise.all([
                 expect(ourProm).rejects.toThrow("User cancelled"),
                 expect(opponentProm).rejects.toThrow("Unexpected message received"),
+            ]);
+        });
+    });
+
+    describe("should be able to connect as a login device", () => {
+        let client: MatrixClient;
+        let ourLogin: MSC4108SignInWithQR;
+        let opponentLogin: MSC4108SignInWithQR;
+
+        beforeEach(async () => {
+            let ourData = Promise.withResolvers<string>();
+            let opponentData = Promise.withResolvers<string>();
+
+            const ourMockSession = {
+                send: vi.fn(async (newData) => {
+                    ourData.resolve(newData);
+                }),
+                receive: vi.fn(() => {
+                    const prom = opponentData.promise;
+                    prom.then(() => {
+                        opponentData = Promise.withResolvers();
+                    });
+                    return prom;
+                }),
+                url,
+                cancelled: false,
+                cancel: () => {
+                    // @ts-ignore
+                    ourMockSession.cancelled = true;
+                    ourData.resolve("");
+                },
+            } as unknown as MSC4108RendezvousSession;
+            const opponentMockSession = {
+                send: vi.fn(async (newData) => {
+                    opponentData.resolve(newData);
+                }),
+                receive: vi.fn(() => {
+                    const prom = ourData.promise;
+                    prom.then(() => {
+                        ourData = Promise.withResolvers();
+                    });
+                    return prom;
+                }),
+                url,
+            } as unknown as MSC4108RendezvousSession;
+
+            client = makeMockClient({ userId: "@alice:example.com", deviceId: "alice", msc4108Enabled: true });
+
+            const ourChannel = new MSC4108SecureChannel(ourMockSession);
+            const qrCodeData = QrCodeData.fromBytes(await ourChannel.generateCode(QrCodeIntent.Login));
+            const opponentChannel = new MSC4108SecureChannel(opponentMockSession, qrCodeData.publicKey);
+
+            ourLogin = new MSC4108SignInWithQR(ourChannel, true);
+            opponentLogin = new MSC4108SignInWithQR(opponentChannel, false, client);
+        });
+
+        it("should be able to connect with opponent and share check code", async () => {
+            expect(ourLogin.checkCode).toBe(opponentLogin.checkCode);
+        });
+
+        it("should be able to connect with opponent and share verificationUri", async () => {
+            fetchMock.post(metadata.device_authorization_endpoint!, {
+                device_code: "test",
+                verification_uri: verificationUriComplete,
+            });
+            await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
+
+            vi.mocked(client.getDevice).mockRejectedValue(new MatrixError({ errcode: "M_NOT_FOUND" }, 404));
+
+            await Promise.all([
+                expect(ourLogin.deviceAuthorizationGrant({ metadata, clientId, deviceId })).resolves.toEqual({
+                    verificationUri: verificationUriComplete,
+                }),
+                expect(opponentLogin.deviceAuthorizationGrant({ clientId, deviceId, metadata })).resolves.toEqual({
+                    verificationUri: verificationUriComplete,
+                }),
+            ]);
+        });
+
+        it("should abort if device already exists", async () => {
+            fetchMock.post(metadata.device_authorization_endpoint!, {
+                device_code: "test",
+                verification_uri: verificationUri,
+            });
+            await Promise.all([ourLogin.negotiateProtocols(), opponentLogin.negotiateProtocols()]);
+
+            vi.mocked(client.getDevice).mockResolvedValue({} as IMyDevice);
+
+            await Promise.all([
+                ourLogin.deviceAuthorizationGrant({ metadata, clientId, deviceId }),
+                expect(opponentLogin.deviceAuthorizationGrant()).rejects.toThrow("Specified device ID already exists"),
             ]);
         });
     });

--- a/spec/integ/rendezvous/rendezvous.spec.ts
+++ b/spec/integ/rendezvous/rendezvous.spec.ts
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { linkNewDeviceByGeneratingQR, MSC4108FailureReason, signInByGeneratingQR } from "../../../src/rendezvous";
+import { ClientPrefix, DEVICE_CODE_SCOPE, type IHttpOpts, type MatrixClient, MatrixHttpApi } from "../../../src";
+import { makeDelegatedAuthConfig } from "../../../src/testing.ts";
+import fetchMock from "@fetch-mock/vitest";
+
+function makeMockClient(): MatrixClient {
+    const baseUrl = "https://example.com";
+    const crypto = {
+        exportSecretsForQrLogin: vi.fn(),
+    };
+    const client = {
+        doesServerSupportUnstableFeature(feature: string) {
+            return Promise.resolve(feature === "org.matrix.msc4108");
+        },
+        getUserId() {
+            return "@user:server";
+        },
+        getDeviceId() {
+            return "DEADBEEF";
+        },
+        baseUrl,
+        getDomain: () => "example.com",
+        getDevice: vi.fn(),
+        getCrypto: vi.fn(() => crypto),
+        getAuthMetadata: vi.fn().mockResolvedValue(makeDelegatedAuthConfig("https://issuer/", [DEVICE_CODE_SCOPE])),
+    } as unknown as MatrixClient;
+    client.http = new MatrixHttpApi<IHttpOpts & { onlyData: true }>(client, {
+        baseUrl: client.baseUrl,
+        prefix: ClientPrefix.Unstable,
+        onlyData: true,
+    });
+    return client;
+}
+
+function mockRendezvousPaths() {
+    const rendezvousUrl = "https://rendezvous.example.com/foobar";
+    fetchMock.postOnce("path:/_matrix/client/unstable/org.matrix.msc4108/rendezvous", { url: rendezvousUrl });
+    fetchMock.delete(rendezvousUrl, 200);
+}
+
+describe("MSC4108", () => {
+    const client = makeMockClient();
+
+    describe("linkNewDeviceByGeneratingQR", () => {
+        it("should generate code successfully", async () => {
+            mockRendezvousPaths();
+            const onFailure = vi.fn();
+            const flow = await linkNewDeviceByGeneratingQR(client, onFailure);
+
+            expect(flow.isNewDevice).toBe(false);
+            expect(flow.isExistingDevice).toBe(true);
+
+            expect(flow.code).toHaveLength(92);
+            expect(onFailure).not.toHaveBeenCalled();
+        });
+
+        it("should fire onFailure if flow was cancelled", async () => {
+            mockRendezvousPaths();
+            const onFailure = vi.fn();
+            const flow = await linkNewDeviceByGeneratingQR(client, onFailure);
+
+            expect(onFailure).not.toHaveBeenCalled();
+            await flow.cancel(MSC4108FailureReason.UserCancelled);
+            expect(onFailure).toHaveBeenCalledWith(MSC4108FailureReason.UserCancelled);
+        });
+    });
+
+    describe("signInByGeneratingQR", () => {
+        it("should generate code successfully", async () => {
+            mockRendezvousPaths();
+            const onFailure = vi.fn();
+            const flow = await signInByGeneratingQR(client, onFailure);
+
+            expect(flow.isNewDevice).toBe(true);
+            expect(flow.isExistingDevice).toBe(false);
+
+            expect(flow.code).toHaveLength(79);
+            expect(onFailure).not.toHaveBeenCalled();
+        });
+
+        it("should fire onFailure if flow was cancelled", async () => {
+            mockRendezvousPaths();
+            const onFailure = vi.fn();
+            const flow = await signInByGeneratingQR(client, onFailure);
+
+            expect(onFailure).not.toHaveBeenCalled();
+            await flow.cancel(MSC4108FailureReason.UserCancelled);
+            expect(onFailure).toHaveBeenCalledWith(MSC4108FailureReason.UserCancelled);
+        });
+    });
+});

--- a/spec/integ/rendezvous/rendezvous.spec.ts
+++ b/spec/integ/rendezvous/rendezvous.spec.ts
@@ -62,7 +62,7 @@ describe("MSC4108", () => {
         it("should generate code successfully", async () => {
             mockRendezvousPaths();
             const onFailure = vi.fn();
-            const flow = await linkNewDeviceByGeneratingQR(client, onFailure);
+            const flow = await linkNewDeviceByGeneratingQR(client, onFailure, new AbortController().signal);
 
             expect(flow.isNewDevice).toBe(false);
             expect(flow.isExistingDevice).toBe(true);
@@ -74,7 +74,7 @@ describe("MSC4108", () => {
         it("should fire onFailure if flow was cancelled", async () => {
             mockRendezvousPaths();
             const onFailure = vi.fn();
-            const flow = await linkNewDeviceByGeneratingQR(client, onFailure);
+            const flow = await linkNewDeviceByGeneratingQR(client, onFailure, new AbortController().signal);
 
             expect(onFailure).not.toHaveBeenCalled();
             await flow.cancel(MSC4108FailureReason.UserCancelled);
@@ -86,7 +86,7 @@ describe("MSC4108", () => {
         it("should generate code successfully", async () => {
             mockRendezvousPaths();
             const onFailure = vi.fn();
-            const flow = await signInByGeneratingQR(client, onFailure);
+            const flow = await signInByGeneratingQR(client, onFailure, new AbortController().signal);
 
             expect(flow.isNewDevice).toBe(true);
             expect(flow.isExistingDevice).toBe(false);
@@ -98,7 +98,7 @@ describe("MSC4108", () => {
         it("should fire onFailure if flow was cancelled", async () => {
             mockRendezvousPaths();
             const onFailure = vi.fn();
-            const flow = await signInByGeneratingQR(client, onFailure);
+            const flow = await signInByGeneratingQR(client, onFailure, new AbortController().signal);
 
             expect(onFailure).not.toHaveBeenCalled();
             await flow.cancel(MSC4108FailureReason.UserCancelled);

--- a/spec/integ/rendezvous/rendezvous.spec.ts
+++ b/spec/integ/rendezvous/rendezvous.spec.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Matrix.org Foundation C.I.C.
+Copyright 2026 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import fetchMock from "@fetch-mock/vitest";
+
 import { linkNewDeviceByGeneratingQR, MSC4108FailureReason, signInByGeneratingQR } from "../../../src/rendezvous";
 import { ClientPrefix, DEVICE_CODE_SCOPE, type IHttpOpts, type MatrixClient, MatrixHttpApi } from "../../../src";
 import { makeDelegatedAuthConfig } from "../../../src/testing.ts";
-import fetchMock from "@fetch-mock/vitest";
 
 function makeMockClient(): MatrixClient {
     const baseUrl = "https://example.com";

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -548,5 +548,23 @@ describe("oidc authorization", () => {
                 },
             });
         });
+
+        it("should handle session expiration", async () => {
+            fetchMock.post(metadata.token_endpoint, { status: 400, body: { error: "authorization_pending" } });
+            const promise = waitForDeviceAuthorization({ clientId, metadata, session });
+
+            vi.setSystemTime(Date.now() + session.expires_in * 1000);
+            await vi.runOnlyPendingTimersAsync();
+
+            await expect(promise).resolves.toStrictEqual({ error: "expired" });
+            expect(fetchMock).toHavePostedTimes(1, metadata.token_endpoint, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "device_code=device&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=xyz789",
+                    );
+                    return true;
+                },
+            });
+        });
     });
 });

--- a/spec/unit/oidc/authorize.spec.ts
+++ b/spec/unit/oidc/authorize.spec.ts
@@ -29,6 +29,9 @@ import {
     generateAuthorizationParams,
     generateAuthorizationUrl,
     generateOidcAuthorizationUrl,
+    generateScope,
+    startDeviceAuthorization,
+    waitForDeviceAuthorization,
 } from "../../../src/oidc/authorize";
 import { OidcError } from "../../../src/oidc/error";
 import { makeDelegatedAuthConfig, mockOpenIdConfiguration } from "../../test-utils/oidc";
@@ -39,6 +42,7 @@ describe("oidc authorization", () => {
     const delegatedAuthConfig = makeDelegatedAuthConfig();
     const authorizationEndpoint = delegatedAuthConfig.authorization_endpoint;
     const clientId = "xyz789";
+    const deviceId = "deadbeef";
     const baseUrl = "https://test.com";
 
     // 14.03.2022 16:15
@@ -441,6 +445,108 @@ describe("oidc authorization", () => {
             await expect(completeAuthorizationCodeGrant(code, state)).rejects.toThrow(
                 new Error(OidcError.InvalidIdToken),
             );
+        });
+    });
+
+    describe("startDeviceAuthorization", () => {
+        it("should make the request with the expected parameters", async () => {
+            const metadata = mockOpenIdConfiguration();
+
+            fetchMock.postOnce(metadata.device_authorization_endpoint!, { device_code: "test" });
+
+            const scope = generateScope(deviceId);
+            const response = await startDeviceAuthorization({ clientId, metadata, scope });
+
+            expect(response).toStrictEqual({ device_code: "test" });
+            expect(fetchMock).toHavePosted(metadata.device_authorization_endpoint!, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "client_id=xyz789&scope=openid+urn%3Amatrix%3Aorg.matrix.msc2967.client%3Aapi%3A*+urn%3Amatrix%3Aorg.matrix.msc2967.client%3Adevice%3Adeadbeef",
+                    );
+                    return true;
+                },
+            });
+        });
+    });
+
+    describe("waitForDeviceAuthorization", () => {
+        const metadata = mockOpenIdConfiguration();
+        const session = {
+            device_code: "device",
+            user_code: "user",
+            verification_uri: "https://verification.uri",
+            expires_in: 10000,
+        };
+
+        it("should resolve to token payload on success", async () => {
+            fetchMock.postOnce(metadata.token_endpoint, { access_token: "test", token_type: "Bearer" });
+            const response = await waitForDeviceAuthorization({ clientId, metadata, session });
+
+            expect(response).toStrictEqual({ access_token: "test", token_type: "Bearer" });
+            expect(fetchMock).toHavePosted(metadata.token_endpoint, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "device_code=device&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=xyz789",
+                    );
+                    return true;
+                },
+            });
+        });
+
+        it("should handle 'authorization_pending' error", async () => {
+            fetchMock.postOnce(metadata.token_endpoint, { status: 400, body: { error: "authorization_pending" } });
+            fetchMock.postOnce(metadata.token_endpoint, { status: 400, body: { error: "authorization_pending" } });
+            fetchMock.postOnce(metadata.token_endpoint, { access_token: "test", token_type: "Bearer" });
+            const promise = waitForDeviceAuthorization({ clientId, metadata, session });
+
+            await vi.advanceTimersByTimeAsync(10000); // two sleeps
+
+            await expect(promise).resolves.toStrictEqual({ access_token: "test", token_type: "Bearer" });
+            expect(fetchMock).toHavePostedTimes(3, metadata.token_endpoint, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "device_code=device&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=xyz789",
+                    );
+                    return true;
+                },
+            });
+        });
+
+        it("should handle 'slow_down' error", async () => {
+            fetchMock.postOnce(metadata.token_endpoint, { status: 400, body: { error: "slow_down" } });
+            fetchMock.postOnce(metadata.token_endpoint, { access_token: "test", token_type: "Bearer" });
+            const promise = waitForDeviceAuthorization({ clientId, metadata, session });
+
+            await vi.advanceTimersByTimeAsync(9000);
+            // We were asked to slow down so should not have retried yet
+            expect(fetchMock).toHavePostedTimes(1, metadata.token_endpoint);
+
+            await vi.advanceTimersByTimeAsync(1000);
+
+            await expect(promise).resolves.toStrictEqual({ access_token: "test", token_type: "Bearer" });
+            expect(fetchMock).toHavePostedTimes(2, metadata.token_endpoint, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "device_code=device&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=xyz789",
+                    );
+                    return true;
+                },
+            });
+        });
+
+        it.each(["access_denied", "expired_token"])("should handle '%s' error", async (error) => {
+            fetchMock.postOnce(metadata.token_endpoint, { status: 400, body: { error } });
+            const response = await waitForDeviceAuthorization({ clientId, metadata, session });
+
+            expect(response).toStrictEqual({ error });
+            expect(fetchMock).toHavePostedTimes(1, metadata.token_endpoint, {
+                matcherFunction: (callLog) => {
+                    expect(callLog.options.body).toBe(
+                        "device_code=device&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&client_id=xyz789",
+                    );
+                    return true;
+                },
+            });
         });
     });
 });

--- a/spec/unit/oidc/register.spec.ts
+++ b/spec/unit/oidc/register.spec.ts
@@ -134,4 +134,45 @@ describe("registerOidcClient()", () => {
             }),
         );
     });
+
+    it("should ask for device_code grant if supported", async () => {
+        const config = {
+            ...delegatedAuthConfig,
+            grant_types_supported: [
+                ...delegatedAuthConfig.grant_types_supported,
+                "urn:ietf:params:oauth:grant-type:device_code",
+            ],
+        };
+
+        fetchMock.post(config.registration_endpoint!, {
+            status: 200,
+            body: JSON.stringify({ client_id: dynamicClientId }),
+        });
+        expect(await registerOidcClient(config, metadata)).toEqual(dynamicClientId);
+        expect(fetchMock.fetchHandler).toHaveFetched(
+            config.registration_endpoint,
+            expect.objectContaining({
+                headers: {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                method: "POST",
+            }),
+        );
+        expect(JSON.parse(fetchMock.callHistory.callLogs[0].options!.body as string)).toEqual(
+            expect.objectContaining({
+                client_name: clientName,
+                client_uri: baseUrl,
+                response_types: ["code"],
+                grant_types: ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"],
+                redirect_uris: [baseUrl],
+                id_token_signed_response_alg: "RS256",
+                token_endpoint_auth_method: "none",
+                application_type: "web",
+                tos_uri: "https://just.testing/tos",
+                policy_uri: "https://policy.just.testing",
+                logo_uri: `${baseUrl}:8443/logo.png`,
+            }),
+        );
+    });
 });

--- a/spec/unit/rendezvous/rendezvous.spec.ts
+++ b/spec/unit/rendezvous/rendezvous.spec.ts
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { isSignInWithQRAvailable } from "../../../src/rendezvous";
+import { ClientPrefix, type IHttpOpts, type MatrixClient, MatrixHttpApi, OAuthGrantType } from "../../../src";
+import { makeDelegatedAuthConfig } from "../../../src/testing.ts";
+
+function makeMockClient(): MatrixClient {
+    const baseUrl = "https://example.com";
+    const crypto = {
+        exportSecretsForQrLogin: vi.fn(),
+    };
+    const client = {
+        doesServerSupportUnstableFeature: vi.fn(),
+        getUserId() {
+            return "@user:server";
+        },
+        getDeviceId() {
+            return "DEADBEEF";
+        },
+        baseUrl,
+        getDomain: () => "example.com",
+        getDevice: vi.fn(),
+        getCrypto: vi.fn(() => crypto),
+        getAuthMetadata: vi.fn(),
+    } as unknown as MatrixClient;
+    client.http = new MatrixHttpApi<IHttpOpts & { onlyData: true }>(client, {
+        baseUrl: client.baseUrl,
+        prefix: ClientPrefix.Unstable,
+        onlyData: true,
+    });
+    return client;
+}
+
+describe("MSC4108", () => {
+    const client = makeMockClient();
+
+    describe("isSignInWithQRAvailable", () => {
+        it.each([
+            [false, false, false],
+            [false, true, false],
+            [true, false, false],
+            [true, true, true],
+        ])(
+            "should return %s if device_code support is %s and msc4108 support is %s",
+            async (deviceCodeSupport, mscSupport, expected) => {
+                const metadata = makeDelegatedAuthConfig(
+                    "https://issuer/",
+                    deviceCodeSupport ? [OAuthGrantType.DeviceAuthorization] : [],
+                );
+                vi.mocked(client.getAuthMetadata).mockResolvedValue(metadata);
+                vi.mocked(client.doesServerSupportUnstableFeature).mockImplementation(
+                    async (feature) => feature === "org.matrix.msc4108" && mscSupport,
+                );
+
+                await expect(isSignInWithQRAvailable(client)).resolves.toBe(expected);
+            },
+        );
+    });
+});

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -353,7 +353,7 @@ export const startDeviceAuthorization = async ({
     scope: string;
     metadata: ValidatedAuthMetadata;
 }): Promise<DeviceAuthorizationResponse> => {
-    const params = new URLSearchParams({ client_id: clientId, scope: scope });
+    const body = new URLSearchParams({ client_id: clientId, scope: scope }).toString();
 
     const url = metadata.device_authorization_endpoint;
     if (!url) {
@@ -365,7 +365,7 @@ export const startDeviceAuthorization = async ({
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",
         },
-        body: params.toString(),
+        body,
     });
 
     return (await response.json()) as DeviceAuthorizationResponse;
@@ -396,7 +396,7 @@ export const waitForDeviceAuthorization = async ({
             device_code: session.device_code,
             grant_type: OAuthGrantType.DeviceAuthorization,
             client_id: clientId,
-        });
+        }).toString();
         const response = await fetch(metadata.token_endpoint, {
             method: Method.Post,
             headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -365,7 +365,6 @@ export const waitForDeviceAuthorization = async ({
         const body = new URLSearchParams({
             device_code: session.device_code,
             grant_type: OAuthGrantType.DeviceAuthorization,
-            // TODO: is auth required here? it is optional in RFC8628
             client_id: clientId,
         });
         const response = await fetch(metadata.token_endpoint, {

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -337,9 +337,10 @@ export interface DeviceAuthorizationResponse {
 
 /**
  * Begin OIDC device authorization flow.
- * @param clientId - the client ID returned from client registration.
- * @param scope - the scope to request for authorization.
- * @param metadata - the validated OIDC metadata for the Identity Provider.
+ * @param options - The device authorization parameters.
+ * @param options.clientId - the client ID returned from client registration.
+ * @param options.scope - the scope to request for authorization.
+ * @param options.metadata - the validated OIDC metadata for the Identity Provider.
  * @returns a promise that resolves to a device access token response,
  *   or an error response if the user denies authorization or the device code expires.
  */
@@ -372,9 +373,10 @@ export const startDeviceAuthorization = async ({
 
 /**
  * Polls the OIDC token endpoint until we get a device access token response, or encounter an unrecoverable error.
- * @param session - the session returned from a previous call to {@link startDeviceAuthorization}.
- * @param metadata - the validated OIDC metadata for the Identity Provider.
- * @param clientId - the client ID returned from client registration.
+ * @param options - The device authorization parameters.
+ * @param options.session - The session returned from a previous call to {@link startDeviceAuthorization}.
+ * @param options.metadata - The validated OIDC metadata for the Identity Provider.
+ * @param options.clientId - The client ID returned from client registration.
  * @returns a promise that resolves to a device access token response,
  *   or an error response if the user denies authorization or the device code expires.
  */

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -38,6 +38,8 @@ import {
 import { sha256 } from "../digest.ts";
 import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { OAuthGrantType } from "./register.ts";
+import { sleep } from "../utils.ts";
+import { Method } from "../http-api";
 
 // reexport for backwards compatibility
 export type { BearerTokenResponse };
@@ -298,6 +300,9 @@ export const completeAuthorizationCodeGrant = async (
     }
 };
 
+/**
+ * Response from the OIDC token endpoint when exchanging a token for grant_type device_code.
+ */
 export interface DeviceAccessTokenResponse {
     id_token?: string;
     access_token: string;
@@ -308,6 +313,9 @@ export interface DeviceAccessTokenResponse {
     session_state?: string;
 }
 
+/**
+ * Error from the OIDC token endpoint when exchanging a token for grant_type device_code.
+ */
 export interface DeviceAccessTokenError {
     error: string;
     error_description?: string;
@@ -315,6 +323,9 @@ export interface DeviceAccessTokenError {
     session_state?: string;
 }
 
+/**
+ * Response from the OIDC device authorization endpoint.
+ */
 export interface DeviceAuthorizationResponse {
     device_code: string;
     user_code: string;
@@ -323,6 +334,15 @@ export interface DeviceAuthorizationResponse {
     expires_in: number;
     interval?: number;
 }
+
+/**
+ * Begin OIDC device authorization flow.
+ * @param clientId - the client ID returned from client registration.
+ * @param scope - the scope to request for authorization.
+ * @param metadata - the validated OIDC metadata for the Identity Provider.
+ * @returns a promise that resolves to a device access token response,
+ *   or an error response if the user denies authorization or the device code expires.
+ */
 export const startDeviceAuthorization = async ({
     clientId,
     scope,
@@ -340,7 +360,7 @@ export const startDeviceAuthorization = async ({
     }
 
     const response = await fetch(url, {
-        method: "POST",
+        method: Method.Post,
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",
         },
@@ -350,6 +370,14 @@ export const startDeviceAuthorization = async ({
     return (await response.json()) as DeviceAuthorizationResponse;
 };
 
+/**
+ * Polls the OIDC token endpoint until we get a device access token response, or encounter an unrecoverable error.
+ * @param session - the session returned from a previous call to {@link startDeviceAuthorization}.
+ * @param metadata - the validated OIDC metadata for the Identity Provider.
+ * @param clientId - the client ID returned from client registration.
+ * @returns a promise that resolves to a device access token response,
+ *   or an error response if the user denies authorization or the device code expires.
+ */
 export const waitForDeviceAuthorization = async ({
     session,
     metadata,
@@ -368,7 +396,7 @@ export const waitForDeviceAuthorization = async ({
             client_id: clientId,
         });
         const response = await fetch(metadata.token_endpoint, {
-            method: "POST",
+            method: Method.Post,
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body,
         });
@@ -387,7 +415,7 @@ export const waitForDeviceAuthorization = async ({
             case "expired_token":
                 return errorResponse;
         }
-        await new Promise((resolve) => setTimeout(resolve, interval));
+        await sleep(interval);
     } while (Date.now() < expiration);
     return { error: "expired" };
 };

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -39,7 +39,7 @@ import { sha256 } from "../digest.ts";
 import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { OAuthGrantType } from "./register.ts";
 import { sleep } from "../utils.ts";
-import { Method } from "../http-api";
+import { Method } from "../http-api/index.ts";
 
 // reexport for backwards compatibility
 export type { BearerTokenResponse };

--- a/src/oidc/authorize.ts
+++ b/src/oidc/authorize.ts
@@ -37,6 +37,7 @@ import {
 } from "./validate.ts";
 import { sha256 } from "../digest.ts";
 import { encodeUnpaddedBase64Url } from "../base64.ts";
+import { OAuthGrantType } from "./register.ts";
 
 // reexport for backwards compatibility
 export type { BearerTokenResponse };
@@ -295,4 +296,99 @@ export const completeAuthorizationCodeGrant = async (
         }
         throw new Error(OidcError.CodeExchangeFailed);
     }
+};
+
+export interface DeviceAccessTokenResponse {
+    id_token?: string;
+    access_token: string;
+    token_type: string;
+    refresh_token?: string;
+    scope?: string;
+    expires_in?: number;
+    session_state?: string;
+}
+
+export interface DeviceAccessTokenError {
+    error: string;
+    error_description?: string;
+    error_uri?: string;
+    session_state?: string;
+}
+
+export interface DeviceAuthorizationResponse {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete?: string;
+    expires_in: number;
+    interval?: number;
+}
+export const startDeviceAuthorization = async ({
+    clientId,
+    scope,
+    metadata,
+}: {
+    clientId: string;
+    scope: string;
+    metadata: ValidatedAuthMetadata;
+}): Promise<DeviceAuthorizationResponse> => {
+    const params = new URLSearchParams({ client_id: clientId, scope: scope });
+
+    const url = metadata.device_authorization_endpoint;
+    if (!url) {
+        throw new Error("No device_authorization_endpoint given");
+    }
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params.toString(),
+    });
+
+    return (await response.json()) as DeviceAuthorizationResponse;
+};
+
+export const waitForDeviceAuthorization = async ({
+    session,
+    metadata,
+    clientId,
+}: {
+    session: DeviceAuthorizationResponse;
+    metadata: ValidatedAuthMetadata;
+    clientId: string;
+}): Promise<DeviceAccessTokenResponse | DeviceAccessTokenError> => {
+    let interval = (session.interval ?? 5) * 1000; // poll interval
+    const expiration = Date.now() + session.expires_in * 1000;
+    do {
+        const body = new URLSearchParams({
+            device_code: session.device_code,
+            grant_type: OAuthGrantType.DeviceAuthorization,
+            // TODO: is auth required here? it is optional in RFC8628
+            client_id: clientId,
+        });
+        const response = await fetch(metadata.token_endpoint, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body,
+        });
+
+        if (response.ok) {
+            return (await response.json()) as DeviceAccessTokenResponse;
+        }
+        const errorResponse = (await response.json()) as DeviceAccessTokenError;
+        switch (errorResponse.error) {
+            case "authorization_pending":
+                break;
+            case "slow_down":
+                interval += 5000;
+                break;
+            case "access_denied":
+            case "expired_token":
+                return errorResponse;
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval));
+    } while (Date.now() < expiration);
+    return { error: "expired" };
 };

--- a/src/oidc/register.ts
+++ b/src/oidc/register.ts
@@ -111,6 +111,11 @@ export const registerOidcClient = async (
         throw new Error(OidcError.DynamicRegistrationNotSupported);
     }
 
+    // ask for device authorization grant if supported
+    if (delegatedAuthConfig.grant_types_supported.includes(OAuthGrantType.DeviceAuthorization)) {
+        grantTypes.push(OAuthGrantType.DeviceAuthorization);
+    }
+
     const commonBase = new URL(clientMetadata.clientUri);
 
     // https://openid.net/specs/openid-connect-registration-1_0.html

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -361,6 +361,11 @@ export class MSC4108SignInWithQR {
         }
     }
 
+    /**
+     * The fourth step in the OIDC QR login process.
+     * The reciprocating device must perform step 5 for this method to resolve.
+     * To be called after {@link deviceAuthorizationGrant} only on the new device.
+     */
     public async completeLoginOnNewDevice({
         clientId,
     }: {

--- a/src/rendezvous/MSC4108SignInWithQR.ts
+++ b/src/rendezvous/MSC4108SignInWithQR.ts
@@ -27,7 +27,16 @@ import { logger } from "../logger.ts";
 import { type MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
 import { MatrixError } from "../http-api/index.ts";
 import { sleep } from "../utils.ts";
-import { OAuthGrantType, type OidcClientConfig } from "../oidc/index.ts";
+import {
+    type DeviceAccessTokenResponse,
+    type DeviceAuthorizationResponse,
+    generateScope,
+    OAuthGrantType,
+    startDeviceAuthorization,
+    type ValidatedAuthMetadata,
+    waitForDeviceAuthorization,
+    type OidcClientConfig,
+} from "../oidc/index.ts";
 import { type CryptoApi } from "../crypto-api/index.ts";
 
 /**
@@ -111,6 +120,8 @@ export class MSC4108SignInWithQR {
     private readonly ourIntent: QrCodeIntent;
     private _code?: Uint8Array;
     private expectingNewDeviceId?: string;
+    private metadata?: ValidatedAuthMetadata;
+    private grantInProgress?: DeviceAuthorizationResponse;
 
     /**
      * Returns the check code for the secure channel or undefined if not generated yet.
@@ -241,14 +252,53 @@ export class MSC4108SignInWithQR {
     /**
      * The second & third step in the OIDC QR login process.
      * To be called after `negotiateProtocols` for the existing device.
-     * To be called after OIDC negotiation for the new device. (Currently unsupported)
+     * To be called after OIDC negotiation for the new device.
+     *
+     * @param input - Required for the new device to start the device authorization grant, not required for the existing device reciprocating the login
      */
-    public async deviceAuthorizationGrant(): Promise<{
+    public async deviceAuthorizationGrant(input?: {
+        metadata: ValidatedAuthMetadata;
+        clientId: string;
+        deviceId: string;
+    }): Promise<{
         verificationUri?: string;
         userCode?: string;
     }> {
         if (this.isNewDevice) {
-            throw new Error("New device flows around OIDC are not yet implemented");
+            if (!input) {
+                throw new Error("Input must be provided for new device");
+            }
+
+            const { metadata, clientId, deviceId } = input;
+
+            const scope = generateScope(deviceId);
+
+            // MSC4108-Flow: NewDevice - start device authorization grant
+            const dagResponse = await startDeviceAuthorization({
+                clientId,
+                scope,
+                metadata,
+            });
+
+            this.metadata = metadata;
+            this.grantInProgress = dagResponse;
+
+            const protocol: DeviceAuthorizationGrantProtocolPayload = {
+                type: PayloadType.Protocol,
+                protocol: "device_authorization_grant",
+                device_id: deviceId,
+                device_authorization_grant: {
+                    verification_uri: dagResponse.verification_uri,
+                    verification_uri_complete: dagResponse.verification_uri_complete,
+                },
+            };
+
+            await this.send(protocol);
+
+            return {
+                verificationUri: dagResponse.verification_uri_complete ?? dagResponse.verification_uri,
+                userCode: dagResponse.user_code,
+            };
         } else {
             // The user needs to do step 7 for the out-of-band confirmation
             // but, first we receive the protocol chosen by the other device so that
@@ -309,6 +359,64 @@ export class MSC4108SignInWithQR {
                 MSC4108FailureReason.UnsupportedProtocol,
             );
         }
+    }
+
+    public async completeLoginOnNewDevice({
+        clientId,
+    }: {
+        clientId: string;
+    }): Promise<DeviceAccessTokenResponse | undefined> {
+        if (!this.isNewDevice || !this.grantInProgress || !this.metadata) {
+            throw new Error("Can only complete login on new device");
+        }
+
+        logger.info("Waiting for protocol accepted message");
+        // wait for accepted message
+        const payload = await this.receive<AcceptedPayload | FailurePayload>();
+
+        if (!payload) {
+            throw new RendezvousError(
+                "No response from existing device",
+                MSC4108FailureReason.UnexpectedMessageReceived,
+            );
+        }
+        if (payload.type === PayloadType.Failure) {
+            throw new RendezvousError("Failed", (payload as FailurePayload).reason);
+        }
+        if (payload.type !== PayloadType.ProtocolAccepted) {
+            throw new RendezvousError("Unexpected message received", MSC4108FailureReason.UnexpectedMessageReceived);
+        }
+
+        // poll for DAG
+        const res = await waitForDeviceAuthorization({
+            session: this.grantInProgress,
+            metadata: this.metadata,
+            clientId,
+        });
+
+        if (!res) {
+            throw new RendezvousError(
+                "No response from device authorization endpoint",
+                ClientRendezvousFailureReason.Unknown,
+            );
+        }
+
+        if ("error" in res) {
+            let reason: MSC4108FailureReason = MSC4108FailureReason.UnexpectedMessageReceived;
+            if (res.error === "expired_token") {
+                reason = MSC4108FailureReason.AuthorizationExpired;
+            } else if (res.error === "access_denied") {
+                reason = MSC4108FailureReason.UserCancelled;
+            }
+            const payload: FailurePayload = {
+                type: PayloadType.Failure,
+                reason,
+            };
+            await this.send(payload);
+            return undefined;
+        }
+
+        return res;
     }
 
     /**

--- a/src/rendezvous/channels/MSC4108SecureChannel.ts
+++ b/src/rendezvous/channels/MSC4108SecureChannel.ts
@@ -257,7 +257,12 @@ export class MSC4108SecureChannel {
             await this.rendezvousSession.cancel(reason);
             this.onFailure?.(reason);
         } finally {
-            await this.close();
+            if (
+                reason !== ClientRendezvousFailureReason.UserDeclined &&
+                reason !== MSC4108FailureReason.UserCancelled
+            ) {
+                await this.close();
+            }
         }
     }
 

--- a/src/rendezvous/channels/MSC4108SecureChannel.ts
+++ b/src/rendezvous/channels/MSC4108SecureChannel.ts
@@ -164,7 +164,10 @@ export class MSC4108SecureChannel {
             logger.info("Waiting for LoginInitiateMessage");
             const loginInitiateMessage = await this.rendezvousSession.receive();
             if (!loginInitiateMessage) {
-                throw new Error("No response from other device");
+                throw new RendezvousError(
+                    "No response from other device",
+                    MSC4108FailureReason.UnexpectedMessageReceived,
+                );
             }
 
             const { channel, message: candidateLoginInitiateMessage } =

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -110,7 +110,7 @@ export async function signInByGeneratingQR(
     abortSignal: AbortSignal,
 ): Promise<MSC4108SignInWithQR> {
     // ensure rust crypto is initialized as needed for the secure channel
-    const rustCryptoPromise = await initRustCrypto();
+    await initRustCrypto();
 
     const session = new MSC4108RendezvousSession({
         onFailure,
@@ -133,11 +133,8 @@ export async function signInByGeneratingQR(
         flow.cancel(MSC4108FailureReason.UserCancelled);
     };
 
-    await Promise.all([
-        // open channel
-        session.send(""),
-        rustCryptoPromise,
-    ]);
+    // open channel
+    await session.send("");
 
     if (!abortSignal.aborted) {
         await flow.generateCode();

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { OAuthGrantType, type MatrixClient } from "../matrix.ts";
+import { type MatrixClient, OAuthGrantType } from "../matrix.ts";
 import { MSC4108FailureReason, type RendezvousFailureListener } from "./RendezvousFailureReason.ts";
 import { MSC4108SignInWithQR } from "./MSC4108SignInWithQR.ts";
 import { MSC4108RendezvousSession } from "./transports/MSC4108RendezvousSession.ts";
 import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
+import { RendezvousIntent } from "./RendezvousIntent.ts";
 
 export * from "./MSC4108SignInWithQR.ts";
 export type * from "./RendezvousChannel.ts";
@@ -65,31 +66,7 @@ export async function linkNewDeviceByGeneratingQR(
     abortSignal: AbortSignal,
 ): Promise<MSC4108SignInWithQR> {
     // we assume rust crypto is already initialised
-    const session = new MSC4108RendezvousSession({
-        onFailure,
-        client,
-    });
-    const channel = new MSC4108SecureChannel(session, undefined, onFailure);
-    const flow = new MSC4108SignInWithQR(channel, false, client, onFailure);
-
-    abortSignal.onabort = (): void => {
-        // Detach failure handlers
-        session.onFailure = undefined;
-        channel.onFailure = undefined;
-        flow.onFailure = undefined;
-        // Cancel the session
-        flow.cancel(MSC4108FailureReason.UserCancelled);
-    };
-
-    if (!abortSignal.aborted) {
-        await session.send(""); // open channel
-    }
-
-    if (!abortSignal.aborted) {
-        await flow.generateCode();
-    }
-
-    return flow;
+    return initGenerateQrFlow(RendezvousIntent.RECIPROCATE_LOGIN_ON_EXISTING_DEVICE, client, onFailure, abortSignal);
 }
 
 /**
@@ -110,15 +87,29 @@ export async function signInByGeneratingQR(
     abortSignal: AbortSignal,
 ): Promise<MSC4108SignInWithQR> {
     // ensure rust crypto is initialized as needed for the secure channel
-    await initRustCrypto();
+    const RustSdkCryptoJs = await import("@matrix-org/matrix-sdk-crypto-wasm");
+    await RustSdkCryptoJs.initAsync();
 
+    return initGenerateQrFlow(RendezvousIntent.LOGIN_ON_NEW_DEVICE, tempClient, onFailure, abortSignal);
+}
+
+async function initGenerateQrFlow(
+    intent: RendezvousIntent,
+    client: MatrixClient,
+    onFailure: RendezvousFailureListener,
+    abortSignal: AbortSignal,
+): Promise<MSC4108SignInWithQR> {
     const session = new MSC4108RendezvousSession({
         onFailure,
-        client: tempClient,
+        client,
     });
-
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
-    const flow = new MSC4108SignInWithQR(channel, false, undefined, onFailure);
+    const flow = new MSC4108SignInWithQR(
+        channel,
+        false,
+        intent === RendezvousIntent.LOGIN_ON_NEW_DEVICE ? undefined : client,
+        onFailure,
+    );
 
     if (abortSignal.aborted) return flow;
 
@@ -131,16 +122,11 @@ export async function signInByGeneratingQR(
         flow.cancel(MSC4108FailureReason.UserCancelled);
     };
 
-    // open channel
-    await session.send("");
+    await session.send(""); // open channel
 
-    if (abortSignal.aborted) return flow;
+    if (!abortSignal.aborted) {
+        await flow.generateCode();
+    }
 
-    await flow.generateCode();
     return flow;
-}
-
-async function initRustCrypto(): Promise<void> {
-    const RustSdkCryptoJs = await import("@matrix-org/matrix-sdk-crypto-wasm");
-    await RustSdkCryptoJs.initAsync();
 }

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type MatrixClient, OAuthGrantType } from "../matrix.ts";
+import { type MatrixClient, OAuthGrantType, type OidcClientConfig } from "../matrix.ts";
 import { MSC4108FailureReason, type RendezvousFailureListener } from "./RendezvousFailureReason.ts";
 import { MSC4108SignInWithQR } from "./MSC4108SignInWithQR.ts";
 import { MSC4108RendezvousSession } from "./transports/MSC4108RendezvousSession.ts";
 import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
 import { RendezvousIntent } from "./RendezvousIntent.ts";
+import { logger } from "../logger.ts";
 
 export * from "./MSC4108SignInWithQR.ts";
 export type * from "./RendezvousChannel.ts";
@@ -38,8 +39,15 @@ export * from "./channels/index.ts";
  * @returns true if the homeserver that the client is connected to supports a variant of sign-in with QR that we can use, false otherwise.
  */
 export async function isSignInWithQRAvailable(client: MatrixClient): Promise<boolean> {
+    let metadata: OidcClientConfig;
+    try {
+        metadata = await client.getAuthMetadata();
+    } catch (e) {
+        logger.warn("Failed to fetch auth metadata, assuming sign-in with QR is unavailable", e);
+        return false;
+    }
+
     // check for support of device authorization grant
-    const metadata = await client.getAuthMetadata();
     if (!metadata.grant_types_supported.includes(OAuthGrantType.DeviceAuthorization)) {
         return false;
     }

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { OAuthGrantType, type MatrixClient } from "../matrix.ts";
+import type { RendezvousFailureListener } from "./RendezvousFailureReason.ts";
+import { MSC4108SignInWithQR } from "./MSC4108SignInWithQR.ts";
+import { MSC4108RendezvousSession } from "./transports/MSC4108RendezvousSession.ts";
+import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
+
 export * from "./MSC4108SignInWithQR.ts";
 export type * from "./RendezvousChannel.ts";
 export type * from "./RendezvousCode.ts";
@@ -23,3 +29,77 @@ export * from "./RendezvousIntent.ts";
 export type * from "./RendezvousTransport.ts";
 export * from "./transports/index.ts";
 export * from "./channels/index.ts";
+
+/**
+ * Check if the homeserver that the client is connected to supports a variant of sign-in with QR that we can use.
+ *
+ * @param client the client to check for sign-in with QR support
+ * @returns true if the homeserver that the client is connected to supports a variant of sign-in with QR that we can use, false otherwise.
+ */
+export async function isSignInWithQRAvailable(client: MatrixClient): Promise<boolean> {
+    // check for support of device authorization grant
+    const metadata = await client.getAuthMetadata();
+    if (!metadata.grant_types_supported.includes(OAuthGrantType.DeviceAuthorization)) {
+        return false;
+    }
+
+    // check for unstable support for MSC4108 2024 version
+    return client.doesServerSupportUnstableFeature("org.matrix.msc4108");
+}
+
+/**
+ * Start a linking flow from an existing authenticated client by generating a QR code that can be scanned by the new device.
+ * The new device will then authenticate with the server and link itself to the same account as the existing client and
+ * share the end-to-end encryption keys.
+ *
+ * @param client the existing client
+ * @param onFailure callback for when the linking process fails
+ * @returns a promise that resolves to an instance of the linking flow
+ */
+export async function linkNewDeviceByGeneratingQR(
+    client: MatrixClient,
+    onFailure: RendezvousFailureListener,
+): Promise<MSC4108SignInWithQR> {
+    // we assume rust crypto is already initialised
+    const session = new MSC4108RendezvousSession({
+        onFailure,
+        client,
+    });
+    await session.send("");
+    const channel = new MSC4108SecureChannel(session, undefined, onFailure);
+    const flow = new MSC4108SignInWithQR(channel, false, client, onFailure);
+
+    await flow.generateCode();
+
+    return flow;
+}
+
+/**
+ * Start a sign-in flow by generating a QR code that can be scanned by an existing authenticated client.
+ * The existing client will then help complete the authentication of the new device and link it to the same account,
+ * sharing the end-to-end encryption keys.
+ *
+ * @param tempClient temporary client used during the flow
+ * @param onFailure callback for when the sign-in process fails
+ * @returns a promise that resolves to an instance of the sign-in flow
+ */
+export async function signInByGeneratingQR(
+    tempClient: MatrixClient,
+    onFailure: RendezvousFailureListener,
+): Promise<MSC4108SignInWithQR> {
+    // ensure rust crypto is initialized as needed for the secure channel
+    const RustSdkCryptoJs = await import("@matrix-org/matrix-sdk-crypto-wasm");
+    await RustSdkCryptoJs.initAsync();
+
+    const session = new MSC4108RendezvousSession({
+        onFailure,
+        client: tempClient,
+    });
+    await session.send("");
+    const channel = new MSC4108SecureChannel(session, undefined, onFailure);
+    const flow = new MSC4108SignInWithQR(channel, false, undefined, onFailure);
+
+    await flow.generateCode();
+
+    return flow;
+}

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { OAuthGrantType, type MatrixClient } from "../matrix.ts";
-import type { RendezvousFailureListener } from "./RendezvousFailureReason.ts";
+import { MSC4108FailureReason, type RendezvousFailureListener } from "./RendezvousFailureReason.ts";
 import { MSC4108SignInWithQR } from "./MSC4108SignInWithQR.ts";
 import { MSC4108RendezvousSession } from "./transports/MSC4108RendezvousSession.ts";
 import { MSC4108SecureChannel } from "./channels/MSC4108SecureChannel.ts";
@@ -54,22 +54,40 @@ export async function isSignInWithQRAvailable(client: MatrixClient): Promise<boo
  *
  * @param client the existing client
  * @param onFailure callback for when the linking process fails
+ * @param abortController an AbortController that can be used to cancel the linking process,
+ *   for example when the user cancels out of the flow.
+ *   This will unbind the {@link onFailure} callback and prevent any further steps in the flow from being executed.
  * @returns a promise that resolves to an instance of the linking flow
  */
 export async function linkNewDeviceByGeneratingQR(
     client: MatrixClient,
     onFailure: RendezvousFailureListener,
+    abortController: AbortController,
 ): Promise<MSC4108SignInWithQR> {
     // we assume rust crypto is already initialised
     const session = new MSC4108RendezvousSession({
         onFailure,
         client,
     });
-    await session.send("");
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
     const flow = new MSC4108SignInWithQR(channel, false, client, onFailure);
 
-    await flow.generateCode();
+    abortController.signal.onabort = (): void => {
+        // Detach failure handlers
+        session.onFailure = undefined;
+        channel.onFailure = undefined;
+        flow.onFailure = undefined;
+        // Cancel the session
+        flow.cancel(MSC4108FailureReason.UserCancelled);
+    };
+
+    if (!abortController.signal.aborted) {
+        await session.send(""); // open channel
+    }
+
+    if (!abortController.signal.aborted) {
+        await flow.generateCode();
+    }
 
     return flow;
 }
@@ -81,25 +99,54 @@ export async function linkNewDeviceByGeneratingQR(
  *
  * @param tempClient temporary client used during the flow for the rendezvous channel
  * @param onFailure callback for when the sign-in process fails
+ * @param abortController an AbortController that can be used to cancel the linking process,
+ *   for example when the user cancels out of the flow.
+ *   This will unbind the {@link onFailure} callback and prevent any further steps in the flow from being executed.
  * @returns a promise that resolves to an instance of the sign-in flow
  */
 export async function signInByGeneratingQR(
     tempClient: MatrixClient,
     onFailure: RendezvousFailureListener,
+    abortController: AbortController,
 ): Promise<MSC4108SignInWithQR> {
     // ensure rust crypto is initialized as needed for the secure channel
-    const RustSdkCryptoJs = await import("@matrix-org/matrix-sdk-crypto-wasm");
-    await RustSdkCryptoJs.initAsync();
+    const rustCryptoPromise = await initRustCrypto();
 
     const session = new MSC4108RendezvousSession({
         onFailure,
         client: tempClient,
     });
-    await session.send("");
+
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
     const flow = new MSC4108SignInWithQR(channel, false, undefined, onFailure);
 
-    await flow.generateCode();
+    if (abortController.signal.aborted) {
+        return flow;
+    }
+
+    abortController.signal.onabort = (): void => {
+        // Detach failure handlers
+        session.onFailure = undefined;
+        channel.onFailure = undefined;
+        flow.onFailure = undefined;
+        // Cancel the session
+        flow.cancel(MSC4108FailureReason.UserCancelled);
+    };
+
+    await Promise.all([
+        // open channel
+        session.send(""),
+        rustCryptoPromise,
+    ]);
+
+    if (!abortController.signal.aborted) {
+        await flow.generateCode();
+    }
 
     return flow;
+}
+
+async function initRustCrypto(): Promise<void> {
+    const RustSdkCryptoJs = await import("@matrix-org/matrix-sdk-crypto-wasm");
+    await RustSdkCryptoJs.initAsync();
 }

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -79,7 +79,7 @@ export async function linkNewDeviceByGeneratingQR(
  * The existing client will then help complete the authentication of the new device and link it to the same account,
  * sharing the end-to-end encryption keys.
  *
- * @param tempClient temporary client used during the flow
+ * @param tempClient temporary client used during the flow for the rendezvous channel
  * @param onFailure callback for when the sign-in process fails
  * @returns a promise that resolves to an instance of the sign-in flow
  */

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -120,9 +120,7 @@ export async function signInByGeneratingQR(
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
     const flow = new MSC4108SignInWithQR(channel, false, undefined, onFailure);
 
-    if (abortSignal.aborted) {
-        return flow;
-    }
+    if (abortSignal.aborted) return flow;
 
     abortSignal.onabort = (): void => {
         // Detach failure handlers
@@ -136,10 +134,9 @@ export async function signInByGeneratingQR(
     // open channel
     await session.send("");
 
-    if (!abortSignal.aborted) {
-        await flow.generateCode();
-    }
+    if (abortSignal.aborted) return flow;
 
+    await flow.generateCode();
     return flow;
 }
 

--- a/src/rendezvous/index.ts
+++ b/src/rendezvous/index.ts
@@ -54,7 +54,7 @@ export async function isSignInWithQRAvailable(client: MatrixClient): Promise<boo
  *
  * @param client the existing client
  * @param onFailure callback for when the linking process fails
- * @param abortController an AbortController that can be used to cancel the linking process,
+ * @param abortSignal an AbortSignal that can be used to cancel the linking process,
  *   for example when the user cancels out of the flow.
  *   This will unbind the {@link onFailure} callback and prevent any further steps in the flow from being executed.
  * @returns a promise that resolves to an instance of the linking flow
@@ -62,7 +62,7 @@ export async function isSignInWithQRAvailable(client: MatrixClient): Promise<boo
 export async function linkNewDeviceByGeneratingQR(
     client: MatrixClient,
     onFailure: RendezvousFailureListener,
-    abortController: AbortController,
+    abortSignal: AbortSignal,
 ): Promise<MSC4108SignInWithQR> {
     // we assume rust crypto is already initialised
     const session = new MSC4108RendezvousSession({
@@ -72,7 +72,7 @@ export async function linkNewDeviceByGeneratingQR(
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
     const flow = new MSC4108SignInWithQR(channel, false, client, onFailure);
 
-    abortController.signal.onabort = (): void => {
+    abortSignal.onabort = (): void => {
         // Detach failure handlers
         session.onFailure = undefined;
         channel.onFailure = undefined;
@@ -81,11 +81,11 @@ export async function linkNewDeviceByGeneratingQR(
         flow.cancel(MSC4108FailureReason.UserCancelled);
     };
 
-    if (!abortController.signal.aborted) {
+    if (!abortSignal.aborted) {
         await session.send(""); // open channel
     }
 
-    if (!abortController.signal.aborted) {
+    if (!abortSignal.aborted) {
         await flow.generateCode();
     }
 
@@ -99,7 +99,7 @@ export async function linkNewDeviceByGeneratingQR(
  *
  * @param tempClient temporary client used during the flow for the rendezvous channel
  * @param onFailure callback for when the sign-in process fails
- * @param abortController an AbortController that can be used to cancel the linking process,
+ * @param abortSignal an AbortSignal that can be used to cancel the linking process,
  *   for example when the user cancels out of the flow.
  *   This will unbind the {@link onFailure} callback and prevent any further steps in the flow from being executed.
  * @returns a promise that resolves to an instance of the sign-in flow
@@ -107,7 +107,7 @@ export async function linkNewDeviceByGeneratingQR(
 export async function signInByGeneratingQR(
     tempClient: MatrixClient,
     onFailure: RendezvousFailureListener,
-    abortController: AbortController,
+    abortSignal: AbortSignal,
 ): Promise<MSC4108SignInWithQR> {
     // ensure rust crypto is initialized as needed for the secure channel
     const rustCryptoPromise = await initRustCrypto();
@@ -120,11 +120,11 @@ export async function signInByGeneratingQR(
     const channel = new MSC4108SecureChannel(session, undefined, onFailure);
     const flow = new MSC4108SignInWithQR(channel, false, undefined, onFailure);
 
-    if (abortController.signal.aborted) {
+    if (abortSignal.aborted) {
         return flow;
     }
 
-    abortController.signal.onabort = (): void => {
+    abortSignal.onabort = (): void => {
         // Detach failure handlers
         session.onFailure = undefined;
         channel.onFailure = undefined;
@@ -139,7 +139,7 @@ export async function signInByGeneratingQR(
         rustCryptoPromise,
     ]);
 
-    if (!abortController.signal.aborted) {
+    if (!abortSignal.aborted) {
         await flow.generateCode();
     }
 

--- a/src/rendezvous/transports/MSC4108RendezvousSession.ts
+++ b/src/rendezvous/transports/MSC4108RendezvousSession.ts
@@ -30,7 +30,7 @@ export class MSC4108RendezvousSession {
     private readonly client?: MatrixClient;
     private readonly fallbackRzServer?: string;
     private readonly fetchFn?: typeof globalThis.fetch;
-    private readonly onFailure?: RendezvousFailureListener;
+    public onFailure?: RendezvousFailureListener;
     private etag?: string;
     private expiresAt?: Date;
     private expiresTimer?: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
For https://github.com/element-hq/wat-internal/issues/188

Moves the link-new-device-by-generating-qr code down from EW to SDK
Adds the sign-in-by-generating-qr code and related underlying changes to empower Signing in with QR on an Element Web/Desktop by using an authenticated Element X to scan the code