### PR TITLE
Support stable identifiers for MSC4268

### DIFF
--- a/spec/test-utils/test-data/generate-test-data.py
+++ b/spec/test-utils/test-data/generate-test-data.py
@@ -279,7 +279,7 @@ export const {prefix}BACKUP_DECRYPTION_KEY_BASE58 = "{ backup_recovery_key }";
 /** Signed backup data, suitable for return from `GET /_matrix/client/v3/room_keys/keys/{{roomId}}/{{sessionId}}` */
 export const {prefix}SIGNED_BACKUP_DATA: KeyBackupInfo = { json.dumps(backup_data, indent=4) };
 
-/** 
+/**
  * Per-room backup data, (supposedly) suitable for return from `GET /_matrix/client/v3/room_keys/keys/{{roomId}}`.
  * Contains the key from {prefix}MEGOLM_SESSION_DATA.
  */
@@ -422,7 +422,7 @@ def build_exported_megolm_key(device_curve_key: x25519.X25519PrivateKey) -> tupl
             "ed25519": encode_base64(ed25519.Ed25519PrivateKey.from_private_bytes(randbytes(32)).public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)),
         },
         "forwarding_curve25519_key_chain": [],
-        "org.matrix.msc3061.shared_history": True,
+        "m.shared_history": True,
     }
 
     return megolm_export, private_key

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -592,53 +592,31 @@ describe("RustCrypto", () => {
             expect(res.length).toEqual(0);
         });
 
-        it("should accept key bundles when we find out about them (stable)", async () => {
-            // Given we are faking that the received to-device message is a
-            // decrypted room key bundle.
+        it.each(["m.room_key_bundle", "io.element.msc4268.room_key_bundle"])(
+            "should accept key bundles when we find out about them",
+            async (type: string) => {
+                // Given we are faking that the received to-device message is a
+                // decrypted room key bundle.
 
-            // @ts-ignore Overriding a private function
-            rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent("m.room_key_bundle")]);
+                // @ts-ignore Overriding a private function
+                rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent(type)]);
 
-            // And that there is a pending key bundle
+                // And that there is a pending key bundle
 
-            // @ts-ignore Overriding a private function
-            rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
-                inviteAcceptedAtMillis: Date.now(),
-                inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
-            });
+                // @ts-ignore Overriding a private function
+                rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
+                    inviteAcceptedAtMillis: Date.now(),
+                    inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
+                });
 
-            // When we process to-device messages
-            rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
-            await rustCrypto.preprocessToDeviceMessages([]);
+                // When we process to-device messages
+                rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
+                await rustCrypto.preprocessToDeviceMessages([]);
 
-            // Then we accepted the key bundle
-            expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
-        });
-
-        it("should accept key bundles when we find out about them (unstable)", async () => {
-            // Given we are faking that the received to-device message is a
-            // decrypted room key bundle (with the unstable type identifier).
-
-            // @ts-ignore Overriding a private function
-            rustCrypto.receiveSyncChanges = vi
-                .fn()
-                .mockReturnValue([keyBundleEvent("io.element.msc4268.room_key_bundle")]);
-
-            // And that there is a pending key bundle
-
-            // @ts-ignore Overriding a private function
-            rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
-                inviteAcceptedAtMillis: Date.now(),
-                inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
-            });
-
-            // When we process to-device messages
-            rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
-            await rustCrypto.preprocessToDeviceMessages([]);
-
-            // Then we accepted the key bundle
-            expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
-        });
+                // Then we accepted the key bundle
+                expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
+            },
+        );
 
         it("should not accept other to-device messages as key bundles when we receive them", async () => {
             // Given we are faking that the received to-device message looks

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -592,6 +592,94 @@ describe("RustCrypto", () => {
             expect(res.length).toEqual(0);
         });
 
+        it("should accept key bundles when we find out about them (stable)", async () => {
+            // Given we are faking that the received to-device message is a
+            // decrypted room key bundle.
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent("m.room_key_bundle")]);
+
+            // And that there is a pending key bundle
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
+                inviteAcceptedAtMillis: Date.now(),
+                inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
+            });
+
+            // When we process to-device messages
+            rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
+            await rustCrypto.preprocessToDeviceMessages([]);
+
+            // Then we accepted the key bundle
+            expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
+        });
+
+        it("should accept key bundles when we find out about them (unstable)", async () => {
+            // Given we are faking that the received to-device message is a
+            // decrypted room key bundle (with the unstable type identifier).
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.receiveSyncChanges = vi
+                .fn()
+                .mockReturnValue([keyBundleEvent("io.element.msc4268.room_key_bundle")]);
+
+            // And that there is a pending key bundle
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
+                inviteAcceptedAtMillis: Date.now(),
+                inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
+            });
+
+            // When we process to-device messages
+            rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
+            await rustCrypto.preprocessToDeviceMessages([]);
+
+            // Then we accepted the key bundle
+            expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
+        });
+
+        it("should not accept other to-device messages as key bundles when we receive them", async () => {
+            // Given we are faking that the received to-device message looks
+            // like a room key bundle, except it has the wrong type.
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent("foo.some_other_type")]);
+
+            // And that there is a pending key bundle
+
+            // @ts-ignore Overriding a private function
+            rustCrypto.olmMachine.getPendingKeyBundleDetailsForRoom = vi.fn().mockReturnValue({
+                inviteAcceptedAtMillis: Date.now(),
+                inviterId: { toString: vi.fn().mockReturnValue("@inv:s.co") },
+            });
+
+            // When we process to-device messages
+            rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
+            await rustCrypto.preprocessToDeviceMessages([]);
+
+            // Then we do not try to accepted a key bundle
+            expect(rustCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalledWith();
+        });
+
+        function keyBundleEvent(type: string): RustSdkCryptoJs.ProcessedToDeviceEvent {
+            return {
+                rawEvent: JSON.stringify({
+                    content: { room_id: "!r:s.co" },
+                    sender: "",
+                    type,
+                }),
+                type: 0,
+                encryptionInfo: {
+                    sender: "",
+                    senderDevice: null,
+                    senderCurve25519Key: "",
+                    isSenderVerified: vi.fn().mockReturnValue(true),
+                },
+            } as any as RustSdkCryptoJs.ProcessedToDeviceEvent;
+        }
+
         it("emits VerificationRequestReceived on incoming m.key.verification.request", async () => {
             rustCrypto = await makeTestRustCrypto(
                 new MatrixHttpApi(new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>(), {

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -2582,7 +2582,7 @@ function rustEncryptionInfoToJsEncryptionInfo(
 }
 
 interface RoomKeyBundleMessage {
-    type: "io.element.msc4268.room_key_bundle";
+    type: "m.room_key_bundle" | "io.element.msc4268.room_key_bundle";
     content: {
         room_id: string;
     };
@@ -2592,13 +2592,16 @@ interface RoomKeyBundleMessage {
  * Determines if the given payload is a RoomKeyBundleMessage.
  *
  * A RoomKeyBundleMessage is identified by having a specific message type
- * ("io.element.msc4268.room_key_bundle") and a valid room_id in its content.
+ * ("m.room_key_bundle") and a valid room_id in its content.
  *
  * @param message - The received to-device message to check.
  * @returns True if the payload matches the RoomKeyBundleMessage structure, false otherwise.
  */
 function isRoomKeyBundleMessage(message: IToDeviceEvent): message is IToDeviceEvent & RoomKeyBundleMessage {
-    return message.type === "io.element.msc4268.room_key_bundle" && typeof message.content.room_id === "string";
+    return (
+        (message.type === "io.element.msc4268.room_key_bundle" || message.type === "m.room_key_bundle") &&
+        typeof message.content.room_id === "string"
+    );
 }
 
 type CryptoEvents = (typeof CryptoEvent)[keyof typeof CryptoEvent];


### PR DESCRIPTION


## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
