### PR TITLE
SECURITY: Update matrix-sdk-crypto-wasm to v18.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^18.2.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^18.3.1",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",
         "content-type": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,8 +214,8 @@ importers:
         specifier: ^7.12.5
         version: 7.29.2
       '@matrix-org/matrix-sdk-crypto-wasm':
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^18.3.1
+        version: 18.3.1
       another-json:
         specifier: ^0.2.0
         version: 0.2.0
@@ -1091,8 +1091,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.2.0':
-    resolution: {integrity: sha512-puyZefvq6sHfqlmkri8umhA44724H2JL0YtX8wlvhGuNl8awX/Q1tZyW2Iekm9ZJP7BtuOqlNdg9oQd6iaGbNw==}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.3.1':
+    resolution: {integrity: sha512-VRjWhE1UgHnPpJ3b9B5+8z71ZC/HICFngPPFIN6ktzmUBKI5RusPujzbAQUoB3CgZ0yU58L99AfSQS4YTztSWw==}
     engines: {node: '>= 18'}
 
   '@matrix-org/olm@3.2.15':
@@ -4981,7 +4981,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.2.0': {}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.3.1': {}
 
   '@matrix-org/olm@3.2.15': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,6 @@ overrides:
 
 allowBuilds:
     unrs-resolver: false
+
+minimumReleaseAgeExclude:
+    - "@matrix-org/matrix-sdk-crypto-wasm@18.3.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,4 +15,4 @@ minimumReleaseAgeExclude:
     # Bypassing for this version, obviously this is only necessary
     # temporarily so if you're reading this, you can almost certainly
     # remove it
-    - "@matrix-org/matrix-sdk-crypto-wasm@18.3.1"
+    - "@matrix-org/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,4 @@ allowBuilds:
     unrs-resolver: false
 
 minimumReleaseAgeExclude:
-    # Bypassing for this version, obviously this is only necessary
-    # temporarily so if you're reading this, you can almost certainly
-    # remove it
     - "@matrix-org/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,4 +12,7 @@ allowBuilds:
     unrs-resolver: false
 
 minimumReleaseAgeExclude:
+    # Bypassing for this version, obviously this is only necessary
+    # temporarily so if you're reading this, you can almost certainly
+    # remove it
     - "@matrix-org/matrix-sdk-crypto-wasm@18.3.1"


### PR DESCRIPTION
Updates to a new version of matrix-sdk-crypto-wasm to resolve [GHSA-wfq4-36m3-9g42](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-wfq4-36m3-9g42) / [CVE-2026-45056](https://www.cve.org/CVERecord?id=CVE-2026-45056).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
