### PR TITLE
Add can_subscribe on RTC member events and move rtc_transports to transports.published

### DIFF
--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -247,6 +247,7 @@ describe("CallMembership", () => {
             application: { "type": "m.call", "m.call.id": "", "m.call.intent": "voice" },
             member: { user_id: "@alice:example.org", device_id: "AAAAAAA", id: "xyzHASHxyz" },
             rtc_transports: [{ type: "livekit" }],
+            transports: { can_subscribe: ["livekit"] },
             versions: [],
             msc4354_sticky_key: "abc123",
         };
@@ -322,6 +323,25 @@ describe("CallMembership", () => {
                 });
             }).toThrow();
         });
+
+        it("accepts membership with no transports for backwards compatibility", () => {
+            expect(() => {
+                createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: undefined });
+            }).not.toThrow();
+        });
+
+        it("rejects membership with incorrect transports", () => {
+            expect(() => {
+                createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: { can_subscribe: [1] } });
+            }).toThrow();
+            expect(() => {
+                createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: { wrong_key: [] } });
+            }).toThrow();
+            expect(() => {
+                createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: "not an object" });
+            }).toThrow();
+        });
+
         it("rejects membership with incorrect sticky_key", () => {
             expect(() => {
                 createCallMembership(makeMockEvent(), membershipTemplate);

--- a/spec/unit/matrixrtc/CallMembership.spec.ts
+++ b/spec/unit/matrixrtc/CallMembership.spec.ts
@@ -246,8 +246,7 @@ describe("CallMembership", () => {
             slot_id: "m.call#",
             application: { "type": "m.call", "m.call.id": "", "m.call.intent": "voice" },
             member: { user_id: "@alice:example.org", device_id: "AAAAAAA", id: "xyzHASHxyz" },
-            rtc_transports: [{ type: "livekit" }],
-            transports: { can_subscribe: ["livekit"] },
+            transports: { published: [{ type: "livekit" }], can_subscribe: ["livekit"] },
             versions: [],
             msc4354_sticky_key: "abc123",
         };
@@ -324,12 +323,6 @@ describe("CallMembership", () => {
             }).toThrow();
         });
 
-        it("accepts membership with no transports for backwards compatibility", () => {
-            expect(() => {
-                createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: undefined });
-            }).not.toThrow();
-        });
-
         it("rejects membership with incorrect transports", () => {
             expect(() => {
                 createCallMembership(makeMockEvent(), { ...membershipTemplate, transports: { can_subscribe: [1] } });
@@ -394,7 +387,7 @@ describe("CallMembership", () => {
             it("gets the correct active transport with oldest_membership", () => {
                 const oldestMembership = createCallMembership(makeMockEvent(), {
                     ...membershipTemplate,
-                    rtc_transports: [{ type: "oldest_transport" }],
+                    transports: { ...membershipTemplate.transports, published: [{ type: "oldest_transport" }] },
                 });
                 const membership = createCallMembership(makeMockEvent(), membershipTemplate);
 

--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -1017,6 +1017,7 @@ describe("MembershipManager", () => {
                             },
                             slot_id: "m.call#ROOM",
                             rtc_transports: [{ type: focus.type, livekit_service_url: focus.livekit_service_url }],
+                            transports: { can_subscribe: ["livekit"] },
                             versions: [],
                             msc4354_sticky_key: "@alice:example.org:AAAAAAA_m.call",
                         },

--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -1016,8 +1016,10 @@ describe("MembershipManager", () => {
                                 device_id: "AAAAAAA",
                             },
                             slot_id: "m.call#ROOM",
-                            rtc_transports: [{ type: focus.type, livekit_service_url: focus.livekit_service_url }],
-                            transports: { can_subscribe: ["livekit"] },
+                            transports: {
+                                published: [{ type: focus.type, livekit_service_url: focus.livekit_service_url }],
+                                can_subscribe: ["livekit"],
+                            },
                             versions: [],
                             msc4354_sticky_key: "@alice:example.org:AAAAAAA_m.call",
                         },

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -64,6 +64,7 @@ export const rtcMembershipTemplate: RtcMembershipData & { user_id: string } = {
     },
     slot_id: "m.call#ROOM",
     versions: [],
+    transports: { can_subscribe: ["livekit"] },
     rtc_transports: [
         {
             type: "livekit",

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -64,25 +64,27 @@ export const rtcMembershipTemplate: RtcMembershipData & { user_id: string } = {
     },
     slot_id: "m.call#ROOM",
     versions: [],
-    transports: { can_subscribe: ["livekit"] },
-    rtc_transports: [
-        {
-            type: "livekit",
-            focus_active: { type: "livekit", focus_selection: "oldest_membership" },
-            foci_preferred: [
-                {
-                    livekit_alias: "!alias:something.org",
-                    livekit_service_url: "https://livekit-jwt.something.io",
-                    type: "livekit",
-                },
-                {
-                    livekit_alias: "!alias:something.org",
-                    livekit_service_url: "https://livekit-jwt.something.dev",
-                    type: "livekit",
-                },
-            ],
-        },
-    ],
+    transports: {
+        published: [
+            {
+                type: "livekit",
+                focus_active: { type: "livekit", focus_selection: "oldest_membership" },
+                foci_preferred: [
+                    {
+                        livekit_alias: "!alias:something.org",
+                        livekit_service_url: "https://livekit-jwt.something.io",
+                        type: "livekit",
+                    },
+                    {
+                        livekit_alias: "!alias:something.org",
+                        livekit_service_url: "https://livekit-jwt.something.dev",
+                        type: "livekit",
+                    },
+                ],
+            },
+        ],
+        can_subscribe: ["livekit"],
+    },
     msc4354_sticky_key: "m.call#",
 };
 

--- a/src/matrixrtc/CallMembership.ts
+++ b/src/matrixrtc/CallMembership.ts
@@ -385,7 +385,7 @@ export class CallMembership {
      * ## RTC Membership
      * Gets the primary transport to use for this RTC membership (m.rtc.member).
      * This will return the primary transport that is used by this call membership to publish their media.
-     * Directly relates to the `rtc_transports` field.
+     * Directly relates to the `transports.published` field.
      *
      * ## Legacy session membership
      * In case of a legacy session membership (m.call.member) this will return the selected transport where
@@ -393,7 +393,7 @@ export class CallMembership {
      * If the `focus_selection` is `oldest_membership` this will return the transport of the oldest membership
      * in the room (based on the `created_ts` field of the session membership).
      * If the `focus_selection` is `multi_sfu` it will return the first transport of the `foci_preferred` list.
-     * (`multi_sfu` is equivalent to how `m.rtc.member` `rtc_transports` work).
+     * (`multi_sfu` is equivalent to how `m.rtc.member` `transports.published` work).
      * @param oldestMembership For backwards compatibility with session membership (legacy). Unused in case of RTC membership.
      * Always required to make the consumer not care if it deals with RTC or session memberships.
      * @returns The transport this membership uses to publish media or undefined if no transport is available.
@@ -402,7 +402,7 @@ export class CallMembership {
         const { kind, data } = this.membershipData;
         switch (kind) {
             case MembershipKind.RTC:
-                return data.rtc_transports[0];
+                return data.transports.published[0];
             case MembershipKind.Session:
                 switch (data.focus_active.focus_selection) {
                     case "oldest_membership":
@@ -422,14 +422,14 @@ export class CallMembership {
     }
 
     /**
-     * The value of the `rtc_transports` field for RTC memberships (m.rtc.member).
+     * The value of the `transports.published` field for RTC memberships (m.rtc.member).
      * Or the value of the `foci_preferred` field for legacy session memberships (m.call.member).
      */
     public get transports(): Transport[] {
         const { kind, data } = this.membershipData;
         switch (kind) {
             case MembershipKind.RTC:
-                return data.rtc_transports;
+                return data.transports.published;
             case MembershipKind.Session:
             default:
                 return data.foci_preferred;

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -1116,6 +1116,7 @@ export class StickyEventMembershipManager extends MembershipManager {
             rtc_transports: livekitTransport
                 ? [{ type: livekitTransport.type, livekit_service_url: livekitTransport.livekit_service_url }]
                 : [],
+            transports: { can_subscribe: ["livekit"] },
             member: { device_id: this.deviceId, user_id: this.userId, id: this.memberId },
             versions: [],
             ...relationObject,

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -1111,12 +1111,14 @@ export class StickyEventMembershipManager extends MembershipManager {
                 ...(this.callIntent ? { "m.call.intent": this.callIntent } : {}),
             },
             slot_id: computeSlotId(this.slotDescription),
-            // Make sure we do not add the alias to the transport.
-            // It is not needed in matrix2.0. The additional session information will be used to find the right alias on the sfu.
-            rtc_transports: livekitTransport
-                ? [{ type: livekitTransport.type, livekit_service_url: livekitTransport.livekit_service_url }]
-                : [],
-            transports: { can_subscribe: ["livekit"] },
+            transports: {
+                // Make sure we do not add the alias to the transport.
+                // It is not needed in matrix2.0. The additional session information will be used to find the right alias on the sfu.
+                published: livekitTransport
+                    ? [{ type: livekitTransport.type, livekit_service_url: livekitTransport.livekit_service_url }]
+                    : [],
+                can_subscribe: ["livekit"],
+            },
             member: { device_id: this.deviceId, user_id: this.userId, id: this.memberId },
             versions: [],
             ...relationObject,

--- a/src/matrixrtc/membershipData/rtc.ts
+++ b/src/matrixrtc/membershipData/rtc.ts
@@ -39,6 +39,9 @@ export interface RtcMembershipData {
     };
     "application": RtcSlotEventContent["application"];
     "rtc_transports": Transport[];
+    "transports": {
+        can_subscribe: string[];
+    };
     "versions": string[];
     "msc4354_sticky_key"?: string;
     "sticky_key"?: string;
@@ -107,6 +110,14 @@ export const checkRtcMembershipData = (data: IContent, sender: string): data is 
                 break;
             }
         }
+    }
+    if (
+        data.transports !== undefined && // Allow this to be missing for now as older clients won't send it
+        (typeof data.transports !== "object" ||
+            !Array.isArray(data.transports.can_subscribe) ||
+            !data.transports.can_subscribe.every((t: unknown) => typeof t === "string"))
+    ) {
+        errors.push(prefix + "transports must be missing or contain the can_subscribe array");
     }
     if (data.versions === undefined || !Array.isArray(data.versions)) {
         errors.push(prefix + "versions must be an array");

--- a/src/matrixrtc/membershipData/rtc.ts
+++ b/src/matrixrtc/membershipData/rtc.ts
@@ -38,8 +38,8 @@ export interface RtcMembershipData {
         rel_type: RelationType.Reference;
     };
     "application": RtcSlotEventContent["application"];
-    "rtc_transports": Transport[];
     "transports": {
+        published: Transport[];
         can_subscribe: string[];
     };
     "versions": string[];
@@ -100,24 +100,24 @@ export const checkRtcMembershipData = (data: IContent, sender: string): data is 
             if (data.application.type.includes("#")) errors.push(prefix + 'application.type must not include "#"');
         }
     }
-    if (data.rtc_transports === undefined || !Array.isArray(data.rtc_transports)) {
-        errors.push(prefix + "rtc_transports must be an array");
+    if (typeof data.transports !== "object" || data.transports === null || !Array.isArray(data.transports.published)) {
+        errors.push(prefix + "transports.published must be an array");
     } else {
         // validate that each transport has at least a string 'type'
-        for (const t of data.rtc_transports) {
+        for (const t of data.transports.published) {
             if (typeof t !== "object" || t === null || typeof (t as any).type !== "string") {
-                errors.push(prefix + "rtc_transports entries must be objects with a string type");
+                errors.push(prefix + "transports.published entries must be objects with a string type");
                 break;
             }
         }
     }
     if (
-        data.transports !== undefined && // Allow this to be missing for now as older clients won't send it
-        (typeof data.transports !== "object" ||
-            !Array.isArray(data.transports.can_subscribe) ||
-            !data.transports.can_subscribe.every((t: unknown) => typeof t === "string"))
+        typeof data.transports !== "object" ||
+        data.transports === null ||
+        !Array.isArray(data.transports.can_subscribe) ||
+        !data.transports.can_subscribe.every((t: unknown) => typeof t === "string")
     ) {
-        errors.push(prefix + "transports must be missing or contain the can_subscribe array");
+        errors.push(prefix + "transports.can_subscribe must be an array of strings");
     }
     if (data.versions === undefined || !Array.isArray(data.versions)) {
         errors.push(prefix + "versions must be an array");


### PR DESCRIPTION
This adds `transports.can_subscribe` from https://github.com/matrix-org/matrix-spec-proposals/pull/4143. It's always hardcoded to `["livekit"]` for now as we have no other transports yet.

Fixes: element-hq/voip-internal#645

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
