### PR TITLE
Drop support for clear RTC to-device messages

### DIFF
--- a/spec/unit/matrixrtc/ToDeviceKeyTransport.spec.ts
+++ b/spec/unit/matrixrtc/ToDeviceKeyTransport.spec.ts
@@ -149,7 +149,7 @@ describe("ToDeviceKeyTransport", () => {
         expect(statistics.counters.roomEventEncryptionKeysReceived).toBe(1);
     });
 
-    it("should drop non-encrypted/clear to-devic events", () => {
+    it("should drop non-encrypted/clear to-device events", () => {
         const receivedKeyResolvers = vi.fn();
         transport.on(KeyTransportEvents.ReceivedKeys, (membership, keyBase64Encoded, index, _timestamp) => {
             receivedKeyResolvers();

--- a/spec/unit/matrixrtc/ToDeviceKeyTransport.spec.ts
+++ b/spec/unit/matrixrtc/ToDeviceKeyTransport.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { type Mocked } from "vitest";
 
-import { makeMockEvent } from "./mocks.ts";
+import { makeMatrixEvent } from "./mocks.ts";
 import { ClientEvent, EventType, type MatrixClient } from "../../../src";
 import { ToDeviceKeyTransport } from "../../../src/matrixrtc/ToDeviceKeyTransport.ts";
 import { getMockClientWithEventEmitter } from "../../test-utils/client.ts";
@@ -122,24 +122,23 @@ describe("ToDeviceKeyTransport", () => {
         const testEncoded = "ABCDEDF";
         const testKeyIndex = 2;
 
-        mockClient.emit(
-            ClientEvent.ToDeviceEvent,
-            makeMockEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, {
-                keys: {
-                    index: testKeyIndex,
-                    key: testEncoded,
-                },
-                member: {
-                    claimed_device_id: "BOBDEVICE",
-                },
-                room_id: roomId,
-                session: {
-                    application: "m.call",
-                    call_id: "",
-                    scope: "m.room",
-                },
-            }),
-        );
+        const mockEvent = makeMatrixEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, {
+            keys: {
+                index: testKeyIndex,
+                key: testEncoded,
+            },
+            member: {
+                claimed_device_id: "BOBDEVICE",
+            },
+            room_id: roomId,
+            session: {
+                application: "m.call",
+                call_id: "",
+                scope: "m.room",
+            },
+        });
+        mockEvent.makeEncrypted(EventType.RoomMessageEncrypted, {}, "", "");
+        mockClient.emit(ClientEvent.ToDeviceEvent, mockEvent);
 
         const { userId, deviceId, keyBase64Encoded, index } = await receivedKeyResolvers.promise;
         expect(userId).toBe("@bob:example.org");
@@ -148,6 +147,41 @@ describe("ToDeviceKeyTransport", () => {
         expect(index).toBe(testKeyIndex);
 
         expect(statistics.counters.roomEventEncryptionKeysReceived).toBe(1);
+    });
+
+    it("should drop non-encrypted/clear to-devic events", () => {
+        const receivedKeyResolvers = vi.fn();
+        transport.on(KeyTransportEvents.ReceivedKeys, (membership, keyBase64Encoded, index, _timestamp) => {
+            receivedKeyResolvers();
+        });
+        transport.start();
+
+        const testEncoded = "ABCDEDF";
+        const testKeyIndex = 2;
+
+        const clearEvent = makeMatrixEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, {
+            keys: {
+                index: testKeyIndex,
+                key: testEncoded,
+            },
+            member: {
+                claimed_device_id: "BOBDEVICE",
+            },
+            room_id: roomId,
+            session: {
+                application: "m.call",
+                call_id: "",
+                scope: "m.room",
+            },
+        });
+        mockClient.emit(ClientEvent.ToDeviceEvent, clearEvent);
+
+        expect(receivedKeyResolvers).toHaveBeenCalledTimes(0);
+
+        clearEvent.makeEncrypted(EventType.RoomMessageEncrypted, {}, "", "");
+        mockClient.emit(ClientEvent.ToDeviceEvent, clearEvent);
+
+        expect(receivedKeyResolvers).toHaveBeenCalledTimes(1);
     });
 
     it("should not sent to ourself", async () => {
@@ -168,24 +202,24 @@ describe("ToDeviceKeyTransport", () => {
         const testEncoded = "ABCDEDF";
         const testKeyIndex = 2;
 
-        mockClient.emit(
-            ClientEvent.ToDeviceEvent,
-            makeMockEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, {
-                keys: {
-                    index: testKeyIndex,
-                    key: testEncoded,
-                },
-                member: {
-                    claimed_device_id: "BOBDEVICE",
-                },
-                room_id: "!anotherroom:id",
-                session: {
-                    application: "m.call",
-                    call_id: "",
-                    scope: "m.room",
-                },
-            }),
-        );
+        const keyEvent = makeMatrixEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, {
+            keys: {
+                index: testKeyIndex,
+                key: testEncoded,
+            },
+            member: {
+                claimed_device_id: "BOBDEVICE",
+            },
+            room_id: "!anotherroom:id",
+            session: {
+                application: "m.call",
+                call_id: "",
+                scope: "m.room",
+            },
+        });
+
+        keyEvent.makeEncrypted(EventType.RoomMessageEncrypted, {}, "", "");
+        mockClient.emit(ClientEvent.ToDeviceEvent, keyEvent);
 
         expect(mockLogger.warn).toHaveBeenCalledWith("Malformed Event: Mismatch roomId");
         expect(statistics.counters.roomEventEncryptionKeysReceived).toBe(0);
@@ -240,7 +274,7 @@ describe("ToDeviceKeyTransport", () => {
 
             mockClient.emit(
                 ClientEvent.ToDeviceEvent,
-                makeMockEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, event),
+                makeMatrixEvent(EventType.CallEncryptionKeysPrefix, "@bob:example.org", undefined, event),
             );
 
             expect(mockLogger.warn).toHaveBeenCalled();

--- a/spec/unit/matrixrtc/mocks.ts
+++ b/spec/unit/matrixrtc/mocks.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { EventEmitter } from "node:stream";
 import { type Mocked, type MockedObject } from "vitest";
 
-import { EventType, type Room, RoomEvent, type MatrixClient, type MatrixEvent } from "../../../src";
+import { EventType, type Room, RoomEvent, type MatrixClient, MatrixEvent } from "../../../src";
 import { CallMembership } from "../../../src/matrixrtc";
 import { secureRandomString } from "../../../src/randomstring";
 import { type RtcMembershipData, type SessionMembershipData } from "../../../src/matrixrtc/membershipData";
@@ -108,6 +108,7 @@ export type MockClient = MockedObject<
         | "cancelPendingEvent"
     >
 >;
+
 /**
  * Mocks a object that has all required methods for a MatrixRTC session client.
  */
@@ -230,6 +231,24 @@ export function makeMockEvent(
         getStateKey: vi.fn().mockReturnValue(stateKey),
         isDecryptionFailure: vi.fn().mockReturnValue(false),
     } as unknown as MatrixEvent;
+}
+
+export function makeMatrixEvent(
+    type: string,
+    sender: string,
+    roomId: string | undefined,
+    content: any,
+    timestamp?: number,
+    stateKey?: string,
+): MatrixEvent {
+    return new MatrixEvent({
+        type,
+        sender,
+        room_id: roomId,
+        content,
+        state_key: stateKey,
+        origin_server_ts: timestamp,
+    });
 }
 
 export function mockRTCEvent(

--- a/src/matrixrtc/ToDeviceKeyTransport.ts
+++ b/src/matrixrtc/ToDeviceKeyTransport.ts
@@ -152,13 +152,13 @@ export class ToDeviceKeyTransport
             return;
         }
 
-        // TODO: Not possible to check if the event is encrypted or not
-        // see https://github.com/matrix-org/matrix-rust-sdk/issues/4883
-        // if (evnt.getWireType() != EventType.RoomMessageEncrypted) {
-        //     // WARN: The call keys were sent in clear. Ignore them
-        //     logger.warn(`Call encryption keys sent in clear from: ${event.getSender()}`);
-        //     return;
-        // }
+        // NB: When received via the widget driver, the to-device events
+        // are properly reconstructed as if they are encrypted (see MatrixEvent#makeEncrypted).
+        if (event.getWireType() != EventType.RoomMessageEncrypted) {
+            // WARN: The call keys were sent in clear. Ignore them
+            this.logger.warn(`Call encryption keys sent in clear from: ${event.getSender()}`);
+            return;
+        }
 
         const content = this.getValidEventContent(event);
         if (!content) return;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

The rust sdk widget driver is now implementing the `encrypted` flag https://github.com/matrix-org/matrix-rust-sdk/pull/6795

It is then ok for the RTC to-device key transport to read the flag in order to ignore keys sent in clear.

This feature was already supported by the ElementWeb driver since long, so no need to synchronize release.
**But** for rust base client the rust-sdk must be merged before Element-Call udpates to this js-sdk change

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
