### PR TITLE
Change MSC3814 dehydrated device `/events` endpoint from POST to GET

### DIFF
--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -120,15 +120,14 @@ describe("Device dehydration", () => {
             // The first time will return a single event, and the second
             // time will return no events (which will signal to the
             // rehydration function that it can stop)
-            const body = JSON.parse(callLog.options.body as string);
-            const nextBatch = body.next_batch ?? "0";
+            const nextBatch = new URL(callLog.url).searchParams.get("next_batch") ?? "0";
             const events = nextBatch === "0" ? [{ sender: "@alice:localhost", type: "m.dummy", content: {} }] : [];
             return {
                 events,
                 next_batch: nextBatch + "1",
             };
         });
-        fetchMock.post(
+        fetchMock.get(
             `path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/${encodeURIComponent(dehydratedDeviceBody.device_id)}/events`,
             eventsResponse,
         );

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1956,7 +1956,7 @@ describe("RustCrypto", () => {
                 device_id: dehydratedDeviceBody.device_id,
                 device_data: dehydratedDeviceBody.device_data,
             });
-            fetchMock.post(
+            fetchMock.get(
                 `path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/${encodeURIComponent(dehydratedDeviceBody.device_id)}/events`,
                 {
                     events: [],
@@ -2062,7 +2062,7 @@ describe("RustCrypto", () => {
                     "path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
                     putDehydratedDeviceMock,
                 );
-                fetchMock.post(/_matrix\/client\/unstable\/org.matrix.msc3814.v1\/dehydrated_device\/.*\/events/, {
+                fetchMock.get(/_matrix\/client\/unstable\/org.matrix.msc3814.v1\/dehydrated_device\/.*\/events/, {
                     status: 200,
                     body: {
                         events: [],

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -36,7 +36,7 @@ interface DehydratedDeviceResp {
     };
 }
 /**
- * The response body of `POST /_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/events`.
+ * The response body of `GET /_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events`.
  */
 interface DehydratedDeviceEventsResp {
     events: IToDeviceEvent[];
@@ -270,10 +270,10 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
         // eslint-disable-next-line no-constant-condition
         while (true) {
             const eventResp: DehydratedDeviceEventsResp = await this.http.authedRequest<DehydratedDeviceEventsResp>(
-                Method.Post,
+                Method.Get,
                 path,
+                nextBatch ? { next_batch: nextBatch } : undefined,
                 undefined,
-                nextBatch ? { next_batch: nextBatch } : {},
                 {
                     prefix: UnstablePrefix,
                 },


### PR DESCRIPTION
This PR is the js-sdk end of https://github.com/element-hq/synapse/pull/19896 , which changes the verb of `/org.matrix.msc3814.v1/dehydrated_device/[device_id]/events` from POST to GET, as per the recent updates to [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814).

This code was initially written by @ara4n and Claude. He and I have looked over it and it looks pretty plausible.

I don't know whether there are any downstream tests that will break because of this (and require an updated Synapse to pass). @uhoreg is working on a test in https://github.com/element-hq/element-web/issues/34034 , so there will be something soon if not.

Part of https://github.com/element-hq/element-meta/issues/2704

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
