### PR TITLE
feat: implement MSC4483 Encrypted Account Data

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -457,6 +457,13 @@ export interface AccountDataEvents extends SecretStorageAccountDataEvents {
 export type WritableAccountDataEvents = Exclude<AccountDataEvents, "m.fully_read" | "m.push_rules">;
 
 /**
+ * Subset of AccountDataEvents, only including events encryptable via MSC4483.
+ *
+ * Currently, this is none.
+ */
+export type EncryptableAccountDataEvents = {};
+
+/**
  * Mapped type from event type to content type for all specified global events encrypted by secret storage.
  *
  * See https://spec.matrix.org/v1.13/client-server-api/#msecret_storagev1aes-hmac-sha2-1
@@ -466,5 +473,6 @@ export interface SecretStorageAccountDataEvents {
     "m.cross_signing.master": SecretInfo;
     "m.cross_signing.self_signing": SecretInfo;
     "m.cross_signing.user_signing": SecretInfo;
+    "dev.zirco.msc4483.account_data.key": SecretInfo;
     "org.matrix.msc3814": SecretInfo;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -54,7 +54,7 @@ import { deepCompare, noUnsafeEventProps, type QueryDict, replaceParam, safeSet,
 import { Direction, EventTimeline } from "./models/event-timeline.ts";
 import { type IActionsObject, PushProcessor } from "./pushprocessor.ts";
 import { AutoDiscovery, type AutoDiscoveryAction } from "./autodiscovery.ts";
-import { encodeUnpaddedBase64Url } from "./base64.ts";
+import { decodeBase64, encodeBase64, encodeUnpaddedBase64Url } from "./base64.ts";
 import { TypedReEmitter } from "./ReEmitter.ts";
 import { logger, type Logger } from "./logger.ts";
 import { SERVICE_TYPES } from "./service-types.ts";
@@ -147,6 +147,7 @@ import {
     UNSTABLE_MSC3088_PURPOSE,
     UNSTABLE_MSC3089_TREE_SUBTYPE,
     type WritableAccountDataEvents,
+    type EncryptableAccountDataEvents,
 } from "./@types/event.ts";
 import {
     GuestAccess,
@@ -247,6 +248,10 @@ import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
 import { type Transport } from "./matrixrtc/index.ts";
 import { RetentionPolicyService } from "./retentionPolicy.ts";
+import { randomBytes } from "node:crypto";
+import decryptAESSecretStorageItem from "./utils/decryptAESSecretStorageItem.ts";
+import { AESEncryptedSecretStoragePayload } from "./types.ts";
+import encryptAESSecretStorageItem from "./utils/encryptAESSecretStorageItem.ts";
 
 export type Store = IStore;
 
@@ -2364,6 +2369,57 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 ? { prefix: "/_matrix/client/unstable/org.matrix.msc3391" }
                 : undefined;
         return await this.http.authedRequest(Method.Delete, path, undefined, undefined, options);
+    }
+
+    public async getAccountDataKey(): Promise<Uint8Array<ArrayBuffer>> {
+        const ADK_ID = "dev.zirco.msc4483.account_data.key";
+
+        let key = await this.secretStorage.get(ADK_ID);
+
+        if (!key) {
+            throw new Error("Account data key not found in secret storage");
+        }
+
+        return decodeBase64(key);
+    }
+
+    public async getOrCreateAccountDataKey(): Promise<Uint8Array<ArrayBuffer>> {
+        // get the ADK secret from secret storage, or create it if it doesn't exist
+        const ADK_ID = "dev.zirco.msc4483.account_data.key";
+
+        let key = await this.secretStorage.get(ADK_ID);
+
+        if (!key) {
+            // generate a new 256 byte secret, base64 encode it, and store it in 4S
+            key = encodeBase64(randomBytes(32));
+
+            await this.secretStorage.store(ADK_ID, key);
+        }
+
+        return decodeBase64(key);
+    }
+
+    public async getEncryptedAccountData<K extends keyof EncryptableAccountDataEvents>(
+        eventType: K,
+    ): Promise<EncryptableAccountDataEvents[K] | null> {
+        const key = await this.getAccountDataKey();
+
+        const event = await this.getAccountDataFromServer(eventType) as never as AESEncryptedSecretStoragePayload;
+        if (!event) {
+            return null;
+        }
+
+        const decrypted = await decryptAESSecretStorageItem(event, key, eventType);
+        return decrypted as EncryptableAccountDataEvents[K];
+    }
+
+    public async setEncryptedAccountData<K extends keyof EncryptableAccountDataEvents>(
+        eventType: K,
+        content: EncryptableAccountDataEvents[K],
+    ): Promise<void> {
+        const key = await this.getOrCreateAccountDataKey();
+        const encrypted = await encryptAESSecretStorageItem(content, key, eventType);
+        await this.setAccountData(eventType, encrypted as never);
     }
 
     /**


### PR DESCRIPTION
I'm not quite sure how to reliably test this, or even if this is the right direction to take things. Early review appreciated and then I'll mark as ready later.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
