### PR TITLE
Include existing data when updating user profile cache

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1337,6 +1337,29 @@ describe("MatrixClient", function () {
             await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");
         });
 
+        it("preserves previously cached keys when writing through the profile cache", async () => {
+            const storedProfile = { other_key: "bar" };
+            const testProfile = { test_key: "foo" };
+            (client.store as MockedObject<IStore>).getUserProfile.mockImplementation(async (requestedUserId) => {
+                expect(requestedUserId).toEqual(userId);
+                return storedProfile;
+            });
+            httpLookups = [
+                {
+                    method: "GET",
+                    prefix: unstableMSC4133Prefix,
+                    path: "/profile/" + encodeURIComponent(userId) + "/test_key",
+                    data: testProfile,
+                },
+            ];
+
+            await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");
+
+            expect(client.store.storeUserProfiles).toHaveBeenCalledWith(
+                new Map([[userId, { ...storedProfile, ...testProfile }]]),
+            );
+        });
+
         it("can set a property in our extended profile", async () => {
             httpLookups = [
                 {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7444,7 +7444,17 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         )) as SyncUserProfile;
 
         // write through to the cache
-        await this.store.storeUserProfiles(new Map([[userId, profile]]));
+        await this.store.storeUserProfiles(
+            new Map([
+                [
+                    userId,
+                    {
+                        ...storedProfile,
+                        ...profile,
+                    },
+                ],
+            ]),
+        );
 
         return profile[key];
     }


### PR DESCRIPTION
We ignored the old data we may have fetched from the cache and overwrote it with new data, which may have erased previously fetched keys from the cache.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
