### PR TITLE
Fix release-gitflow not handling pnpm-lock.yaml conflicts correctly

### DIFF
--- a/.github/workflows/release-gitflow.yml
+++ b/.github/workflows/release-gitflow.yml
@@ -53,10 +53,7 @@ jobs:
                   git config --global user.name "RiotRobot"
 
             - name: Merge to develop
-              run: |
-                  git checkout develop
-                  git merge -X ours master
-                  pnpm install --lockfile-only --fix-lockfile --frozen-lockfile=false --ignore-scripts
+              run: .action-repo/scripts/release/merge-master-to-develop.sh
 
             - name: Reset dependencies
               if: inputs.dependencies

--- a/scripts/release/merge-master-develop.sh
+++ b/scripts/release/merge-master-develop.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ex
+
+git checkout develop
+git merge origin/master --no-commit --no-ff || true
+
+CONFLICTS=$(git diff --name-only --diff-filter=U)
+
+if [ -n "$CONFLICTS" ]; then
+    if echo "$CONFLICTS" | grep -q 'package.json'; then
+        # Merge package.json in a way where we prefer all changes from `develop`
+        # except for the `version` field which we take from `master`.
+        git show HEAD:package.json > package.ours.json         # develop
+        git show FETCH_HEAD:package.json > package.theirs.json # master
+
+        jq -s '(.[0].version) as $masterVersion | (reduce .[] as $item ({}; . * $item)) | .version = $masterVersion' package.theirs.json package.ours.json > package.json
+        rm package.ours.json package.theirs.json
+        git add package.json
+    fi
+
+    # Reset lockfile to ours (develop) to clear raw text syntax errors
+    if echo "$CONFLICTS" | grep -q 'pnpm-lock.yaml'; then
+        git checkout --ours pnpm-lock.yaml
+    fi
+
+    # Fallback for any other files
+    git checkout --ours . 2>/dev/null || true
+fi
+
+# Rebuild lockfile based on the unified package.json
+pnpm install --lockfile-only --ignore-scripts --frozen-lockfile=false
+
+# Commit and push
+git add .
+git commit --no-edit
+git push origin develop


### PR DESCRIPTION
`version` must be kept from the master branch - all other fields should prefer develop.

Without this, pnpm will be given a possibly corrupted pnpm-lock.yaml file to repair, which it will be loosening some dependencies and possibly breaking the develop branch post-merge


Tested locally against the parents of https://github.com/element-hq/element-web/commit/2ee42a002e52ae832906704621c5012f2a57c8c0