### PR TITLE
Improve types for `/room_keys/version` requests

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -445,7 +445,14 @@ describe("crypto", () => {
             });
 
             it("fails with HISTORICAL_MESSAGE_BACKUP_UNCONFIGURED when the backup is broken", async () => {
-                fetchMock.get("path:/_matrix/client/v3/room_keys/version", {});
+                // A backup with an unknown algorithm
+                fetchMock.get("path:/_matrix/client/v3/room_keys/version", {
+                    algorithm: "boo",
+                    auth_data: {},
+                    version: "1",
+                    etag: "",
+                    count: 0,
+                });
                 expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
                 await startClientAndAwaitFirstSync();
 

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -467,7 +467,7 @@ describe("crypto", () => {
                     .getCrypto()!
                     .storeSessionBackupPrivateKey(
                         Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                        testData.SIGNED_BACKUP_DATA.version!,
+                        testData.SIGNED_BACKUP_DATA.version,
                     );
 
                 // Tell Alice to trust the dummy device that signed the backup

--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -519,7 +519,7 @@ describe("History Sharing", () => {
             .getCrypto()!
             .storeSessionBackupPrivateKey(
                 Buffer.from(BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                SIGNED_BACKUP_DATA.version!,
+                SIGNED_BACKUP_DATA.version,
             );
 
         await aliceClient.getCrypto()!.checkKeyBackupAndEnable();

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -192,7 +192,7 @@ describe("megolm-keys backup", () => {
                 const aliceCrypto = aliceClient.getCrypto()!;
                 await aliceCrypto.storeSessionBackupPrivateKey(
                     Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                    testData.SIGNED_BACKUP_DATA.version!,
+                    testData.SIGNED_BACKUP_DATA.version,
                 );
 
                 // start after saving the private key
@@ -328,7 +328,7 @@ describe("megolm-keys backup", () => {
             const check = await aliceCrypto.checkKeyBackupAndEnable();
             await aliceCrypto.storeSessionBackupPrivateKey(
                 decodeRecoveryKey(testData.BACKUP_DECRYPTION_KEY_BASE58),
-                check!.backupInfo!.version!,
+                check!.backupInfo!.version,
             );
 
             const result = await advanceTimersUntil(aliceCrypto.restoreKeyBackup());
@@ -378,7 +378,7 @@ describe("megolm-keys backup", () => {
 
             await aliceCrypto.storeSessionBackupPrivateKey(
                 decodeRecoveryKey(testData.BACKUP_DECRYPTION_KEY_BASE58),
-                check!.backupInfo!.version!,
+                check!.backupInfo!.version,
             );
 
             const progressCallback = vi.fn();
@@ -437,7 +437,7 @@ describe("megolm-keys backup", () => {
             const check = await aliceCrypto.checkKeyBackupAndEnable();
             await aliceCrypto.storeSessionBackupPrivateKey(
                 decodeRecoveryKey(testData.BACKUP_DECRYPTION_KEY_BASE58),
-                check!.backupInfo!.version!,
+                check!.backupInfo!.version,
             );
 
             const progressCallback = vi.fn();
@@ -494,7 +494,7 @@ describe("megolm-keys backup", () => {
             const check = await aliceCrypto.checkKeyBackupAndEnable();
             await aliceCrypto.storeSessionBackupPrivateKey(
                 decodeRecoveryKey(testData.BACKUP_DECRYPTION_KEY_BASE58),
-                check!.backupInfo!.version!,
+                check!.backupInfo!.version,
             );
 
             const result = await aliceCrypto.restoreKeyBackup();
@@ -580,7 +580,7 @@ describe("megolm-keys backup", () => {
 
             const someRoomKeys = testData.MEGOLM_SESSION_DATA_ARRAY;
 
-            const uploadMockEmitter = mockUploadEmitter(testData.SIGNED_BACKUP_DATA.version!);
+            const uploadMockEmitter = mockUploadEmitter(testData.SIGNED_BACKUP_DATA.version);
 
             const uploadPromises = someRoomKeys.map(
                 (data) =>
@@ -662,7 +662,7 @@ describe("megolm-keys backup", () => {
             const result = await aliceCrypto.checkKeyBackupAndEnable();
             expect(result).toBeTruthy();
 
-            mockUploadEmitter(testData.SIGNED_BACKUP_DATA.version!);
+            mockUploadEmitter(testData.SIGNED_BACKUP_DATA.version);
             await aliceCrypto.importRoomKeys(someRoomKeys);
 
             // The backup loop is waiting a random amount of time to avoid different clients firing at the same time.
@@ -866,7 +866,7 @@ describe("megolm-keys backup", () => {
         // Delete the backup and we are expecting the key backup to be disabled
         const keyBackupStatus = Promise.withResolvers<boolean>();
         aliceClient.once(CryptoEvent.KeyBackupStatus, (enabled) => keyBackupStatus.resolve(enabled));
-        await aliceCrypto.deleteKeyBackupVersion(testData.SIGNED_BACKUP_DATA.version!);
+        await aliceCrypto.deleteKeyBackupVersion(testData.SIGNED_BACKUP_DATA.version);
         expect(await keyBackupStatus.promise).toBe(false);
 
         // The backup info should not be available anymore
@@ -906,7 +906,7 @@ describe("megolm-keys backup", () => {
             await aliceClient.startClient();
             await aliceCrypto.storeSessionBackupPrivateKey(
                 Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                testData.SIGNED_BACKUP_DATA.version!,
+                testData.SIGNED_BACKUP_DATA.version,
             );
 
             const result = await aliceCrypto.isKeyBackupTrusted(testData.SIGNED_BACKUP_DATA);
@@ -920,7 +920,7 @@ describe("megolm-keys backup", () => {
             await aliceClient.startClient();
             await aliceCrypto.storeSessionBackupPrivateKey(
                 Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                testData.SIGNED_BACKUP_DATA.version!,
+                testData.SIGNED_BACKUP_DATA.version,
             );
 
             const backup: KeyBackupInfo = JSON.parse(JSON.stringify(testData.SIGNED_BACKUP_DATA));
@@ -961,7 +961,7 @@ describe("megolm-keys backup", () => {
             // Alice does *not* trust the device that signed the backup, but *does* have the decryption key.
             await aliceCrypto.storeSessionBackupPrivateKey(
                 Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                testData.SIGNED_BACKUP_DATA.version!,
+                testData.SIGNED_BACKUP_DATA.version,
             );
 
             const result = await aliceCrypto.checkKeyBackupAndEnable();
@@ -1077,7 +1077,7 @@ describe("megolm-keys backup", () => {
             const aliceCrypto = aliceClient.getCrypto()!;
             await aliceCrypto.storeSessionBackupPrivateKey(
                 Buffer.from(testData.BACKUP_DECRYPTION_KEY_BASE64, "base64"),
-                testData.SIGNED_BACKUP_DATA.version!,
+                testData.SIGNED_BACKUP_DATA.version,
             );
 
             // start after saving the private key

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -1243,6 +1243,8 @@ describe("verification", () => {
             auth_data: {
                 public_key: "hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo",
             },
+            etag: "",
+            count: 0,
         };
 
         /** {@link unsignedMatchingBackupInfo}, with the addition of a signature */
@@ -1254,6 +1256,8 @@ describe("verification", () => {
             auth_data: {
                 public_key: "EjDwCYkwp1R0i33ctD73Wg2/Og0mOBr066Spjqqaqqo",
             },
+            etag: "",
+            count: 0,
         };
 
         /** {@link unsignedNonMatchingBackupInfo}, with the addition of a signature */
@@ -1265,6 +1269,8 @@ describe("verification", () => {
             auth_data: {
                 public_key: "EjDwCYkwp1R0i33ctD73Wg2/Og0mOBr066Spjqqaqqo",
             },
+            etag: "",
+            count: 0,
         };
 
         beforeEach(async () => {

--- a/spec/test-utils/test-data/generate-test-data.py
+++ b/spec/test-utils/test-data/generate-test-data.py
@@ -20,7 +20,7 @@ This file is a Python script to generate test data for crypto tests.
 To run it:
 
 python -m venv env
-./env/bin/pip install cryptography canonicaljson
+./env/bin/pip install cryptography canonicaljson base58
 ./env/bin/python generate-test-data.py > index.ts
 """
 
@@ -172,6 +172,8 @@ def build_test_data(user_data, prefix = "") -> str:
         "auth_data": {
             "public_key": b64_backup_public_key,
         },
+        "etag": "",
+        "count": 0,
     }
     # sign with our device key
     sig = sign_json(backup_data["auth_data"], private_key)

--- a/spec/test-utils/test-data/index.ts
+++ b/spec/test-utils/test-data/index.ts
@@ -232,7 +232,9 @@ export const SIGNED_BACKUP_DATA: KeyBackupInfo = {
                 "ed25519:test_device": "KDSNeumirTsd8piI0oVfv/wzg4J4HlEc7rs5XhODFcJ/YAcUdg65ajsZG+rLI0TQOSSGjorJqcrSiSB1HRSCAA"
             }
         }
-    }
+    },
+    "etag": "",
+    "count": 0
 };
 
 /**
@@ -463,7 +465,9 @@ export const BOB_SIGNED_BACKUP_DATA: KeyBackupInfo = {
                 "ed25519:bob_device": "lDIMj3VC0WazE2FamGHpmbiqKf9Z4pO4qapZ5TL5BnD3c+dvb+2waOEd6pgay/pmrQ6MW4Eu2KDEpe1fnHc3BA"
             }
         }
-    }
+    },
+    "etag": "",
+    "count": 0
 };
 
 /**

--- a/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
+++ b/spec/unit/rust-crypto/PerSessionKeyBackupDownloader.spec.ts
@@ -131,9 +131,9 @@ describe("PerSessionKeyBackupDownloader", () => {
 
     describe("Given valid backup available", () => {
         beforeEach(async () => {
-            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
+            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version);
             mockOlmMachine.getBackupKeys.mockResolvedValue({
-                backupVersion: TestData.SIGNED_BACKUP_DATA.version!,
+                backupVersion: TestData.SIGNED_BACKUP_DATA.version,
                 decryptionKey: RustSdkCryptoJs.BackupDecryptionKey.fromBase64(TestData.BACKUP_DECRYPTION_KEY_BASE64),
             } as unknown as RustSdkCryptoJs.BackupKeys);
 
@@ -345,7 +345,7 @@ describe("PerSessionKeyBackupDownloader", () => {
             // there is a backup
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
             // it is trusted
-            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
+            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version);
             // but the key is not cached
             mockOlmMachine.getBackupKeys.mockResolvedValue({} as RustSdkCryptoJs.BackupKeys);
 
@@ -364,7 +364,7 @@ describe("PerSessionKeyBackupDownloader", () => {
             // there is a backup
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", testData.SIGNED_BACKUP_DATA);
             // it is trusted
-            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
+            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version);
             // but the cached key has the wrong version
             mockOlmMachine.getBackupKeys.mockResolvedValue({
                 backupVersion: "0",
@@ -433,10 +433,10 @@ describe("PerSessionKeyBackupDownloader", () => {
             expect(downloader.isKeyBackupDownloadConfigured()).toBe(false);
 
             // Now the backup becomes trusted
-            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
+            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version);
             // And we have the key in cache
             mockOlmMachine.getBackupKeys.mockResolvedValue({
-                backupVersion: TestData.SIGNED_BACKUP_DATA.version!,
+                backupVersion: TestData.SIGNED_BACKUP_DATA.version,
                 decryptionKey: RustSdkCryptoJs.BackupDecryptionKey.fromBase64(TestData.BACKUP_DECRYPTION_KEY_BASE64),
             } as unknown as RustSdkCryptoJs.BackupKeys);
 
@@ -458,10 +458,10 @@ describe("PerSessionKeyBackupDownloader", () => {
             // there is a backup
             mockRustBackupManager.getServerBackupInfo.mockResolvedValue(TestData.SIGNED_BACKUP_DATA);
             // It's trusted
-            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version!);
+            mockRustBackupManager.getActiveBackupVersion.mockResolvedValue(TestData.SIGNED_BACKUP_DATA.version);
             // And we have the key in cache
             mockOlmMachine.getBackupKeys.mockResolvedValue({
-                backupVersion: TestData.SIGNED_BACKUP_DATA.version!,
+                backupVersion: TestData.SIGNED_BACKUP_DATA.version,
                 decryptionKey: RustSdkCryptoJs.BackupDecryptionKey.fromBase64(TestData.BACKUP_DECRYPTION_KEY_BASE64),
             } as unknown as RustSdkCryptoJs.BackupKeys);
         });

--- a/spec/unit/rust-crypto/backup.spec.ts
+++ b/spec/unit/rust-crypto/backup.spec.ts
@@ -48,7 +48,7 @@ describe("Upload keys to backup", () => {
 
         mockOlmMachine = {
             getBackupKeys: vi.fn().mockResolvedValue({
-                backupVersion: TestData.SIGNED_BACKUP_DATA.version!,
+                backupVersion: TestData.SIGNED_BACKUP_DATA.version,
                 decryptionKey: RustSdkCryptoJs.BackupDecryptionKey.fromBase64(TestData.BACKUP_DECRYPTION_KEY_BASE64),
             } as unknown as RustSdkCryptoJs.BackupKeys),
             backupRoomKeys: vi.fn(),

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -48,6 +48,7 @@ import {
     MatrixHttpApi,
     MemoryCryptoStore,
     TypedEventEmitter,
+    MatrixError,
 } from "../../../src";
 import { emitPromise, mkEvent, waitFor } from "../../test-utils/test-utils";
 import { type CryptoBackend } from "../../../src/common-crypto/CryptoBackend";
@@ -841,6 +842,8 @@ describe("RustCrypto", () => {
                         return Promise.resolve({ version: "1", algorithm: backupAlg, auth_data: backupAuthData });
                     } else if (method === "GET" && backupAuthData) {
                         return Promise.resolve({ version: "1", algorithm: backupAlg, auth_data: backupAuthData });
+                    } else {
+                        throw new MatrixError({ errcode: "M_NOT_FOUND" }, 404);
                     }
                 }
                 return Promise.resolve({});
@@ -2367,7 +2370,12 @@ describe("RustCrypto", () => {
             });
             // If the backup is deleted, we will return an empty object
             fetchMock.get("path:/_matrix/client/v3/room_keys/version", () => {
-                return backupIsDeleted ? {} : testData.SIGNED_BACKUP_DATA;
+                return backupIsDeleted
+                    ? {
+                          status: 404,
+                          body: { errcode: "M_NOT_FOUND" },
+                      }
+                    : testData.SIGNED_BACKUP_DATA;
             });
 
             let dehydratedDeviceIsDeleted = false;

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -67,7 +67,7 @@ import {
     EventShieldReason,
     type ImportRoomKeysOpts,
     type KeyBackupCheck,
-    type KeyBackupInfo,
+    type NewKeyBackupInfo,
     type VerificationRequest,
 } from "../../../src/crypto-api";
 import * as testData from "../../test-utils/test-data";
@@ -2377,7 +2377,7 @@ describe("RustCrypto", () => {
             });
 
             // A new key backup should be created after the reset
-            let newKeyBackupInfo!: KeyBackupInfo;
+            let newKeyBackupInfo!: NewKeyBackupInfo;
             fetchMock.post("path:/_matrix/client/v3/room_keys/version", (callLog) => {
                 newKeyBackupInfo = JSON.parse(callLog.options.body as string);
                 return { version: "2" };

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1531,7 +1531,7 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto();
             await rustCrypto.storeSessionBackupPrivateKey(
                 new TextEncoder().encode(key),
-                testData.SIGNED_BACKUP_DATA.version!,
+                testData.SIGNED_BACKUP_DATA.version,
             );
             const fetched = await rustCrypto.getSessionBackupPrivateKey();
             expect(new TextDecoder().decode(fetched!)).toEqual(key);
@@ -1756,7 +1756,7 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto();
             const olmMachine: OlmMachine = rustCrypto["olmMachine"];
 
-            const backupVersion = testData.SIGNED_BACKUP_DATA.version!;
+            const backupVersion = testData.SIGNED_BACKUP_DATA.version;
             await olmMachine.enableBackupV1(
                 (testData.SIGNED_BACKUP_DATA.auth_data as Curve25519AuthData).public_key,
                 backupVersion,
@@ -1799,7 +1799,7 @@ describe("RustCrypto", () => {
             const rustCrypto = await makeTestRustCrypto();
             const olmMachine: OlmMachine = rustCrypto["olmMachine"];
 
-            const backupVersion = testData.SIGNED_BACKUP_DATA.version!;
+            const backupVersion = testData.SIGNED_BACKUP_DATA.version;
             await olmMachine.enableBackupV1(
                 (testData.SIGNED_BACKUP_DATA.auth_data as Curve25519AuthData).public_key,
                 backupVersion,

--- a/src/crypto-api/keybackup.ts
+++ b/src/crypto-api/keybackup.ts
@@ -33,16 +33,24 @@ export interface Aes256AuthData {
 }
 
 /**
- * Information about a server-side key backup.
+ * Information about a new server-side key backup.
+ *
+ * The type of the request body for [`POST /_matrix/client/v3/room_keys/version`](https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3room_keysversion).
+ */
+export interface NewKeyBackupInfo {
+    algorithm: string;
+    auth_data: ISigned & (Curve25519AuthData | Aes256AuthData);
+}
+
+/**
+ * Information about an existing server-side key backup.
  *
  * Returned by [`GET /_matrix/client/v3/room_keys/version`](https://spec.matrix.org/v1.7/client-server-api/#get_matrixclientv3room_keysversion).
  */
-export interface KeyBackupInfo {
-    algorithm: string;
-    auth_data: ISigned & (Curve25519AuthData | Aes256AuthData);
-    count?: number;
-    etag?: string;
-    version?: string; // number contained within
+export interface KeyBackupInfo extends NewKeyBackupInfo {
+    count: number;
+    etag: string;
+    version: string; // number contained within
 }
 
 /**

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -382,9 +382,9 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         // we also checked it has a valid `version`.
         await this.olmMachine.enableBackupV1(
             (backupInfo.auth_data as Curve25519AuthData).public_key,
-            backupInfo.version!,
+            backupInfo.version,
         );
-        this.activeBackupVersion = backupInfo.version!;
+        this.activeBackupVersion = backupInfo.version;
 
         this.emit(CryptoEvent.KeyBackupStatus, true);
 

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -326,11 +326,6 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
             return null;
         }
         this.checkedForBackup = true;
-
-        if (backupInfo && !backupInfo.version) {
-            this.logger.warn("active backup lacks a useful 'version'; ignoring it");
-            backupInfo = undefined;
-        }
         this.serverBackupInfo = backupInfo;
 
         const activeVersion = await this.getActiveBackupVersion();

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -27,6 +27,7 @@ import {
     type KeyBackupRestoreOpts,
     type KeyBackupRestoreResult,
     type KeyBackupRoomSessions,
+    type NewKeyBackupInfo,
 } from "../crypto-api/keybackup.ts";
 import { type Logger } from "../logger.ts";
 import { ClientPrefix, type IHttpOpts, MatrixError, type MatrixHttpApi, Method } from "../http-api/index.ts";
@@ -580,14 +581,16 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
         await signObject(authData);
 
+        const backupData: NewKeyBackupInfo = {
+            algorithm: pubKey.algorithm,
+            auth_data: authData,
+        };
+
         const res = await this.http.authedRequest<{ version: string }>(
             Method.Post,
             "/room_keys/version",
             undefined,
-            {
-                algorithm: pubKey.algorithm,
-                auth_data: authData,
-            },
+            backupData,
             {
                 prefix: ClientPrefix.V3,
             },


### PR DESCRIPTION
Currently we have a single interface which serves both as the request body for `POST /_matrix/client/v3/room_keys/version`, and the response body for `GET /_matrix/client/v3/room_keys/version`. Although the two are related, the latter has a bunch of mandatory fields, so the single interface serves neither purpose well.

Let's create a new type for the POST request body.

Suggest review commit-by-commit.