### PR TITLE
Fix pre-initialization thread edits when target is known

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -899,6 +899,86 @@ describe("Thread", () => {
                 expect(replaceIds[2]).toBe(edit3.getId());
             });
 
+            it("aggregates edits while initialization is pending when their target is already known", async () => {
+                const previousSupport = Thread.hasServerSideSupport;
+                Thread.setServerSideSupport(FeatureSupport.Stable);
+
+                const myUserId = "@alice:example.org";
+                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, {
+                    timelineSupport: false,
+                });
+                const client = testClient.client;
+                client.supportsThreads = vi.fn().mockReturnValue(true);
+
+                const room = new Room("!room:z", client, myUserId, {
+                    pendingEventOrdering: PendingEventOrdering.Detached,
+                });
+                vi.spyOn(client, "getRoom").mockReturnValue(room);
+
+                const rootEvent = mkMessage({ room: room.roomId, user: myUserId, msg: "Root", event: true });
+                const originalMessage = mkMessage({
+                    room: room.roomId,
+                    user: myUserId,
+                    msg: "Thinking…",
+                    relatesTo: {
+                        "rel_type": THREAD_RELATION_TYPE.name,
+                        "event_id": rootEvent.getId()!,
+                        "m.in_reply_to": { event_id: rootEvent.getId()! },
+                    },
+                    event: true,
+                });
+                rootEvent.setUnsigned({
+                    "m.relations": {
+                        [THREAD_RELATION_TYPE.name]: {
+                            count: 1,
+                            current_user_participated: true,
+                            latest_event: originalMessage.event,
+                        },
+                    },
+                });
+
+                vi.spyOn(client, "fetchRoomEvent").mockResolvedValue(rootEvent.event);
+                const paginationStarted = Promise.withResolvers<void>();
+                const finishPagination = Promise.withResolvers<void>();
+                const freshOriginalMessage = new MatrixEvent({ ...originalMessage.event });
+                vi.spyOn(client, "paginateEventTimeline").mockImplementation(async (timeline) => {
+                    paginationStarted.resolve();
+                    await finishPagination.promise;
+                    timeline.getTimelineSet().addEventToTimeline(freshOriginalMessage, timeline, {
+                        toStartOfTimeline: false,
+                        roomState: room.currentState,
+                        addToState: false,
+                    });
+                    return true;
+                });
+
+                const thread = room.createThread(rootEvent.getId()!, rootEvent, [originalMessage], false);
+
+                try {
+                    await paginationStarted.promise;
+                    const onUpdate = vi.fn();
+                    thread.on(ThreadEvent.Update, onUpdate);
+                    const edit1 = mkEdit(originalMessage, client, myUserId, room.roomId, "First chunk", 1);
+                    const edit2 = mkEdit(originalMessage, client, myUserId, room.roomId, "Complete answer", 2);
+
+                    thread.addEvent(edit1, false);
+                    thread.addEvent(edit2, false);
+
+                    await vi.waitFor(() => expect(originalMessage.replacingEvent()).toBe(edit2));
+                    expect(onUpdate).toHaveBeenCalled();
+
+                    const initialized = emitPromise(thread, RoomEvent.TimelineReset);
+                    finishPagination.resolve();
+                    await initialized;
+
+                    await vi.waitFor(() => expect(freshOriginalMessage.replacingEvent()).toBe(edit2));
+                    expect(freshOriginalMessage.getContent().body).toBe("Complete answer");
+                } finally {
+                    finishPagination.resolve();
+                    Thread.setServerSideSupport(previousSupport);
+                }
+            });
+
             it("Reactions aggregate pre-init and remain idempotent on replay", async () => {
                 const myUserId = "@alice:example.org";
                 const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, {

--- a/src/models/relations-container.ts
+++ b/src/models/relations-container.ts
@@ -20,6 +20,7 @@ import { EventStatus, type MatrixEvent, MatrixEventEvent } from "./event.ts";
 import { type EventTimelineSet } from "./event-timeline-set.ts";
 import { type MatrixClient } from "../client.ts";
 import { type Room } from "./room.ts";
+import { logger } from "../logger.ts";
 
 export class RelationsContainer {
     // A tree of objects to access a set of related children for an event, as in:
@@ -88,30 +89,53 @@ export class RelationsContainer {
      *
      * @param event - The new child event to be aggregated.
      * @param timelineSet - The event timeline set within which to search for the related event if any.
+     * @param targetEvent - A known relation target to use when it is not in the timeline yet.
+     * @returns A promise which resolves after aggregation when `targetEvent` is supplied.
      */
-    public aggregateChildEvent(event: MatrixEvent, timelineSet?: EventTimelineSet): void {
+    public aggregateChildEvent(event: MatrixEvent, timelineSet?: EventTimelineSet): void;
+    public aggregateChildEvent(
+        event: MatrixEvent,
+        timelineSet: EventTimelineSet,
+        targetEvent: MatrixEvent,
+    ): Promise<void>;
+    public aggregateChildEvent(
+        event: MatrixEvent,
+        timelineSet?: EventTimelineSet,
+        targetEvent?: MatrixEvent,
+    ): void | Promise<void> {
+        const aggregation = this.aggregateChildEventInternal(event, timelineSet, targetEvent);
+        if (targetEvent) return aggregation;
+
+        void aggregation.catch((error) => logger.error("Failed to aggregate child event: ", error));
+    }
+
+    private aggregateChildEventInternal(
+        event: MatrixEvent,
+        timelineSet?: EventTimelineSet,
+        targetEvent?: MatrixEvent,
+    ): Promise<void> {
         if (event.isRedacted() || event.status === EventStatus.CANCELLED) {
-            return;
+            return Promise.resolve();
         }
 
         const relation = event.getRelation();
-        if (!relation) return;
-
-        const onEventDecrypted = (): void => {
-            if (event.isDecryptionFailure()) {
-                // This could for example happen if the encryption keys are not yet available.
-                // The event may still be decrypted later. Register the listener again.
-                event.once(MatrixEventEvent.Decrypted, onEventDecrypted);
-                return;
-            }
-
-            this.aggregateChildEvent(event, timelineSet);
-        };
+        if (!relation) return Promise.resolve();
 
         // If the event is currently encrypted, wait until it has been decrypted.
         if (event.isBeingDecrypted() || event.shouldAttemptDecryption()) {
-            event.once(MatrixEventEvent.Decrypted, onEventDecrypted);
-            return;
+            return new Promise<void>((resolve, reject) => {
+                const onEventDecrypted = (): void => {
+                    if (event.isDecryptionFailure()) {
+                        // This could for example happen if the encryption keys are not yet available.
+                        // The event may still be decrypted later. Register the listener again.
+                        event.once(MatrixEventEvent.Decrypted, onEventDecrypted);
+                        return;
+                    }
+
+                    void this.aggregateChildEventInternal(event, timelineSet, targetEvent).then(resolve, reject);
+                };
+                event.once(MatrixEventEvent.Decrypted, onEventDecrypted);
+            });
         }
 
         const { event_id: relatesToEventId, rel_type: relationType } = relation;
@@ -130,20 +154,26 @@ export class RelationsContainer {
         }
 
         let relationsWithEventType = relationsWithRelType.get(eventType);
+        const isNewRelationCollection = !relationsWithEventType;
+        let targetEventUpdate = Promise.resolve();
         if (!relationsWithEventType) {
             relationsWithEventType = new Relations(relationType!, eventType, this.client);
             relationsWithRelType.set(eventType, relationsWithEventType);
+        }
 
+        if (isNewRelationCollection || targetEvent) {
             const room = this.room ?? timelineSet?.room;
             const relatesToEvent =
                 timelineSet?.findEventById(relatesToEventId!) ??
                 room?.findEventById(relatesToEventId!) ??
-                room?.getPendingEvent(relatesToEventId!);
+                room?.getPendingEvent(relatesToEventId!) ??
+                targetEvent;
             if (relatesToEvent) {
-                relationsWithEventType.setTargetEvent(relatesToEvent);
+                targetEventUpdate = relationsWithEventType.setTargetEvent(relatesToEvent);
             }
         }
 
-        relationsWithEventType.addEvent(event);
+        const addEventUpdate = relationsWithEventType.addEvent(event);
+        return Promise.all([targetEventUpdate, addEventUpdate]).then(() => undefined);
     }
 }

--- a/src/models/relations-container.ts
+++ b/src/models/relations-container.ts
@@ -89,10 +89,16 @@ export class RelationsContainer {
      *
      * @param event - The new child event to be aggregated.
      * @param timelineSet - The event timeline set within which to search for the related event if any.
-     * @param targetEvent - A known relation target to use when it is not in the timeline yet.
-     * @returns A promise which resolves after aggregation when `targetEvent` is supplied.
      */
     public aggregateChildEvent(event: MatrixEvent, timelineSet?: EventTimelineSet): void;
+    /**
+     * Add a relation event using a known target that is not in the timeline yet.
+     *
+     * @param event - The new child event to be aggregated.
+     * @param timelineSet - The event timeline set within which to search for the related event.
+     * @param targetEvent - The known relation target.
+     * @returns A promise which resolves after aggregation.
+     */
     public aggregateChildEvent(
         event: MatrixEvent,
         timelineSet: EventTimelineSet,

--- a/src/models/relations.ts
+++ b/src/models/relations.ts
@@ -336,7 +336,7 @@ export class Relations extends TypedEventEmitter<RelationsEvent, EventHandlerMap
      * @param targetEvent - the event the relations are related to.
      */
     public async setTargetEvent(event: MatrixEvent): Promise<void> {
-        if (this.targetEvent) {
+        if (this.targetEvent === event) {
             return;
         }
         this.targetEvent = event;

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -132,6 +132,8 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
      */
     public initialEventsFetched = !Thread.hasServerSideSupport;
     private initalEventFetchProm: Promise<boolean> | undefined;
+    private preInitEventTargets = new Map<string, MatrixEvent>();
+    private preInitObserverState = { active: true };
 
     /**
      * An array of events to add to the timeline once the thread has been initialised
@@ -170,6 +172,9 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
         this.reEmitter = new TypedReEmitter(this);
 
         this.reEmitter.reEmit(this.timelineSet, [RoomEvent.Timeline, RoomEvent.TimelineReset]);
+        this.once(ThreadEvent.Delete, () => {
+            this.preInitObserverState.active = false;
+        });
 
         this.room.on(MatrixEventEvent.BeforeRedaction, this.onBeforeRedaction);
         this.room.on(RoomEvent.Redaction, this.onRedaction);
@@ -364,6 +369,15 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
         // Modify this event to point at our room's state, and mark its thread
         // as this.
         this.setEventMetadata(event);
+        const eventId = event.getId();
+        if (
+            !this.initialEventsFetched &&
+            eventId &&
+            !event.isRelation(RelationType.Annotation) &&
+            !event.isRelation(RelationType.Replace)
+        ) {
+            this.preInitEventTargets.set(eventId, event);
+        }
 
         // Decide whether this event is going to be added at the end of the timeline.
         const lastReply = this.lastReply();
@@ -438,11 +452,32 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
              */
             this.replayEvents?.push(event);
 
-            // For annotations (reactions), aggregate immediately (pre-init) to keep
-            // reaction counts/summary visible while the thread is still initialising.
-            // Only aggregate as child: parent aggregation is unnecessary here.
+            // Aggregate annotations immediately to keep reaction counts visible.
             if (event.isRelation(RelationType.Annotation)) {
                 this.timelineSet.relations?.aggregateChildEvent(event, this.timelineSet);
+            }
+
+            // Edits can also be aggregated immediately when their target is already
+            // known. If it is not known yet, replay still handles them after pagination.
+            if (event.isRelation(RelationType.Replace)) {
+                const targetEventId = event.getRelation()?.event_id;
+                const targetEvent = targetEventId ? this.findPreInitTargetEvent(targetEventId) : undefined;
+                if (targetEvent && targetEventId) {
+                    const weakThread = new WeakRef(this);
+                    const observerState = this.preInitObserverState;
+                    const eventId = event.getId();
+                    void this.timelineSet.relations
+                        .aggregateChildEvent(event, this.timelineSet, targetEvent)
+                        .then(() => {
+                            const thread = weakThread.deref();
+                            if (!thread || !observerState.active) return;
+                            const effectiveTarget = thread.findPreInitTargetEvent(targetEventId);
+                            if (effectiveTarget?.replacingEvent()?.getId() === eventId) {
+                                thread.emit(ThreadEvent.Update, thread);
+                            }
+                        })
+                        .catch((error) => logger.error("Failed to aggregate pre-initialization thread edit: ", error));
+                }
             }
         } else {
             // Case 2: this is happening later, and we have a timeline. In
@@ -472,6 +507,15 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
             }
             // Aggregation is handled by EventTimelineSet when inserting/adding.
         }
+    }
+
+    private findPreInitTargetEvent(eventId: string): MatrixEvent | undefined {
+        return (
+            this.timelineSet.findEventById(eventId) ??
+            this.room.findEventById(eventId) ??
+            this.preInitEventTargets.get(eventId) ??
+            (this.lastEvent?.getId() === eventId ? this.lastEvent : undefined)
+        );
     }
 
     public async processEvent(event: MatrixEvent | null | undefined): Promise<void> {
@@ -642,6 +686,7 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
                         this.addEvent(event, false);
                     }
                     this.replayEvents = null;
+                    this.preInitEventTargets.clear();
                     // just to make sure that, if we've created a timeline window for this thread before the thread itself
                     // existed (e.g. when creating a new thread), we'll make sure the panel is force refreshed correctly.
                     this.emit(RoomEvent.TimelineReset, this.room, this.timelineSet, true);


### PR DESCRIPTION
[MindRoom](https://github.com/mindroom-ai/mindroom) uses Matrix edits as a streaming transport for AI replies. A reply first appears as a short placeholder such as `Thinking…`, then gets edited repeatedly as the answer is generated.

The original version of this problem was reported in [element-hq/element-web#30617](https://github.com/element-hq/element-web/issues/30617) and led to #4980. That fix correctly defers edits when their target has not been loaded yet, so they can be replayed after thread initialization.

We later hit a narrower remaining race in the MindRoom Chat room overview ([downstream context](https://github.com/mindroom-ai/mindroom-chat/pull/193)). The placeholder event was already available to the UI, but initial thread pagination was still pending. Deferring every edit in that state meant the room preview could remain on `Thinking…` for the whole streamed response even though the SDK already had both the target and its edits.

This keeps the #4980 behavior when the target is unknown. When the target is already known, edits are aggregated immediately and the thread emits an update so previews can render the new content. Initial pagination can also replace the cached target with a fresh `MatrixEvent` instance for the same event ID, so relation collections now rebind to that new instance instead of keeping only the first object they saw.

The regression test holds pagination open, sends two edits to a known placeholder, verifies that the placeholder and thread update before pagination completes, then completes pagination with a fresh target object and verifies that the final edit is rebound to it. The existing target-not-yet-loaded test still covers the deferred replay path from #4980.

Validated with:

- `pnpm test`
- `pnpm build`
- `pnpm lint`

Notes: Fix thread previews that can remain on stale pre-initialization content after edits arrive.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).