### PR TITLE
Change the MSC3814 dehydrated device `/events` endpoint paging to match spec conventions

### DIFF
--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -120,7 +120,7 @@ describe("Device dehydration", () => {
             // The first time will return a single event, and the second
             // time will return no events (which will signal to the
             // rehydration function that it can stop)
-            const nextBatch = new URL(callLog.url).searchParams.get("next_batch") ?? "0";
+            const nextBatch = new URL(callLog.url).searchParams.get("from") ?? "0";
             const events = nextBatch === "0" ? [{ sender: "@alice:localhost", type: "m.dummy", content: {} }] : [];
             return {
                 events,

--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -116,10 +116,9 @@ describe("Device dehydration", () => {
             },
         });
         const eventsResponse = vi.fn((callLog: CallLog) => {
-            // rehydrating should make two calls to the /events endpoint.
-            // The first time will return a single event, and the second
-            // time will return no events (which will signal to the
-            // rehydration function that it can stop)
+            // Rehydrating should make three calls to the /events endpoint. Each
+            // time we will received one event. The third time, next_batch will
+            // be missing, so we know we don't need to make a fourth request.
             const from = new URL(callLog.url).searchParams.get("from") ?? "0";
 
             switch (from) {

--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -120,12 +120,29 @@ describe("Device dehydration", () => {
             // The first time will return a single event, and the second
             // time will return no events (which will signal to the
             // rehydration function that it can stop)
-            const nextBatch = new URL(callLog.url).searchParams.get("from") ?? "0";
-            const events = nextBatch === "0" ? [{ sender: "@alice:localhost", type: "m.dummy", content: {} }] : [];
-            return {
-                events,
-                next_batch: nextBatch + "1",
-            };
+            const from = new URL(callLog.url).searchParams.get("from") ?? "0";
+
+            switch (from) {
+                case "0":
+                    return {
+                        events: [{ sender: "@alice:localhost", type: "m.dummy", content: { batch: 0 } }],
+                        next_batch: "1",
+                    };
+                case "1":
+                    return {
+                        events: [{ sender: "@alice:localhost", type: "m.dummy", content: { batch: 1 } }],
+                        next_batch: "2",
+                    };
+                case "2":
+                    return {
+                        events: [{ sender: "@alice:localhost", type: "m.dummy", content: { batch: 2 } }],
+                        // next_batch is missing, meaning there are no more events
+                    };
+                default:
+                    // Because the previous batch did not provide `next_batch`,
+                    // we stopped polling, so we should not get here.
+                    throw new Error(`Unexpected call with from=${from}`);
+            }
         });
         fetchMock.get(
             `path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/${encodeURIComponent(dehydratedDeviceBody.device_id)}/events`,
@@ -135,12 +152,12 @@ describe("Device dehydration", () => {
         expect(dehydrationCount).toEqual(3);
 
         expect(setDehydrationCount).toEqual(2);
-        expect(eventsResponse.mock.calls).toHaveLength(2);
+        expect(eventsResponse.mock.calls).toHaveLength(3);
 
         expect(rehydrationStartedCounter.counter).toEqual(1);
         expect(rehydrationCompletedCounter.counter).toEqual(1);
         expect(creationEventCounter.counter).toEqual(3);
-        expect(rehydrationProgressCounter.counter).toEqual(1);
+        expect(rehydrationProgressCounter.counter).toEqual(3);
         expect(dehydrationKeyCachedEventCounter.counter).toEqual(2);
 
         // test that if we get an error when we try to rotate, it emits an event

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1960,7 +1960,6 @@ describe("RustCrypto", () => {
                 `path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/${encodeURIComponent(dehydratedDeviceBody.device_id)}/events`,
                 {
                     events: [],
-                    next_batch: "token",
                 },
             );
 

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -2065,7 +2065,6 @@ describe("RustCrypto", () => {
                     status: 200,
                     body: {
                         events: [],
-                        next_batch: "foo",
                     },
                 });
                 getDehydratedDeviceMock.mockClear();

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -272,7 +272,7 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
             const eventResp: DehydratedDeviceEventsResp = await this.http.authedRequest<DehydratedDeviceEventsResp>(
                 Method.Get,
                 path,
-                nextBatch ? { next_batch: nextBatch } : undefined,
+                nextBatch ? { "from": nextBatch } : undefined,
                 undefined,
                 {
                     prefix: UnstablePrefix,

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -40,7 +40,7 @@ interface DehydratedDeviceResp {
  */
 interface DehydratedDeviceEventsResp {
     events: IToDeviceEvent[];
-    next_batch: string;
+    next_batch?: string;
 }
 
 /**
@@ -267,28 +267,29 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
         const path = encodeUri("/dehydrated_device/$device_id/events", {
             $device_id: dehydratedDeviceResp.device_id,
         });
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+
+        do {
             const eventResp: DehydratedDeviceEventsResp = await this.http.authedRequest<DehydratedDeviceEventsResp>(
                 Method.Get,
                 path,
-                nextBatch ? { "from": nextBatch } : undefined,
+                nextBatch ? { from: nextBatch } : undefined,
                 undefined,
                 {
                     prefix: UnstablePrefix,
                 },
             );
 
-            if (eventResp.events.length === 0) {
-                break;
-            }
             toDeviceCount += eventResp.events.length;
             nextBatch = eventResp.next_batch;
-            const roomKeyInfos = await rehydratedDevice.receiveEvents(JSON.stringify(eventResp.events));
-            roomKeyCount += roomKeyInfos.length;
 
-            this.emit(CryptoEvent.RehydrationProgress, roomKeyCount, toDeviceCount);
-        }
+            if (eventResp.events.length > 0) {
+                const roomKeyInfos = await rehydratedDevice.receiveEvents(JSON.stringify(eventResp.events));
+                roomKeyCount += roomKeyInfos.length;
+
+                this.emit(CryptoEvent.RehydrationProgress, roomKeyCount, toDeviceCount);
+            }
+        } while (nextBatch !== undefined);
+
         this.logger.info(`dehydration: received ${roomKeyCount} room keys from ${toDeviceCount} to-device events`);
         this.emit(CryptoEvent.RehydrationCompleted);
 


### PR DESCRIPTION
To match [the spec requirements for pagination](https://spec.matrix.org/v1.9/appendices/#pagination):

* rename the query parameter of `/org.matrix.msc3814.v1/dehydrated_device/[device_id]/events` to `from`, and
* omit `next_batch` from the response content if there are no more events to fetch

This matches [the changes that are coming in MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814#discussion_r1540896531).

Since this change follows https://github.com/matrix-org/matrix-js-sdk/pull/5392 , presumably in the same release, we don't need to keep any compatible version for the old API.

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/5392
Part of https://github.com/element-hq/element-meta/issues/2799

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
