### PR TITLE
Add mechanism to locally enforce MSC1763 retention rules

### DIFF
--- a/spec/TestClient.ts
+++ b/spec/TestClient.ts
@@ -48,6 +48,8 @@ export class TestClient implements IE2EKeyReceiver, ISyncResponder {
     public deviceKeys?: IDeviceKeys | null;
     public oneTimeKeys?: Record<string, IOneTimeKey>;
 
+    public readonly _unstable_shouldApplyMessageRetention = false;
+
     constructor(
         public readonly userId?: string,
         public readonly deviceId?: string,

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -28,16 +28,14 @@ const ONE_WEEK_MS = 7 * ONE_DAY_MS;
 describe("RoomRetentionPolicy", () => {
     let room: Room;
     let getCachedMock: ReturnType<typeof vi.fn>;
-    let vapeEventsFromRoom: ReturnType<typeof vi.fn>;
+    let removeEventsFromRoom: ReturnType<typeof vi.fn>;
     let retentionPolicyUpdateHandler: (() => void) | undefined;
     let eventCounter = 0;
 
-    // Access the private retention policy via the room instance
     function getPolicy(): RoomRetentionPolicy {
         return (room as unknown as { retention: RoomRetentionPolicy }).retention;
     }
 
-    // Trigger a policy recalculation using the current getCachedMock return value
     async function applyPolicy(): Promise<void> {
         retentionPolicyUpdateHandler!();
         await flushPromises();
@@ -71,7 +69,7 @@ describe("RoomRetentionPolicy", () => {
         eventCounter = 0;
         retentionPolicyUpdateHandler = undefined;
         getCachedMock = vi.fn().mockResolvedValue(undefined);
-        vapeEventsFromRoom = vi.fn().mockResolvedValue(undefined);
+        removeEventsFromRoom = vi.fn().mockResolvedValue(undefined);
 
         const mockClient = {
             supportsThreads: vi.fn().mockReturnValue(true),
@@ -83,7 +81,7 @@ describe("RoomRetentionPolicy", () => {
                 }),
                 getCached: getCachedMock,
             },
-            store: { vapeEventsFromRoom },
+            store: { removeEventsFromRoom },
             // Enable retention so Room creates a RoomRetentionPolicy and addLiveEvents works
             _unstable_shouldApplyMessageRetention: true,
         } as unknown as MockedObject<MatrixClient>;
@@ -239,15 +237,15 @@ describe("RoomRetentionPolicy", () => {
             expect(redactSpy.mock.calls[0][0].event.redacts).toBe(expiredEvent.getId());
         });
 
-        it("calls vapeEventsFromRoom for expired events", async () => {
+        it("calls removeEventsFromRoom for expired events", async () => {
             const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
             await room.addLiveEvents([expiredEvent], { addToState: false });
 
             getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
-            await flushPromises(); // vapeEventsFromRoom is fire-and-forget
+            await flushPromises(); // removeEventsFromRoom is fire-and-forget
 
-            expect(vapeEventsFromRoom).toHaveBeenCalledWith(ROOM_ID, [expiredEvent.getId()]);
+            expect(removeEventsFromRoom).toHaveBeenCalledWith(ROOM_ID, [expiredEvent.getId()]);
         });
 
         it("does not include state events in expiry processing", async () => {
@@ -472,6 +470,13 @@ describe("RoomRetentionPolicy", () => {
             // Only one timer should be pending; advance past the debounce
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
             vi.advanceTimersByTime(200);
+
+            // processTimeline ran once; no expired events
+            expect(redactSpy).not.toHaveBeenCalled();
+        });
+    });
+});
+ime(200);
 
             // processTimeline ran once; no expired events
             expect(redactSpy).not.toHaveBeenCalled();

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -1,0 +1,482 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { type MockedObject } from "vitest";
+
+import { EventType, type MatrixClient, MatrixEvent, Room, RoomEvent, RoomStateEvent } from "../../../src";
+import { type RoomRetentionPolicy } from "../../../src/models/room-retention";
+import { flushPromises } from "../../test-utils/flushPromises";
+
+const ROOM_ID = "!room:example.org";
+const USER_ID = "@user:example.org";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_WEEK_MS = 7 * ONE_DAY_MS;
+
+describe("RoomRetentionPolicy", () => {
+    let room: Room;
+    let getCachedMock: ReturnType<typeof vi.fn>;
+    let vapeEventsFromRoom: ReturnType<typeof vi.fn>;
+    let retentionPolicyUpdateHandler: (() => void) | undefined;
+    let eventCounter = 0;
+
+    // Access the private retention policy via the room instance
+    function getPolicy(): RoomRetentionPolicy {
+        return (room as unknown as { retention: RoomRetentionPolicy }).retention;
+    }
+
+    // Trigger a policy recalculation using the current getCachedMock return value
+    async function applyPolicy(): Promise<void> {
+        retentionPolicyUpdateHandler!();
+        await flushPromises();
+    }
+
+    function makeMessageEvent(ts: number, eventId = `$msg_${eventCounter++}`): MatrixEvent {
+        return new MatrixEvent({
+            type: "m.room.message",
+            content: { body: "test" },
+            event_id: eventId,
+            sender: USER_ID,
+            origin_server_ts: ts,
+            room_id: ROOM_ID,
+        });
+    }
+
+    function makeRetentionStateEvent(content: object, type = "m.room.retention"): MatrixEvent {
+        return new MatrixEvent({
+            type,
+            state_key: "",
+            content,
+            event_id: `$retention_${type}`,
+            room_id: ROOM_ID,
+            sender: USER_ID,
+            origin_server_ts: Date.now(),
+        });
+    }
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        eventCounter = 0;
+        retentionPolicyUpdateHandler = undefined;
+        getCachedMock = vi.fn().mockResolvedValue(undefined);
+        vapeEventsFromRoom = vi.fn().mockResolvedValue(undefined);
+
+        const mockClient = {
+            supportsThreads: vi.fn().mockReturnValue(true),
+            decryptEventIfNeeded: vi.fn().mockReturnThis(),
+            getUserId: vi.fn().mockReturnValue(USER_ID),
+            retentionPolicyService: {
+                on: vi.fn((event: string, handler: () => void) => {
+                    if (event === "update") retentionPolicyUpdateHandler = handler;
+                }),
+                getCached: getCachedMock,
+            },
+            store: { vapeEventsFromRoom },
+            // Enable retention so Room creates a RoomRetentionPolicy and addLiveEvents works
+            _unstable_shouldApplyMessageRetention: true,
+        } as unknown as MockedObject<MatrixClient>;
+
+        room = new Room(ROOM_ID, mockClient, USER_ID);
+        // Allow the constructor's void handleRetentionUpdate() call to complete
+        await flushPromises();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("shouldEventBeRetained", () => {
+        it("retains all events when no policy is set", () => {
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(true);
+        });
+
+        it("retains recent events within max_lifetime", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 1000))).toBe(true);
+        });
+
+        it("does not retain events older than max_lifetime", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_WEEK_MS - 1000))).toBe(false);
+        });
+    });
+
+    describe("policy resolution", () => {
+        it("applies no policy when there is no server or room state policy", () => {
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(true);
+        });
+
+        it("uses stable room state event (m.room.retention)", async () => {
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 1000))).toBe(true);
+        });
+
+        it("uses unstable room state event (org.matrix.msc1763.retention)", async () => {
+            room.currentState.setStateEvents([
+                makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS }, "org.matrix.msc1763.retention"),
+            ]);
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
+        });
+
+        it("prefers unstable room state over stable when both are present", async () => {
+            // unstable: 1 day, stable: 1 week — the unstable (shorter) policy should apply
+            room.currentState.setStateEvents([
+                makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS }, "org.matrix.msc1763.retention"),
+                makeRetentionStateEvent({ max_lifetime: ONE_WEEK_MS }, "m.room.retention"),
+            ]);
+            await applyPolicy();
+
+            // A 2-day-old event should be expired under the 1-day unstable policy
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 2 * ONE_DAY_MS))).toBe(false);
+        });
+
+        it("server room-specific policy overrides room state policy", async () => {
+            // Room state says 1 day, server says 1 week for this specific room
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            await applyPolicy();
+
+            // A 2-day-old event should be retained (server says 1 week)
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 2 * ONE_DAY_MS))).toBe(true);
+            // An 8-day-old event should not be retained
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 8 * ONE_DAY_MS))).toBe(false);
+        });
+
+        it("uses server wildcard policy when no room-specific policy exists", async () => {
+            getCachedMock.mockResolvedValue({ policies: { "*": { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
+        });
+
+        it("clamps room state max_lifetime to server maximum limit", async () => {
+            // Room says 1 week, server caps max at 1 day — effective policy is 1 day
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_WEEK_MS })]);
+            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { max: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            // 2-day-old event should be expired (clamped down to 1 day)
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 2 * ONE_DAY_MS))).toBe(false);
+        });
+
+        it("clamps room state max_lifetime to server minimum limit", async () => {
+            // Room says 1 day, server requires minimum 1 week — effective policy is 1 week
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
+            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { min: ONE_WEEK_MS } } });
+            await applyPolicy();
+
+            // A 2-day-old event should still be retained (clamped up to 1 week)
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 2 * ONE_DAY_MS))).toBe(true);
+        });
+
+        it("uses server min limit when room state has no max_lifetime", async () => {
+            // Room state exists but omits max_lifetime; server limit provides the fallback min
+            room.currentState.setStateEvents([makeRetentionStateEvent({})]);
+            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { min: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
+        });
+    });
+
+    describe("processTimeline", () => {
+        it("redacts expired events when policy is applied", async () => {
+            const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
+            await room.addLiveEvents([expiredEvent], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(redactSpy).toHaveBeenCalledOnce();
+            const redactionArg = redactSpy.mock.calls[0][0];
+            expect(redactionArg.getType()).toBe(EventType.RoomRedaction);
+            expect(redactionArg.event.redacts).toBe(expiredEvent.getId());
+            expect(redactionArg.getContent().reason).toBe("Retention policy");
+        });
+
+        it("does not redact non-expired events", async () => {
+            await room.addLiveEvents([makeMessageEvent(Date.now() - 1000)], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            await applyPolicy();
+
+            expect(redactSpy).not.toHaveBeenCalled();
+        });
+
+        it("only redacts expired events among a mixed set", async () => {
+            const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
+            const recentEvent = makeMessageEvent(Date.now() - 1000);
+            await room.addLiveEvents([expiredEvent, recentEvent], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(redactSpy).toHaveBeenCalledOnce();
+            expect(redactSpy.mock.calls[0][0].event.redacts).toBe(expiredEvent.getId());
+        });
+
+        it("calls vapeEventsFromRoom for expired events", async () => {
+            const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
+            await room.addLiveEvents([expiredEvent], { addToState: false });
+
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+            await flushPromises(); // vapeEventsFromRoom is fire-and-forget
+
+            expect(vapeEventsFromRoom).toHaveBeenCalledWith(ROOM_ID, [expiredEvent.getId()]);
+        });
+
+        it("does not include state events in expiry processing", async () => {
+            const oldStateEvent = new MatrixEvent({
+                type: "m.room.topic",
+                state_key: "",
+                content: { topic: "Old topic" },
+                event_id: "$old_state",
+                sender: USER_ID,
+                origin_server_ts: 0,
+                room_id: ROOM_ID,
+            });
+            room.currentState.setStateEvents([oldStateEvent]);
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const stateEventRedacted = redactSpy.mock.calls.some(
+                ([call]) => call.event.redacts === oldStateEvent.getId(),
+            );
+            expect(stateEventRedacted).toBe(false);
+        });
+
+        it("schedules a future check for events that are not yet expired", async () => {
+            const expiresIn = 1000; // event expires in ~1 second from now
+            const soonToExpire = makeMessageEvent(Date.now() - ONE_DAY_MS + expiresIn);
+            await room.addLiveEvents([soonToExpire], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(redactSpy).not.toHaveBeenCalled(); // not expired yet
+
+            vi.advanceTimersByTime(expiresIn + 100);
+
+            expect(redactSpy).toHaveBeenCalledOnce();
+        });
+
+        it("schedules next check based on the earliest-expiring event, not the latest", async () => {
+            // BUG: A wrong sort comparator causes the LATEST-expiring event to be scheduled,
+            // so the EARLIEST-expiring event is not processed on time.
+            const soonExpiry = 1000; // expires in 1 second
+            const laterExpiry = ONE_DAY_MS / 2; // expires in 12 hours
+
+            const soonToExpire = makeMessageEvent(Date.now() - ONE_DAY_MS + soonExpiry, "$soon");
+            const laterToExpire = makeMessageEvent(Date.now() - ONE_DAY_MS + laterExpiry, "$later");
+            // Deliberately add in descending timestamp order to expose sort dependency
+            await room.addLiveEvents([laterToExpire, soonToExpire], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(redactSpy).not.toHaveBeenCalled();
+
+            // Advance just past the sooner expiry (1.1 seconds)
+            vi.advanceTimersByTime(soonExpiry + 100);
+
+            // The earliest-expiring event should be processed
+            expect(redactSpy).toHaveBeenCalledOnce();
+            expect(redactSpy.mock.calls[0][0].event.redacts).toBe(soonToExpire.getId());
+        });
+
+        it("does not process timeline when no policy is active", async () => {
+            await room.addLiveEvents([makeMessageEvent(0)], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            // No applyPolicy call — policy stays null
+            vi.advanceTimersByTime(ONE_WEEK_MS);
+
+            expect(redactSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("event listener binding", () => {
+        it("binds timeline listener when retention policy becomes active", async () => {
+            const onSpy = vi.spyOn(room, "on");
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const timelineBindings = onSpy.mock.calls.filter(([event]) => event === RoomEvent.Timeline);
+            expect(timelineBindings.length).toBe(1);
+        });
+
+        it("does not bind timeline listener when no retention policy", async () => {
+            const onSpy = vi.spyOn(room, "on");
+            // applyPolicy with undefined (no-op, already the default state from beforeEach)
+            await applyPolicy();
+
+            const timelineBindings = onSpy.mock.calls.filter(([event]) => event === RoomEvent.Timeline);
+            expect(timelineBindings.length).toBe(0);
+        });
+
+        it("unbinds timeline listener when retention policy is removed", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const offSpy = vi.spyOn(room, "off");
+
+            // Remove the policy
+            getCachedMock.mockResolvedValue(undefined);
+            await applyPolicy();
+
+            const timelineUnbindings = offSpy.mock.calls.filter(([event]) => event === RoomEvent.Timeline);
+            expect(timelineUnbindings.length).toBe(1);
+        });
+    });
+
+    describe("reactivity", () => {
+        it("recalculates policy when stable retention room state event changes", async () => {
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(true);
+
+            // setStateEvents emits RoomStateEvent.Events internally
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
+            await flushPromises();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(false);
+        });
+
+        it("recalculates policy when unstable retention room state event changes", async () => {
+            room.currentState.setStateEvents([
+                makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS }, "org.matrix.msc1763.retention"),
+            ]);
+            await flushPromises();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(false);
+        });
+
+        it("ignores irrelevant room state events", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const callsBefore = getCachedMock.mock.calls.length;
+
+            const nameEvent = new MatrixEvent({
+                type: "m.room.name",
+                state_key: "",
+                content: { name: "New Name" },
+                event_id: "$name",
+                room_id: ROOM_ID,
+                sender: USER_ID,
+            });
+            room.emit(RoomStateEvent.Events, nameEvent, room.currentState, null);
+            await flushPromises();
+
+            expect(getCachedMock.mock.calls.length).toBe(callsBefore);
+        });
+
+        it("ignores retention state events with a non-empty state key", async () => {
+            const callsBefore = getCachedMock.mock.calls.length;
+
+            const nonEmptyKeyEvent = new MatrixEvent({
+                type: "m.room.retention",
+                state_key: "non_empty",
+                content: { max_lifetime: ONE_DAY_MS },
+                event_id: "$retention_non_empty",
+                room_id: ROOM_ID,
+                sender: USER_ID,
+            });
+            room.emit(RoomStateEvent.Events, nonEmptyKeyEvent, room.currentState, null);
+            await flushPromises();
+
+            expect(getCachedMock.mock.calls.length).toBe(callsBefore);
+        });
+
+        it("recalculates policy on global retention service update", async () => {
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(true);
+
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(false);
+        });
+
+        it("re-processes timeline when policy becomes active via state event", async () => {
+            const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
+            await room.addLiveEvents([expiredEvent], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+
+            // setStateEvents emits RoomStateEvent.Events internally, triggering recalculation
+            room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
+            await flushPromises();
+
+            expect(redactSpy).toHaveBeenCalledOnce();
+            expect(redactSpy.mock.calls[0][0].event.redacts).toBe(expiredEvent.getId());
+        });
+    });
+
+    describe("timeline update debouncing", () => {
+        it("processes timeline after the 200ms debounce following a timeline update", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const recentEvent = makeMessageEvent(Date.now() - 1000);
+            // addLiveEvents will trigger the RoomEvent.Timeline listener (bound now that policy is active)
+            await room.addLiveEvents([recentEvent], { addToState: false });
+
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+
+            // Nothing should fire before the 200ms debounce
+            vi.advanceTimersByTime(199);
+            expect(redactSpy).not.toHaveBeenCalled();
+
+            // After 200ms the debounce fires and processTimeline runs
+            vi.advanceTimersByTime(1);
+            expect(redactSpy).not.toHaveBeenCalled(); // event is not expired
+        });
+
+        it("debounces multiple rapid timeline updates into a single processing pass", async () => {
+            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            await applyPolicy();
+
+            const recentEvent = makeMessageEvent(Date.now() - 1000);
+
+            // Emit several rapid timeline update events (simulating a burst of live events)
+            for (let i = 0; i < 5; i++) {
+                room.emit(RoomEvent.Timeline, recentEvent, room, undefined, false, { liveEvent: true });
+            }
+            await flushPromises();
+
+            // Only one timer should be pending; advance past the debounce
+            const redactSpy = vi.spyOn(room, "tryApplyRedaction");
+            vi.advanceTimersByTime(200);
+
+            // processTimeline ran once; no expired events
+            expect(redactSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -463,7 +463,7 @@ describe("RoomRetentionPolicy", () => {
 
             // Emit several rapid timeline update events (simulating a burst of live events)
             for (let i = 0; i < 5; i++) {
-                room.emit(RoomEvent.Timeline, recentEvent, room, undefined, false, { liveEvent: true });
+                room.emit(RoomEvent.Timeline, recentEvent, room, undefined, false, { liveEvent: true } as any);
             }
             await flushPromises();
 

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -476,10 +476,3 @@ describe("RoomRetentionPolicy", () => {
         });
     });
 });
-ime(200);
-
-            // processTimeline ran once; no expired events
-            expect(redactSpy).not.toHaveBeenCalled();
-        });
-    });
-});

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -68,7 +68,7 @@ describe("RoomRetentionPolicy", () => {
         vi.useFakeTimers();
         eventCounter = 0;
         retentionPolicyUpdateHandler = undefined;
-        getCachedMock = vi.fn().mockResolvedValue(undefined);
+        getCachedMock = vi.fn().mockReturnValue(undefined);
         removeEventsFromRoom = vi.fn().mockResolvedValue(undefined);
 
         const mockClient = {
@@ -101,14 +101,14 @@ describe("RoomRetentionPolicy", () => {
         });
 
         it("retains recent events within max_lifetime", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
             await applyPolicy();
 
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - 1000))).toBe(true);
         });
 
         it("does not retain events older than max_lifetime", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
             await applyPolicy();
 
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_WEEK_MS - 1000))).toBe(false);
@@ -152,7 +152,7 @@ describe("RoomRetentionPolicy", () => {
         it("server room-specific policy overrides room state policy", async () => {
             // Room state says 1 day, server says 1 week for this specific room
             room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
             await applyPolicy();
 
             // A 2-day-old event should be retained (server says 1 week)
@@ -162,7 +162,7 @@ describe("RoomRetentionPolicy", () => {
         });
 
         it("uses server wildcard policy when no room-specific policy exists", async () => {
-            getCachedMock.mockResolvedValue({ policies: { "*": { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { "*": { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
@@ -171,7 +171,7 @@ describe("RoomRetentionPolicy", () => {
         it("clamps room state max_lifetime to server maximum limit", async () => {
             // Room says 1 week, server caps max at 1 day — effective policy is 1 day
             room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_WEEK_MS })]);
-            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { max: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ limits: { max_lifetime: { max: ONE_DAY_MS } } });
             await applyPolicy();
 
             // 2-day-old event should be expired (clamped down to 1 day)
@@ -181,7 +181,7 @@ describe("RoomRetentionPolicy", () => {
         it("clamps room state max_lifetime to server minimum limit", async () => {
             // Room says 1 day, server requires minimum 1 week — effective policy is 1 week
             room.currentState.setStateEvents([makeRetentionStateEvent({ max_lifetime: ONE_DAY_MS })]);
-            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { min: ONE_WEEK_MS } } });
+            getCachedMock.mockReturnValue({ limits: { max_lifetime: { min: ONE_WEEK_MS } } });
             await applyPolicy();
 
             // A 2-day-old event should still be retained (clamped up to 1 week)
@@ -191,7 +191,7 @@ describe("RoomRetentionPolicy", () => {
         it("uses server min limit when room state has no max_lifetime", async () => {
             // Room state exists but omits max_lifetime; server limit provides the fallback min
             room.currentState.setStateEvents([makeRetentionStateEvent({})]);
-            getCachedMock.mockResolvedValue({ limits: { max_lifetime: { min: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ limits: { max_lifetime: { min: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(Date.now() - ONE_DAY_MS - 1000))).toBe(false);
@@ -204,7 +204,7 @@ describe("RoomRetentionPolicy", () => {
             await room.addLiveEvents([expiredEvent], { addToState: false });
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(redactSpy).toHaveBeenCalledOnce();
@@ -218,7 +218,7 @@ describe("RoomRetentionPolicy", () => {
             await room.addLiveEvents([makeMessageEvent(Date.now() - 1000)], { addToState: false });
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_WEEK_MS } } });
             await applyPolicy();
 
             expect(redactSpy).not.toHaveBeenCalled();
@@ -230,7 +230,7 @@ describe("RoomRetentionPolicy", () => {
             await room.addLiveEvents([expiredEvent, recentEvent], { addToState: false });
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(redactSpy).toHaveBeenCalledOnce();
@@ -241,7 +241,7 @@ describe("RoomRetentionPolicy", () => {
             const expiredEvent = makeMessageEvent(Date.now() - 2 * ONE_DAY_MS);
             await room.addLiveEvents([expiredEvent], { addToState: false });
 
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
             await flushPromises(); // removeEventsFromRoom is fire-and-forget
 
@@ -261,7 +261,7 @@ describe("RoomRetentionPolicy", () => {
             room.currentState.setStateEvents([oldStateEvent]);
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const stateEventRedacted = redactSpy.mock.calls.some(
@@ -276,7 +276,7 @@ describe("RoomRetentionPolicy", () => {
             await room.addLiveEvents([soonToExpire], { addToState: false });
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(redactSpy).not.toHaveBeenCalled(); // not expired yet
@@ -296,7 +296,7 @@ describe("RoomRetentionPolicy", () => {
             await room.addLiveEvents([laterToExpire, soonToExpire], { addToState: false });
 
             const redactSpy = vi.spyOn(room, "tryApplyRedaction");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(redactSpy).not.toHaveBeenCalled();
@@ -323,7 +323,7 @@ describe("RoomRetentionPolicy", () => {
     describe("event listener binding", () => {
         it("binds timeline listener when retention policy becomes active", async () => {
             const onSpy = vi.spyOn(room, "on");
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const timelineBindings = onSpy.mock.calls.filter(([event]) => event === RoomEvent.Timeline);
@@ -340,13 +340,13 @@ describe("RoomRetentionPolicy", () => {
         });
 
         it("unbinds timeline listener when retention policy is removed", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const offSpy = vi.spyOn(room, "off");
 
             // Remove the policy
-            getCachedMock.mockResolvedValue(undefined);
+            getCachedMock.mockReturnValue(undefined);
             await applyPolicy();
 
             const timelineUnbindings = offSpy.mock.calls.filter(([event]) => event === RoomEvent.Timeline);
@@ -375,7 +375,7 @@ describe("RoomRetentionPolicy", () => {
         });
 
         it("ignores irrelevant room state events", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const callsBefore = getCachedMock.mock.calls.length;
@@ -414,7 +414,7 @@ describe("RoomRetentionPolicy", () => {
         it("recalculates policy on global retention service update", async () => {
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(true);
 
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             expect(getPolicy().shouldEventBeRetained(makeMessageEvent(0))).toBe(false);
@@ -437,7 +437,7 @@ describe("RoomRetentionPolicy", () => {
 
     describe("timeline update debouncing", () => {
         it("processes timeline after the 200ms debounce following a timeline update", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const recentEvent = makeMessageEvent(Date.now() - 1000);
@@ -456,7 +456,7 @@ describe("RoomRetentionPolicy", () => {
         });
 
         it("debounces multiple rapid timeline updates into a single processing pass", async () => {
-            getCachedMock.mockResolvedValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
+            getCachedMock.mockReturnValue({ policies: { [ROOM_ID]: { max_lifetime: ONE_DAY_MS } } });
             await applyPolicy();
 
             const recentEvent = makeMessageEvent(Date.now() - 1000);

--- a/spec/unit/models/room-retention.spec.ts
+++ b/spec/unit/models/room-retention.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { type MockedObject } from "vitest";
 
 import { EventType, type MatrixClient, MatrixEvent, Room, RoomEvent, RoomStateEvent } from "../../../src";
-import { type RoomRetentionPolicy } from "../../../src/models/room-retention";
+import type { RoomRetentionPolicy } from "../../../src/models/room-retention";
 import { flushPromises } from "../../test-utils/flushPromises";
 
 const ROOM_ID = "!room:example.org";
@@ -288,9 +288,7 @@ describe("RoomRetentionPolicy", () => {
             expect(redactSpy).toHaveBeenCalledOnce();
         });
 
-        it("schedules next check based on the earliest-expiring event, not the latest", async () => {
-            // BUG: A wrong sort comparator causes the LATEST-expiring event to be scheduled,
-            // so the EARLIEST-expiring event is not processed on time.
+        it("schedules next check based on the earliest-expiring event", async () => {
             const soonExpiry = 1000; // expires in 1 second
             const laterExpiry = ONE_DAY_MS / 2; // expires in 12 hours
 

--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -29,7 +29,7 @@ describe("Relations", function () {
     });
 
     it("should deduplicate annotations", function () {
-        const room = new Room("room123", null!, null!);
+        const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), null!);
         const relations = new Relations("m.annotation", "m.reaction", room);
 
         // Create an instance of an annotation
@@ -193,7 +193,7 @@ describe("Relations", function () {
 
         // Add the target event first, then the relation event
         {
-            const room = new Room("room123", null!, null!);
+            const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), null!);
             const relationsCreated = new Promise((resolve) => {
                 targetEvent.once(MatrixEventEvent.RelationsCreated, resolve);
             });
@@ -207,7 +207,7 @@ describe("Relations", function () {
 
         // Add the relation event first, then the target event
         {
-            const room = new Room("room123", null!, null!);
+            const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), null!);
             const relationsCreated = new Promise((resolve) => {
                 targetEvent.once(MatrixEventEvent.RelationsCreated, resolve);
             });
@@ -221,7 +221,7 @@ describe("Relations", function () {
     });
 
     it("should re-use Relations between all timeline sets in a room", async () => {
-        const room = new Room("room123", null!, null!);
+        const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), null!);
         const timelineSet1 = new EventTimelineSet(room);
         const timelineSet2 = new EventTimelineSet(room);
         expect(room.relations).toBe(timelineSet1.relations);
@@ -230,7 +230,7 @@ describe("Relations", function () {
 
     it("should ignore m.replace for state events", async () => {
         const userId = "@bob:example.com";
-        const room = new Room("room123", null!, userId);
+        const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), userId);
         const relations = new Relations("m.replace", "m.room.topic", room);
 
         // Create an instance of a state event with rel_type m.replace

--- a/spec/unit/relations.spec.ts
+++ b/spec/unit/relations.spec.ts
@@ -20,7 +20,7 @@ import { MatrixEvent, MatrixEventEvent } from "../../src/models/event";
 import { Room } from "../../src/models/room";
 import { Relations, RelationsEvent } from "../../src/models/relations";
 import { TestClient } from "../TestClient";
-import { RelationType } from "../../src";
+import { MatrixClient, RelationType } from "../../src";
 import { logger } from "../../src/logger";
 
 describe("Relations", function () {
@@ -86,7 +86,7 @@ describe("Relations", function () {
         const relationType = RelationType.Reference;
         const eventType = M_POLL_START.stable!;
         const altEventTypes = [M_POLL_START.unstable!];
-        const room = new Room("room123", null!, null!);
+        const room = new Room("room123", new MatrixClient({ baseUrl: "http://example.org" }), null!);
 
         it("should not add events without a relation", async () => {
             // dont pollute console

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -4344,6 +4344,7 @@ describe("Room", function () {
             content: {
                 msc4354_sticky_key: "foobar",
             },
+            origin_server_ts: 0,
             sender: "@alice:example.org",
             unsigned: {},
         };

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -35,10 +35,12 @@ import {
     type IEvent,
     type IRelationsRequestOpts,
     type IStateEventWithRoomId,
+    IStickyEvent,
     JoinRule,
-    type MatrixClient,
+    MatrixClient,
     MatrixEvent,
     MatrixEventEvent,
+    MatrixHttpApi,
     PendingEventOrdering,
     PollEvent,
     RelationType,
@@ -58,6 +60,7 @@ import { logger } from "../../src/logger";
 import { flushPromises } from "../test-utils/flushPromises";
 import { KnownMembership } from "../../src/@types/membership";
 import type { CryptoBackend } from "../../src/common-crypto/CryptoBackend";
+import { RetentionPolicyService } from "../../src/retentionPolicy";
 
 describe("Room", function () {
     const roomId = "!foo:bar";
@@ -2024,7 +2027,7 @@ describe("Room", function () {
         });
 
         it("should remove cancelled events from the timeline", function () {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             const eventA = utils.mkMessage({
                 room: roomId,
                 user: userA,
@@ -2169,12 +2172,12 @@ describe("Room", function () {
 
     describe("getMyMembership", function () {
         it("should return synced membership if membership isn't available yet", function () {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             room.updateMyMembership(KnownMembership.Invite);
             expect(room.getMyMembership()).toEqual(JoinRule.Invite);
         });
         it("should emit a Room.myMembership event on a change", function () {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             const events: {
                 membership: string;
                 oldMembership?: string;
@@ -2196,7 +2199,7 @@ describe("Room", function () {
 
     describe("getDMInviter", () => {
         it("should delegate to RoomMember::getDMInviter if available", () => {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             room.currentState.markOutOfBandMembersStarted();
             room.currentState.setOutOfBandMembers([
                 new MatrixEvent({
@@ -2214,7 +2217,7 @@ describe("Room", function () {
         });
 
         it("should fall back to summary heroes and return the first one", () => {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             room.updateMyMembership(KnownMembership.Invite);
             room.setSummary({
                 "m.heroes": [userA, userC],
@@ -2226,7 +2229,7 @@ describe("Room", function () {
         });
 
         it("should return undefined if we're not joined or invited to the room", () => {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, new MatrixClient({ baseUrl: "http://example.org" }), userA);
             expect(room.getDMInviter()).toBeUndefined();
             room.updateMyMembership(KnownMembership.Leave);
             expect(room.getDMInviter()).toBeUndefined();
@@ -2265,15 +2268,16 @@ describe("Room", function () {
     });
 
     describe("getAvatarFallbackMember", () => {
+        const client = new MatrixClient({ baseUrl: "any" });
         it("should return undefined if the room isn't a 1:1", () => {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, client, userA);
             room.currentState.setJoinedMemberCount(2);
             room.currentState.setInvitedMemberCount(1);
             expect(room.getAvatarFallbackMember()).toBeUndefined();
         });
 
         it("should use summary heroes member if 1:1", () => {
-            const room = new Room(roomId, null!, userA);
+            const room = new Room(roomId, client, userA);
             room.currentState.markOutOfBandMembersStarted();
             room.currentState.setOutOfBandMembers([
                 new MatrixEvent({
@@ -2293,9 +2297,9 @@ describe("Room", function () {
             expect(room.getAvatarFallbackMember()?.userId).toBe(userD);
         });
 
-        it("should return undefined if the room is a 1:1 plus functional member", async function () {
-            const room = new Room(roomId, null!, userA);
-            await room.currentState.setStateEvents([
+        it("should return undefined if the room is a 1:1 plus functional member", function () {
+            const room = new Room(roomId, client, userA);
+            room.currentState.setStateEvents([
                 utils.mkMembership({
                     user: userA,
                     mship: "join",
@@ -2323,9 +2327,9 @@ describe("Room", function () {
             expect(room.getAvatarFallbackMember()).toBeUndefined();
         });
 
-        it("should pick nonfunctional member from summary heroes if room is a 1:1 plus functional member", async function () {
-            const room = new Room(roomId, null!, userA);
-            await room.currentState.setStateEvents([
+        it("should pick nonfunctional member from summary heroes if room is a 1:1 plus functional member", function () {
+            const room = new Room(roomId, client, userA);
+            room.currentState.setStateEvents([
                 utils.mkMembership({
                     user: userA,
                     mship: "join",
@@ -4298,5 +4302,76 @@ describe("Room", function () {
     it("saves and retrieves the bump stamp", () => {
         room.setBumpStamp(123456789);
         expect(room.getBumpStamp()).toEqual(123456789);
+    });
+
+    describe.only("should handle retention", () => {
+        let room: Room;
+        beforeEach(async () => {
+            vitest.useFakeTimers();
+            const client = vitest.mockObject(
+                new MatrixClient({
+                    baseUrl: "http://example.org",
+                    unstableMSC1763Retention: true,
+                }),
+            );
+            client.retentionPolicyService.getCached = vitest.fn().mockReturnValue({
+                policies: {
+                    "*": {
+                        max_lifetime: 1000,
+                    },
+                },
+            });
+            client.supportsThreads.mockReturnValue(true);
+            room = new Room("!room:id", client, "@my:user");
+        });
+
+        it("should NOT filter live events before the retention period", async () => {
+            const events = [mkMessage({ ts: Date.now() - 999 })];
+            await room.addLiveEvents(events, { addToState: false });
+            expect(room.getLiveTimeline().getEvents()).toHaveLength(1);
+        });
+        it("should filter live events before the retention period", async () => {
+            const events = [mkMessage({ ts: Date.now() - 1000 })];
+            await room.addLiveEvents(events, { addToState: false });
+            expect(room.getLiveTimeline().getEvents()).toHaveLength(0);
+        });
+
+        const stickyEvent: IStickyEvent = {
+            event_id: "$foo:bar",
+            room_id: "!roomId",
+            type: "org.example.any_type",
+            msc4354_sticky: {
+                duration_ms: 15000,
+            },
+            content: {
+                msc4354_sticky_key: "foobar",
+            },
+            sender: "@alice:example.org",
+            unsigned: {},
+        };
+        it("should NOT filter sticky events before the retention period", async () => {
+            const events = [new MatrixEvent({ ...stickyEvent, origin_server_ts: Date.now() - 999 })];
+            room._unstable_addStickyEvents(events);
+            expect([...room._unstable_getStickyEvents()]).toHaveLength(1);
+        });
+        it("should filter sticky events after the retention period", async () => {
+            const events = [new MatrixEvent({ ...stickyEvent, origin_server_ts: Date.now() - 1000 })];
+            room._unstable_addStickyEvents(events);
+            expect([...room._unstable_getStickyEvents()]).toHaveLength(0);
+        });
+        it("should NOT filter threaded events before the retention period", async () => {
+            const threadRoot = mkMessage();
+            const threadResponse1 = mkThreadResponse(threadRoot, { ts: Date.now() - 999 });
+            await room.addLiveEvents([threadRoot], { addToState: false });
+            room.processThreadedEvents([threadResponse1], false);
+            expect(room.getThreads()).toHaveLength(1);
+        });
+        it("should filter threaded events after the retention period", async () => {
+            const threadRoot = mkMessage();
+            const threadResponse1 = mkThreadResponse(threadRoot, { ts: Date.now() - 1000 });
+            await room.addLiveEvents([threadRoot], { addToState: false });
+            room.processThreadedEvents([threadResponse1], false);
+            expect(room.getThreads()).toHaveLength(0);
+        });
     });
 });

--- a/spec/unit/room.spec.ts
+++ b/spec/unit/room.spec.ts
@@ -35,12 +35,11 @@ import {
     type IEvent,
     type IRelationsRequestOpts,
     type IStateEventWithRoomId,
-    IStickyEvent,
+    type IStickyEvent,
     JoinRule,
     MatrixClient,
     MatrixEvent,
     MatrixEventEvent,
-    MatrixHttpApi,
     PendingEventOrdering,
     PollEvent,
     RelationType,
@@ -60,7 +59,6 @@ import { logger } from "../../src/logger";
 import { flushPromises } from "../test-utils/flushPromises";
 import { KnownMembership } from "../../src/@types/membership";
 import type { CryptoBackend } from "../../src/common-crypto/CryptoBackend";
-import { RetentionPolicyService } from "../../src/retentionPolicy";
 
 describe("Room", function () {
     const roomId = "!foo:bar";
@@ -4304,7 +4302,7 @@ describe("Room", function () {
         expect(room.getBumpStamp()).toEqual(123456789);
     });
 
-    describe.only("should handle retention", () => {
+    describe("should handle retention", () => {
         let room: Room;
         beforeEach(async () => {
             vitest.useFakeTimers();

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -65,6 +65,7 @@ import { type LocalNotificationSettings } from "./local_notifications.ts";
 import { type IPushRules } from "./PushRules.ts";
 import { type SecretInfo, type SecretStorageKeyDescription } from "../secret-storage.ts";
 import { type POLICIES_ACCOUNT_EVENT_TYPE } from "../models/invites-ignorer-types.ts";
+import { ROOM_RETENTION_TYPE, type RoomRetentionContent } from "./retention.ts";
 
 export enum EventType {
     // Room state events
@@ -162,6 +163,10 @@ export enum EventType {
 
     // Policy servers
     RoomPolicy = "org.matrix.msc4284.policy",
+
+    // Retention
+    RetentionPolicy = "m.room.retention",
+    RetentionPolicyUnstable = "org.matrix.msc1763.retention",
 }
 
 export enum RelationType {
@@ -396,6 +401,10 @@ export interface StateEvents {
 
     // MSC3672
     [M_BEACON_INFO.name]: MBeaconInfoEventContent;
+
+    // MSC1763
+    [ROOM_RETENTION_TYPE.name]: RoomRetentionContent | EmptyObject;
+    [ROOM_RETENTION_TYPE.altName]: RoomRetentionContent | EmptyObject;
 }
 
 /**

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -65,7 +65,7 @@ import { type LocalNotificationSettings } from "./local_notifications.ts";
 import { type IPushRules } from "./PushRules.ts";
 import { type SecretInfo, type SecretStorageKeyDescription } from "../secret-storage.ts";
 import { type POLICIES_ACCOUNT_EVENT_TYPE } from "../models/invites-ignorer-types.ts";
-import { ROOM_RETENTION_TYPE, type RoomRetentionContent } from "./retention.ts";
+import type { ROOM_RETENTION_TYPE, RoomRetentionContent } from "./retention.ts";
 
 export enum EventType {
     // Room state events

--- a/src/@types/retention.ts
+++ b/src/@types/retention.ts
@@ -1,0 +1,16 @@
+import { UnstableValue } from "../NamespacedValue.ts";
+
+/**
+ * Event type for a room policy event.
+ * NOTE: While MSC1763 has not been merged, `m.room.retention` is unfortunately
+ * already in use in production.
+ */
+export const ROOM_RETENTION_TYPE = new UnstableValue("m.room.retention", "org.matrix.msc1763.retention");
+
+/**
+ * The content of a `m.room.retention` state event.
+ */
+export interface RoomRetentionContent {
+    max_lifetime?: number;
+    min_lifetime?: number;
+}

--- a/src/capabilityPoller.ts
+++ b/src/capabilityPoller.ts
@@ -16,6 +16,8 @@ limitations under the License.
 
 import { type IHttpOpts, type MatrixHttpApi } from "./http-api/index.ts";
 import { type Logger } from "./logger.ts";
+import { TypedEventEmitter } from "./models/typed-event-emitter.ts";
+import { deepCompare } from "./utils.ts";
 
 // How often we update the server capabilities.
 // 6 hours - an arbitrary value, but they should change very infrequently.
@@ -27,7 +29,10 @@ const CAPABILITIES_RETRY_MS = 30 * 1000;
 /**
  * Manages storing and periodically refreshing the server capabilities.
  */
-export abstract class CapabilityPoller<ResponseType> {
+export abstract class CapabilityPoller<ResponseType> extends TypedEventEmitter<
+    "update",
+    { update: (data: ResponseType) => void }
+> {
     protected cached?: ResponseType;
     private retryTimeout?: ReturnType<typeof setTimeout>;
     private refreshTimeout?: ReturnType<typeof setInterval>;
@@ -35,7 +40,10 @@ export abstract class CapabilityPoller<ResponseType> {
     public constructor(
         protected readonly logger: Logger,
         protected readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
-    ) {}
+        private readonly name: string,
+    ) {
+        super();
+    }
 
     /**
      * Starts periodically fetching the server capabilities.
@@ -62,16 +70,21 @@ export abstract class CapabilityPoller<ResponseType> {
     public abstract fetch(): Promise<ResponseType>;
 
     private poll = async (): Promise<void> => {
+        this.logger.debug("Checking capabilites");
         try {
+            const current = this.cached;
             await this.fetch();
             this.clearTimeouts();
-            this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
-            this.logger.debug("Fetched new server capabilities");
+            this.refreshTimeout = globalThis.setTimeout(this.poll, CAPABILITIES_CACHE_MS);
+            this.logger.debug(`Fetched new server ${this.name}`);
+            if (this.cached && !deepCompare(current, this.cached)) {
+                this.emit("update", this.cached);
+            }
         } catch (e) {
             this.clearTimeouts();
             const howLong = Math.floor(CAPABILITIES_RETRY_MS + Math.random() * 5000);
-            this.retryTimeout = setTimeout(this.poll, howLong);
-            this.logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
+            this.retryTimeout = globalThis.setTimeout(this.poll, howLong);
+            this.logger.warn(`Failed to refresh ${this.name}: retrying in ${howLong}ms`, e);
         }
     };
 

--- a/src/capabilityPoller.ts
+++ b/src/capabilityPoller.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { type IHttpOpts, type MatrixHttpApi } from "./http-api/index.ts";
+import { type Logger } from "./logger.ts";
+
+// How often we update the server capabilities.
+// 6 hours - an arbitrary value, but they should change very infrequently.
+const CAPABILITIES_CACHE_MS = 6 * 60 * 60 * 1000;
+
+// How long we want before retrying if we couldn't fetch
+const CAPABILITIES_RETRY_MS = 30 * 1000;
+
+/**
+ * Manages storing and periodically refreshing the server capabilities.
+ */
+export abstract class CapabilityPoller<ResponseType> {
+    protected cached?: ResponseType;
+    private retryTimeout?: ReturnType<typeof setTimeout>;
+    private refreshTimeout?: ReturnType<typeof setInterval>;
+
+    public constructor(
+        protected readonly logger: Logger,
+        protected readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+    ) {}
+
+    /**
+     * Starts periodically fetching the server capabilities.
+     */
+    public start(): void {
+        this.poll().then();
+    }
+
+    /**
+     * Stops the service
+     */
+    public stop(): void {
+        this.clearTimeouts();
+    }
+
+    /**
+     * Returns the cached capabilities, or undefined if none are cached.
+     * @returns the current capabilities, if any.
+     */
+    public getCached(): ResponseType | undefined {
+        return this.cached;
+    }
+
+    public abstract fetch(): Promise<ResponseType>;
+
+    private poll = async (): Promise<void> => {
+        try {
+            await this.fetch();
+            this.clearTimeouts();
+            this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
+            this.logger.debug("Fetched new server capabilities");
+        } catch (e) {
+            this.clearTimeouts();
+            const howLong = Math.floor(CAPABILITIES_RETRY_MS + Math.random() * 5000);
+            this.retryTimeout = setTimeout(this.poll, howLong);
+            this.logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
+        }
+    };
+
+    private clearTimeouts(): void {
+        if (this.refreshTimeout) {
+            clearInterval(this.refreshTimeout);
+            this.refreshTimeout = undefined;
+        }
+        if (this.retryTimeout) {
+            clearTimeout(this.retryTimeout);
+            this.retryTimeout = undefined;
+        }
+    }
+}

--- a/src/capabilityPoller.ts
+++ b/src/capabilityPoller.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,8 +249,7 @@ import {
 import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
 import { type Transport } from "./matrixrtc/index.ts";
-import type { RetentionConfigurationResponse } from "./models/room-retention.ts";
-import { RetentionPolicyService } from "./retentionPolicy.ts";
+import { RetentionPolicyService, type RetentionConfigurationResponse } from "./retentionPolicy.ts";
 
 export type Store = IStore;
 
@@ -1334,7 +1333,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public readonly matrixRTC: MatrixRTCSessionManager;
 
     private serverCapabilitiesService: ServerCapabilities;
-    private retentionPolicyService: RetentionPolicyService;
+    public readonly retentionPolicyService: RetentionPolicyService;
 
     public constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -1976,18 +1975,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      */
     public fetchCapabilities(): Promise<Capabilities> {
         return this.serverCapabilitiesService.fetch();
-    }
-
-    /**
-     * Gets the cached retention policy of the homeserver, returning cached ones if available.
-     * If there are no cached retention policies and none can be fetched, throw an exception.
-     *
-     * @returns Promise resolving with The capabilities of the homeserver
-     */
-    public async getRetentionPolicy(): Promise<RetentionConfigurationResponse> {
-        const caps = this.retentionPolicyService.getCached();
-        if (caps) return caps;
-        return this.retentionPolicyService.fetch();
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -545,6 +545,11 @@ export interface IStartClientOpts {
      * Will only work if the server supports MSC4429.
      */
     unstableMSC4429SyncUserProfileFields?: string[];
+
+    /**
+     * Locally remove events past the server global or per room retention setting.
+     */
+    unstableMSC1763Retention?: boolean;
 }
 
 export interface IStoredClientOpts extends IStartClientOpts {}
@@ -1451,6 +1456,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     public get store(): Store {
         return this._store;
+    }
+
+    // eslint-disable-next-line
+    public get _unstable_shouldApplyMessageRetention(): boolean {
+        return !!this.clientOpts?.unstableMSC1763Retention;
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -463,6 +463,11 @@ export interface ICreateClientOpts {
      * Defaults to the built-in global logger; see {@link DebugLogger} for an alternative.
      */
     logger?: Logger;
+
+    /**
+     * Locally remove events past the server global or per room retention setting.
+     */
+    unstableMSC1763Retention?: boolean;
 }
 
 export interface IMatrixClientCreateOpts extends ICreateClientOpts {
@@ -546,11 +551,6 @@ export interface IStartClientOpts {
      * Will only work if the server supports MSC4429.
      */
     unstableMSC4429SyncUserProfileFields?: string[];
-
-    /**
-     * Locally remove events past the server global or per room retention setting.
-     */
-    unstableMSC1763Retention?: boolean;
 }
 
 export interface IStoredClientOpts extends IStartClientOpts {}
@@ -1334,6 +1334,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     private serverCapabilitiesService: ServerCapabilities;
     public readonly retentionPolicyService: RetentionPolicyService;
+    // eslint-disable-next-line
+    public readonly _unstable_shouldApplyMessageRetention: boolean;
 
     public constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -1413,6 +1415,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.serverCapabilitiesService = new ServerCapabilities(this.logger, this.http);
         this.retentionPolicyService = new RetentionPolicyService(this.logger, this.http);
+        this._unstable_shouldApplyMessageRetention = opts.unstableMSC1763Retention ?? false;
 
         this.on(ClientEvent.Sync, this.fixupRoomNotifications);
 
@@ -1459,11 +1462,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
     public get store(): Store {
         return this._store;
-    }
-
-    // eslint-disable-next-line
-    public get _unstable_shouldApplyMessageRetention(): boolean {
-        return !!this.clientOpts?.unstableMSC1763Retention;
     }
 
     /**
@@ -6219,19 +6217,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 prefix: `${ClientPrefix.Unstable}/org.matrix.msc4143`,
             })
         ).rtc_transports;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    public async _unstable_getMessageRetentionConfiguration(): Promise<RetentionConfigurationResponse> {
-        return await this.http.authedRequest<RetentionConfigurationResponse>(
-            Method.Get,
-            "/retention/configuration",
-            undefined,
-            undefined,
-            {
-                prefix: `${ClientPrefix.Unstable}/org.matrix.msc1763`,
-            },
-        );
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,6 +249,8 @@ import {
 import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
 import { type Transport } from "./matrixrtc/index.ts";
+import type { RetentionConfigurationResponse } from "./models/room-retention.ts";
+import { RetentionPolicyService } from "./retentionPolicy.ts";
 
 export type Store = IStore;
 
@@ -1332,6 +1334,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     public readonly matrixRTC: MatrixRTCSessionManager;
 
     private serverCapabilitiesService: ServerCapabilities;
+    private retentionPolicyService: RetentionPolicyService;
 
     public constructor(opts: IMatrixClientCreateOpts) {
         super();
@@ -1410,6 +1413,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.matrixRTC = new MatrixRTCSessionManager(this.logger, this);
 
         this.serverCapabilitiesService = new ServerCapabilities(this.logger, this.http);
+        this.retentionPolicyService = new RetentionPolicyService(this.logger, this.http);
 
         this.on(ClientEvent.Sync, this.fixupRoomNotifications);
 
@@ -1540,6 +1544,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.toDeviceMessageQueue.start();
         this.serverCapabilitiesService.start();
+        if (opts?.unstableMSC1763Retention) {
+            this.retentionPolicyService?.start();
+        }
     }
 
     /**
@@ -1946,9 +1953,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns Promise resolving with The capabilities of the homeserver
      */
     public async getCapabilities(): Promise<Capabilities> {
-        const caps = this.serverCapabilitiesService.getCachedCapabilities();
+        const caps = this.serverCapabilitiesService.getCached();
         if (caps) return caps;
-        return this.serverCapabilitiesService.fetchCapabilities();
+        return this.serverCapabilitiesService.fetch();
     }
 
     /**
@@ -1958,7 +1965,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns The capabilities of the homeserver
      */
     public getCachedCapabilities(): Capabilities | undefined {
-        return this.serverCapabilitiesService.getCachedCapabilities();
+        return this.serverCapabilitiesService.getCached();
     }
 
     /**
@@ -1968,7 +1975,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @returns A promise which resolves to the capabilities of the homeserver
      */
     public fetchCapabilities(): Promise<Capabilities> {
-        return this.serverCapabilitiesService.fetchCapabilities();
+        return this.serverCapabilitiesService.fetch();
+    }
+
+    /**
+     * Gets the cached retention policy of the homeserver, returning cached ones if available.
+     * If there are no cached retention policies and none can be fetched, throw an exception.
+     *
+     * @returns Promise resolving with The capabilities of the homeserver
+     */
+    public async getRetentionPolicy(): Promise<RetentionConfigurationResponse> {
+        const caps = this.retentionPolicyService.getCached();
+        if (caps) return caps;
+        return this.retentionPolicyService.fetch();
     }
 
     /**
@@ -6213,6 +6232,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 prefix: `${ClientPrefix.Unstable}/org.matrix.msc4143`,
             })
         ).rtc_transports;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public async _unstable_getMessageRetentionConfiguration(): Promise<RetentionConfigurationResponse> {
+        return await this.http.authedRequest<RetentionConfigurationResponse>(
+            Method.Get,
+            "/retention/configuration",
+            undefined,
+            undefined,
+            {
+                prefix: `${ClientPrefix.Unstable}/org.matrix.msc1763`,
+            },
+        );
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,7 +249,7 @@ import {
 import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
 import { type Transport } from "./matrixrtc/index.ts";
-import { RetentionPolicyService, type RetentionConfigurationResponse } from "./retentionPolicy.ts";
+import { RetentionPolicyService } from "./retentionPolicy.ts";
 
 export type Store = IStore;
 
@@ -1541,7 +1541,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.toDeviceMessageQueue.start();
         this.serverCapabilitiesService.start();
-        if (opts?.unstableMSC1763Retention) {
+        if (this._unstable_shouldApplyMessageRetention) {
             this.retentionPolicyService?.start();
         }
     }

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -71,6 +71,7 @@ export * from "./@types/location.ts";
 export * from "./@types/threepids.ts";
 export * from "./@types/auth.ts";
 export * from "./@types/polls.ts";
+export * from "./@types/retention.ts";
 export type * from "./@types/local_notifications.ts";
 export type * from "./@types/registration.ts";
 export * from "./@types/read_receipts.ts";

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -21,6 +21,7 @@ import { type Logger, logger as rootLogger } from "../logger.ts";
 import { EventType } from "../@types/event.ts";
 import type { RetentionPolicyService } from "../retentionPolicy.ts";
 import type { IStore } from "../store/index.ts";
+import { ROOM_RETENTION_TYPE, type RoomRetentionContent } from "../@types/retention.ts";
 
 /**
  * Applies https://github.com/matrix-org/matrix-spec-proposals/pull/1763 by checking the current
@@ -97,15 +98,14 @@ export class RoomRetentionPolicy {
     };
 
     private readonly recalculateRetention = async (roomState: RoomState): Promise<void> => {
-        const unstableEvent = roomState
-            .getStateEvents("org.matrix.msc1763.retention")
-            .find((e) => e.getStateKey() === "");
-        const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
+        const unstableEvent = roomState.getStateEvents(ROOM_RETENTION_TYPE.name).find((e) => e.getStateKey() === "");
+        const stableEvent = roomState.getStateEvents(ROOM_RETENTION_TYPE.altName).find((e) => e.getStateKey() === "");
 
         const serverPolicy = this.retentionService.getCached();
 
         const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
-        const roomStatePolicy = unstableEvent?.getContent() ?? stableEvent?.getContent();
+        const roomStatePolicy =
+            unstableEvent?.getContent<RoomRetentionContent>() ?? stableEvent?.getContent<RoomRetentionContent>();
 
         const content =
             // * if the homeserver defines a specific retention policy for this room, then use this policy as the effective retention policy of the room.

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -29,14 +29,14 @@ import { EventType } from "../@types/event";
  *   - Loop
  */
 export class RoomRetentionPolicy {
-    private minRetention: number | null = null;
+    // minRetention is not implemented.
     private maxRetention: number | null = null;
     private retentionTimeout?: ReturnType<typeof setTimeout>;
     private readonly logger: Logger;
 
     public constructor(private readonly room: Room) {
         this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
-        room.on(RoomEvent.Timeline, this.timelineUpdated);
+        room.on(RoomEvent.Timeline, () => this.timelineUpdated());
         room.on(RoomStateEvent.Events, this.roomStateUpdate);
     }
 
@@ -62,7 +62,6 @@ export class RoomRetentionPolicy {
 
         if (!content) {
             this.maxRetention = null;
-            this.minRetention = null;
             return;
         }
 
@@ -83,34 +82,43 @@ export class RoomRetentionPolicy {
             }
         }
         this.maxRetention = maxLifetime;
-        this.minRetention = minLifetime ?? null;
-
         this.logger.info("currentStateUpdated", minLifetime, maxLifetime);
         this.processTimeline();
     };
 
-    private readonly timelineUpdated = (): void => {
+    private readonly timelineUpdated = (nextTs = 200): void => {
+        this.logger.info("timelineUpdated");
         if (this.retentionTimeout) {
             clearTimeout(this.retentionTimeout);
         }
         this.retentionTimeout = setTimeout(() => {
             this.processTimeline();
             this.retentionTimeout = undefined;
-        }, 200);
-        this.logger.info("timelineUpdated");
+        }, nextTs);
     };
 
     private processTimeline(): void {
         if (!this.maxRetention) {
             return; // No policy, skip.
         }
+        this.logger.info(`Running processTimeline`);
         const expireBefore = Date.now() - this.maxRetention;
-        const expiredEvents = this.room
+        const events = this.room
             .getLiveTimeline()
             .getEvents()
-            .filter((ev) => ev.getTs() < expireBefore);
+            .filter((ev) => ev.getStateKey() === undefined || ev.isRedacted() || ev.getType() === "m.room.redacation");
+
+        const expiredEvents = events.filter((ev) => ev.getTs() < expireBefore);
+        const [earliestExpiringEvent] = events.filter((ev) => ev.getTs() >= expireBefore).sort((ev) => ev.getTs());
+
+        if (earliestExpiringEvent) {
+            const nextTs = earliestExpiringEvent.getTs() + this.maxRetention - Date.now();
+            this.logger.info(`Next expiry scheduled for ${nextTs}`);
+            this.timelineUpdated(nextTs);
+        }
+
         if (expiredEvents.length === 0) {
-            this.logger.info(`Found no expired events`, expireBefore, this.room.getLiveTimeline().getEvents());
+            this.logger.info("Found no expired events");
             return;
         }
         this.logger.info(`Found ${expiredEvents.length} expired events`);
@@ -118,14 +126,26 @@ export class RoomRetentionPolicy {
             this.room.tryApplyRedaction(
                 new MatrixEvent({
                     type: EventType.RoomRedaction,
+                    sender: event.getSender(),
                     event_id: "$synthetic_redaction",
                     room_id: this.room.roomId,
                     redacts: event.getId(),
-                    content: {},
+                    content: {
+                        reason: "Retention policy",
+                    },
                     origin_server_ts: Date.now(),
                     unsigned: {},
                 }),
             );
         }
+        // TODO: Asyncify
+        void this.room.client.store
+            .vapeEventsFromRoom(
+                this.room.roomId,
+                expiredEvents.map((e) => e.getId()!),
+            )
+            .catch((ex) => {
+                this.logger.warn(`Failed to vape events from store`, ex);
+            });
     }
 }

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -221,7 +221,7 @@ export class RoomRetentionPolicy {
         }
         // TODO: Asyncify
         void this.store
-            .vapeEventsFromRoom(
+            .removeEventsFromRoom(
                 this.room.roomId,
                 expiredEvents.map((e) => e.getId()!),
             )

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -19,6 +19,8 @@ import { RoomEvent, type Room } from "./room.ts";
 import { RoomStateEvent, type RoomState } from "./room-state.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { EventType } from "../@types/event.ts";
+import type { RetentionPolicyService } from "../retentionPolicy.ts";
+import type { IStore } from "../store/index.ts";
 
 /**
  * Applies https://github.com/matrix-org/matrix-spec-proposals/pull/1763 by checking the current
@@ -34,7 +36,11 @@ export class RoomRetentionPolicy {
     private retentionTimeout?: ReturnType<typeof setTimeout>;
     private readonly logger: Logger;
 
-    public constructor(private readonly room: Room) {
+    public constructor(
+        private readonly room: Room,
+        private readonly retentionService: RetentionPolicyService,
+        private readonly store: IStore,
+    ) {
         this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
 
         // Recalculate on room state update.
@@ -49,7 +55,7 @@ export class RoomRetentionPolicy {
         });
 
         // Recalculate our retention whenever the global policy changes.
-        this.room.client.retentionPolicyService.on("update", () => {
+        this.retentionService.on("update", () => {
             this.logger.info("Got global retention policy update!");
             void this.handleRetentionUpdate();
         });
@@ -97,7 +103,7 @@ export class RoomRetentionPolicy {
         const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
 
         // TODO: Error handle.
-        const serverPolicy = await this.room.client.retentionPolicyService.getCached();
+        const serverPolicy = await this.retentionService.getCached();
 
         const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
         const roomStatePolicy = unstableEvent?.getContent() ?? stableEvent?.getContent();
@@ -182,7 +188,9 @@ export class RoomRetentionPolicy {
             .filter((ev) => ev.getStateKey() === undefined && !ev.isRedacted() && ev.getType() !== "m.room.redaction");
 
         const expiredEvents = events.filter((ev) => ev.getTs() < expireBefore);
-        const [earliestExpiringEvent] = events.filter((ev) => ev.getTs() >= expireBefore).sort((a, b) => a.getTs() - b.getTs());
+        const [earliestExpiringEvent] = events
+            .filter((ev) => ev.getTs() >= expireBefore)
+            .sort((a, b) => a.getTs() - b.getTs());
 
         if (earliestExpiringEvent) {
             const nextTs = earliestExpiringEvent.getTs() + this.maxRetention - Date.now();
@@ -212,7 +220,7 @@ export class RoomRetentionPolicy {
             );
         }
         // TODO: Asyncify
-        void this.room.client.store
+        void this.store
             .vapeEventsFromRoom(
                 this.room.roomId,
                 expiredEvents.map((e) => e.getId()!),

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { MatrixEvent } from "../models/event";
+import { RoomEvent, type Room } from "./room";
+import { RoomStateEvent, type RoomState } from "./room-state";
+import { type Logger, logger as rootLogger } from "../logger";
+import { EventType } from "../@types/event";
+
+/**
+ * Applies https://github.com/matrix-org/matrix-spec-proposals/pull/1763 by checking the current
+ * state of the room and applying the *latest* retention policy to all preceeding events.
+ * Currently does not:
+ *   - Apply global server policies (requires Synapse work)
+ *   - React at all to `min_retention` configs.
+ *   - Loop
+ */
+export class RoomRetentionPolicy {
+    private minRetention: number | null = null;
+    private maxRetention: number | null = null;
+    private retentionTimeout?: ReturnType<typeof setTimeout>;
+    private readonly logger: Logger;
+
+    public constructor(private readonly room: Room) {
+        this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
+        room.on(RoomEvent.Timeline, this.timelineUpdated);
+        room.on(RoomStateEvent.Events, this.roomStateUpdate);
+    }
+
+    private readonly roomStateUpdate = (event: MatrixEvent, state: RoomState, prevEvent: MatrixEvent | null): void => {
+        if (
+            event.getStateKey() !== "" ||
+            (event.getType() !== "org.matrix.msc1763.retention" && event.getType() !== "m.room.retention")
+        ) {
+            return;
+        }
+        this.logger.info("roomStateUpdate", event.getType(), event.getContent());
+        this.currentStateUpdated(state);
+    };
+
+    private readonly currentStateUpdated = (roomState: RoomState): void => {
+        const unstableEvent = roomState
+            .getStateEvents("org.matrix.msc1763.retention")
+            .find((e) => e.getStateKey() === "");
+        const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
+        this.logger.info("currentStateUpdated", unstableEvent, stableEvent);
+
+        const content = unstableEvent?.getContent() ?? stableEvent?.getContent();
+
+        if (!content) {
+            this.maxRetention = null;
+            this.minRetention = null;
+            return;
+        }
+
+        // Parse it
+        const { min_lifetime: minLifetime, max_lifetime: maxLifetime } = content;
+        if (typeof maxLifetime !== "number") {
+            throw Error(`max_lifetime must be a number, got "${maxLifetime}"`);
+        }
+        if (maxLifetime < 0 || !Number.isInteger(maxLifetime)) {
+            throw Error(`max_lifetime must be >= 0, got ${maxLifetime}`);
+        }
+        if (minLifetime !== undefined) {
+            if (typeof minLifetime !== "number") {
+                throw Error(`min_lifetime must be a number, got "${minLifetime}"`);
+            }
+            if (minLifetime < 0 || !Number.isInteger(minLifetime)) {
+                throw Error(`min_lifetime must be >= 0, got ${minLifetime}`);
+            }
+        }
+        this.maxRetention = maxLifetime;
+        this.minRetention = minLifetime ?? null;
+
+        this.logger.info("currentStateUpdated", minLifetime, maxLifetime);
+        this.processTimeline();
+    };
+
+    private readonly timelineUpdated = (): void => {
+        if (this.retentionTimeout) {
+            clearTimeout(this.retentionTimeout);
+        }
+        this.retentionTimeout = setTimeout(() => {
+            this.processTimeline();
+            this.retentionTimeout = undefined;
+        }, 200);
+        this.logger.info("timelineUpdated");
+    };
+
+    private processTimeline(): void {
+        if (!this.maxRetention) {
+            return; // No policy, skip.
+        }
+        const expireBefore = Date.now() - this.maxRetention;
+        const expiredEvents = this.room
+            .getLiveTimeline()
+            .getEvents()
+            .filter((ev) => ev.getTs() < expireBefore);
+        if (expiredEvents.length === 0) {
+            this.logger.info(`Found no expired events`, expireBefore, this.room.getLiveTimeline().getEvents());
+            return;
+        }
+        this.logger.info(`Found ${expiredEvents.length} expired events`);
+        for (const event of expiredEvents) {
+            this.room.tryApplyRedaction(
+                new MatrixEvent({
+                    type: EventType.RoomRedaction,
+                    event_id: "$synthetic_redaction",
+                    room_id: this.room.roomId,
+                    redacts: event.getId(),
+                    content: {},
+                    origin_server_ts: Date.now(),
+                    unsigned: {},
+                }),
+            );
+        }
+    }
+}

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -37,11 +37,11 @@ export class RoomRetentionPolicy {
 
     public constructor(private readonly room: Room) {
         this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
-        room.on(RoomEvent.Timeline, () => this.timelineUpdated());
+        // Only bind RoomEvent.Timeline once we know we have a retention policy.
         room.on(RoomStateEvent.Events, (...params) => {
             void (async (): Promise<void> => {
                 try {
-                    await this.roomStateUpdate(...params);
+                    this.roomStateUpdate(...params);
                 } catch (ex) {
                     this.logger.warn("Failed to calculate new retention rules", ex);
                 }
@@ -62,7 +62,16 @@ export class RoomRetentionPolicy {
         } // otherwise, call this every time we see a state update.
 
         this.logger.info("roomStateUpdate", event.getType(), event.getContent());
+        const hadRetentionPeriod = this.maxRetention !== null;
         this.currentStateUpdated(state);
+        if (hadRetentionPeriod !== (this.maxRetention !== null)) {
+            // We've changed
+            if (this.maxRetention) {
+                this.room.on(RoomEvent.Timeline, this.timelineUpdated);
+            } else {
+                this.room.off(RoomEvent.Timeline, this.timelineUpdated);
+            }
+        }
     };
 
     private readonly currentStateUpdated = async (roomState: RoomState): Promise<void> => {
@@ -134,8 +143,12 @@ export class RoomRetentionPolicy {
         this.processTimeline();
     };
 
-    private readonly timelineUpdated = (nextTs = 200): void => {
+    private readonly timelineUpdated = (): void => {
         this.logger.info("timelineUpdated");
+        this.scheduleTimelineCheck(200);
+    };
+
+    private readonly scheduleTimelineCheck = (nextTs: number): void => {
         if (this.retentionTimeout) {
             clearTimeout(this.retentionTimeout);
         }
@@ -162,7 +175,7 @@ export class RoomRetentionPolicy {
         if (earliestExpiringEvent) {
             const nextTs = earliestExpiringEvent.getTs() + this.maxRetention - Date.now();
             this.logger.info(`Next expiry scheduled for ${nextTs}`);
-            this.timelineUpdated(nextTs);
+            this.scheduleTimelineCheck(nextTs);
         }
 
         if (expiredEvents.length === 0) {

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "../models/event";
-import { RoomEvent, type Room } from "./room";
-import { RoomStateEvent, type RoomState } from "./room-state";
-import { type Logger, logger as rootLogger } from "../logger";
-import { EventType } from "../@types/event";
+import { MatrixEvent } from "../models/event.ts";
+import { RoomEvent, type Room } from "./room.ts";
+import { RoomStateEvent, type RoomState } from "./room-state.ts";
+import { type Logger, logger as rootLogger } from "../logger.ts";
+import { EventType } from "../@types/event.ts";
+import { type RetentionConfigurationResponse } from "../retentionPolicy.ts";
 
 /**
  * Applies https://github.com/matrix-org/matrix-spec-proposals/pull/1763 by checking the current
@@ -37,52 +38,99 @@ export class RoomRetentionPolicy {
     public constructor(private readonly room: Room) {
         this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
         room.on(RoomEvent.Timeline, () => this.timelineUpdated());
-        room.on(RoomStateEvent.Events, this.roomStateUpdate);
+        room.on(RoomStateEvent.Events, (...params) => {
+            void (async (): Promise<void> => {
+                try {
+                    await this.roomStateUpdate(...params);
+                } catch (ex) {
+                    this.logger.warn("Failed to calculate new retention rules", ex);
+                }
+            })();
+        });
     }
 
     private readonly roomStateUpdate = (event: MatrixEvent, state: RoomState, prevEvent: MatrixEvent | null): void => {
-        if (
-            event.getStateKey() !== "" ||
-            (event.getType() !== "org.matrix.msc1763.retention" && event.getType() !== "m.room.retention")
-        ) {
-            return;
-        }
+        // TODO: Make this cheaper.
+        if (this.maxRetention) {
+            // If we *have* a room retention policy, only update if a state event appears.
+            if (
+                event.getStateKey() !== "" ||
+                (event.getType() !== "org.matrix.msc1763.retention" && event.getType() !== "m.room.retention")
+            ) {
+                return;
+            }
+        } // otherwise, call this every time we see a state update.
+
         this.logger.info("roomStateUpdate", event.getType(), event.getContent());
         this.currentStateUpdated(state);
     };
 
-    private readonly currentStateUpdated = (roomState: RoomState): void => {
+    private readonly currentStateUpdated = async (roomState: RoomState): Promise<void> => {
         const unstableEvent = roomState
             .getStateEvents("org.matrix.msc1763.retention")
             .find((e) => e.getStateKey() === "");
         const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
         this.logger.info("currentStateUpdated", unstableEvent, stableEvent);
 
-        const content = unstableEvent?.getContent() ?? stableEvent?.getContent();
+        // TODO: Error handle.
+        const serverPolicy: RetentionConfigurationResponse | null = await this.room.client
+            .getRetentionPolicy()
+            .catch((ex) => null);
+
+        const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
+        const roomStatePolicy = unstableEvent?.getContent() ?? stableEvent?.getContent();
+
+        const content =
+            // * if the homeserver defines a specific retention policy for this room, then use this policy as the effective retention policy of the room.
+            serverRoomPolicy ??
+            // * otherwise, if the state of the room includes a `m.room.retention` event with an empty state key:
+            roomStatePolicy ??
+            // * otherwise, if the state of the room does not include a m.room.retention event with an empty state key:
+            serverPolicy?.policies?.["*"];
 
         if (!content) {
+            // * otherwise, don't apply a retention policy in this room.
             this.maxRetention = null;
             return;
         }
 
+        const validatePolicy = !serverRoomPolicy && roomStatePolicy;
+
         // Parse it
-        const { min_lifetime: minLifetime, max_lifetime: maxLifetime } = content;
+        let { max_lifetime: maxLifetime } = content;
+
+        if (!maxLifetime && validatePolicy) {
+            // if there is no value specified in the room's state, use the limit's min value for the effective retention policy of the room (which can be null or absent).
+            maxLifetime = serverPolicy?.limits?.max_lifetime?.min;
+            if (!maxLifetime) {
+                this.maxRetention = null;
+                return;
+            }
+        }
+
         if (typeof maxLifetime !== "number") {
             throw Error(`max_lifetime must be a number, got "${maxLifetime}"`);
         }
         if (maxLifetime < 0 || !Number.isInteger(maxLifetime)) {
             throw Error(`max_lifetime must be >= 0, got ${maxLifetime}`);
         }
-        if (minLifetime !== undefined) {
-            if (typeof minLifetime !== "number") {
-                throw Error(`min_lifetime must be a number, got "${minLifetime}"`);
-            }
-            if (minLifetime < 0 || !Number.isInteger(minLifetime)) {
-                throw Error(`min_lifetime must be >= 0, got ${minLifetime}`);
-            }
-        }
         this.maxRetention = maxLifetime;
-        this.logger.info("currentStateUpdated", minLifetime, maxLifetime);
+
+        if (validatePolicy && serverPolicy?.limits?.max_lifetime) {
+            // We're using room state so we need to validate this policy matches the server.
+            /**
+            if the value specified in the room's state complies with the limit, use this value for the effective retention policy of the room.
+            if the value specified in the room's state is lower than the limit's min value, use the min value for the effective retention policy of the room.
+            if the value specified in the room's state is greater than the limit's max value, use the max value for the effective retention policy of the room.
+            */
+            this.maxRetention = Math.max(this.maxRetention, serverPolicy.limits.max_lifetime.min ?? 0);
+            this.maxRetention = Math.min(
+                this.maxRetention,
+                serverPolicy.limits.max_lifetime.max ?? Number.MAX_SAFE_INTEGER,
+            );
+        }
+
+        this.logger.info("calculated new maxLifetime", maxLifetime, "ms");
         this.processTimeline();
     };
 

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -102,7 +102,6 @@ export class RoomRetentionPolicy {
             .find((e) => e.getStateKey() === "");
         const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
 
-        // TODO: Error handle.
         const serverPolicy = await this.retentionService.getCached();
 
         const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
@@ -219,14 +218,13 @@ export class RoomRetentionPolicy {
                 }),
             );
         }
-        // TODO: Asyncify
         void this.store
             .removeEventsFromRoom(
                 this.room.roomId,
                 expiredEvents.map((e) => e.getId()!),
             )
             .catch((ex) => {
-                this.logger.warn(`Failed to vape events from store`, ex);
+                this.logger.warn(`Failed to remove events from store`, ex);
             });
     }
 }

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -19,7 +19,6 @@ import { RoomEvent, type Room } from "./room.ts";
 import { RoomStateEvent, type RoomState } from "./room-state.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { EventType } from "../@types/event.ts";
-import { type RetentionConfigurationResponse } from "../retentionPolicy.ts";
 
 /**
  * Applies https://github.com/matrix-org/matrix-spec-proposals/pull/1763 by checking the current
@@ -37,34 +36,51 @@ export class RoomRetentionPolicy {
 
     public constructor(private readonly room: Room) {
         this.logger = rootLogger.getChild(`RetentionPolicy ${room.roomId}`);
-        // Only bind RoomEvent.Timeline once we know we have a retention policy.
-        room.on(RoomStateEvent.Events, (...params) => {
-            void (async (): Promise<void> => {
-                try {
-                    this.roomStateUpdate(...params);
-                } catch (ex) {
-                    this.logger.warn("Failed to calculate new retention rules", ex);
-                }
-            })();
-        });
-    }
 
-    private readonly roomStateUpdate = (event: MatrixEvent, state: RoomState, prevEvent: MatrixEvent | null): void => {
-        // TODO: Make this cheaper.
-        if (this.maxRetention) {
-            // If we *have* a room retention policy, only update if a state event appears.
+        // Recalculate on room state update.
+        room.on(RoomStateEvent.Events, (event) => {
             if (
                 event.getStateKey() !== "" ||
                 (event.getType() !== "org.matrix.msc1763.retention" && event.getType() !== "m.room.retention")
             ) {
                 return;
             }
-        } // otherwise, call this every time we see a state update.
+            void this.handleRetentionUpdate();
+        });
 
-        this.logger.info("roomStateUpdate", event.getType(), event.getContent());
+        // Recalculate our retention whenever the global policy changes.
+        this.room.client.retentionPolicyService.on("update", () => {
+            this.logger.info("Got global retention policy update!");
+            void this.handleRetentionUpdate();
+        });
+        // Do an initial check on construction.
+        void this.handleRetentionUpdate();
+
+        // Only bind RoomEvent.Timeline once we know we have a retention policy.
+    }
+
+    public shouldEventBeRetained(ev: MatrixEvent): boolean {
+        if (!this.maxRetention) {
+            return true;
+        }
+        const expireBefore = Date.now() - this.maxRetention;
+        return ev.getTs() > expireBefore;
+    }
+
+    private readonly handleRetentionUpdate = async (): Promise<void> => {
+        // First store if we currently have a retention period.
         const hadRetentionPeriod = this.maxRetention !== null;
-        this.currentStateUpdated(state);
+
+        try {
+            await this.recalculateRetention(this.room.currentState);
+        } catch (err) {
+            this.logger.warn("Failed to recalculate retention policy", err);
+            return;
+        }
+
+        // Bind/unbind the Timeline event handler based on whether we should be running retention.
         if (hadRetentionPeriod !== (this.maxRetention !== null)) {
+            this.logger.info("retention recalculated to be", this.maxRetention);
             // We've changed
             if (this.maxRetention) {
                 this.room.on(RoomEvent.Timeline, this.timelineUpdated);
@@ -74,17 +90,14 @@ export class RoomRetentionPolicy {
         }
     };
 
-    private readonly currentStateUpdated = async (roomState: RoomState): Promise<void> => {
+    private readonly recalculateRetention = async (roomState: RoomState): Promise<void> => {
         const unstableEvent = roomState
             .getStateEvents("org.matrix.msc1763.retention")
             .find((e) => e.getStateKey() === "");
         const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
-        this.logger.info("currentStateUpdated", unstableEvent, stableEvent);
 
         // TODO: Error handle.
-        const serverPolicy: RetentionConfigurationResponse | null = await this.room.client
-            .getRetentionPolicy()
-            .catch((ex) => null);
+        const serverPolicy = await this.room.client.retentionPolicyService.getCached();
 
         const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
         const roomStatePolicy = unstableEvent?.getContent() ?? stableEvent?.getContent();
@@ -139,7 +152,6 @@ export class RoomRetentionPolicy {
             );
         }
 
-        this.logger.info("calculated new maxLifetime", maxLifetime, "ms");
         this.processTimeline();
     };
 
@@ -167,10 +179,10 @@ export class RoomRetentionPolicy {
         const events = this.room
             .getLiveTimeline()
             .getEvents()
-            .filter((ev) => ev.getStateKey() === undefined || ev.isRedacted() || ev.getType() === "m.room.redacation");
+            .filter((ev) => ev.getStateKey() === undefined && !ev.isRedacted() && ev.getType() !== "m.room.redaction");
 
         const expiredEvents = events.filter((ev) => ev.getTs() < expireBefore);
-        const [earliestExpiringEvent] = events.filter((ev) => ev.getTs() >= expireBefore).sort((ev) => ev.getTs());
+        const [earliestExpiringEvent] = events.filter((ev) => ev.getTs() >= expireBefore).sort((a, b) => a.getTs() - b.getTs());
 
         if (earliestExpiringEvent) {
             const nextTs = earliestExpiringEvent.getTs() + this.maxRetention - Date.now();

--- a/src/models/room-retention.ts
+++ b/src/models/room-retention.ts
@@ -102,7 +102,7 @@ export class RoomRetentionPolicy {
             .find((e) => e.getStateKey() === "");
         const stableEvent = roomState.getStateEvents("m.room.retention").find((e) => e.getStateKey() === "");
 
-        const serverPolicy = await this.retentionService.getCached();
+        const serverPolicy = this.retentionService.getCached();
 
         const serverRoomPolicy = serverPolicy?.policies?.[this.room.roomId];
         const roomStatePolicy = unstableEvent?.getContent() ?? stableEvent?.getContent();

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -1871,6 +1871,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         timeline: EventTimeline,
         paginationToken?: string,
     ): void {
+        // ALWAYS filter out any events that are past retention
+        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
         timeline.getTimelineSet().addEventsToTimeline(events, toStartOfTimeline, addToState, timeline, paginationToken);
     }
 
@@ -2461,6 +2463,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
 
     private addThreadedEvents(threadId: string, events: MatrixEvent[], toStartOfTimeline = false): void {
         const thread = this.getThread(threadId);
+        // ALWAYS filter out any events that are past retention
+        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
         if (thread) {
             thread.addEvents(events, toStartOfTimeline);
         } else {
@@ -2474,6 +2478,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     public processThreadedEvents(events: MatrixEvent[], toStartOfTimeline: boolean): void {
         events.forEach(this.tryApplyRedaction);
+        // ALWAYS filter out any events that are past retention
+        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
 
         const eventsByThread: { [threadId: string]: MatrixEvent[] } = {};
         for (const event of events) {
@@ -3089,6 +3095,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             throw new Error("duplicateStrategy MUST be either 'replace' or 'ignore'");
         }
 
+        // ALWAYS filter out any events that are past retention
+        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
+
         // sanity check that the live timeline is still live
         this.assertTimelineSetsAreLive();
 
@@ -3483,6 +3492,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     // eslint-disable-next-line
     public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEventsStore["addStickyEvents"]> {
+        // ALWAYS filter out any events that are past retention
+        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
+
         return this.stickyEvents.addStickyEvents(events);
     }
 

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -78,6 +78,7 @@ import { KnownMembership, type Membership } from "../@types/membership.ts";
 import { type Capabilities, type IRoomVersionsCapability, RoomVersionStability } from "../serverCapabilities.ts";
 import { type MSC4186Hero } from "../sliding-sync.ts";
 import { RoomStickyEventsStore, RoomStickyEventsEvent, type RoomStickyEventsMap } from "./room-sticky-events.ts";
+import { RoomRetentionPolicy } from "./room-retention.ts";
 
 // These constants are used as sane defaults when the homeserver doesn't support
 // the m.room_versions capability. In practice, KNOWN_SAFE_ROOM_VERSION should be
@@ -454,6 +455,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     private stickyEvents = new RoomStickyEventsStore();
 
+    private readonly retention: RoomRetentionPolicy;
+
     /**
      * Construct a new Room.
      *
@@ -530,6 +533,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.membersPromise = undefined;
         }
+
+        this.retention = new RoomRetentionPolicy(this);
     }
 
     private threadTimelineSetsPromise: Promise<[EventTimelineSet, EventTimelineSet]> | null = null;
@@ -2620,7 +2625,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         }
     }
 
-    private tryApplyRedaction = (event: MatrixEvent): void => {
+    public readonly tryApplyRedaction = (event: MatrixEvent): void => {
         // FIXME: apply redactions to notification list
 
         // NB: We continue to add the redaction event to the timeline at the

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -455,6 +455,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     private stickyEvents = new RoomStickyEventsStore();
 
+    //@ts-expect-error
     private readonly retention: RoomRetentionPolicy;
 
     /**
@@ -533,8 +534,9 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.membersPromise = undefined;
         }
-
-        this.retention = new RoomRetentionPolicy(this);
+        if (this.client._unstable_shouldApplyMessageRetention) {
+            this.retention = new RoomRetentionPolicy(this);
+        }
     }
 
     private threadTimelineSetsPromise: Promise<[EventTimelineSet, EventTimelineSet]> | null = null;

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -2389,7 +2389,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         threadId?: string;
     } {
         if (!this.client?.supportsThreads()) {
-            console.log("no thready!");
             return {
                 shouldLiveInRoom: true,
                 shouldLiveInThread: false,
@@ -2409,7 +2408,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const parentEventId = event.getAssociatedId();
         const threadRootId = event.threadRootId;
 
-        console.log("eventShouldLiveIn", isThreadRelation, parentEventId, threadRootId);
         // Where the parent is the thread root and this is a non-thread relation this should live only in the main timeline
         if (!!parentEventId && !isThreadRelation && (threadRootId === parentEventId || roots?.has(parentEventId!))) {
             return {
@@ -2464,7 +2462,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     private addThreadedEvents(threadId: string, events: MatrixEvent[], toStartOfTimeline = false): void {
-        console.log("AddThreadedEvents", threadId);
         const thread = this.getThread(threadId);
         if (thread) {
             thread.addEvents(events, toStartOfTimeline);
@@ -2485,7 +2482,6 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const eventsByThread: { [threadId: string]: MatrixEvent[] } = {};
         for (const event of events) {
             const { threadId, shouldLiveInThread } = this.eventShouldLiveIn(event);
-            console.log("processThreadedEvents", threadId, shouldLiveInThread);
             if (shouldLiveInThread && !eventsByThread[threadId!]) {
                 eventsByThread[threadId!] = [];
             }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -455,8 +455,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      */
     private stickyEvents = new RoomStickyEventsStore();
 
-    //@ts-expect-error
-    private readonly retention: RoomRetentionPolicy;
+    private readonly retention?: RoomRetentionPolicy;
 
     /**
      * Construct a new Room.

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -535,7 +535,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
             this.membersPromise = undefined;
         }
         if (this.client._unstable_shouldApplyMessageRetention) {
-            this.retention = new RoomRetentionPolicy(this);
+            this.retention = new RoomRetentionPolicy(this, client.retentionPolicyService, client.store);
         }
     }
 
@@ -2389,6 +2389,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         threadId?: string;
     } {
         if (!this.client?.supportsThreads()) {
+            console.log("no thready!");
             return {
                 shouldLiveInRoom: true,
                 shouldLiveInThread: false,
@@ -2408,6 +2409,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         const parentEventId = event.getAssociatedId();
         const threadRootId = event.threadRootId;
 
+        console.log("eventShouldLiveIn", isThreadRelation, parentEventId, threadRootId);
         // Where the parent is the thread root and this is a non-thread relation this should live only in the main timeline
         if (!!parentEventId && !isThreadRelation && (threadRootId === parentEventId || roots?.has(parentEventId!))) {
             return {
@@ -2462,9 +2464,8 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     }
 
     private addThreadedEvents(threadId: string, events: MatrixEvent[], toStartOfTimeline = false): void {
+        console.log("AddThreadedEvents", threadId);
         const thread = this.getThread(threadId);
-        // ALWAYS filter out any events that are past retention
-        events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
         if (thread) {
             thread.addEvents(events, toStartOfTimeline);
         } else {
@@ -2477,13 +2478,14 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * Adds events to a thread's timeline. Will fire "Thread.update"
      */
     public processThreadedEvents(events: MatrixEvent[], toStartOfTimeline: boolean): void {
-        events.forEach(this.tryApplyRedaction);
         // ALWAYS filter out any events that are past retention
         events = events.filter((e) => this.retention?.shouldEventBeRetained(e) ?? true);
+        events.forEach(this.tryApplyRedaction);
 
         const eventsByThread: { [threadId: string]: MatrixEvent[] } = {};
         for (const event of events) {
             const { threadId, shouldLiveInThread } = this.eventShouldLiveIn(event);
+            console.log("processThreadedEvents", threadId, shouldLiveInThread);
             if (shouldLiveInThread && !eventsByThread[threadId!]) {
                 eventsByThread[threadId!] = [];
             }

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -533,7 +533,7 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
         } else {
             this.membersPromise = undefined;
         }
-        if (this.client._unstable_shouldApplyMessageRetention) {
+        if (this.client?._unstable_shouldApplyMessageRetention) {
             this.retention = new RoomRetentionPolicy(this, client.retentionPolicyService, client.store);
         }
     }

--- a/src/retentionPolicy.ts
+++ b/src/retentionPolicy.ts
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import { CapabilityPoller } from "./capabilityPoller.ts";
-import { ClientPrefix, IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.ts";
-import { Logger } from "./logger.ts";
+import { ClientPrefix, type IHttpOpts, type MatrixHttpApi, Method } from "./http-api/index.ts";
+import type { Logger } from "./logger.ts";
 
 export interface RetentionConfigurationResponse {
     policies?: Record<

--- a/src/retentionPolicy.ts
+++ b/src/retentionPolicy.ts
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 import { CapabilityPoller } from "./capabilityPoller.ts";
-import { ClientPrefix, Method } from "./http-api/index.ts";
+import { ClientPrefix, IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.ts";
+import { Logger } from "./logger.ts";
 
 export interface RetentionConfigurationResponse {
     policies?: Record<
@@ -41,6 +42,9 @@ export interface RetentionConfigurationResponse {
  * Manages storing and periodically refreshing the server capabilities.
  */
 export class RetentionPolicyService extends CapabilityPoller<RetentionConfigurationResponse> {
+    public constructor(logger: Logger, http: MatrixHttpApi<IHttpOpts & { onlyData: true }>) {
+        super(logger, http, "retention policy");
+    }
     /**
      * Fetches the latest server capabilities from the homeserver and returns them, or rejects
      * on failure.

--- a/src/retentionPolicy.ts
+++ b/src/retentionPolicy.ts
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { CapabilityPoller } from "./capabilityPoller.ts";
+import { ClientPrefix, Method } from "./http-api/index.ts";
+
+export interface RetentionConfigurationResponse {
+    policies?: Record<
+        string,
+        {
+            max_lifetime?: number;
+            min_lifetime?: number;
+        }
+    >;
+    limits?: {
+        min_lifetime?: {
+            min?: number;
+            max?: number;
+        };
+        max_lifetime?: {
+            min?: number;
+            max?: number;
+        };
+    };
+}
+
+/**
+ * Manages storing and periodically refreshing the server capabilities.
+ */
+export class RetentionPolicyService extends CapabilityPoller<RetentionConfigurationResponse> {
+    /**
+     * Fetches the latest server capabilities from the homeserver and returns them, or rejects
+     * on failure.
+     */
+    public fetch = async (): Promise<RetentionConfigurationResponse> => {
+        const resp = await this.http.authedRequest<RetentionConfigurationResponse>(
+            Method.Get,
+            "/retention/configuration",
+            undefined,
+            undefined,
+            {
+                prefix: `${ClientPrefix.Unstable}/org.matrix.msc1763`,
+            },
+        );
+        this.cached = resp;
+        return this.cached;
+    };
+}

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import { CapabilityPoller } from "./capabilityPoller.ts";
-import { IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.ts";
-import { Logger } from "./logger.ts";
+import { type IHttpOpts, type MatrixHttpApi, Method } from "./http-api/index.ts";
+import type { Logger } from "./logger.ts";
 
 export interface ICapability {
     enabled: boolean;

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 import { CapabilityPoller } from "./capabilityPoller.ts";
-import { Method } from "./http-api/index.ts";
+import { IHttpOpts, MatrixHttpApi, Method } from "./http-api/index.ts";
+import { Logger } from "./logger.ts";
 
 export interface ICapability {
     enabled: boolean;
@@ -71,6 +72,9 @@ type CapabilitiesResponse = {
  * Manages storing and periodically refreshing the server capabilities.
  */
 export class ServerCapabilities extends CapabilityPoller<Capabilities> {
+    public constructor(logger: Logger, http: MatrixHttpApi<IHttpOpts & { onlyData: true }>) {
+        super(logger, http, "server capabilities");
+    }
     /**
      * Fetches the latest server capabilities from the homeserver and returns them, or rejects
      * on failure.

--- a/src/serverCapabilities.ts
+++ b/src/serverCapabilities.ts
@@ -14,15 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type IHttpOpts, type MatrixHttpApi, Method } from "./http-api/index.ts";
-import { type Logger } from "./logger.ts";
-
-// How often we update the server capabilities.
-// 6 hours - an arbitrary value, but they should change very infrequently.
-const CAPABILITIES_CACHE_MS = 6 * 60 * 60 * 1000;
-
-// How long we want before retrying if we couldn't fetch
-const CAPABILITIES_RETRY_MS = 30 * 1000;
+import { CapabilityPoller } from "./capabilityPoller.ts";
+import { Method } from "./http-api/index.ts";
 
 export interface ICapability {
     enabled: boolean;
@@ -77,70 +70,14 @@ type CapabilitiesResponse = {
 /**
  * Manages storing and periodically refreshing the server capabilities.
  */
-export class ServerCapabilities {
-    private capabilities?: Capabilities;
-    private retryTimeout?: ReturnType<typeof setTimeout>;
-    private refreshTimeout?: ReturnType<typeof setInterval>;
-
-    public constructor(
-        private readonly logger: Logger,
-        private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
-    ) {}
-
-    /**
-     * Starts periodically fetching the server capabilities.
-     */
-    public start(): void {
-        this.poll().then();
-    }
-
-    /**
-     * Stops the service
-     */
-    public stop(): void {
-        this.clearTimeouts();
-    }
-
-    /**
-     * Returns the cached capabilities, or undefined if none are cached.
-     * @returns the current capabilities, if any.
-     */
-    public getCachedCapabilities(): Capabilities | undefined {
-        return this.capabilities;
-    }
-
+export class ServerCapabilities extends CapabilityPoller<Capabilities> {
     /**
      * Fetches the latest server capabilities from the homeserver and returns them, or rejects
      * on failure.
      */
-    public fetchCapabilities = async (): Promise<Capabilities> => {
+    public fetch = async (): Promise<Capabilities> => {
         const resp = await this.http.authedRequest<CapabilitiesResponse>(Method.Get, "/capabilities");
-        this.capabilities = resp["capabilities"];
-        return this.capabilities;
+        this.cached = resp["capabilities"];
+        return this.cached;
     };
-
-    private poll = async (): Promise<void> => {
-        try {
-            await this.fetchCapabilities();
-            this.clearTimeouts();
-            this.refreshTimeout = setTimeout(this.poll, CAPABILITIES_CACHE_MS);
-            this.logger.debug("Fetched new server capabilities");
-        } catch (e) {
-            this.clearTimeouts();
-            const howLong = Math.floor(CAPABILITIES_RETRY_MS + Math.random() * 5000);
-            this.retryTimeout = setTimeout(this.poll, howLong);
-            this.logger.warn(`Failed to refresh capabilities: retrying in ${howLong}ms`, e);
-        }
-    };
-
-    private clearTimeouts(): void {
-        if (this.refreshTimeout) {
-            clearInterval(this.refreshTimeout);
-            this.refreshTimeout = undefined;
-        }
-        if (this.retryTimeout) {
-            clearTimeout(this.retryTimeout);
-            this.retryTimeout = undefined;
-        }
-    }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -274,6 +274,13 @@ export interface IStore {
     getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
 
     /**
+     * TODO
+     * @param roomId
+     * @param eventIds
+     */
+    vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void>;
+
+    /**
      * Stop the store and perform any appropriate cleanup
      */
     destroy(): Promise<void>;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -274,11 +274,12 @@ export interface IStore {
     getUserProfile(userId: string): Promise<SyncUserProfile | undefined>;
 
     /**
-     * TODO
-     * @param roomId
-     * @param eventIds
+     * Remove all stored events matching the given IDs from the stored accumulated
+     * sync.
+     * @param roomId The target room.
+     * @param eventIds IDs of events to remove.
      */
-    vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void>;
+    removeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void>;
 
     /**
      * Stop the store and perform any appropriate cleanup

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -633,6 +633,16 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         await txnAsPromise(txn);
     }
 
+    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+        try {
+            this.syncAccumulator.vapeEventsFromRoom(roomId, eventIds);
+            const syncData = this.syncAccumulator.getJSON(true);
+            await Promise.all([this.persistSyncData(syncData.nextBatch, syncData.roomsData)]);
+        } finally {
+            this.syncToDatabasePromise = undefined;
+        }
+    }
+
     /*
      * Close the database
      */

--- a/src/store/indexeddb-local-backend.ts
+++ b/src/store/indexeddb-local-backend.ts
@@ -633,9 +633,9 @@ export class LocalIndexedDBStoreBackend implements IIndexedDBBackend {
         await txnAsPromise(txn);
     }
 
-    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+    public async removeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
         try {
-            this.syncAccumulator.vapeEventsFromRoom(roomId, eventIds);
+            this.syncAccumulator.removeEventsFromRoom(roomId, eventIds);
             const syncData = this.syncAccumulator.getJSON(true);
             await Promise.all([this.persistSyncData(syncData.nextBatch, syncData.roomsData)]);
         } finally {

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -158,6 +158,10 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
         await this.doCmd("removeUserProfiles", [userIds]);
     }
 
+    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+        await this.doCmd("vapeEventsFromRoom", [roomId, eventIds]);
+    }
+
     private ensureStarted(): Promise<void> {
         if (!this.startPromise) {
             this.worker = this.workerFactory();

--- a/src/store/indexeddb-remote-backend.ts
+++ b/src/store/indexeddb-remote-backend.ts
@@ -158,8 +158,8 @@ export class RemoteIndexedDBStoreBackend implements IIndexedDBBackend {
         await this.doCmd("removeUserProfiles", [userIds]);
     }
 
-    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
-        await this.doCmd("vapeEventsFromRoom", [roomId, eventIds]);
+    public async removeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+        await this.doCmd("removeEventsFromRoom", [roomId, eventIds]);
     }
 
     private ensureStarted(): Promise<void> {

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -455,7 +455,7 @@ export class MemoryStore implements IStore {
         userIds.forEach((userId) => this.userProfiles.delete(userId));
     }
 
-    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+    public async removeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
         // Can ignore as there is no backing store.
     }
 

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -455,6 +455,10 @@ export class MemoryStore implements IStore {
         userIds.forEach((userId) => this.userProfiles.delete(userId));
     }
 
+    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+        // Can ignore as there is no backing store.
+    }
+
     public async destroy(): Promise<void> {
         // Nothing to do
     }

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -289,7 +289,7 @@ export class StubStore implements IStore {
     public async destroy(): Promise<void> {
         // Nothing to do
     }
-    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+    public async removeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
         // Nothing to do
     }
 }

--- a/src/store/stub.ts
+++ b/src/store/stub.ts
@@ -289,4 +289,7 @@ export class StubStore implements IStore {
     public async destroy(): Promise<void> {
         // Nothing to do
     }
+    public async vapeEventsFromRoom(roomId: string, eventIds: string[]): Promise<void> {
+        // Nothing to do
+    }
 }

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -782,7 +782,7 @@ export class SyncAccumulator {
         return this.nextBatch!;
     }
 
-    public vapeEventsFromRoom(roomId: string, eventIds: string[]): void {
+    public removeEventsFromRoom(roomId: string, eventIds: string[]): void {
         this.joinRooms[roomId]._timeline = this.joinRooms[roomId]._timeline.filter(
             (ev) => !eventIds.includes(ev.event.event_id),
         );

--- a/src/sync-accumulator.ts
+++ b/src/sync-accumulator.ts
@@ -781,6 +781,15 @@ export class SyncAccumulator {
     public getNextBatchToken(): string {
         return this.nextBatch!;
     }
+
+    public vapeEventsFromRoom(roomId: string, eventIds: string[]): void {
+        this.joinRooms[roomId]._timeline = this.joinRooms[roomId]._timeline.filter(
+            (ev) => !eventIds.includes(ev.event.event_id),
+        );
+        this.joinRooms[roomId]._stickyEvents = this.joinRooms[roomId]._stickyEvents.filter(
+            (ev) => !eventIds.includes(ev.event.event_id),
+        );
+    }
 }
 
 function setState(eventMap: Record<string, Record<string, IStateEvent>>, event: IRoomEvent | IStateEvent): void {


### PR DESCRIPTION
Supersedes #5341
Partially implements MSC1763

This implements the data removal aspects of MSC1763 clientside, currently limited to checking the `max_lifetime` of the local rules. This should bubble up a synthetic redaction to client apps, and clear stored event information from the store.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
