### PR TITLE
feat(widget): Discover rtc transports for widget (MSC4515)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "content-type": "^2.0.0",
         "loglevel": "^1.9.2",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.16.1",
+        "matrix-widget-api": "^1.18.0",
         "p-retry": "8",
         "sdp-transform": "^3.0.0",
         "unhomoglyph": "^1.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       matrix-widget-api:
-        specifier: ^1.16.1
-        version: 1.17.0
+        specifier: ^1.18.0
+        version: 1.18.0
       p-retry:
         specifier: '8'
         version: 8.0.0
@@ -2315,8 +2315,8 @@ packages:
   matrix-mock-request@2.6.0:
     resolution: {integrity: sha512-D0n+FsoMvHBrBoo60IeGhyrNoCBdT8n+Wl+LMW+k5aR+k9QAxqGopPzJNk1tqeaJLFUhmvYLuNc8/VBKRpPy+Q==}
 
-  matrix-widget-api@1.17.0:
-    resolution: {integrity: sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==}
+  matrix-widget-api@1.18.0:
+    resolution: {integrity: sha512-4T2f2koWmx05p1BLcT/9YGGGPSXpPT+PA4Oap/5fjhXsWPxMGJiGL97YpANMYLKsnE1sScYFeuyxIgdc1Qo+Ew==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -4447,7 +4447,7 @@ snapshots:
     dependencies:
       expect: 30.4.1
 
-  matrix-widget-api@1.17.0:
+  matrix-widget-api@1.18.0:
     dependencies:
       '@types/events': 3.0.3
       events: 3.3.0

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -46,6 +46,7 @@ import { type ToDeviceBatch } from "../../src/models/ToDeviceMessage";
 import { sleep } from "../../src/utils";
 import { SlidingSync } from "../../src/sliding-sync";
 import { logger } from "../../src/logger";
+import { ConnectionError } from "../../src/http-api/errors";
 import { flushPromises } from "../test-utils/flushPromises";
 import { RoomStickyEventsEvent, type RoomStickyEventsMap } from "../../src/models/room-sticky-events";
 
@@ -98,6 +99,7 @@ class MockWidgetApi extends EventEmitter {
     });
     public readStateEvents = vi.fn(async () => []);
     public getTurnServers = vi.fn(async () => []);
+    public getRtcTransports = vi.fn(async () => ({ rtc_transports: [] }));
     public sendContentLoaded = vi.fn().mockResolvedValue(undefined);
 
     public transport = {
@@ -1231,5 +1233,42 @@ describe("RoomWidgetClient", () => {
         emitServer2!();
         expect(await emittedServer).toEqual([clientServer2]);
         expect(client.getTurnServers()).toEqual([clientServer2]);
+    });
+
+    describe("RTC transports", () => {
+        const transport = { type: "livekit", livekit_service_url: "https://livekit-jwt.example.com" };
+
+        it("requests the capability when opted in", async () => {
+            await makeClient({ rtcTransports: true });
+            expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4515RtcTransports);
+        });
+
+        it("does not request the capability when not opted in", async () => {
+            await makeClient({});
+            expect(widgetApi.requestCapability).not.toHaveBeenCalledWith(MatrixCapabilities.MSC4515RtcTransports);
+        });
+
+        it("gets RTC transports from the host", async () => {
+            widgetApi.getRtcTransports.mockResolvedValue({ rtc_transports: [transport] });
+
+            await makeClient({ rtcTransports: true });
+            expect(await client._unstable_getRTCTransports()).toEqual([transport]);
+            expect(widgetApi.getRtcTransports).toHaveBeenCalled();
+        });
+
+        it("propagates errors from the host", async () => {
+            const error = new Error("Missing capability");
+            widgetApi.getRtcTransports.mockRejectedValue(error);
+
+            await makeClient({ rtcTransports: true });
+            await expect(client._unstable_getRTCTransports()).rejects.toThrow(error);
+        });
+
+        it("maps a widget timeout to a ConnectionError", async () => {
+            widgetApi.getRtcTransports.mockRejectedValue(new Error("Request timed out"));
+
+            await makeClient({ rtcTransports: true });
+            await expect(client._unstable_getRTCTransports()).rejects.toThrow(ConnectionError);
+        });
     });
 });

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -32,6 +32,8 @@ import {
     UnstableApiVersion,
 } from "matrix-widget-api";
 
+import { type Transport } from "./matrixrtc/index.ts";
+
 import { MatrixEvent, type IEvent, type IContent, EventStatus } from "./models/event.ts";
 import {
     type ISendEventResponse,
@@ -137,6 +139,13 @@ export interface ICapabilities {
      * @defaultValue false
      */
     receiveSticky?: boolean;
+
+    /**
+     * Whether this client needs to be able to discover the RTC transports the host can reach.
+     * @experimental Part of MSC4515
+     * @defaultValue false
+     */
+    rtcTransports?: boolean;
 }
 
 export enum RoomWidgetClientEvent {
@@ -284,6 +293,9 @@ export class RoomWidgetClient extends MatrixClient {
         }
         if (capabilities.turnServers) {
             this.widgetApi.requestCapability(MatrixCapabilities.MSC3846TurnServers);
+        }
+        if (capabilities.rtcTransports) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4515RtcTransports);
         }
     }
 
@@ -620,6 +632,23 @@ export class RoomWidgetClient extends MatrixClient {
             matrix_server_name: token.matrix_server_name,
             token_type: token.token_type,
         };
+    }
+
+    /**
+     * Returns a set of configured RTC transports supported by the homeserver.
+     *
+     * Overrides the homeserver-side {@link MatrixClient._unstable_getRTCTransports} (MSC4143):
+     * a widget cannot make authenticated homeserver calls itself, so we ask the host over the
+     * widget API instead (MSC4515). Requires the `rtcTransports` capability and a host that
+     * advertises the `org.matrix.msc4515` API version (otherwise the request throws).
+     */
+    public override async _unstable_getRTCTransports(): Promise<Transport[]> {
+        const { rtc_transports: rtcTransports } = await this.widgetApi
+            .getRtcTransports()
+            .catch(timeoutToConnectionError);
+        // The widget-api IRtcTransport and the js-sdk Transport types are structurally compatible.
+        // We recreate the objects so the linter catches any future divergence in the shapes.
+        return rtcTransports.map((transport) => ({ ...transport }));
     }
 
     public async queueToDevice({ eventType, batch }: ToDeviceBatch): Promise<void> {

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -646,9 +646,7 @@ export class RoomWidgetClient extends MatrixClient {
         const { rtc_transports: rtcTransports } = await this.widgetApi
             .getRtcTransports()
             .catch(timeoutToConnectionError);
-        // The widget-api IRtcTransport and the js-sdk Transport types are structurally compatible.
-        // We recreate the objects so the linter catches any future divergence in the shapes.
-        return rtcTransports.map((transport) => ({ ...transport }));
+        return rtcTransports;
     }
 
     public async queueToDevice({ eventType, batch }: ToDeviceBatch): Promise<void> {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
Fixes https://github.com/matrix-org/matrix-js-sdk/issues/5245

Support [MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515) rtc transport discovery for widgets.

Draft because depends of widget-api PR https://github.com/matrix-org/matrix-widget-api/pull/165

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
