### PR TITLE
Fix restarting delayed events via compatibility path in RoomWidgetClient

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -558,7 +558,7 @@ describe("RoomWidgetClient", () => {
                             updateDelayedEvent = widgetApi.cancelScheduledDelayedEvent;
                             break;
                         case UpdateDelayedEventAction.Restart:
-                            updateDelayedEvent = widgetApi.cancelScheduledDelayedEvent;
+                            updateDelayedEvent = widgetApi.restartScheduledDelayedEvent;
                             break;
                         case UpdateDelayedEventAction.Send:
                             updateDelayedEvent = widgetApi.sendScheduledDelayedEvent;

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -532,7 +532,7 @@ export class RoomWidgetClient extends MatrixClient {
                 await this.widgetApi.cancelScheduledDelayedEvent(delayId).catch(timeoutToConnectionError);
                 break;
             case UpdateDelayedEventAction.Restart:
-                await this.widgetApi.cancelScheduledDelayedEvent(delayId).catch(timeoutToConnectionError);
+                await this.widgetApi.restartScheduledDelayedEvent(delayId).catch(timeoutToConnectionError);
                 break;
             case UpdateDelayedEventAction.Send:
                 await this.widgetApi.sendScheduledDelayedEvent(delayId).catch(timeoutToConnectionError);


### PR DESCRIPTION
This was a typo introduced in df88edfda0aa00ad1d574e367f024db9a927e96b.