### PR TITLE
MatrixRTC: Preserve original error as `cause` when wrapping in scheduler

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -22,6 +22,7 @@ import {
     HTTPError,
     MatrixError,
     UnsupportedDelayedEventsEndpointError,
+    UnsupportedStickyEventsEndpointError,
     type Room,
     MAX_STICKY_DURATION_MS,
 } from "../../../src";
@@ -1036,6 +1037,27 @@ describe("MembershipManager", () => {
                     // ..once
                     expect(client._unstable_sendStickyDelayedEvent).toHaveBeenCalledTimes(1);
                 });
+            });
+            it("preserves UnsupportedStickyEventsEndpointError on `cause` when wrapping", async () => {
+                const stickyError = new UnsupportedStickyEventsEndpointError(
+                    "Server does not support the sticky events",
+                    "sendStickyEvent",
+                );
+                (client._unstable_sendStickyEvent as Mock<any>).mockRejectedValue(stickyError);
+
+                const unrecoverableError = vi.fn();
+                const memberManager = new StickyEventMembershipManager(
+                    undefined,
+                    room,
+                    client,
+                    callSession,
+                    "@alice:example.org:AAAAAAA_m.call",
+                );
+                memberManager.join([], focus, unrecoverableError);
+                await vi.advanceTimersByTimeAsync(1);
+
+                expect(unrecoverableError).toHaveBeenCalled();
+                expect(unrecoverableError.mock.lastCall![0].cause).toBe(stickyError);
             });
         });
     });

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -207,6 +207,8 @@ export class MembershipManager
      * transport selection will be used instead.
      * @param onError This will be called once the membership manager encounters an unrecoverable error.
      * This should bubble up the the frontend to communicate that the call does not work in the current environment.
+     * The original underlying error is preserved as `error.cause`, so consumers can `instanceof`-check the typed
+     * cause.
      */
     public join(fociPreferred: Transport[], multiSfuFocus?: Transport, onError?: (error: unknown) => void): void {
         if (this.scheduler.running) {

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -103,7 +103,11 @@ export class ActionScheduler {
                         // `this.wakeup` can also be called and sets the `wakeupUpdate` object while we are in the handler.
                         handlerResult = await this.membershipLoopHandler(nextAction.type as MembershipActionType);
                     } catch (e) {
-                        throw Error(`The MembershipManager shut down because of the end condition: ${e}`);
+                        // Preserve the original error as `cause`.
+                        throw new Error(
+                            `The MembershipManager shut down because of the end condition: ${e}`,
+                            { cause: e },
+                        );
                     }
                 }
                 // remove the processed action only after we are done processing

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -104,10 +104,9 @@ export class ActionScheduler {
                         handlerResult = await this.membershipLoopHandler(nextAction.type as MembershipActionType);
                     } catch (e) {
                         // Preserve the original error as `cause`.
-                        throw new Error(
-                            `The MembershipManager shut down because of the end condition: ${e}`,
-                            { cause: e },
-                        );
+                        throw new Error(`The MembershipManager shut down because of the end condition: ${e}`, {
+                            cause: e,
+                        });
                     }
                 }
                 // remove the processed action only after we are done processing


### PR DESCRIPTION
## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
