### PR TITLE
fix(runtime): add Promise.withResolvers compatibility fallback for Hermes

### DIFF
--- a/spec/unit/promise.spec.ts
+++ b/spec/unit/promise.spec.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { promiseWithResolvers } from "../../src/promise";
+
+describe("promiseWithResolvers", () => {
+    it("creates a deferred promise when Promise.withResolvers is unavailable", async () => {
+        const originalDescriptor = Object.getOwnPropertyDescriptor(Promise, "withResolvers");
+
+        Object.defineProperty(Promise, "withResolvers", {
+            value: undefined,
+            configurable: true,
+            writable: true,
+        });
+
+        try {
+            const deferred = promiseWithResolvers<number>();
+
+            deferred.resolve(42);
+            await expect(deferred.promise).resolves.toBe(42);
+        } finally {
+            if (originalDescriptor) {
+                Object.defineProperty(Promise, "withResolvers", originalDescriptor);
+            } else {
+                delete (Promise as PromiseConstructor & { withResolvers?: unknown }).withResolvers;
+            }
+        }
+    });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -130,6 +130,7 @@ import {
     type SendDelayedEventRequestOpts,
     type SendDelayedEventResponse,
 } from "./@types/requests.ts";
+import { promiseWithResolvers } from "./promise.ts";
 import {
     type AccountDataEvents,
     EventType,
@@ -2258,7 +2259,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (existingData && deepCompare(existingData.event.content, content)) return {};
 
         // Create a promise which will resolve when the update is received
-        const updatedResolvers = Promise.withResolvers<void>();
+        const updatedResolvers = promiseWithResolvers<void>();
         function accountDataListener(event: MatrixEvent): void {
             // Note that we cannot safely check that the content matches what we expected, because there is a race:
             //   * We set the new content
@@ -5568,7 +5569,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             } else if (!hasDontNotifyRule) {
                 // Remove the existing one before setting the mute push rule
                 // This is a workaround to SYN-590 (Push rule update fails)
-                const doneResolvers = Promise.withResolvers<void>();
+                const doneResolvers = promiseWithResolvers<void>();
                 this.deletePushRule(scope, PushRuleKind.RoomSpecific, roomPushRule.rule_id)
                     .then(() => {
                         this.addPushRule(scope, PushRuleKind.RoomSpecific, roomId, {

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -59,6 +59,7 @@ import { type Room } from "./models/room.ts";
 import { type ToDeviceBatch, type ToDevicePayload } from "./models/ToDeviceMessage.ts";
 import { MapWithDefault, type QueryDict, recursiveMapToObject } from "./utils.ts";
 import { type EmptyObject, TypedEventEmitter, UnsupportedDelayedEventsEndpointError } from "./matrix.ts";
+import { promiseWithResolvers } from "./promise.ts";
 
 interface IStateEventRequest {
     eventType: string;
@@ -291,7 +292,7 @@ export class RoomWidgetClient extends MatrixClient {
         return (await this.widgetApi.getClientVersions()).includes(UnstableApiVersion.MSC2762_UPDATE_STATE);
     }
 
-    private readonly syncApiResolver = Promise.withResolvers<void>();
+    private readonly syncApiResolver = promiseWithResolvers<void>();
     public async startClient(opts: IStartClientOpts = {}): Promise<void> {
         this.lifecycle = new AbortController();
 

--- a/src/http-api/index.ts
+++ b/src/http-api/index.ts
@@ -29,6 +29,7 @@ import * as callbacks from "../realtime-callbacks.ts";
 import { Method } from "./method.ts";
 import { ConnectionError } from "./errors.ts";
 import { parseErrorResponse } from "./utils.ts";
+import { promiseWithResolvers } from "../promise.ts";
 
 export * from "./interface.ts";
 export * from "./prefix.ts";
@@ -65,7 +66,7 @@ export class MatrixHttpApi<O extends IHttpOpts> extends FetchHttpApi<O> {
             total: 0,
             abortController,
         } as Upload;
-        const uploadResolvers = Promise.withResolvers<UploadResponse>();
+        const uploadResolvers = promiseWithResolvers<UploadResponse>();
 
         if (globalThis.XMLHttpRequest) {
             const xhr = new globalThis.XMLHttpRequest();

--- a/src/interactive-auth.ts
+++ b/src/interactive-auth.ts
@@ -20,6 +20,7 @@ import { logger } from "./logger.ts";
 import { type MatrixClient } from "./client.ts";
 import { MatrixError } from "./http-api/index.ts";
 import { type UserIdentifier } from "./@types/auth.ts";
+import { promiseWithResolvers } from "./promise.ts";
 
 const EMAIL_STAGE_TYPE = "m.login.email.identity";
 const MSISDN_STAGE_TYPE = "m.login.msisdn";
@@ -302,7 +303,7 @@ export class InteractiveAuth<T> {
     public async attemptAuth(): Promise<T> {
         // This promise will be quite long-lived and will resolve when the
         // request is authenticated and completes successfully.
-        this.attemptAuthDeferred = Promise.withResolvers();
+        this.attemptAuthDeferred = promiseWithResolvers();
         // pluck the promise out now, as doRequest may clear before we return
         const promise = this.attemptAuthDeferred.promise;
 

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -36,6 +36,7 @@ import {
 import { type RtcMembershipData, type SessionMembershipData } from "./membershipData/index.ts";
 import { computeSlotId } from "./utils.ts";
 import { isLivekitTransportConfig } from "./LivekitTransport.ts";
+import { promiseWithResolvers } from "../promise.ts";
 
 /* MembershipActionTypes:
 On Join:  ───────────────┐   ┌───────────────(1)───────────┐
@@ -255,7 +256,7 @@ export class MembershipManager
         // So we do not check scheduler.actions/scheduler.insertions
         if (!this.leavePromiseResolvers) {
             // reset scheduled actions so we will not do any new actions.
-            this.leavePromiseResolvers = Promise.withResolvers<boolean>();
+            this.leavePromiseResolvers = promiseWithResolvers<boolean>();
             this.activated = false;
             this.scheduler.initiateLeave();
             if (timeout) setTimeout(() => this.leavePromiseResolvers?.resolve(false), timeout);

--- a/src/promise.ts
+++ b/src/promise.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Compatibility wrapper for runtimes that do not support Promise.withResolvers().
+ */
+export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+    if (typeof Promise.withResolvers === "function") {
+        return Promise.withResolvers<T>();
+    }
+
+    let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+    let reject: (reason?: unknown) => void = () => undefined;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return { promise, resolve, reject };
+}

--- a/src/rust-crypto/OutgoingRequestsManager.ts
+++ b/src/rust-crypto/OutgoingRequestsManager.ts
@@ -19,6 +19,7 @@ import { type OlmMachine, type OutgoingRequest } from "@matrix-org/matrix-sdk-cr
 import { type OutgoingRequestProcessor } from "./OutgoingRequestProcessor.ts";
 import { type Logger } from "../logger.ts";
 import { logDuration } from "../utils.ts";
+import { promiseWithResolvers } from "../promise.ts";
 
 /**
  * OutgoingRequestsManager: responsible for processing outgoing requests from the OlmMachine.
@@ -74,7 +75,7 @@ export class OutgoingRequestsManager {
         // In order to circumvent the race, we set a flag which tells the loop to go round once again even if the
         // queue appears to be empty.
         if (!this.nextLoopDeferred) {
-            this.nextLoopDeferred = Promise.withResolvers();
+            this.nextLoopDeferred = promiseWithResolvers();
         }
 
         // ... and wait for it to complete.

--- a/src/rust-crypto/verification.ts
+++ b/src/rust-crypto/verification.ts
@@ -36,6 +36,7 @@ import { type MatrixEvent } from "../models/event.ts";
 import { EventType, MsgType } from "../@types/event.ts";
 import { VerificationMethod } from "../types.ts";
 import type { Logger } from "../logger.ts";
+import { promiseWithResolvers } from "../promise.ts";
 
 /**
  * An incoming, or outgoing, request to verify a user or a device via cross-signing.
@@ -485,7 +486,7 @@ abstract class BaseRustVerifer<InnerType extends RustSdkCryptoJs.Qr | RustSdkCry
     ) {
         super();
 
-        this.completionDeferred = Promise.withResolvers();
+        this.completionDeferred = promiseWithResolvers();
 
         // As with RustVerificationRequest, we need to avoid a reference cycle.
         // See the comments in RustVerificationRequest.

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -24,6 +24,7 @@ import { EventType } from "./@types/event.ts";
 import { removeElement } from "./utils.ts";
 import { calculateRetryBackoff, type MatrixError } from "./http-api/index.ts";
 import { type ISendEventResponse } from "./@types/requests.ts";
+import { promiseWithResolvers } from "./promise.ts";
 
 const DEBUG = false; // set true to enable console logging.
 
@@ -188,7 +189,7 @@ export class MatrixScheduler<T = ISendEventResponse> {
         if (!this.queues[queueName]) {
             this.queues[queueName] = [];
         }
-        const eventResolvers = Promise.withResolvers<T>();
+        const eventResolvers = promiseWithResolvers<T>();
         this.queues[queueName].push({
             event: event,
             resolvers: eventResolvers,

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -21,6 +21,7 @@ import { type IStateEventWithRoomId, type ISyncResponse } from "../matrix.ts";
 import { type IIndexedDBBackend, type UserTuple } from "./indexeddb-backend.ts";
 import { type IndexedToDeviceBatch, type ToDeviceBatchWithTxnId } from "../models/ToDeviceMessage.ts";
 import { type SyncUserProfile } from "../models/user.ts";
+import { promiseWithResolvers } from "../promise.ts";
 
 export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
     private worker?: Worker;
@@ -176,7 +177,7 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
         // the promise automatically gets rejected
         return Promise.resolve().then(() => {
             const seq = this.nextSeq++;
-            const def = Promise.withResolvers<T>();
+            const def = promiseWithResolvers<T>();
 
             this.inFlight[seq] = def;
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -65,6 +65,7 @@ import { type IEventsResponse } from "./@types/requests.ts";
 import { UNREAD_THREAD_NOTIFICATIONS } from "./@types/sync.ts";
 import { Feature, ServerSupport } from "./feature.ts";
 import { KnownMembership } from "./@types/membership.ts";
+import { promiseWithResolvers } from "./promise.ts";
 
 // /sync requests allow you to set a timeout= but the request may continue
 // beyond that and wedge forever, so we need to track how long we are willing
@@ -1606,7 +1607,7 @@ export class SyncApi {
             this.pokeKeepAlive();
         }
         if (!this.connectionReturnedResolvers) {
-            this.connectionReturnedResolvers = Promise.withResolvers();
+            this.connectionReturnedResolvers = promiseWithResolvers();
         }
         return this.connectionReturnedResolvers.promise;
     }


### PR DESCRIPTION
## Summary

This PR fixes runtime failures in environments where `Promise.withResolvers()` is not implemented (notably React Native with Hermes), by introducing a small internal compatibility helper and using it at all affected call sites.

## Why

`matrix-js-sdk` currently invokes `Promise.withResolvers()` directly in multiple runtime paths.

In Hermes-based runtimes where that API is unavailable, event sending can fail before queueing with errors like:

```text
TypeError: Promise.withResolvers is not a function (it is undefined)
```

A commonly hit path is event sending through `MatrixScheduler#queueEvent`.

## What changed

- Added a helper (`promiseWithResolvers`) that:
  - uses `Promise.withResolvers()` when available,
  - falls back to a compatible deferred created via `new Promise((resolve, reject) => ...)` when unavailable.
- Replaced direct runtime calls to `Promise.withResolvers()` with the helper in affected source files.
- Added unit coverage for the fallback behavior.

## Behavioral impact

- No behavior change in runtimes that already support `Promise.withResolvers()`.
- Restores compatibility in runtimes that do not support it (including Hermes).
- Deferred shape remains the same (`{ promise, resolve, reject }`).

## Testing strategy

1. Unit test coverage:
- Run `pnpm test -- spec/unit/promise.spec.ts`.
- Verify fallback path passes when `Promise.withResolvers` is temporarily undefined.

2. Type/lint checks:
- Run `pnpm lint:types`.
- Run `pnpm lint:js`.

3. Repro validation (Hermes / RN app):
- Use a React Native / Expo app with Hermes and `matrix-js-sdk` 41.4.0 (or this branch build).
- Create/start a Matrix client and send an event.
- Verify no `Promise.withResolvers` runtime error occurs and event queue/send proceeds.

## Notes

Notes: Fix a runtime compatibility bug where direct `Promise.withResolvers()` usage could fail in Hermes-based React Native environments, preventing event queueing/sending.

## Labels suggestion

- `T-Defect`

## Fixes

Fixes https://github.com/matrix-org/matrix-js-sdk/issues/5309

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
