### PR TITLE
Remove support for MSC3391 & MSC3852

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -79,7 +79,6 @@ import {
 } from "../../src/models/invites-ignorer";
 import { type QueryDict } from "../../src/utils";
 import { type SyncState } from "../../src/sync";
-import * as featureUtils from "../../src/feature";
 import { StubStore } from "../../src/store/stub";
 import { type ServerSideSecretStorageImpl } from "../../src/secret-storage";
 import { KnownMembership } from "../../src/@types/membership";
@@ -3095,99 +3094,6 @@ describe("MatrixClient", function () {
 
             // THEN there should be no REST call
             expect(fetchMock.callHistory.calls(/account_data/).length).toEqual(0);
-        });
-    });
-
-    describe("delete account data", () => {
-        const TEST_HOMESERVER_URL = "https://alice-server.com";
-
-        /** Create and start a MatrixClient, connected to the `TEST_HOMESERVER_URL` */
-        async function setUpClient(versionsResponse: object = { versions: ["1"] }): Promise<MatrixClient> {
-            fetchMock.getOnce(new URL("/_matrix/client/versions", TEST_HOMESERVER_URL).toString(), versionsResponse);
-            fetchMock.getOnce(new URL("/_matrix/client/v3/capabilities", TEST_HOMESERVER_URL).toString(), {});
-            fetchMock.getOnce(new URL("/_matrix/client/v3/pushrules/", TEST_HOMESERVER_URL).toString(), {});
-            fetchMock.postOnce(
-                new URL(`/_matrix/client/v3/user/${encodeURIComponent(userId)}/filter`, TEST_HOMESERVER_URL).toString(),
-                { filter_id: "fid" },
-            );
-            fetchMock.getOnce(
-                new URL(
-                    `/_matrix/client/v3/user/${encodeURIComponent(userId)}/filter/fid`,
-                    TEST_HOMESERVER_URL,
-                ).toString(),
-                {},
-            );
-
-            const client = createClient({ baseUrl: TEST_HOMESERVER_URL, userId });
-            await client.startClient();
-
-            return client;
-        }
-
-        it("makes correct request when deletion is supported by server in unstable versions", async () => {
-            const eventType = "im.vector.test";
-            const versionsResponse = {
-                versions: ["1"],
-                unstable_features: {
-                    "org.matrix.msc3391": true,
-                },
-            };
-            const client = await setUpClient(versionsResponse);
-
-            const url = new URL(
-                `/_matrix/client/unstable/org.matrix.msc3391/user/${encodeURIComponent(userId)}/account_data/${eventType}`,
-                TEST_HOMESERVER_URL,
-            ).toString();
-            fetchMock.delete(url, {});
-
-            await client.deleteAccountData(eventType);
-
-            expect(fetchMock.callHistory.calls(url).length).toEqual(1);
-        });
-
-        it("makes correct request when deletion is supported by server based on matrix version", async () => {
-            const eventType = "im.vector.test";
-            // we don't have a stable version for account data deletion yet to test this code path with
-            // so mock the support map to fake stable support
-            const stableSupportedDeletionMap = new Map();
-            stableSupportedDeletionMap.set(featureUtils.Feature.AccountDataDeletion, featureUtils.ServerSupport.Stable);
-            vi.spyOn(featureUtils, "buildFeatureSupportMap").mockResolvedValue(stableSupportedDeletionMap);
-
-            const client = await setUpClient();
-
-            const url = new URL(
-                `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${eventType}`,
-                TEST_HOMESERVER_URL,
-            ).toString();
-            fetchMock.delete(url, {});
-
-            await client.deleteAccountData(eventType);
-
-            expect(fetchMock.callHistory.calls(url).length).toEqual(1);
-        });
-
-        it("makes correct request when deletion is not supported by server", async () => {
-            const eventType = "im.vector.test";
-
-            const syncResponder = new SyncResponder(TEST_HOMESERVER_URL);
-            const client = await setUpClient();
-
-            const url = new URL(
-                `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/${eventType}`,
-                TEST_HOMESERVER_URL,
-            ).toString();
-            fetchMock.put(url, {});
-
-            const setProm = client.deleteAccountData(eventType);
-            syncResponder.sendOrQueueSyncResponse({
-                account_data: { events: [{ type: eventType, content: {} }] },
-            });
-            await setProm;
-
-            // account data updated with empty content
-            const lastCall = fetchMock.callHistory.lastCall(url);
-            expect(lastCall).toBeDefined();
-            expect(lastCall?.options?.body).toEqual("{}");
         });
     });
 

--- a/spec/unit/stores/memory.spec.ts
+++ b/spec/unit/stores/memory.spec.ts
@@ -43,8 +43,8 @@ describe("MemoryStore", () => {
             store.storeAccountDataEvents([event1, event2, event4]);
             // remove event1, add event3
             store.storeAccountDataEvents([event1Empty, event3, event4Updated]);
-            // removed
-            expect(store.getAccountData(event1.getType())).toEqual(undefined);
+            // "removed"
+            expect(store.getAccountData(event1.getType())?.getContent()).toEqual({});
             // not removed
             expect(store.getAccountData(event2.getType())).toEqual(event2);
             // added

--- a/src/client.ts
+++ b/src/client.ts
@@ -2351,7 +2351,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Sets the users thamsc3391t the current user should ignore.
+     * Sets the users that the current user should ignore.
      * @param userIds - the user IDs to ignore
      * @returns Promise which resolves: an empty object
      * @returns Rejects: with an error response.

--- a/src/client.ts
+++ b/src/client.ts
@@ -256,11 +256,6 @@ const SCROLLBACK_DELAY_MS = 3000;
 
 const TURN_CHECK_INTERVAL = 10 * 60 * 1000; // poll for turn credentials every 10 minutes
 
-export const UNSTABLE_MSC3852_LAST_SEEN_UA = new UnstableValue(
-    "last_seen_user_agent",
-    "org.matrix.msc3852.last_seen_user_agent",
-);
-
 export interface IKeysUploadResponse {
     one_time_key_counts: {
         [algorithm: string]: number;
@@ -777,13 +772,10 @@ interface IUserDirectoryResponse {
 }
 
 export interface IMyDevice {
-    "device_id": string;
-    "display_name"?: string;
-    "last_seen_ip"?: string;
-    "last_seen_ts"?: number;
-    // UNSTABLE_MSC3852_LAST_SEEN_UA
-    "last_seen_user_agent"?: string;
-    "org.matrix.msc3852.last_seen_user_agent"?: string;
+    device_id: string;
+    display_name?: string;
+    last_seen_ip?: string;
+    last_seen_ts?: number;
 }
 
 export interface Keys {
@@ -2345,21 +2337,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     public async deleteAccountData(eventType: keyof WritableAccountDataEvents): Promise<void> {
-        const msc3391DeleteAccountDataServerSupport = this.canSupport.get(Feature.AccountDataDeletion);
-        // if deletion is not supported overwrite with empty content
-        if (msc3391DeleteAccountDataServerSupport === ServerSupport.Unsupported) {
-            await this.setAccountData(eventType, {});
-            return;
-        }
-        const path = utils.encodeUri("/user/$userId/account_data/$type", {
-            $userId: this.getSafeUserId(),
-            $type: eventType,
-        });
-        const options =
-            msc3391DeleteAccountDataServerSupport === ServerSupport.Unstable
-                ? { prefix: "/_matrix/client/unstable/org.matrix.msc3391" }
-                : undefined;
-        return await this.http.authedRequest(Method.Delete, path, undefined, undefined, options);
+        await this.setAccountData(eventType, {});
     }
 
     /**
@@ -2373,7 +2351,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Sets the users that the current user should ignore.
+     * Sets the users thamsc3391t the current user should ignore.
      * @param userIds - the user IDs to ignore
      * @returns Promise which resolves: an empty object
      * @returns Rejects: with an error response.

--- a/src/feature.ts
+++ b/src/feature.ts
@@ -55,9 +55,6 @@ const featureSupportResolver: Record<string, FeatureSupportCondition> = {
     [Feature.RelationBasedRedactions]: {
         unstablePrefixes: ["org.matrix.msc3912"],
     },
-    [Feature.AccountDataDeletion]: {
-        unstablePrefixes: ["org.matrix.msc3391"],
-    },
     [Feature.RelationsRecursion]: {
         unstablePrefixes: ["org.matrix.msc3981"],
         matrixVersion: "v1.10",

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -292,13 +292,7 @@ export class MemoryStore implements IStore {
      */
     public storeAccountDataEvents(events: MatrixEvent[]): void {
         events.forEach((event) => {
-            // MSC3391: an event with content of {} should be interpreted as deleted
-            const isDeleted = !Object.keys(event.getContent()).length;
-            if (isDeleted) {
-                this.accountData.delete(event.getType());
-            } else {
-                this.accountData.set(event.getType(), event);
-            }
+            this.accountData.set(event.getType(), event);
         });
     }
 


### PR DESCRIPTION
As they were both rejected & closed.

Synapse already removed support for MSC3852 which means it already did nothing: https://github.com/element-hq/synapse/pull/19430

Requires https://github.com/element-hq/element-web/pull/34400