### PR TITLE
MSC4287: remove unstable prefix m.org.matrix.custom.backup_disabled

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -419,8 +419,6 @@ export interface AccountDataEvents extends SecretStorageAccountDataEvents {
 
     // MSC4287: Sharing key backup preference between clients - used to mark that the user opted out of key storage
     "m.key_backup": { enabled: boolean };
-    // MSC4287 unstable prefix (note the boolean property has the opposite sense)
-    "m.org.matrix.custom.backup_disabled": { disabled: boolean };
 
     "m.identity_server": { base_url: string | null };
     [key: `${typeof LOCAL_NOTIFICATION_SETTINGS_PREFIX.name}.${string}`]: LocalNotificationSettings;


### PR DESCRIPTION
On hold for now. https://github.com/matrix-org/matrix-js-sdk/pull/5258 was merged on 2026-04-15 and we need to wait long enough for clients to write the value to the stable prefix `m.key_backup` before we turn off support for the unstable prefix.

Depends on https://github.com/element-hq/element-web/pull/33695

Related: https://github.com/matrix-org/matrix-rust-sdk/pull/6634

MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/4287

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
