### PR TITLE
fix the sticky events duplication bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "lint:knip": "knip",
         "test": "vitest run",
         "test:watch": "vitest watch",
+        "test:bug-5205": "vitest run spec/unit/models/room-sticky-events.spec.ts -t \"issue #5205\"",
         "coverage": "pnpm test --coverage"
     },
     "repository": {

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -421,4 +421,73 @@ describe("RoomStickyEvents", () => {
             expect(emitSpy).toHaveBeenCalledWith([], [{ current: ev, previous: newerEv }], []);
         });
     });
+
+    /**
+     * https://github.com/matrix-org/matrix-js-sdk/issues/5205
+     *
+     * Regression guard for the *bug*, not the fix: passes while duplicate stickies exist,
+     * fails once duplicate sticky memberships are prevented.
+     */
+    describe("issue #5205", () => {
+        const rtcStickyBase = {
+            room_id: "!room:example.org",
+            type: "m.rtc.member",
+            msc4354_sticky: { duration_ms: 15000 },
+            sender: "@bob:example.org",
+            origin_server_ts: Date.now(),
+            unsigned: {},
+        };
+
+        it("proves duplicate unkeyed + keyed RTC membership stickies exist (bug #5205)", () => {
+            const unkeyedPreDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$unkeyed:example.org",
+                type: "m.room.encrypted",
+                content: {},
+            });
+            const keyedAfterDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$keyed:example.org",
+                content: { msc4354_sticky_key: "member-uuid-1" },
+            });
+
+            stickyEvents.addStickyEvents([unkeyedPreDecrypt]);
+            stickyEvents.addStickyEvents([keyedAfterDecrypt]);
+
+            const active = [...stickyEvents.getStickyEvents()];
+            const unkeyed = stickyEvents.getUnkeyedStickyEvent(rtcStickyBase.sender, "m.room.encrypted");
+            const keyed = stickyEvents.getKeyedStickyEvent(rtcStickyBase.sender, rtcStickyBase.type, "member-uuid-1");
+
+            expect(active).toHaveLength(2);
+            expect(unkeyed).toHaveLength(1);
+            expect(keyed).toBe(keyedAfterDecrypt);
+            expect(active).toContain(unkeyedPreDecrypt);
+            expect(active).toContain(keyedAfterDecrypt);
+        });
+
+        it("proves duplicate for Matrix 2.0 org.matrix.msc4143.rtc.member (bug #5205)", () => {
+            const msc4143Type = "org.matrix.msc4143.rtc.member";
+            const unkeyedPreDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$unkeyed-m2:example.org",
+                type: "m.room.encrypted",
+                content: {},
+            });
+            const keyedAfterDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$keyed-m2:example.org",
+                type: msc4143Type,
+                content: { msc4354_sticky_key: "member-uuid-1" },
+            });
+
+            stickyEvents.addStickyEvents([unkeyedPreDecrypt]);
+            stickyEvents.addStickyEvents([keyedAfterDecrypt]);
+
+            expect([...stickyEvents.getStickyEvents()]).toHaveLength(2);
+            expect(stickyEvents.getKeyedStickyEvent(rtcStickyBase.sender, msc4143Type, "member-uuid-1")).toBe(
+                keyedAfterDecrypt,
+            );
+            expect(stickyEvents.getUnkeyedStickyEvent(rtcStickyBase.sender, "m.room.encrypted")).toHaveLength(1);
+        });
+    });
 });

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -758,7 +758,7 @@ export class RoomWidgetClient extends MatrixClient {
             }
 
             this.emit(ClientEvent.Event, event);
-            if (event.unstableStickyInfo !== undefined) this.room!._unstable_addStickyEvents([event]);
+            if (event.unstableStickyInfo !== undefined) await this.room!._unstable_addStickyEvents([event]);
             this.setSyncState(SyncState.Syncing);
             logger.info(`Received event ${event.getId()} ${event.getType()}`);
         } else {

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -156,6 +156,12 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
         const stickyEvent = event as StickyMatrixEvent;
 
         if (stickyKey === undefined) {
+            // Encrypted stickies have no readable msc4354_sticky_key yet. They will be re-added
+            // after decryption via Room._unstable_addStickyEvents. Storing them now would create a
+            // duplicate unkeyed entry alongside the later keyed one.
+            // See https://github.com/matrix-org/matrix-js-sdk/issues/5205
+            if (event.isEncrypted() || type === "m.room.encrypted") return { added: false };
+
             this.unkeyedStickyEvents.add(stickyEvent);
             // Recalculate the next expiry time.
             this.nextStickyEventExpiryTs = Math.min(event.unstableStickyExpiresAt, this.nextStickyEventExpiryTs);

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3471,12 +3471,65 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     /**
      * Add a series of sticky events, emitting `RoomEvent.StickyEvents` if any
      * changes were made.
+     *
+     * Encrypted sticky events are decrypted before being passed to the store so that
+     * their `msc4354_sticky_key` is available. This prevents a duplicate unkeyed entry
+     * being created alongside the keyed one that arrives after decryption.
+     * See https://github.com/matrix-org/matrix-js-sdk/issues/5205
+     *
      * @param events A set of new sticky events.
      * @internal
      */
     // eslint-disable-next-line
-    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEventsStore["addStickyEvents"]> {
-        return this.stickyEvents.addStickyEvents(events);
+    public async _unstable_addStickyEvents(
+        events: MatrixEvent[],
+    ): Promise<ReturnType<RoomStickyEventsStore["addStickyEvents"]>> {
+        const results = await Promise.allSettled(events.map((event) => this.decryptStickyEvent(event)));
+        const decrypted = results.flatMap((r) => (r.status === "fulfilled" && r.value !== null ? [r.value] : []));
+        return this.stickyEvents.addStickyEvents(decrypted);
+    }
+
+    /**
+     * Resolves a sticky event to its decrypted form before it is inserted into the store.
+     *
+     * Returns `null` for events that should not be stored: those with missing sticky metadata,
+     * or encrypted events that still lack a `msc4354_sticky_key` after a decryption attempt.
+     * Never throws — decrypt failures are logged and treated as skipped events so that a single
+     * undecryptable sticky cannot abort the surrounding sync processing.
+     */
+    private async decryptStickyEvent(event: MatrixEvent): Promise<MatrixEvent | null> {
+        if (event.unstableStickyInfo === undefined) return null;
+
+        // Already has a key — nothing to do.
+        if (typeof event.getContent().msc4354_sticky_key === "string") return event;
+
+        // Plain (non-encrypted) unkeyed sticky — allowed through as-is.
+        if (!event.isEncrypted() && !event.shouldAttemptDecryption()) return event;
+
+        if (!this.client.getCrypto()) {
+            logger.debug(`Skipping encrypted sticky event ${event.getId()}: crypto not available`);
+            return null;
+        }
+
+        try {
+            await this.client.decryptEventIfNeeded(event);
+            if (event.isBeingDecrypted()) await event.getDecryptionPromise();
+        } catch (e) {
+            logger.warn(`Failed to decrypt sticky event ${event.getId()}, skipping`, e);
+            return null;
+        }
+
+        if (typeof event.getContent().msc4354_sticky_key === "string") {
+            return event;
+        }
+
+        // Still encrypted after decrypt attempt — drop it; the store would reject it anyway.
+        if (event.isEncrypted()) {
+            logger.debug(`Skipping sticky event ${event.getId()}: still encrypted after decryption attempt`);
+            return null;
+        }
+
+        return event;
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1466,7 +1466,7 @@ export class SyncApi {
                 );
                 // Note: We calculate sticky events before emitting `.Room` as it's nice to have
                 // sticky events calculated and ready to go.
-                room._unstable_addStickyEvents(stickyEventsAndStickyEventsFromTheTimeline);
+                await room._unstable_addStickyEvents(stickyEventsAndStickyEventsFromTheTimeline);
 
                 room.recalculate();
                 if (joinObj.isBrandNewRoom) {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Changes

- Added test, it will succeed when the fix is not applied. Now it fails after the fix.
- The fix is that we parse these sticky events, if they are encrypted -> decrypt first, and then if the required one does not exist -> add a new one.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
