### PR TITLE
Validate that an error from OAuth token refresh looks like an OAuth error before treating as logout

### DIFF
--- a/spec/unit/oauth/tokenRefresher.spec.ts
+++ b/spec/unit/oauth/tokenRefresher.spec.ts
@@ -238,5 +238,65 @@ describe("OidcTokenRefresher", () => {
 
             await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
+
+        it("should not throw TokenRefreshLogoutError on a 4xx without a JSON body", async () => {
+            fetchMock.modifyRoute("token-endpoint", {
+                response: {
+                    status: 403,
+                    headers: {
+                        "Content-Type": "text/html",
+                    },
+                    body: "<html><body>Blocked by your network administrator</body></html>",
+                },
+            });
+
+            const fn = vi.fn();
+            const refresher = new TokenRefresher(auth, fn);
+
+            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+        });
+
+        it("should not throw TokenRefreshLogoutError on a 4xx with a JSON body which is not an OAuth 2.0 error", async () => {
+            fetchMock.modifyRoute("token-endpoint", {
+                response: {
+                    status: 429,
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: {
+                        some: "field",
+                    },
+                },
+            });
+
+            const fn = vi.fn();
+            const refresher = new TokenRefresher(auth, fn);
+
+            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+        });
+
+        it("should throw TokenRefreshLogoutError on a 4xx Matrix API error code which looks like an OAuth 2.0 error", async () => {
+            // The C-S API [standard error response](https://spec.matrix.org/v1.18/client-server-api/#standard-error-response)
+            // is hard to distinguish from an RFC 6749 error response. This test asserts the current logic from
+            // https://spec.matrix.org/v1.18/client-server-api/#refresh-token-grant where a 4xx response is treated as a
+            // logout even if the body is a misidentified Matrix API error response.
+            fetchMock.modifyRoute("token-endpoint", {
+                response: {
+                    status: 429,
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: {
+                        errcode: "M_LIMIT_EXCEEDED",
+                        error: "Rate limited",
+                    },
+                },
+            });
+
+            const fn = vi.fn();
+            const refresher = new TokenRefresher(auth, fn);
+
+            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.toThrow(TokenRefreshLogoutError);
+        });
     });
 });

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { secureRandomString } from "../randomstring.ts";
-import { OAuth2Error } from "./error.ts";
+import { OAuth2Error, type OAuth2ErrorResponse } from "./error.ts";
 import { type ValidatedAuthMetadata } from "./discover.ts";
 import {
     hasOptionalNumberProperty,
@@ -127,10 +127,7 @@ export function isValidDeviceAccessTokenResponse(response: unknown): response is
 /**
  * Error from the OAuth2 token endpoint when exchanging a token for grant_type device_code.
  */
-export interface DeviceAccessTokenError {
-    error: string;
-    error_description?: string;
-    error_uri?: string;
+export interface DeviceAccessTokenError extends OAuth2ErrorResponse {
     session_state?: string;
 }
 

--- a/src/oauth/error.ts
+++ b/src/oauth/error.ts
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { hasOptionalStringProperty, hasRequiredStringProperty, isRecord } from "../@types/type-guards.ts";
+import { HTTPError } from "../http-api/errors.ts";
+
 /**
  * Errors expected to be encountered during OAuth2 discovery, client registration, and authentication.
  * Not intended to be displayed directly to the user.
@@ -31,4 +34,72 @@ export enum OAuth2Error {
     RefreshTokenFailed = "Failed to refresh token",
     RevokeTokenFailed = "Failed to revoke token",
     DeviceAuthorizationGrantFailed = "Failed to perform device authorization grant",
+}
+
+/**
+ * An error response from an OAuth 2.0 endpoint,
+ * as specified in https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+ */
+export interface OAuth2ErrorResponse {
+    /** A single ASCII error code, e.g. `invalid_grant`. */
+    error: string;
+    /** Human-readable ASCII text providing additional information about the error. */
+    error_description?: string;
+    /** A URI identifying a human-readable web page with information about the error. */
+    error_uri?: string;
+}
+
+/**
+ * Check whether the given (JSON-parsed) response body is an OAuth 2.0 error response
+ * as specified in https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+ * @param response - the parsed response body to check
+ * @returns whether the response is a valid {@link OAuth2ErrorResponse}
+ */
+export function isOAuth2ErrorResponse(response: unknown): response is OAuth2ErrorResponse {
+    return (
+        isRecord(response) &&
+        hasRequiredStringProperty(response, "error") &&
+        hasOptionalStringProperty(response, "error_description") &&
+        hasOptionalStringProperty(response, "error_uri")
+    );
+}
+
+/**
+ * An error thrown when a request to an OAuth 2.0 endpoint fails.
+ *
+ * If the endpoint responded with a JSON body matching the error response format specified in
+ * https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 then it is available as {@link errorResponse}.
+ */
+export class OAuth2HTTPError extends HTTPError implements OAuth2ErrorResponse {
+    /**
+     * RFC 6749 section 5.2 error code, e.g. `invalid_grant`
+     *
+     * IANA matains a registry of valid values at
+     * https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#extensions-error
+     */
+    public error: string;
+
+    /**
+     * RFC 6749 section 5.2 human-readable ASCII text providing additional information about the error.
+     * This field is optional and may be omitted by the endpoint.
+     */
+    public error_description?: string;
+
+    /**
+     * RFC 6749 section 5.2 URI identifying a human-readable web page with information about the error.
+     * This field is optional and may be omitted by the endpoint.
+     */
+    public error_uri?: string;
+
+    public constructor(
+        msg: string,
+        httpStatus: number | undefined,
+        httpHeaders: Headers | undefined,
+        { error, error_description, error_uri }: OAuth2ErrorResponse,
+    ) {
+        super(msg, httpStatus, httpHeaders);
+        this.error = error;
+        this.error_description = error_description;
+        this.error_uri = error_uri;
+    }
 }

--- a/src/oauth/error.ts
+++ b/src/oauth/error.ts
@@ -65,10 +65,8 @@ export function isOAuth2ErrorResponse(response: unknown): response is OAuth2Erro
 }
 
 /**
- * An error thrown when a request to an OAuth 2.0 endpoint fails.
- *
- * If the endpoint responded with a JSON body matching the error response format specified in
- * https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 then it is available as {@link errorResponse}.
+ * An error thrown when a request to an OAuth 2.0 endpoint fails with a body matching the error
+ * response format specified in [RFC 6749 section 5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2).
  */
 export class OAuth2HTTPError extends HTTPError implements OAuth2ErrorResponse {
     /**

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -36,7 +36,7 @@ import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { sha256 } from "../digest.ts";
 import { HTTPError, Method } from "../http-api/index.ts";
 import { logger } from "../logger.ts";
-import { OAuth2Error } from "./error.ts";
+import { isOAuth2ErrorResponse, OAuth2Error, type OAuth2ErrorResponse, OAuth2HTTPError } from "./error.ts";
 import { secureRandomString } from "../randomstring.ts";
 import { type NonEmptyArray } from "../@types/common.ts";
 
@@ -289,7 +289,20 @@ export class OAuth2 {
         });
 
         if (res.status >= 400) {
-            throw new HTTPError(error, res.status, res.headers);
+            let errorResponse: OAuth2ErrorResponse | undefined;
+            try {
+                const body = await res.json();
+                if (isOAuth2ErrorResponse(body)) {
+                    errorResponse = body;
+                }
+            } catch {
+                // The endpoint didn't give us a JSON body, so we definitely have no OAuth 2.0 error response to use
+            }
+            if (errorResponse) {
+                throw new OAuth2HTTPError(error, res.status, res.headers, errorResponse);
+            } else {
+                throw new HTTPError(error, res.status, res.headers);
+            }
         }
 
         return await res.json();

--- a/src/oauth/tokenRefresher.ts
+++ b/src/oauth/tokenRefresher.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { type AccessTokens, HTTPError, type TokenRefreshFunction, TokenRefreshLogoutError } from "../http-api/index.ts";
+import { OAuth2HTTPError } from "./error.ts";
 import { type OAuth2 } from "./index.ts";
 
 /**
@@ -54,8 +55,14 @@ export class TokenRefresher {
     };
 
     private shouldLogoutOnError(error: HTTPError): boolean {
-        // As per https://spec.matrix.org/v1.18/client-server-api/#refresh-token-grant
-        return typeof error.httpStatus === "number" && error.httpStatus < 500 && error.httpStatus >= 400;
+        // Treat as logout as per https://spec.matrix.org/v1.18/client-server-api/#refresh-token-grant
+        // after making sure it is an RFC 6749 section 5.2 error response
+        return (
+            error instanceof OAuth2HTTPError &&
+            typeof error.httpStatus === "number" &&
+            error.httpStatus < 500 &&
+            error.httpStatus >= 400
+        );
     }
 
     private async getNewTokens(refreshToken: string): Promise<AccessTokens> {


### PR DESCRIPTION
The spec says for handling errors when making a (https://spec.matrix.org/v1.19/client-server-api/#refresh-token-grant request:

> The client MUST handle access token refresh failures as follows:
>
> - If the refresh fails due to network issues or a 5xx HTTP status code from the server, the client should retry the request with the old refresh token later.
> - If the refresh fails due to a 4xx HTTP status code from the server, the client should consider the session logged out.

This is in the context that the token endpoint is specified to return well-formed RFC 6749 responses.

This PR validates that the 4xx response looks like an OAuth error prior to treating it as the a session logout which reverts the logic to be closer to what it was prior to https://github.com/matrix-org/matrix-js-sdk/pull/5390.

[For interest, the [equivalent logic in matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/blob/85873619dabaa21cc40444ef58053704ced695f9/crates/matrix-sdk/src/client/futures.rs#L128-L149) has an even stricter check and only treats as a logout if the OAuth error code is `invalid_grant`. MSC4526 proposes to standardise on similar behaviour]

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
