### PR TITLE
Defer key bundle downloads on server-initiated joins (MSC4509)

### DIFF
--- a/spec/unit/matrix-client-key-bundle.spec.ts
+++ b/spec/unit/matrix-client-key-bundle.spec.ts
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, beforeEach, it, expect, vi, type Mocked } from "vitest";
+
+import {
+    ClientEvent,
+    EventType,
+    type ICreateClientOpts,
+    MatrixClient,
+    MatrixEvent,
+    MatrixEventEvent,
+    RoomMember,
+    RoomMemberEvent,
+} from "../../src";
+import { KnownMembership, type Membership } from "../../src/@types/membership";
+import { type CryptoBackend } from "../../src/common-crypto/CryptoBackend";
+import { flushPromises } from "../test-utils/flushPromises";
+
+const userId = "@alice:example.org";
+const inviter = "@bob:example.org";
+const roomId = "!room:example.org";
+
+describe("MatrixClient key bundles for server-initiated joins", () => {
+    let client: MatrixClient;
+    let mockCrypto: Mocked<CryptoBackend>;
+
+    function makeClient(opts: Partial<ICreateClientOpts> = {}): void {
+        client = new MatrixClient({
+            baseUrl: "https://test.example.org",
+            userId,
+            accessToken: "token",
+            fetchFn: vi.fn(),
+            ...opts,
+        });
+        mockCrypto = {
+            markRoomAsPendingKeyBundle: vi.fn().mockResolvedValue(undefined),
+            maybeAcceptKeyBundle: vi.fn().mockResolvedValue(undefined),
+        } as unknown as Mocked<CryptoBackend>;
+        client["cryptoBackend"] = mockCrypto;
+    }
+
+    function emitMembership(
+        membership: Membership,
+        oldMembership: Membership,
+        { sender = inviter, unsigned = {} }: { sender?: string; unsigned?: object } = {},
+    ): void {
+        const event = new MatrixEvent({
+            type: EventType.RoomMember,
+            room_id: roomId,
+            state_key: userId,
+            sender,
+            content: { membership },
+            unsigned,
+        });
+        const member = new RoomMember(roomId, userId);
+        member.membership = membership;
+        client.emit(RoomMemberEvent.Membership, event, member, oldMembership);
+    }
+
+    function emitClaim(claimRoomId: unknown, sender = userId): void {
+        client.emit(
+            ClientEvent.ToDeviceEvent,
+            new MatrixEvent({
+                type: "org.matrix.msc4509.key_bundle_claim",
+                sender,
+                content: { room_id: claimRoomId as string },
+            }),
+        );
+    }
+
+    describe("with MSC4509 disabled (the default)", () => {
+        beforeEach(() => {
+            makeClient();
+        });
+
+        it("eagerly accepts the key bundle on an invite -> join transition", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+            expect(mockCrypto.markRoomAsPendingKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+        });
+
+        it("recovers the inviter from unsigned.prev_sender when the invite was not seen", async () => {
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, {
+                sender: userId,
+                unsigned: { prev_content: { membership: KnownMembership.Invite }, prev_sender: inviter },
+            });
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+        });
+
+        it("ignores key_bundle_claim to-device messages", async () => {
+            emitClaim(roomId);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+        });
+
+        it("logs rather than throwing when accepting the bundle fails", async () => {
+            const loggerError = vi.spyOn(client["logger"], "error").mockImplementation(() => {});
+            mockCrypto.maybeAcceptKeyBundle.mockRejectedValue(new Error("nope"));
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+            expect(loggerError).toHaveBeenCalledWith(expect.stringContaining(roomId), expect.any(Error));
+        });
+    });
+
+    describe("with MSC4509 enabled", () => {
+        beforeEach(() => {
+            makeClient({ unstableMSC4509KeyBundleClaim: true });
+        });
+
+        it("defers the key bundle on a knock -> join transition until designated", async () => {
+            // An accepted knock can be auto-joined straight past the invited state, with the
+            // invite coalesced away: the join's prev_content carries the invite.
+            emitMembership(KnownMembership.Join, KnownMembership.Knock, {
+                sender: userId,
+                unsigned: { prev_content: { membership: KnownMembership.Invite }, prev_sender: inviter },
+            });
+            await flushPromises();
+            expect(mockCrypto.markRoomAsPendingKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+
+            emitClaim(roomId);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+        });
+
+        it("accepts at join time when the designation raced ahead of the join", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitClaim(roomId);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+        });
+
+        it("claims the deferred bundle upon an undecryptable event in the room", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+
+            const undecryptable = new MatrixEvent({
+                type: EventType.RoomMessageEncrypted,
+                room_id: roomId,
+                event_id: "$undecryptable",
+                sender: inviter,
+            });
+            vi.spyOn(undecryptable, "isDecryptionFailure").mockReturnValue(true);
+            client.emit(MatrixEventEvent.Decrypted, undecryptable);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith(roomId, inviter);
+            // A second undecryptable event should not claim again.
+            client.emit(MatrixEventEvent.Decrypted, undecryptable);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).toHaveBeenCalledTimes(1);
+        });
+
+        it("only trusts designations from our own user with a valid room_id", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+
+            emitClaim(roomId, "@mallory:example.org");
+            emitClaim(undefined);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+        });
+
+        it("does nothing on designation if the crypto backend has gone away", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+
+            client["cryptoBackend"] = undefined;
+            emitClaim(roomId);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+        });
+
+        it("logs rather than throwing when the deferred claim fails", async () => {
+            const loggerError = vi.spyOn(client["logger"], "error").mockImplementation(() => {});
+            mockCrypto.maybeAcceptKeyBundle.mockRejectedValue(new Error("nope"));
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+
+            emitClaim(roomId);
+            await flushPromises();
+            expect(loggerError).toHaveBeenCalledWith(expect.stringContaining(roomId), expect.any(Error));
+        });
+
+        it("forgets the deferred bundle when we leave the room", async () => {
+            emitMembership(KnownMembership.Invite, KnownMembership.Leave);
+            emitMembership(KnownMembership.Join, KnownMembership.Invite, { sender: userId });
+            await flushPromises();
+
+            emitMembership(KnownMembership.Leave, KnownMembership.Join, { sender: userId });
+            emitClaim(roomId);
+            await flushPromises();
+            expect(mockCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -1310,6 +1310,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     // A manager for determining which invites should be ignored.
     public readonly ignoredInvites: IgnoredInvites;
 
+    /** Map from room ID to the user who invited us, for rooms with a pending invite.
+     * Used to do the key-bundle bookkeeping if the server joins us to the room itself
+     * (e.g. auto-accepting a knock, synapse#16307) rather than via `joinRoom`. */
+    private readonly pendingKeyBundleInviters = new Map<string, string>();
+
     public readonly matrixRTC: MatrixRTCSessionManager;
 
     private serverCapabilitiesService: ServerCapabilities;
@@ -1429,6 +1434,43 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.ignoredInvites = new IgnoredInvites(this);
         this._secretStorage = new ServerSideSecretStorageImpl(this, opts.cryptoCallbacks ?? {});
+
+        // If the server joins us to a room we were invited to — e.g. automatically accepting a
+        // knock we made (https://github.com/element-hq/synapse/issues/16307) — `joinRoom` never
+        // runs, so nothing does the shared-history key bundle bookkeeping it would otherwise
+        // have done. Watch our own membership: remember who invited us, and on an
+        // invite -> join transition run the same mark-pending/maybe-accept dance as `joinRoom`
+        // (idempotent when the join did come from `joinRoom`).
+        this.on(RoomMemberEvent.Membership, (event, member, oldMembership) => {
+            if (member.userId !== this.getUserId()) return;
+            if (member.membership === KnownMembership.Invite) {
+                const inviter = event.getSender();
+                if (inviter) this.pendingKeyBundleInviters.set(member.roomId, inviter);
+            } else if (
+                member.membership === KnownMembership.Join &&
+                oldMembership === KnownMembership.Invite &&
+                this.cryptoBackend
+            ) {
+                const inviter = this.pendingKeyBundleInviters.get(member.roomId);
+                this.pendingKeyBundleInviters.delete(member.roomId);
+                if (inviter && inviter !== this.getUserId()) {
+                    const cryptoBackend = this.cryptoBackend;
+                    (async () => {
+                        // Flag that we are waiting for a key bundle, then try to accept one we
+                        // may already have received. Mirrors `joinRoom`.
+                        await cryptoBackend.markRoomAsPendingKeyBundle(member.roomId, inviter);
+                        await cryptoBackend.maybeAcceptKeyBundle(member.roomId, inviter);
+                    })().catch((e) => {
+                        this.logger.error(
+                            `Error accepting key bundle for auto-joined room ${member.roomId}:`,
+                            e,
+                        );
+                    });
+                }
+            } else if (member.membership === KnownMembership.Leave) {
+                this.pendingKeyBundleInviters.delete(member.roomId);
+            }
+        });
 
         // having lots of event listeners is not unusual. 0 means "unlimited".
         this.setMaxListeners(0);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1439,8 +1439,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         // knock we made (https://github.com/element-hq/synapse/issues/16307) — `joinRoom` never
         // runs, so nothing does the shared-history key bundle bookkeeping it would otherwise
         // have done. Watch our own membership: remember who invited us, and on an
-        // invite -> join transition run the same mark-pending/maybe-accept dance as `joinRoom`
-        // (idempotent when the join did come from `joinRoom`).
+        // invite -> join (or knock -> join: an accepted knock can be auto-joined straight past
+        // the invited state, the invite coalesced away) transition run the same
+        // mark-pending/maybe-accept dance as `joinRoom` (idempotent when the join did come from
+        // `joinRoom`).
         this.on(RoomMemberEvent.Membership, (event, member, oldMembership) => {
             if (member.userId !== this.getUserId()) return;
             if (member.membership === KnownMembership.Invite) {
@@ -1448,11 +1450,18 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 if (inviter) this.pendingKeyBundleInviters.set(member.roomId, inviter);
             } else if (
                 member.membership === KnownMembership.Join &&
-                oldMembership === KnownMembership.Invite &&
+                (oldMembership === KnownMembership.Invite || oldMembership === KnownMembership.Knock) &&
                 this.cryptoBackend
             ) {
-                const inviter = this.pendingKeyBundleInviters.get(member.roomId);
+                let inviter = this.pendingKeyBundleInviters.get(member.roomId);
                 this.pendingKeyBundleInviters.delete(member.roomId);
+                if (!inviter && event.getPrevContent().membership === KnownMembership.Invite) {
+                    // We never saw the invite itself (coalesced away, or we restarted between
+                    // invite and join): recover the inviter from the join event's
+                    // `unsigned.prev_sender` — a Synapse extension, but the same source
+                    // `RoomMember.getDMInviter` already relies on for accepted DM invites.
+                    inviter = event.getUnsigned().prev_sender;
+                }
                 if (inviter && inviter !== this.getUserId()) {
                     const cryptoBackend = this.cryptoBackend;
                     (async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -252,6 +252,11 @@ export type Store = IStore;
 
 export type ResetTimelineCallback = (roomId: string) => boolean;
 
+/** MSC4509: to-device message type by which the server designates one of our user's
+ * devices as the eager downloader of an MSC4268 room key bundle after a server-initiated
+ * join. */
+const UNSTABLE_KEY_BUNDLE_CLAIM_TYPE = "org.matrix.msc4509.key_bundle_claim";
+
 const SCROLLBACK_DELAY_MS = 3000;
 
 const TURN_CHECK_INTERVAL = 10 * 60 * 1000; // poll for turn credentials every 10 minutes
@@ -458,6 +463,16 @@ export interface ICreateClientOpts {
      * Locally remove events past the server global or per room retention setting.
      */
     unstableMSC1763Retention?: boolean;
+
+    /**
+     * Enable unstable MSC4509 support: on a server-initiated room join, defer downloading
+     * the room's MSC4268 key bundle until the server designates this device via an
+     * `org.matrix.msc4509.key_bundle_claim` to-device message (or until the first
+     * undecryptable event in the room). When disabled, `key_bundle_claim` messages are
+     * ignored and every device downloads the bundle eagerly, as `joinRoom` would.
+     * Default: false.
+     */
+    unstableMSC4509KeyBundleClaim?: boolean;
 }
 
 export interface IMatrixClientCreateOpts extends ICreateClientOpts {
@@ -1315,6 +1330,19 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * (e.g. auto-accepting a knock, synapse#16307) rather than via `joinRoom`. */
     private readonly pendingKeyBundleInviters = new Map<string, string>();
 
+    /** Map from room ID to inviter, for rooms the server joined us to whose key bundle
+     * we are deferring (MSC4509): the bundle is only downloaded if the server designates
+     * us as the claimer, or lazily on the first undecryptable event in the room. */
+    private readonly lazyKeyBundleRooms = new Map<string, string>();
+
+    /** Room IDs for which an `org.matrix.msc4509.key_bundle_claim` designation arrived
+     * before we processed the corresponding join. */
+    private readonly earlyKeyBundleClaims = new Set<string>();
+
+    /** Whether unstable MSC4509 key-bundle-claim handling is enabled
+     * ({@link ICreateClientOpts.unstableMSC4509KeyBundleClaim}). */
+    private readonly msc4509KeyBundleClaimEnabled: boolean;
+
     public readonly matrixRTC: MatrixRTCSessionManager;
 
     private serverCapabilitiesService: ServerCapabilities;
@@ -1400,6 +1428,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         this.serverCapabilitiesService = new ServerCapabilities(this.logger, this.http);
         this.retentionPolicyService = new RetentionPolicyService(this.logger, this.http);
         this._unstable_shouldApplyMessageRetention = opts.unstableMSC1763Retention ?? false;
+        this.msc4509KeyBundleClaimEnabled = opts.unstableMSC4509KeyBundleClaim ?? false;
 
         this.on(ClientEvent.Sync, this.fixupRoomNotifications);
 
@@ -1464,25 +1493,79 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 }
                 if (inviter && inviter !== this.getUserId()) {
                     const cryptoBackend = this.cryptoBackend;
-                    (async () => {
-                        // Flag that we are waiting for a key bundle, then try to accept one we
-                        // may already have received. Mirrors `joinRoom`.
-                        await cryptoBackend.markRoomAsPendingKeyBundle(member.roomId, inviter);
-                        await cryptoBackend.maybeAcceptKeyBundle(member.roomId, inviter);
+                    const finalInviter = inviter;
+                    (async (): Promise<void> => {
+                        // Flag that we are waiting for a key bundle, as `joinRoom` would have.
+                        await cryptoBackend.markRoomAsPendingKeyBundle(member.roomId, finalInviter);
+                        // Unlike a client-initiated join, this join happened on all of our
+                        // user's devices at once, so don't eagerly download the bundle from
+                        // every one of them (MSC4509): only claim it now if the server has
+                        // designated us as the claimer; otherwise wait to be designated, or
+                        // for the first undecryptable event in the room.
+                        if (!this.msc4509KeyBundleClaimEnabled) {
+                            // MSC4509 disabled: download eagerly, as `joinRoom` would.
+                            await cryptoBackend.maybeAcceptKeyBundle(member.roomId, finalInviter);
+                        } else if (this.earlyKeyBundleClaims.delete(member.roomId)) {
+                            await cryptoBackend.maybeAcceptKeyBundle(member.roomId, finalInviter);
+                        } else {
+                            this.lazyKeyBundleRooms.set(member.roomId, finalInviter);
+                        }
                     })().catch((e) => {
-                        this.logger.error(
-                            `Error accepting key bundle for auto-joined room ${member.roomId}:`,
-                            e,
-                        );
+                        this.logger.error(`Error accepting key bundle for auto-joined room ${member.roomId}:`, e);
                     });
                 }
             } else if (member.membership === KnownMembership.Leave) {
                 this.pendingKeyBundleInviters.delete(member.roomId);
+                this.lazyKeyBundleRooms.delete(member.roomId);
+                this.earlyKeyBundleClaims.delete(member.roomId);
+            }
+        });
+
+        // MSC4509: the server may designate this device as the one which should eagerly
+        // download a room key bundle after a server-initiated join (see above). Only our
+        // own homeserver can deliver a to-device message with our own user as sender.
+        this.on(ClientEvent.ToDeviceEvent, (event) => {
+            if (!this.msc4509KeyBundleClaimEnabled) return;
+            if (event.getType() !== UNSTABLE_KEY_BUNDLE_CLAIM_TYPE) return;
+            if (event.getSender() !== this.getUserId()) return;
+            const roomId = event.getContent().room_id;
+            if (typeof roomId !== "string") return;
+            this.claimLazyKeyBundle(roomId, "designated by the server");
+        });
+
+        // MSC4509: lazy fallback — if we deferred a room's key bundle and then hit an
+        // event we cannot decrypt in that room, fetch the bundle after all.
+        this.on(MatrixEventEvent.Decrypted, (event) => {
+            const roomId = event.getRoomId();
+            if (event.isDecryptionFailure() && roomId && this.lazyKeyBundleRooms.has(roomId)) {
+                this.claimLazyKeyBundle(roomId, "undecryptable event");
             }
         });
 
         // having lots of event listeners is not unusual. 0 means "unlimited".
         this.setMaxListeners(0);
+    }
+
+    /**
+     * Download and import a deferred room key bundle (MSC4509) for a room the server
+     * joined us to, if we haven't already.
+     *
+     * If the room's join hasn't been processed yet (a designation racing ahead of the
+     * join in the same sync), remember the designation for the join handler instead.
+     */
+    private claimLazyKeyBundle(roomId: string, reason: string): void {
+        const inviter = this.lazyKeyBundleRooms.get(roomId);
+        if (!inviter) {
+            this.earlyKeyBundleClaims.add(roomId);
+            return;
+        }
+        this.lazyKeyBundleRooms.delete(roomId);
+        const cryptoBackend = this.cryptoBackend;
+        if (!cryptoBackend) return;
+        this.logger.info(`Claiming deferred key bundle for ${roomId}: ${reason}`);
+        cryptoBackend.maybeAcceptKeyBundle(roomId, inviter).catch((e) => {
+            this.logger.error(`Error accepting deferred key bundle for room ${roomId}:`, e);
+        });
     }
 
     public set store(newStore: Store) {


### PR DESCRIPTION
A server-initiated join (e.g. an auto-accepted knock) lands on all of our user's devices in the same sync instant, so each would eagerly download the MSC4268 room key bundle. Instead, only download it when the server designates this device as the claimer (a new org.matrix.msc4509.key_bundle_claim to-device message, only trusted from our own user), or lazily upon the first undecryptable event in the room. Client-initiated joins via joinRoom keep the eager behaviour.

The MSC4509 behaviour is unstable, so it is opt-in via the new `unstableMSC4509KeyBundleClaim` client option: when unset (the default), key_bundle_claim messages are ignored and server-initiated joins keep the eager per-device download. Element Web enables it behind a `share_history_on_autojoin` feature flag (PR to follow).