### PR TITLE
Fix package failing to load in Node ESM due to directory import

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -165,6 +165,9 @@
                 "no-console": "error",
                 "no-extra-boolean-cast": "error",
                 "unicorn/prefer-node-protocol": "off",
+
+                // Require extensions on imports to maintain Node compatibility and avoid issues with ESM resolution
+                "import/extensions": ["error", "ignorePackages"],
             },
         },
         {

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -24,7 +24,7 @@ import {
     hasRequiredStringProperty,
     isRecord,
 } from "../@types/type-guards.ts";
-import { Method } from "../http-api";
+import { Method } from "../http-api/index.ts";
 import { OAuthGrantType } from "./register.ts";
 import { sleep } from "../utils.ts";
 

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -34,7 +34,7 @@ import {
 } from "./register.ts";
 import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { sha256 } from "../digest.ts";
-import { HTTPError, Method } from "../http-api";
+import { HTTPError, Method } from "../http-api/index.ts";
 import { logger } from "../logger.ts";
 import { OAuth2Error } from "./error.ts";
 import { secureRandomString } from "../randomstring.ts";


### PR DESCRIPTION
Fixes #5459.

`src/oauth/index.ts` and `src/oauth/authorize.ts` import `../http-api` without an extension. That emits a directory import into `lib`, and Node ESM does not resolve directories, so it throws `ERR_UNSUPPORTED_DIR_IMPORT`. Because `lib/matrix.js` re-exports `./oauth`, this takes down any plain `import { createClient } from "matrix-js-sdk"` in a Node ESM project on 42.0.0 and 42.1.0-rc.0.

Changed both to `../http-api/index.ts`, matching the other 13 http-api imports in `src`.

I verified the fix against the published 42.0.0 by rewriting those two lines in `lib` to the emitted form (`../http-api/index.js`), after which the package imports cleanly on Node 22 and 24.

Notes: Fix matrix-js-sdk failing to import in Node ESM environments
