### PR TITLE
Enable encrypted history sharing by default

### DIFF
--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -225,7 +225,7 @@ describe("History Sharing", () => {
         const toDeviceMessageProm = expectSendToDeviceMessage(aliceHomeserverUrl, "m.room.encrypted");
         // POST https://alice-server.com/_matrix/client/v3/rooms/!room%3Aexample.com/invite
         fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId());
 
         const uploadedBlob = await uploadProm;
         const sentToDeviceRequest = await toDeviceMessageProm;
@@ -247,7 +247,7 @@ describe("History Sharing", () => {
         fetchMock.postOnce(`${bobHomeserverUrl}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
             room_id: ROOM_ID,
         });
-        await bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        await bobClient.joinRoom(ROOM_ID);
 
         // Bob receives and attempts to decrypt the megolm message, but should not be able to (yet).
         const event = await bobReceivesEvent(
@@ -318,7 +318,7 @@ describe("History Sharing", () => {
         const toDeviceMessageProm = expectSendToDeviceMessage(aliceHomeserverUrl, "m.room.encrypted");
         // POST https://alice-server.com/_matrix/client/v3/rooms/!room%3Aexample.com/invite
         fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId());
 
         const uploadedBlob = await uploadProm;
         const sentToDeviceRequest = await toDeviceMessageProm;
@@ -340,7 +340,7 @@ describe("History Sharing", () => {
         fetchMock.postOnce(`${bobHomeserverUrl}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
             room_id: ROOM_ID,
         });
-        await bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        await bobClient.joinRoom(ROOM_ID);
 
         // Bob receives and attempts to decrypt the megolm message, but should not be able to (yet).
         const event = await bobReceivesEvent(
@@ -406,7 +406,7 @@ describe("History Sharing", () => {
         const toDeviceMessageProm = expectSendToDeviceMessage(aliceHomeserverUrl, "m.room.encrypted");
         // POST https://alice-server.com/_matrix/client/v3/rooms/!room%3Aexample.com/invite
         fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId());
 
         const uploadedBlob = await uploadProm;
         const sentToDeviceRequest = await toDeviceMessageProm;
@@ -428,7 +428,7 @@ describe("History Sharing", () => {
         fetchMock.post(`${bobHomeserverUrl}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
             room_id: ROOM_ID,
         });
-        await bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        await bobClient.joinRoom(ROOM_ID);
 
         // Bob receives and attempts to decrypt the megolm message, but should not be able to (yet).
         const event = await bobReceivesEvent(
@@ -478,7 +478,7 @@ describe("History Sharing", () => {
         expect(room?.getMyMembership()).toEqual(KnownMembership.Leave);
 
         // Bob rejoins
-        await bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        await bobClient.joinRoom(ROOM_ID);
 
         // Now the bundle arrives
         fetchMock.getOnce(`begin:${bobHomeserverUrl}/_matrix/client/v1/media/download/alice-server/here`, {
@@ -563,7 +563,7 @@ describe("History Sharing", () => {
         const uploadProm = expectUploadRequest(alice);
         const toDeviceMessageProm = expectSendToDeviceMessage(aliceHomeserverUrl, "m.room.encrypted");
         fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId());
         const uploadedBlob = await uploadProm;
         const sentToDeviceRequest = await toDeviceMessageProm;
         debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
@@ -600,7 +600,7 @@ describe("History Sharing", () => {
             return new Promise(() => {});
         });
         // meaning the /join request will block
-        bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        bobClient.joinRoom(ROOM_ID);
         await downloadStarted.promise;
 
         // Tear down the client, and start again
@@ -673,7 +673,7 @@ describe("History Sharing", () => {
         debug(`Alice sent encrypted room event: ${JSON.stringify(secondMessage)}`);
 
         fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`, {});
-        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+        await aliceClient.invite(ROOM_ID, bobClient.getSafeUserId());
 
         const inviteEvent = mkEventCustom({
             type: "m.room.member",
@@ -697,7 +697,7 @@ describe("History Sharing", () => {
             room_id: ROOM_ID,
         });
 
-        await bobClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+        await bobClient.joinRoom(ROOM_ID);
 
         // Bob receives only the first message.
         const bobSyncResponse = getSyncResponse(
@@ -818,7 +818,7 @@ describe("History Sharing", () => {
                 `${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(ROOM_ID)}/invite`,
                 {},
             );
-            await aliceClient.invite(ROOM_ID, charlieClient.getSafeUserId(), { shareEncryptedHistory: true });
+            await aliceClient.invite(ROOM_ID, charlieClient.getSafeUserId());
             const uploadedBlob = await uploadProm;
             sentToDeviceRequest = await toDeviceMessageProm;
             debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
@@ -852,7 +852,7 @@ describe("History Sharing", () => {
             fetchMock.getOnce(`begin:${charlieHomeserverUrl}/_matrix/client/v1/media/download/alice-server/here`, {
                 body: uploadedBlob,
             });
-            await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+            await charlieClient.joinRoom(ROOM_ID);
 
             // Charlie syncs to receive M1 and ensure he can read it.
             syncResponse = getSyncResponse(
@@ -1013,7 +1013,7 @@ describe("History Sharing", () => {
             fetchMock.postOnce(`${charlieHomeserverUrl}/_matrix/client/v3/join/${encodeURIComponent(ROOM_ID)}`, {
                 room_id: ROOM_ID,
             });
-            await charlieClient.joinRoom(ROOM_ID, { acceptSharedHistory: true });
+            await charlieClient.joinRoom(ROOM_ID);
             syncResponse = {
                 next_batch: "4",
                 rooms: {
@@ -1076,7 +1076,7 @@ async function assertInviteAndShareHistory(alice: TestClient, bob: TestClient, r
     const uploadProm = expectUploadRequest(alice);
     const toDeviceMessageProm = expectSendToDeviceMessage(aliceHomeserverUrl, "m.room.encrypted");
     fetchMock.postOnce(`${aliceHomeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`, {});
-    await aliceClient.invite(roomId, bobClient.getSafeUserId(), { shareEncryptedHistory: true });
+    await aliceClient.invite(roomId, bobClient.getSafeUserId());
     const uploadedBlob = await uploadProm;
     const sentToDeviceRequest = await toDeviceMessageProm;
     debug(`Alice sent encrypted to-device events: ${JSON.stringify(sentToDeviceRequest)}`);
@@ -1108,7 +1108,7 @@ async function assertInviteAndShareHistory(alice: TestClient, bob: TestClient, r
     fetchMock.getOnce(`begin:${bobHomeserverUrl}/_matrix/client/v1/media/download/alice-server/here`, {
         body: uploadedBlob,
     });
-    await bobClient.joinRoom(roomId, { acceptSharedHistory: true });
+    await bobClient.joinRoom(roomId);
 }
 
 function mkInviteEvent(inviter: MatrixClient, recipient: MatrixClient): Partial<IRoomEvent> {

--- a/src/@types/requests.ts
+++ b/src/@types/requests.ts
@@ -40,10 +40,10 @@ export interface IJoinRoomOpts {
     viaServers?: string[];
 
     /**
-     * When accepting an invite, whether to accept encrypted history shared by the inviter via the experimental
-     * support for [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
+     * Previously, configured whether to accept encrypted history shared by the inviter. This is now always enabled,
+     * and the setting is only retained to avoid a breaking change to the API. It has no effect.
      *
-     * @experimental
+     * @deprecated
      */
     acceptSharedHistory?: boolean;
 }
@@ -56,13 +56,10 @@ export interface InviteOpts {
     reason?: string;
 
     /**
-     * Before sending the invite, if the room is encrypted, share the keys for any messages sent while the history
-     * visibility was `shared`, via the experimental
-     * support for [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268). If the room's current
-     * history visibility setting is neither `shared` nor `world_readable`, history sharing will be disabled to prevent
-     * exposing keys for messages sent prior to the visibility restriction.
+     * Previously, configured whether to send encrypted history if the visibility settings allow it.
+     * This is now always enabled, and the setting is only retained to avoid a breaking change to the API. It has no effect.
      *
-     * @experimental
+     * @deprecated
      */
     shareEncryptedHistory?: boolean;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -2428,7 +2428,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         const res = await this.http.authedRequest<{ room_id: string }>(Method.Post, path, queryParams, data);
 
         const roomId = res.room_id;
-        if (opts.acceptSharedHistory && inviter && this.cryptoBackend) {
+        if (inviter && this.cryptoBackend) {
             // Flag upfront that we are waiting for a key bundle, so that if we crash mid-import, we can try again.
             await this.cryptoBackend.markRoomAsPendingKeyBundle(roomId, inviter);
             // Try to accept the room key bundle specified in a `m.room_key_bundle` to-device message we (might have) already received.
@@ -4086,14 +4086,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             opts = { reason: opts };
         }
 
-        if (opts.shareEncryptedHistory) {
-            const historyVisibility = this.getRoom(roomId)?.getHistoryVisibility() ?? HistoryVisibility.Shared;
-            // We should only share room history if the *current* visibility allows it.
-            if ([HistoryVisibility.Invited, HistoryVisibility.Joined].includes(historyVisibility)) {
-                this.logger.debug("Not sharing message history as the room history visibility is currently unshared");
-            } else {
-                await this.cryptoBackend?.shareRoomHistoryWithUser(roomId, userId);
-            }
+        const historyVisibility = this.getRoom(roomId)?.getHistoryVisibility() ?? HistoryVisibility.Shared;
+        // We should only share room history if the *current* visibility allows it.
+        if ([HistoryVisibility.Invited, HistoryVisibility.Joined].includes(historyVisibility)) {
+            this.logger.debug("Not sharing message history as the room history visibility is currently unshared");
+        } else {
+            await this.cryptoBackend?.shareRoomHistoryWithUser(roomId, userId);
         }
 
         return await this.membershipChange(roomId, userId, KnownMembership.Invite, opts.reason);


### PR DESCRIPTION
MSC4268 is now canon, and we can enable encrypted history sharing for all apps.

Part of https://github.com/element-hq/element-meta/issues/3208