### PR TITLE
Switch to default node linker

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-nodeLinker: hoisted
-
 peerDependencyRules:
     allowedVersions:
         eslint: "8"

--- a/spec/test-utils/client.ts
+++ b/spec/test-utils/client.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type MockedObject } from "vitest";
+import { type Mock, type MockedObject } from "vitest";
 
 import { type ClientEventHandlerMap, type EmittedEvents, type MatrixClient } from "../../src/client";
 import { TypedEventEmitter } from "../../src/models/typed-event-emitter";
@@ -65,14 +65,14 @@ export const getMockClientWithEventEmitter = (
  * ```
  */
 export const mockClientMethodsUser = (userId = "@alice:domain") => ({
-    getUserId: vi.fn().mockReturnValue(userId),
-    getSafeUserId: vi.fn().mockReturnValue(userId),
-    getUser: vi.fn().mockReturnValue(new User(userId)),
-    isGuest: vi.fn().mockReturnValue(false),
-    mxcUrlToHttp: vi.fn().mockReturnValue("mock-mxcUrlToHttp"),
+    getUserId: vi.fn().mockReturnValue(userId) as Mock,
+    getSafeUserId: vi.fn().mockReturnValue(userId) as Mock,
+    getUser: vi.fn().mockReturnValue(new User(userId)) as Mock,
+    isGuest: vi.fn().mockReturnValue(false) as Mock,
+    mxcUrlToHttp: vi.fn().mockReturnValue("mock-mxcUrlToHttp") as Mock,
     credentials: { userId },
-    getThreePids: vi.fn().mockResolvedValue({ threepids: [] }),
-    getAccessToken: vi.fn(),
+    getThreePids: vi.fn().mockResolvedValue({ threepids: [] }) as Mock,
+    getAccessToken: vi.fn() as Mock,
 });
 
 /**
@@ -84,8 +84,8 @@ export const mockClientMethodsUser = (userId = "@alice:domain") => ({
  * ```
  */
 export const mockClientMethodsEvents = () => ({
-    decryptEventIfNeeded: vi.fn(),
-    getPushActionsForEvent: vi.fn(),
+    decryptEventIfNeeded: vi.fn() as Mock,
+    getPushActionsForEvent: vi.fn() as Mock,
 });
 
 /**

--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { type Mock } from "vitest";
+
 import {
     type ClientEvent,
     type ClientEventHandlerMap,
@@ -461,8 +463,8 @@ export class MockCallMatrixClient extends TypedEventEmitter<EmittedEvents, Emitt
     public getSyncState = vi.fn<MatrixClient["getSyncState"]>().mockReturnValue(SyncState.Syncing);
 
     public getRooms = vi.fn<MatrixClient["getRooms"]>().mockReturnValue([]);
-    public getRoom = vi.fn();
-    public getFoci = vi.fn();
+    public getRoom: Mock = vi.fn();
+    public getFoci: Mock = vi.fn();
 
     public supportsThreads(): boolean {
         return true;


### PR DESCRIPTION
to make most of the benefits out of pnpm

Matches the change we made in element-web 

There are some edge cases where typescript is confused, but they are rare and almost always only signal real issues, like trying to export types which are not available to consumers, except in the case of tests where dev dependencies can affect it.