### PR TITLE
MatrixRTC: Support the optional leave_reason in rtc membership content

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -26,7 +26,14 @@ import {
     type Room,
     MAX_STICKY_DURATION_MS,
 } from "../../../src";
-import { MembershipManagerEvent, Status, type Transport, type LivekitFocusSelection } from "../../../src/matrixrtc";
+import {
+    MembershipManagerEvent,
+    Status,
+    type Transport,
+    type LivekitFocusSelection,
+    type LeaveReason,
+    LEAVE_REASON_DELAYED,
+} from "../../../src/matrixrtc";
 import {
     makeMockClient,
     makeMockRoom,
@@ -36,6 +43,7 @@ import {
 } from "./mocks.ts";
 import { MembershipManager, StickyEventMembershipManager } from "../../../src/matrixrtc/MembershipManager.ts";
 import { type SessionMembershipData } from "../../../src/matrixrtc/membershipData/index.ts";
+import { logger } from "../../../src/logger.ts";
 
 /**
  * Create a promise that will resolve once a mocked method is called.
@@ -74,6 +82,10 @@ function createAsyncHandle<T>(method: MockedFunction<(...args: any[]) => any>) {
 }
 
 const callSession = { id: "ROOM", application: "m.call" };
+
+const membershipDelayedLeaveContent = {
+    leave_reason: LEAVE_REASON_DELAYED,
+};
 
 describe("MembershipManager", () => {
     let client: MockClient;
@@ -158,7 +170,7 @@ describe("MembershipManager", () => {
                     room.roomId,
                     { delay: 8000 },
                     "org.matrix.msc3401.call.member",
-                    {},
+                    membershipDelayedLeaveContent,
                     "_@alice:example.org_AAAAAAA_m.call",
                 );
                 expect(client._unstable_sendDelayedStateEvent).toHaveBeenCalledTimes(1);
@@ -197,7 +209,7 @@ describe("MembershipManager", () => {
                     room.roomId,
                     { delay: 8000 },
                     "org.matrix.msc3401.call.member",
-                    {},
+                    membershipDelayedLeaveContent,
                     "_@alice:example.org_AAAAAAA_m.callcustom",
                 );
                 expect(client._unstable_sendDelayedStateEvent).toHaveBeenCalledTimes(1);
@@ -286,7 +298,13 @@ describe("MembershipManager", () => {
                     await sendDelayedStateExceedAttempt.then(); // needed to resolve after the send attempt catches
                     await sendDelayedStateAttempt;
                     const callProps = (d: number) => {
-                        return [room!.roomId, { delay: d }, "org.matrix.msc3401.call.member", {}, userStateKey];
+                        return [
+                            room!.roomId,
+                            { delay: d },
+                            "org.matrix.msc3401.call.member",
+                            membershipDelayedLeaveContent,
+                            userStateKey,
+                        ];
                     };
                     expect(client._unstable_sendDelayedStateEvent).toHaveBeenNthCalledWith(1, ...callProps(9000));
                     expect(client._unstable_sendDelayedStateEvent).toHaveBeenNthCalledWith(2, ...callProps(7500));
@@ -364,7 +382,7 @@ describe("MembershipManager", () => {
                     room.roomId,
                     { delay: 123456 },
                     "org.matrix.msc3401.call.member",
-                    {},
+                    membershipDelayedLeaveContent,
                     "_@alice:example.org_AAAAAAA_m.call",
                 );
             });
@@ -452,23 +470,35 @@ describe("MembershipManager", () => {
 
     describe("leave()", () => {
         // TODO add rate limit cases.
-        it("resolves delayed leave event when leave is called", async () => {
-            const manager = new MembershipManager({}, room, client, callSession);
+        it("canceled delayed leave event when leave is called", async () => {
+            const manager = new MembershipManager({}, room, client, callSession, logger);
             manager.join([focus]);
-            await vi.advanceTimersByTimeAsync(1);
-            await manager.leave();
-            expect(client._unstable_sendScheduledDelayedEvent).toHaveBeenLastCalledWith("id");
-            expect(client.sendStateEvent).toHaveBeenCalled();
+            await vi.runOnlyPendingTimersAsync();
+            const aReason: LeaveReason = {
+                code: "test_leave",
+                reason: "the test leave",
+            };
+            await manager.leave(0, aReason);
+            expect(client._unstable_cancelScheduledDelayedEvent).toHaveBeenLastCalledWith("id");
+            expect(client.sendStateEvent).toHaveBeenCalledTimes(2);
+            expect(client.sendStateEvent).toHaveBeenLastCalledWith(
+                expect.anything(),
+                expect.anything(),
+                {
+                    leave_reason: aReason,
+                },
+                expect.anything(),
+            );
             expect(manager.delayId).toBe(undefined);
         });
-        it("send leave event when leave is called and resolving delayed leave fails unknown error", async () => {
+        it("send leave event when leave is called and clearing delayed leave fails unknown error", async () => {
             const manager = new MembershipManager({}, room, client, callSession);
             manager.join([focus]);
             await vi.advanceTimersByTimeAsync(1);
-            (client._unstable_sendScheduledDelayedEvent as Mock<any>).mockRejectedValue("unknown");
+            (client._unstable_cancelScheduledDelayedEvent as Mock<any>).mockRejectedValue("unknown");
             await manager.leave();
 
-            // We send a normal leave event since we failed using sendScheduledDelayedEvent.
+            // We send the leave event even if cancelScheduledDelayedEvent fails.
             expect(client.sendStateEvent).toHaveBeenLastCalledWith(
                 room.roomId,
                 "org.matrix.msc3401.call.member",
@@ -483,7 +513,7 @@ describe("MembershipManager", () => {
             const manager = new MembershipManager({}, room, client, callSession);
             manager.join([focus]);
             await vi.advanceTimersByTimeAsync(1);
-            (client._unstable_sendScheduledDelayedEvent as Mock<any>).mockRejectedValue(
+            (client._unstable_cancelScheduledDelayedEvent as Mock<any>).mockRejectedValue(
                 new MatrixError({ errcode: "M_NOT_FOUND" }, 404),
             );
             await manager.leave();
@@ -495,11 +525,13 @@ describe("MembershipManager", () => {
                 {},
                 "_@alice:example.org_AAAAAAA_m.call",
             );
+            expect(client._unstable_sendScheduledDelayedEvent).not.toHaveBeenCalled();
             expect(manager.delayId).toBe(undefined);
         });
         it("does nothing if not joined", async () => {
             const manager = new MembershipManager({}, room, client, callSession);
             await expect(manager.leave()).resolves.toBeTruthy();
+            expect(client._unstable_cancelScheduledDelayedEvent).not.toHaveBeenCalled();
             expect(client._unstable_sendDelayedStateEvent).not.toHaveBeenCalled();
             expect(client.sendStateEvent).not.toHaveBeenCalled();
         });
@@ -815,6 +847,7 @@ describe("MembershipManager", () => {
             for (let i = 0; i < 10; i++) {
                 await vi.advanceTimersByTimeAsync(2000);
             }
+            await vi.runAllTimersAsync();
             expect(delayEventSendError).toHaveBeenCalled();
         });
         // because legacy does not have a retry limit and no mechanism to communicate unrecoverable errors.
@@ -829,7 +862,7 @@ describe("MembershipManager", () => {
                     new Headers({ "Retry-After": "1" }),
                 ),
             );
-            const manager = new MembershipManager({}, room, client, callSession);
+            const manager = new MembershipManager({}, room, client, callSession, logger);
             manager.join([focus], focusActive, delayEventRestartError);
 
             for (let i = 0; i < 10; i++) {
@@ -1030,7 +1063,9 @@ describe("MembershipManager", () => {
                         { delay: 8000 },
                         null,
                         "org.matrix.msc4143.rtc.member",
+
                         {
+                            leave_reason: membershipDelayedLeaveContent.leave_reason,
                             msc4354_sticky_key: "@alice:example.org:AAAAAAA_m.call",
                         },
                     );
@@ -1058,6 +1093,45 @@ describe("MembershipManager", () => {
 
                 expect(unrecoverableError).toHaveBeenCalled();
                 expect(unrecoverableError.mock.lastCall![0].cause).toBe(stickyError);
+            });
+        });
+
+        describe("leave()", () => {
+            it("canceled delayed leave event when leave is called", async () => {
+                const manager = new StickyEventMembershipManager(
+                    undefined,
+                    room,
+                    client,
+                    callSession,
+                    "@alice:example.org:AAAAAAA_m.call",
+                    logger,
+                );
+                manager.join([], focus);
+
+                await waitForMockCall(client._unstable_sendStickyEvent, Promise.resolve({ event_id: "id" }));
+
+                const aReason: LeaveReason = {
+                    code: "test_leave",
+                    reason: "the test leave",
+                };
+                await manager.leave(0, aReason);
+                // The delayed leave
+                expect(client._unstable_sendStickyDelayedEvent).toHaveBeenCalledTimes(1);
+                // The cancel of the delayed
+                expect(client._unstable_cancelScheduledDelayedEvent).toHaveBeenLastCalledWith("id");
+                // The join and the leave
+                expect(client._unstable_sendStickyEvent).toHaveBeenCalledTimes(2);
+                expect(client._unstable_sendStickyEvent).toHaveBeenLastCalledWith(
+                    expect.anything(),
+                    expect.anything(),
+                    null,
+                    "org.matrix.msc4143.rtc.member",
+                    {
+                        leave_reason: aReason,
+                        msc4354_sticky_key: expect.anything(),
+                    },
+                );
+                expect(manager.delayId).toBe(undefined);
             });
         });
     });

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -58,6 +58,8 @@ import {
     type IRTCDeclineContent,
     type EncryptionKeysEventContent,
     type ICallNotifyContent,
+    type LeaveMembershipEventContent,
+    type LeaveReason,
 } from "../matrixrtc/types.ts";
 import { type M_POLL_END, type M_POLL_START, type PollEndEventContent, type PollStartEventContent } from "./polls.ts";
 import { type RtcMembershipData, type SessionMembershipData } from "../matrixrtc/membershipData/index.ts";
@@ -359,7 +361,7 @@ export interface TimelineEvents {
     [M_BEACON.name]: MBeaconEventContent;
     [M_POLL_START.name]: PollStartEventContent;
     [M_POLL_END.name]: PollEndEventContent;
-    [EventType.RTCMembership]: RtcMembershipData | { msc4354_sticky_key: string }; // An object containing just the sticky key is empty.
+    [EventType.RTCMembership]: RtcMembershipData | { msc4354_sticky_key: string; leave_reason?: LeaveReason }; // An object containing just the sticky key is empty.
 }
 
 /**
@@ -394,7 +396,11 @@ export interface StateEvents {
 
     // MSC3401
     [EventType.GroupCallPrefix]: IGroupCallRoomState;
-    [EventType.GroupCallMemberPrefix]: IGroupCallRoomMemberState | SessionMembershipData | EmptyObject;
+    [EventType.GroupCallMemberPrefix]:
+        | IGroupCallRoomMemberState
+        | SessionMembershipData
+        | LeaveMembershipEventContent
+        | EmptyObject;
     [EventType.RTCMembership]: RtcMembershipData | EmptyObject;
     // MSC3089
     [UNSTABLE_MSC3089_BRANCH.name]: MSC3089EventContent;

--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -361,7 +361,7 @@ export interface TimelineEvents {
     [M_BEACON.name]: MBeaconEventContent;
     [M_POLL_START.name]: PollStartEventContent;
     [M_POLL_END.name]: PollEndEventContent;
-    [EventType.RTCMembership]: RtcMembershipData | { msc4354_sticky_key: string; leave_reason?: LeaveReason }; // An object containing just the sticky key is empty.
+    [EventType.RTCMembership]: RtcMembershipData | { msc4354_sticky_key: string; leave_reason?: LeaveReason };
 }
 
 /**

--- a/src/matrixrtc/IMembershipManager.ts
+++ b/src/matrixrtc/IMembershipManager.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type { CallMembership } from "./CallMembership.ts";
-import type { RTCCallIntent, Status, Transport } from "./types.ts";
+import type { LeaveReason, RTCCallIntent, Status, Transport } from "./types.ts";
 import { type TypedEventEmitter } from "../models/typed-event-emitter.ts";
 
 export enum MembershipManagerEvent {
@@ -103,10 +103,11 @@ export interface IMembershipManager extends TypedEventEmitter<
     /**
      * Send all necessary events to make this user leave the RTC session.
      * @param timeout the maximum duration in ms until the promise is forced to resolve.
+     * @param leaveReason the reason to send in the leave event. If `undefined`, no reason is sent.
      * @returns It resolves with true in case the leave was sent successfully.
      * It resolves with false in case we hit the timeout before sending successfully.
      */
-    leave(timeout?: number): Promise<boolean>;
+    leave(timeout?: number, leaveReason?: LeaveReason): Promise<boolean>;
     /**
      * Call this if the MatrixRTC session members have changed.
      */

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -35,6 +35,7 @@ import type {
     RTCCallIntent,
     Transport,
     SlotDescription,
+    LeaveReason,
 } from "./types.ts";
 import {
     MembershipManagerEvent,
@@ -566,7 +567,10 @@ export class MatrixRTCSession extends TypedEventEmitter<
      * A timeout can be provided so that there is a guarantee for the promise to resolve.
      * @returns Whether the membership update was attempted and did not time out.
      */
-    public async leaveRoomSession(timeout: number | undefined = undefined): Promise<boolean> {
+    public async leaveRoomSession(
+        timeout: number | undefined = undefined,
+        leaveReason: LeaveReason | undefined = undefined,
+    ): Promise<boolean> {
         if (!this.isJoined()) {
             this.logger.info(`Not joined to session in room ${this.roomSubset.roomId}: ignoring leave call`);
             return false;
@@ -576,7 +580,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
 
         this.encryptionManager!.leave();
 
-        const leavePromise = this.membershipManager!.leave(timeout);
+        const leavePromise = this.membershipManager!.leave(timeout, leaveReason);
         this.emit(MatrixRTCSessionEvent.JoinStateChanged, false);
 
         return await leavePromise;
@@ -857,7 +861,7 @@ function quickFilterNonRelevantContents(content: IContent, logger: Logger): bool
     // Ignore sticky keys for the count
     const eventKeysCount = Object.keys(content).filter((k) => k !== "msc4354_sticky_key").length;
     // Don't even bother about empty events (saves us from costly type/"key in" checks in bigger rooms)
-    if (eventKeysCount === 0) return false;
+    if (eventKeysCount === 0 || (eventKeysCount === 1 && "leave_reason" in content)) return false;
 
     // We first decide if it's a MSC4143 event (per device state key)
     if (eventKeysCount > 1 && "application" in content) {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -565,6 +565,9 @@ export class MatrixRTCSession extends TypedEventEmitter<
      * The membership update required to leave the session will retry if it fails.
      * Without network connection the promise will never resolve.
      * A timeout can be provided so that there is a guarantee for the promise to resolve.
+     *
+     * @param timeout
+     * @param leaveReason - The reason for the leave
      * @returns Whether the membership update was attempted and did not time out.
      */
     public async leaveRoomSession(

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -588,7 +588,7 @@ export class MatrixRTCSession extends TypedEventEmitter<
      * Without network connection the promise will never resolve.
      * A timeout can be provided so that there is a guarantee for the promise to resolve.
      *
-     * @param timeout
+     * @param timeout - Optional timeout in milliseconds that fires if the leave takes too long to complete.
      * @param leaveReason - The reason for the leave
      * @returns Whether the membership update was attempted and did not time out.
      */

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -17,20 +17,28 @@ import { AbortError } from "p-retry";
 
 import { EventType, RelationType } from "../@types/event.ts";
 import { type ISendEventResponse, type SendDelayedEventResponse } from "../@types/requests.ts";
-import { type EmptyObject } from "../@types/common.ts";
 import type { MatrixClient } from "../client.ts";
 import { ConnectionError, HTTPError, MatrixError } from "../http-api/errors.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { type Room } from "../models/room.ts";
 import { type CallMembership, DEFAULT_EXPIRE_DURATION } from "./CallMembership.ts";
-import { type Transport, isMyMembership, type RTCCallIntent, Status, type SlotDescription } from "./types.ts";
+import {
+    isMyMembership,
+    LEAVE_REASON_DELAYED,
+    type LeaveMembershipEventContent,
+    type LeaveReason,
+    type RTCCallIntent,
+    type SlotDescription,
+    Status,
+    type Transport,
+} from "./types.ts";
 import { type MembershipConfig, type SessionConfig } from "./MatrixRTCSession.ts";
 import { ActionScheduler, type ActionUpdate } from "./MembershipManagerActionScheduler.ts";
 import { TypedEventEmitter } from "../models/typed-event-emitter.ts";
 import { UnsupportedDelayedEventsEndpointError } from "../errors.ts";
 import {
-    MembershipManagerEvent,
     type IMembershipManager,
+    MembershipManagerEvent,
     type MembershipManagerEventHandlerMap,
 } from "./IMembershipManager.ts";
 import { type RtcMembershipData, type SessionMembershipData } from "./membershipData/index.ts";
@@ -58,10 +66,10 @@ On Join:  ───────────────┐   ┌─────�
 
 On Leave: ─────────  STOP ALL ABOVE
                            ▼
-            ┌────────────────────────────────┐
-            │ SendScheduledDelayedLeaveEvent │
-            └────────────────────────────────┘
-                           │(5)
+            ┌─────────────────────────────────────┐
+            │ CancelledScheduledDelayedLeaveEvent │
+            └─────────────────────────────────────┘
+                           │
                            ▼
                     ┌──────────────┐
                     │SendLeaveEvent│
@@ -107,13 +115,22 @@ export enum MembershipActionType {
     UpdateExpiry = "UpdateExpiry",
     //  -> MembershipActionType.Update if the timeout has passed so the next update is required.
 
-    SendScheduledDelayedLeaveEvent = "SendScheduledDelayedLeaveEvent",
-    //  -> MembershipActionType.SendLeaveEvent on failure (not found) we need to send the leave manually and cannot use the scheduled delayed event
-    //  -> DelayedLeaveActionType.SendScheduledDelayedLeaveEvent on error we try again.
+    CancelledScheduledDelayedLeaveEvent = "CancelledScheduledDelayedLeaveEvent",
+    //  -> MembershipActionType.SendLeaveEvent
+    //  -> DelayedLeaveActionType.CancelledScheduledDelayedLeaveEvent on error we try again
 
     SendLeaveEvent = "SendLeaveEvent",
     // -> MembershipActionType.SendLeaveEvent
 }
+
+export type MembershipActionData = {
+    SendDelayedEvent: undefined;
+    SendJoinEvent: undefined;
+    RestartDelayedEvent: undefined;
+    UpdateExpiry: undefined;
+    CancelledScheduledDelayedLeaveEvent: undefined;
+    SendLeaveEvent: { leaveReason?: LeaveReason };
+};
 
 /**
  * @internal
@@ -144,9 +161,13 @@ export interface MembershipManagerState {
     probablyLeft: boolean;
 }
 
-function createInsertActionUpdate(type: MembershipActionType, offset?: number): ActionUpdate {
+function createInsertActionUpdate(
+    type: MembershipActionType,
+    offset?: number,
+    data?: MembershipActionData[MembershipActionType],
+): ActionUpdate {
     return {
-        insert: [{ ts: Date.now() + (offset ?? 0), type }],
+        insert: [{ ts: Date.now() + (offset ?? 0), type, data }],
     };
 }
 
@@ -186,12 +207,13 @@ export class MembershipManager
     implements IMembershipManager
 {
     private activated = false;
-    private readonly logger: Logger;
+    protected readonly logger: Logger;
     protected callIntent: RTCCallIntent | undefined;
 
     public isActivated(): boolean {
         return this.activated;
     }
+
     // DEPRECATED use isActivated
     public isJoined(): boolean {
         return this.isActivated();
@@ -243,23 +265,23 @@ export class MembershipManager
     }
 
     /**
-     * Leave from the call (Send an rtc session event with content: `{}`)
+     * Leave from the call (Send an rtc session event with content: `{ leave_reason: xxx }`)
      * @param timeout the maximum duration this promise will take to resolve
+     * @param leaveReason the reason for the leave.
      * @returns true if it managed to leave and false if the timeout condition happened.
      */
-    public leave(timeout?: number): Promise<boolean> {
+    public leave(timeout?: number, leaveReason?: LeaveReason): Promise<boolean> {
         if (!this.scheduler.running) {
             this.logger.warn("Called MembershipManager.leave() even though the MembershipManager is not running");
             return Promise.resolve(true);
         }
-
         // We use the promise to track if we already scheduled a leave event
         // So we do not check scheduler.actions/scheduler.insertions
         if (!this.leavePromiseResolvers) {
             // reset scheduled actions so we will not do any new actions.
             this.leavePromiseResolvers = Promise.withResolvers<boolean>();
             this.activated = false;
-            this.scheduler.initiateLeave();
+            this.scheduler.initiateLeave(leaveReason);
             if (timeout) setTimeout(() => this.leavePromiseResolvers?.resolve(false), timeout);
         }
         return this.leavePromiseResolvers.promise;
@@ -334,7 +356,7 @@ export class MembershipManager
         this.stateKey = this.makeMembershipStateKey(userId, deviceId);
         this.state = MembershipManager.defaultState;
         this.callIntent = joinConfig?.callIntent;
-        this.scheduler = new ActionScheduler((type): Promise<ActionUpdate> => {
+        this.scheduler = new ActionScheduler((type, data): Promise<ActionUpdate> => {
             if (this.oldStatus) {
                 // we put this at the beginning of the actions scheduler loop handle callback since it is a loop this
                 // is equivalent to running it at the end of the loop. (just after applying the status/action list changes)
@@ -348,7 +370,7 @@ export class MembershipManager
             }
             this.oldStatus = this.status;
             this.logger.debug(`MembershipManager before processing action. status=${this.oldStatus}`);
-            return this.membershipLoopHandler(type);
+            return this.membershipLoopHandler(type, data);
         }, this.logger);
     }
 
@@ -363,6 +385,7 @@ export class MembershipManager
 
     // MembershipManager mutable state.
     private state: MembershipManagerState;
+
     private static get defaultState(): MembershipManagerState {
         return {
             hasMemberStateEvent: false,
@@ -375,6 +398,7 @@ export class MembershipManager
             probablyLeft: false,
         };
     }
+
     // Membership Event static parameters:
     protected deviceId: string;
     protected userId: string;
@@ -419,7 +443,10 @@ export class MembershipManager
     }
 
     // LOOP HANDLER:
-    private async membershipLoopHandler(type: MembershipActionType): Promise<ActionUpdate> {
+    private async membershipLoopHandler(
+        type: MembershipActionType,
+        data?: MembershipActionData[MembershipActionType],
+    ): Promise<ActionUpdate> {
         switch (type) {
             case MembershipActionType.SendDelayedEvent: {
                 // Before we start we check if we come from a state where we have a delay id.
@@ -443,16 +470,22 @@ export class MembershipManager
                 }
                 return this.restartDelayedEvent(this.state.delayId);
             }
-            case MembershipActionType.SendScheduledDelayedLeaveEvent: {
+            case MembershipActionType.CancelledScheduledDelayedLeaveEvent: {
                 // We are already good
                 if (!this.state.hasMemberStateEvent) {
-                    return { replace: [] };
+                    this.logger.debug(
+                        "MembershipManager: CancelledScheduledDelayedLeaveEvent but we are already not joined. No action needed.",
+                    );
+                    return {};
                 }
-                if (this.state.delayId) {
-                    return this.sendScheduledDelayedLeaveEventOrFallbackToSendLeaveEvent(this.state.delayId);
-                } else {
-                    return createInsertActionUpdate(MembershipActionType.SendLeaveEvent);
+                if (!this.state.delayId) {
+                    this.logger.debug(
+                        "MembershipManager: CancelledScheduledDelayedLeaveEvent but we do not have a delayId. Ignoring action.",
+                    );
+                    return {};
                 }
+
+                return this.sendCancelDelayedLeaveEvent(this.state.delayId);
             }
             case MembershipActionType.SendJoinEvent: {
                 return this.sendJoinEvent();
@@ -467,7 +500,7 @@ export class MembershipManager
                 }
                 // This is only a fallback in case we do not have working delayed events support.
                 // first we should try to just send the scheduled leave event
-                return this.sendFallbackLeaveEvent();
+                return this.sendLeaveEvent(data?.leaveReason);
             }
         }
     }
@@ -478,7 +511,9 @@ export class MembershipManager
             this.room.roomId,
             { delay: this.delayedLeaveEventDelayMs },
             EventType.GroupCallMemberPrefix,
-            {},
+            {
+                leave_reason: LEAVE_REASON_DELAYED,
+            },
             this.stateKey,
         );
 
@@ -644,42 +679,37 @@ export class MembershipManager
             });
     }
 
-    private async sendScheduledDelayedLeaveEventOrFallbackToSendLeaveEvent(delayId: string): Promise<ActionUpdate> {
+    private async sendCancelDelayedLeaveEvent(delayId: string): Promise<ActionUpdate> {
         return await this.client
-            ._unstable_sendScheduledDelayedEvent(delayId)
+            ._unstable_cancelScheduledDelayedEvent(delayId)
             .then(() => {
-                this.state.hasMemberStateEvent = false;
                 this.setAndEmitDelayId(undefined);
-                this.resetRateLimitCounter(MembershipActionType.SendScheduledDelayedLeaveEvent);
-
-                return { replace: [] };
+                this.resetRateLimitCounter(MembershipActionType.CancelledScheduledDelayedLeaveEvent);
+                return {};
             })
             .catch((e) => {
-                const repeatActionType = MembershipActionType.SendLeaveEvent;
+                const repeatActionType = MembershipActionType.CancelledScheduledDelayedLeaveEvent;
                 if (this.isUnsupportedDelayedEndpoint(e)) return {};
                 if (this.isNotFoundError(e)) {
                     this.setAndEmitDelayId(undefined);
-                    return createInsertActionUpdate(repeatActionType);
+                    return {};
                 }
-                const update = this.actionUpdateFromErrors(e, repeatActionType, "sendScheduledDelayedEvent");
+                const update = this.actionUpdateFromErrors(e, repeatActionType, "CancelledScheduledDelayedLeaveEvent");
                 if (update) return update;
 
                 // On any other error we fall back to SendLeaveEvent (this includes hard errors from rate limiting)
-                this.logger.warn(
-                    "Encountered unexpected error during SendScheduledDelayedLeaveEvent. Falling back to SendLeaveEvent",
-                    e,
-                );
-                return createInsertActionUpdate(repeatActionType);
+                this.logger.warn("Encountered unexpected error during CancelledScheduledDelayedLeaveEvent.", e);
+                return {};
             });
     }
 
     protected clientSendMembership: (
-        myMembership: RtcMembershipData | SessionMembershipData | EmptyObject,
+        myMembership: RtcMembershipData | SessionMembershipData | LeaveMembershipEventContent,
     ) => Promise<ISendEventResponse> = (myMembership) => {
         return this.client.sendStateEvent(
             this.room.roomId,
             EventType.GroupCallMemberPrefix,
-            myMembership as EmptyObject | SessionMembershipData,
+            myMembership as LeaveMembershipEventContent | SessionMembershipData,
             this.stateKey,
         );
     };
@@ -748,8 +778,11 @@ export class MembershipManager
                 throw e;
             });
     }
-    private async sendFallbackLeaveEvent(): Promise<ActionUpdate> {
-        return await this.clientSendMembership({})
+
+    private async sendLeaveEvent(leave_reason?: LeaveReason): Promise<ActionUpdate> {
+        return await this.clientSendMembership({
+            leave_reason,
+        })
             .then(() => {
                 this.resetRateLimitCounter(MembershipActionType.SendLeaveEvent);
                 this.state.hasMemberStateEvent = false;
@@ -860,6 +893,7 @@ export class MembershipManager
         const updateNetwork = this.actionUpdateFromNetworkErrorRetry(error, type);
         if (updateNetwork) return updateNetwork;
     }
+
     /**
      * Check if we have a rate limit error and schedule the same action again if we dont exceed the rate limit retry count yet.
      * @param error the error causing this handler check/execution
@@ -1001,7 +1035,7 @@ export class MembershipManager
                     return Status.Connecting;
                 case MembershipActionType.UpdateExpiry: // where no delayed events
                     return Status.Connected;
-                case MembershipActionType.SendScheduledDelayedLeaveEvent:
+                case MembershipActionType.CancelledScheduledDelayedLeaveEvent:
                 case MembershipActionType.SendLeaveEvent:
                     return Status.Disconnecting;
                 default:
@@ -1016,6 +1050,10 @@ export class MembershipManager
                 types.includes(MembershipActionType.UpdateExpiry)
             ) {
                 return Status.Connected;
+            }
+
+            if (types.includes(MembershipActionType.CancelledScheduledDelayedLeaveEvent)) {
+                return Status.Disconnecting;
             }
         } else if (actions.length === 3) {
             const types = actions.map((a) => a.type);
@@ -1040,6 +1078,7 @@ export class MembershipManager
     public get probablyLeft(): boolean {
         return this.state.probablyLeft;
     }
+
     public get delayId(): string | undefined {
         return this.state.delayId;
     }
@@ -1064,18 +1103,25 @@ export class StickyEventMembershipManager extends MembershipManager {
         super(joinConfig, room, clientWithSticky, sessionDescription, parentLogger);
     }
 
-    protected clientSendDelayedDisconnectMembership: () => Promise<SendDelayedEventResponse> = () =>
-        this.clientWithSticky._unstable_sendStickyDelayedEvent(
+    protected clientSendDelayedDisconnectMembership: () => Promise<SendDelayedEventResponse> = () => {
+        this.logger.debug(
+            `StickyMembershipManager send delayed disconnect membership event memberId: ${this.memberId}`,
+        );
+        return this.clientWithSticky._unstable_sendStickyDelayedEvent(
             this.room.roomId,
             MEMBERSHIP_STICKY_DURATION_MS,
             { delay: this.delayedLeaveEventDelayMs },
             null,
             EventType.RTCMembership,
-            { msc4354_sticky_key: this.memberId },
+            {
+                leave_reason: LEAVE_REASON_DELAYED,
+                msc4354_sticky_key: this.memberId,
+            },
         );
+    };
 
     protected clientSendMembership: (
-        myMembership: RtcMembershipData | SessionMembershipData | EmptyObject,
+        myMembership: RtcMembershipData | SessionMembershipData | LeaveMembershipEventContent,
     ) => Promise<ISendEventResponse> = (myMembership) => {
         return this.clientWithSticky._unstable_sendStickyEvent(
             this.room.roomId,

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -500,7 +500,7 @@ export class MembershipManager
                     this.logger.debug(
                         "MembershipManager: SendLeaveEvent but we are already not joined. No action needed.",
                     );
-                    return { replace: [] };
+                    return {};
                 }
                 return this.sendLeaveEvent(data?.leaveReason);
             }
@@ -696,7 +696,7 @@ export class MembershipManager
                     this.setAndEmitDelayId(undefined);
                     return {};
                 }
-                const update = this.actionUpdateFromErrors(e, repeatActionType, "CancelledScheduledDelayedLeaveEvent");
+                const update = this.actionUpdateFromErrors(e, repeatActionType, "cancelScheduledDelayedEvent");
                 if (update) return update;
 
                 // On any other error we fall back to SendLeaveEvent (this includes hard errors from rate limiting)

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -82,7 +82,6 @@ On Leave: ─────────  STOP ALL ABOVE
     sending it is the next step
 (4) Both (UpdateExpiry and RestartDelayedEvent) actions are
     scheduled when successfully sending the state event
-(5) Only if delayed event sending failed (fallback)
 (s) Successful restart/resend
 */
 
@@ -498,8 +497,6 @@ export class MembershipManager
                 if (!this.state.hasMemberStateEvent) {
                     return { replace: [] };
                 }
-                // This is only a fallback in case we do not have working delayed events support.
-                // first we should try to just send the scheduled leave event
                 return this.sendLeaveEvent(data?.leaveReason);
             }
         }

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -66,14 +66,15 @@ On Join:  ───────────────┐   ┌─────�
 
 On Leave: ─────────  STOP ALL ABOVE
                            ▼
-            ┌─────────────────────────────────────┐
-            │ CancelledScheduledDelayedLeaveEvent │
-            └─────────────────────────────────────┘
-                           │
-                           ▼
                     ┌──────────────┐
                     │SendLeaveEvent│
                     └──────────────┘
+                           │
+                           ▼
+        ┌─────────────────────────────────────┐
+        │ CancelledScheduledDelayedLeaveEvent │
+        └─────────────────────────────────────┘
+
 (1) [Not found error] results in resending the delayed event
 (2) [hasMemberEvent = true] Sending the delayed event if we
     already have a call member event results jumping to the
@@ -114,12 +115,12 @@ export enum MembershipActionType {
     UpdateExpiry = "UpdateExpiry",
     //  -> MembershipActionType.Update if the timeout has passed so the next update is required.
 
-    CancelledScheduledDelayedLeaveEvent = "CancelledScheduledDelayedLeaveEvent",
-    //  -> MembershipActionType.SendLeaveEvent
-    //  -> DelayedLeaveActionType.CancelledScheduledDelayedLeaveEvent on error we try again
-
     SendLeaveEvent = "SendLeaveEvent",
-    // -> MembershipActionType.SendLeaveEvent
+    // -> MembershipActionType.SendLeaveEvent for retry
+    // -> MembershipActionType.CancelledScheduledDelayedLeaveEvent
+
+    CancelledScheduledDelayedLeaveEvent = "CancelledScheduledDelayedLeaveEvent",
+    //  -> DelayedLeaveActionType.CancelledScheduledDelayedLeaveEvent on error we try again
 }
 
 export type MembershipActionData = {
@@ -412,12 +413,15 @@ export class MembershipManager
     private get networkErrorRetryMs(): number {
         return this.joinConfig?.networkErrorRetryMs ?? 3_000;
     }
+
     private get membershipEventExpiryMs(): number {
         return this.joinConfig?.membershipEventExpiryMs ?? DEFAULT_EXPIRE_DURATION;
     }
+
     private get membershipEventExpiryHeadroomMs(): number {
         return this.joinConfig?.membershipEventExpiryHeadroomMs ?? 5_000;
     }
+
     private computeNextExpiryActionTs(iteration: number): number {
         return (
             this.state.startTime +
@@ -425,18 +429,23 @@ export class MembershipManager
             this.membershipEventExpiryHeadroomMs
         );
     }
+
     protected get delayedLeaveEventDelayMs(): number {
         return this.delayedLeaveEventDelayMsOverride ?? this.joinConfig?.delayedLeaveEventDelayMs ?? 8_000;
     }
+
     private get delayedLeaveEventRestartMs(): number {
         return this.joinConfig?.delayedLeaveEventRestartMs ?? 5_000;
     }
+
     private get maximumRateLimitRetryCount(): number {
         return this.joinConfig?.maximumRateLimitRetryCount ?? 10;
     }
+
     private get maximumNetworkErrorRetryCount(): number {
         return this.joinConfig?.maximumNetworkErrorRetryCount ?? 10;
     }
+
     private get delayedLeaveEventRestartLocalTimeoutMs(): number {
         return this.joinConfig?.delayedLeaveEventRestartLocalTimeoutMs ?? 2000;
     }
@@ -470,13 +479,6 @@ export class MembershipManager
                 return this.restartDelayedEvent(this.state.delayId);
             }
             case MembershipActionType.CancelledScheduledDelayedLeaveEvent: {
-                // We are already good
-                if (!this.state.hasMemberStateEvent) {
-                    this.logger.debug(
-                        "MembershipManager: CancelledScheduledDelayedLeaveEvent but we are already not joined. No action needed.",
-                    );
-                    return {};
-                }
                 if (!this.state.delayId) {
                     this.logger.debug(
                         "MembershipManager: CancelledScheduledDelayedLeaveEvent but we do not have a delayId. Ignoring action.",
@@ -495,6 +497,9 @@ export class MembershipManager
             case MembershipActionType.SendLeaveEvent: {
                 // We are good already
                 if (!this.state.hasMemberStateEvent) {
+                    this.logger.debug(
+                        "MembershipManager: SendLeaveEvent but we are already not joined. No action needed.",
+                    );
                     return { replace: [] };
                 }
                 return this.sendLeaveEvent(data?.leaveReason);
@@ -682,7 +687,7 @@ export class MembershipManager
             .then(() => {
                 this.setAndEmitDelayId(undefined);
                 this.resetRateLimitCounter(MembershipActionType.CancelledScheduledDelayedLeaveEvent);
-                return {};
+                return { replace: [] };
             })
             .catch((e) => {
                 const repeatActionType = MembershipActionType.CancelledScheduledDelayedLeaveEvent;
@@ -783,7 +788,7 @@ export class MembershipManager
             .then(() => {
                 this.resetRateLimitCounter(MembershipActionType.SendLeaveEvent);
                 this.state.hasMemberStateEvent = false;
-                return { replace: [] };
+                return {};
             })
             .catch((e) => {
                 const update = this.actionUpdateFromErrors(e, MembershipActionType.SendLeaveEvent, "sendStateEvent");
@@ -1133,6 +1138,7 @@ export class StickyEventMembershipManager extends MembershipManager {
         ["sendStateEvent", "_unstable_sendStickyEvent"],
         ["sendDelayedStateEvent", "_unstable_sendStickyDelayedEvent"],
     ]);
+
     protected actionUpdateFromErrors(e: unknown, t: MembershipActionType, m: string): ActionUpdate | undefined {
         return super.actionUpdateFromErrors(e, t, StickyEventMembershipManager.nameMap.get(m) ?? "unknown");
     }

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -1,7 +1,8 @@
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { type EmptyObject } from "../matrix.ts";
 import { sleep } from "../utils.ts";
-import { MembershipActionType } from "./MembershipManager.ts";
+import { type MembershipActionData, MembershipActionType } from "./MembershipManager.ts";
+import { type LeaveReason } from "./types.ts";
 
 /** @internal */
 export interface Action {
@@ -14,6 +15,11 @@ export interface Action {
      * can also be thought of as the type of the action
      */
     type: MembershipActionType;
+
+    /**
+     * Additional parameters of the action
+     */
+    data?: MembershipActionData[MembershipActionType];
 }
 
 /** @internal */
@@ -47,7 +53,10 @@ export class ActionScheduler {
 
     public constructor(
         /** This is the callback called for each scheduled action (`this.addAction()`) */
-        private membershipLoopHandler: (type: MembershipActionType) => Promise<ActionUpdate>,
+        private membershipLoopHandler: (
+            type: MembershipActionType,
+            data: MembershipActionData[MembershipActionType],
+        ) => Promise<ActionUpdate>,
         parentLogger?: Logger,
     ) {
         this.logger = (parentLogger ?? rootLogger).getChild(`[NewMembershipActionScheduler]`);
@@ -101,7 +110,10 @@ export class ActionScheduler {
                     );
                     try {
                         // `this.wakeup` can also be called and sets the `wakeupUpdate` object while we are in the handler.
-                        handlerResult = await this.membershipLoopHandler(nextAction.type as MembershipActionType);
+                        handlerResult = await this.membershipLoopHandler(
+                            nextAction.type as MembershipActionType,
+                            nextAction.data,
+                        );
                     } catch (e) {
                         // Preserve the original error as `cause`.
                         throw new Error(`The MembershipManager shut down because of the end condition: ${e}`, {
@@ -132,7 +144,19 @@ export class ActionScheduler {
     public initiateJoin(): void {
         this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendDelayedEvent }] });
     }
-    public initiateLeave(): void {
-        this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendScheduledDelayedLeaveEvent }] });
+    public initiateLeave(leaveReason?: LeaveReason): void {
+        this.wakeup?.({
+            replace: [
+                {
+                    ts: Date.now(),
+                    type: MembershipActionType.CancelledScheduledDelayedLeaveEvent,
+                },
+                {
+                    ts: Date.now(),
+                    type: MembershipActionType.SendLeaveEvent,
+                    data: leaveReason ? { leaveReason } : undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -149,12 +149,12 @@ export class ActionScheduler {
             replace: [
                 {
                     ts: Date.now(),
-                    type: MembershipActionType.CancelledScheduledDelayedLeaveEvent,
+                    type: MembershipActionType.SendLeaveEvent,
+                    data: leaveReason ? { leaveReason } : undefined,
                 },
                 {
                     ts: Date.now(),
-                    type: MembershipActionType.SendLeaveEvent,
-                    data: leaveReason ? { leaveReason } : undefined,
+                    type: MembershipActionType.CancelledScheduledDelayedLeaveEvent,
                 },
             ],
         });

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -142,10 +142,10 @@ export class ActionScheduler {
     }
 
     public initiateJoin(): void {
-        this.wakeup?.({ replace: [{ ts: Date.now(), type: MembershipActionType.SendDelayedEvent }] });
+        this.wakeup({ replace: [{ ts: Date.now(), type: MembershipActionType.SendDelayedEvent }] });
     }
     public initiateLeave(leaveReason?: LeaveReason): void {
-        this.wakeup?.({
+        this.wakeup({
             replace: [
                 {
                     ts: Date.now(),

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -111,7 +111,7 @@ export class ActionScheduler {
                     try {
                         // `this.wakeup` can also be called and sets the `wakeupUpdate` object while we are in the handler.
                         handlerResult = await this.membershipLoopHandler(
-                            nextAction.type as MembershipActionType,
+                            nextAction.type,
                             nextAction.data,
                         );
                     } catch (e) {

--- a/src/matrixrtc/MembershipManagerActionScheduler.ts
+++ b/src/matrixrtc/MembershipManagerActionScheduler.ts
@@ -110,10 +110,7 @@ export class ActionScheduler {
                     );
                     try {
                         // `this.wakeup` can also be called and sets the `wakeupUpdate` object while we are in the handler.
-                        handlerResult = await this.membershipLoopHandler(
-                            nextAction.type,
-                            nextAction.data,
-                        );
+                        handlerResult = await this.membershipLoopHandler(nextAction.type, nextAction.data);
                     } catch (e) {
                         // Preserve the original error as `cause`.
                         throw new Error(`The MembershipManager shut down because of the end condition: ${e}`, {

--- a/src/matrixrtc/index.ts
+++ b/src/matrixrtc/index.ts
@@ -20,5 +20,11 @@ export * from "./MatrixRTCSession.ts";
 export * from "./MatrixRTCSessionManager.ts";
 export type * from "./types.ts";
 export { type SessionMembershipData, type RtcMembershipData } from "./membershipData/index.ts";
-export { Status, parseCallNotificationContent, isMyMembership } from "./types.ts";
+export {
+    Status,
+    parseCallNotificationContent,
+    isMyMembership,
+    LEAVE_REASON_DELAYED,
+    LEAVE_REASON_HANGUP,
+} from "./types.ts";
 export { MembershipManagerEvent } from "./IMembershipManager.ts";

--- a/src/matrixrtc/index.ts
+++ b/src/matrixrtc/index.ts
@@ -26,5 +26,6 @@ export {
     isMyMembership,
     LEAVE_REASON_DELAYED,
     LEAVE_REASON_HANGUP,
+    LEAVE_REASON_SLOT_CLOSED,
 } from "./types.ts";
 export { MembershipManagerEvent } from "./IMembershipManager.ts";

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -225,3 +225,31 @@ export interface SlotDescription {
      */
     id: string;
 }
+
+export type LeaveMembershipEventContent = {
+    leave_reason?: LeaveReason;
+};
+
+export type LeaveCode = "delayed_leaved" | "user_action" | string;
+
+/**
+ * Provides context on why the client left.
+ */
+export type LeaveReason = {
+    /** Identifier for the specific leave cause. Machine-readable.*/
+    code: LeaveCode;
+    /** Optional human-readable explanation of the leave reason */
+    reason?: string;
+};
+
+/** The member left through a scheduled delayed leave event */
+export const LEAVE_REASON_DELAYED: LeaveReason = {
+    code: "delayed_leaved",
+    reason: "The user was removed due to inactivity (no heartbeat received).",
+};
+
+/** The member left intentionally (e.g. by hanging up a call) */
+export const LEAVE_REASON_HANGUP: LeaveReason = {
+    code: "user_leave",
+    reason: "The user intentionally left the rtc session.",
+};

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -262,17 +262,17 @@ export type LeaveReason = {
 /** The member left through a scheduled delayed leave event */
 export const LEAVE_REASON_DELAYED: LeaveReason = {
     code: "delayed_leave",
-    reason: "The user was removed due to inactivity (no heartbeat received).",
+    reason: "The member left through a scheduled delayed leave event.",
 };
 
 /** The member left intentionally (e.g. by hanging up a call) */
 export const LEAVE_REASON_HANGUP: LeaveReason = {
     code: "leave",
-    reason: "The user intentionally left the rtc session.",
+    reason: "The member left intentionally (e.g. by hanging up a call).",
 };
 
 /** The member left because the call slot was closed */
 export const LEAVE_REASON_SLOT_CLOSED: LeaveReason = {
     code: "slot_closed",
-    reason: "The member left because the slot was closed midway through the session",
+    reason: "The member left because the slot was closed midway through the session.",
 };

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -230,7 +230,7 @@ export type LeaveMembershipEventContent = {
     leave_reason?: LeaveReason;
 };
 
-export type LeaveCode = "delayed_leaved" | "user_action" | string;
+export type LeaveCode = "delayed_leaved" | "leave" | "slot_closed" | string;
 
 /**
  * Provides context on why the client left.
@@ -250,6 +250,12 @@ export const LEAVE_REASON_DELAYED: LeaveReason = {
 
 /** The member left intentionally (e.g. by hanging up a call) */
 export const LEAVE_REASON_HANGUP: LeaveReason = {
-    code: "user_leave",
+    code: "leave",
     reason: "The user intentionally left the rtc session.",
+};
+
+/** The member left because the call slot was closed */
+export const LEAVE_SLOT_CLOSED: LeaveReason = {
+    code: "slot_closed",
+    reason: "The member left because the slot was closed midway through the session",
 };

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -230,7 +230,7 @@ export type LeaveMembershipEventContent = {
     leave_reason?: LeaveReason;
 };
 
-export type LeaveCode = "delayed_leaved" | "leave" | "slot_closed" | string;
+export type LeaveCode = "delayed_leave" | "leave" | "slot_closed" | string;
 
 /**
  * Provides context on why the client left.
@@ -244,7 +244,7 @@ export type LeaveReason = {
 
 /** The member left through a scheduled delayed leave event */
 export const LEAVE_REASON_DELAYED: LeaveReason = {
-    code: "delayed_leaved",
+    code: "delayed_leave",
     reason: "The user was removed due to inactivity (no heartbeat received).",
 };
 

--- a/src/matrixrtc/types.ts
+++ b/src/matrixrtc/types.ts
@@ -255,7 +255,7 @@ export const LEAVE_REASON_HANGUP: LeaveReason = {
 };
 
 /** The member left because the call slot was closed */
-export const LEAVE_SLOT_CLOSED: LeaveReason = {
+export const LEAVE_REASON_SLOT_CLOSED: LeaveReason = {
     code: "slot_closed",
     reason: "The member left because the slot was closed midway through the session",
 };


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Adds support for `leave_reason` as per [MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143)

Breaking change:
- Leave event has now a `leave_reason` optional key instead of enpty
- Previously for leaving the membership manager was just firing the scheduled leave, now we are cancelling it, then we send a proper leave event with the reason 

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
