### PR TITLE
Fix oxfmt command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "gendoc": "typedoc",
         "lint": "pnpm lint:types && pnpm lint:js && pnpm lint:workflows",
         "lint:js": "oxlint && oxfmt --check",
-        "lint:js-fix": "oxfmt --log-level=warn --write . && oxlint --fix src spec",
+        "lint:js-fix": "oxfmt --write . && oxlint --fix src spec",
         "lint:types": "tsc --noEmit",
         "lint:workflows": "find .github/workflows -type f \\( -iname '*.yaml' -o -iname '*.yml' \\) | xargs -I {} sh -c 'echo \"Linting {}\"; action-validator \"{}\"'",
         "lint:knip": "knip && knip --strict --exclude unlisted,dependencies,binaries",


### PR DESCRIPTION
Command is failing before `--log-level` isn't a valid argument

```
❯ pnpm lint:js-fix
Already up to date

   ╭──────────────────────────────────────────────╮
   │                                              │
   │      Update available! 11.2.2 → 11.9.0.      │
   │     Changelog: https://pnpm.io/v/11.9.0      │
   │   To update, run: corepack use pnpm@11.9.0   │
   │                                              │
   ╰──────────────────────────────────────────────╯

Done in 223ms using pnpm v11.2.2
$ oxfmt --log-level=warn --write . && oxlint --fix src spec
Error: --log-level is not expected in this context
[ELIFECYCLE] Command failed with exit code 1.
```