### PR TITLE
fix unnecessary round-trip delay

### DIFF
--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {
+    DeviceLists,
     KeysBackupRequest,
     KeysClaimRequest,
     KeysQueryRequest,
@@ -26,6 +27,7 @@ import {
     SignatureUploadRequest,
     ToDeviceRequest,
     UploadSigningKeysRequest,
+    UserId,
 } from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import { type Logger } from "../logger.ts";
@@ -124,6 +126,24 @@ export class OutgoingRequestProcessor {
             }
         } else {
             this.logger.trace(`Outgoing request type:${msg.type} does not have an ID`);
+        }
+
+        // After uploading cross-signing signatures, immediately notify the OlmMachine
+        // that the signed users' device lists have changed. This causes it to schedule
+        // a KeysQueryRequest for those users in the current outgoing-requests loop,
+        // so trust status is updated without waiting for the next /sync to deliver
+        // device_lists.changed.
+        if (msg instanceof SignatureUploadRequest) {
+            const signedUsers = Object.keys(
+                (JSON.parse(msg.body) as { signed_keys: Record<string, unknown> }).signed_keys,
+            );
+            if (signedUsers.length > 0) {
+                const devices = new DeviceLists(
+                    signedUsers.map((u) => new UserId(u)),
+                    [],
+                );
+                await this.olmMachine.receiveSyncChanges("[]", devices, new Map(), undefined);
+            }
         }
     }
 


### PR DESCRIPTION
# problem

After a successful cross-signing verification (e.g. SAS emoji), the verified device continues to appear as unverified in the UI until the next /sync cycle delivers device_lists.changed for the verified user. This adds an unnecessary round-trip delay of up to 30 seconds.

# root cause

When SAS verification completes, the Rust OLM machine generates a SignatureUploadRequest. OutgoingRequestsManager picks it up on the next onSyncCompleted call and sends `POST /keys/signatures/upload`. After markRequestAsSent, the OLM machine records that the signature was uploaded - but it does not automatically schedule a KeysQueryRequest for the signed users.

The only way the machine learns that a re-query is needed is via receiveSyncChanges with those users in device_lists.changed. This normally comes from the next `/sync` response, which includes `device_lists.changed` because the server writes a user_signatures stream entry and (after the companion [Synapse fix](https://github.com/element-hq/synapse/pull/19831)) wakes up the long-poll immediately. Even so, a full sync round-trip is still required before `registerUserIdentityUpdatedCallback` fires and `CryptoEvent.UserTrustStatusChanged` is emitted.

# fix

After markRequestAsSent for a SignatureUploadRequest, parse the signed user IDs directly from msg.body.signed_keys and call olmMachine.receiveSyncChanges with those users in DeviceLists.changed:

```javascript
if (msg instanceof SignatureUploadRequest) {
    const signedUsers = Object.keys(
        (JSON.parse(msg.body) as { signed_keys: Record<string, unknown> }).signed_keys,
    );
    if (signedUsers.length > 0) {
        const devices = new DeviceLists(signedUsers.map((u) => new UserId(u)), []);
        await this.olmMachine.receiveSyncChanges("[]", devices, new Map(), undefined);
    }
}
```

This causes the OLM machine to immediately schedule a KeysQueryRequest for the signed users. OutgoingRequestsManager processes it in the same loop iteration (it re-runs the loop whenever any request succeeds), so markRequestAsSent for the key query fires `registerUserIdentityUpdatedCallback -> CryptoEvent.UserTrustStatusChanged` - all within the same onSyncCompleted callback, with no
additional sync cycle required.
