### PR TITLE
Add method `CryptoApi.getUserCrossSigningKeys`

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -2137,6 +2137,21 @@ describe("crypto", () => {
                 expect(verificationStatus.needsUserApproval).toBe(false);
             }
         });
+
+        describe("getUserCrossSigningKeys", () => {
+            it("returns null for unknown user", async () => {
+                const id = await aliceClient.getCrypto()!.getUserCrossSigningKeys("@unknown:xyz");
+                expect(id).toBe(null);
+            });
+
+            it("returns three keys for local user", async () => {
+                const id = await aliceClient.getCrypto()!.getUserCrossSigningKeys(TEST_USER_ID);
+
+                expect(id?.master_key).toEqual(SIGNED_CROSS_SIGNING_KEYS_DATA.master_keys![TEST_USER_ID]);
+                expect(id?.self_signing_key).toEqual(SIGNED_CROSS_SIGNING_KEYS_DATA.self_signing_keys![TEST_USER_ID]);
+                expect(id?.user_signing_key).toEqual(SIGNED_CROSS_SIGNING_KEYS_DATA.user_signing_keys![TEST_USER_ID]);
+            });
+        });
     });
 
     /** Guards against downgrade attacks from servers hiding or manipulating the crypto settings. */

--- a/src/client.ts
+++ b/src/client.ts
@@ -223,6 +223,7 @@ import { type CryptoBackend } from "./common-crypto/CryptoBackend.ts";
 import { RUST_SDK_STORE_PREFIX } from "./rust-crypto/constants.ts";
 import {
     type CrossSigningKeyInfo,
+    type CrossSigningKeys,
     type CryptoApi,
     type CryptoCallbacks,
     CryptoEvent,
@@ -570,14 +571,6 @@ export const UNSTABLE_MSC4354_STICKY_EVENTS = "org.matrix.msc4354";
 export const UNSTABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133";
 export const STABLE_MSC4133_EXTENDED_PROFILES = "uk.tcpip.msc4133.stable";
 
-enum CrossSigningKeyType {
-    MasterKey = "master_key",
-    SelfSigningKey = "self_signing_key",
-    UserSigningKey = "user_signing_key",
-}
-
-export type CrossSigningKeys = Record<CrossSigningKeyType, CrossSigningKeyInfo>;
-
 export type SendToDeviceContentMap = Map<string, Map<string, Record<string, any>>>;
 
 export interface ISignedKey {
@@ -587,6 +580,9 @@ export interface ISignedKey {
     algorithms: string[];
     device_id: string;
 }
+
+// re-export for backwards compatibility
+export { type CrossSigningKeys };
 
 export type KeySignatures = Record<string, Record<string, CrossSigningKeyInfo | ISignedKey>>;
 export interface IUploadKeySignaturesResponse {

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -1222,10 +1222,15 @@ export interface CreateSecretStorageOpts {
 
 /** Types of cross-signing key */
 export enum CrossSigningKey {
-    Master = "master",
-    SelfSigning = "self_signing",
-    UserSigning = "user_signing",
+    Master = "master_key",
+    SelfSigning = "self_signing_key",
+    UserSigning = "user_signing_key",
 }
+
+/** All of a user's cross-signing keys.
+ * @see https://spec.matrix.org/v1.7/client-server-api/#post_matrixclientv3keysdevice_signingupload
+ */
+export type CrossSigningKeys = Record<CrossSigningKey, CrossSigningKeyInfo>;
 
 /**
  * Information on one of the cross-signing keys.

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -265,9 +265,17 @@ export interface CryptoApi {
      *
      * This is useful if the user was previously verified but is not anymore
      * ({@link UserVerificationStatus.wasCrossSigningVerified}) and it is not possible to verify him again now.
-     *
      */
     withdrawVerificationRequirement(userId: string): Promise<void>;
+
+    /**
+     * Get the given user's public cross-signing keys, if they have published any, and we have fetched them to
+     * our store.
+     *
+     * Normally this is only useful to applications as debug info, since the SDK handles keeping track of a
+     * user's identity, and whether their devices are verified.
+     */
+    getUserCrossSigningKeys(userId: string): Promise<Partial<CrossSigningKeys> | null>;
 
     /**
      * Get the verification status of a given device.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -42,6 +42,7 @@ import {
     type BackupTrustInfo,
     type BootstrapCrossSigningOpts,
     type CreateSecretStorageOpts,
+    type CrossSigningKeys,
     CrossSigningKey,
     type CrossSigningKeyInfo,
     type CrossSigningStatus,
@@ -769,6 +770,29 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         }
 
         await userIdentity.withdrawVerification();
+    }
+
+    /**
+     * Implementation of {@link CryptoApi#getUserCrossSigningKeys}.
+     */
+    public async getUserCrossSigningKeys(userId: string): Promise<Partial<CrossSigningKeys> | null> {
+        const userIdentity = await this.getOlmMachineOrThrow().getIdentity(new RustSdkCryptoJs.UserId(userId));
+
+        if (!userIdentity) {
+            return null;
+        }
+
+        const result: Partial<CrossSigningKeys> = {
+            master_key: JSON.parse(userIdentity.masterKey),
+            self_signing_key: JSON.parse(userIdentity.selfSigningKey),
+        };
+
+        // The USK is only visible for our own identity
+        if ("userSigningKey" in userIdentity) {
+            result.user_signing_key = JSON.parse(userIdentity.userSigningKey);
+        }
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
I want to expose user identities in the dev tools, so we need to expose it from the js-sdk.