### PR TITLE
Add support for key rotation participant limit

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -889,6 +889,47 @@ describe("MatrixRTCSession", () => {
 
             await sess.leaveRoomSession();
         });
+
+        it("reports and emits when the key rotation participant limit is reached", async () => {
+            client.encryptAndSendToDevice = vi.fn().mockResolvedValue(undefined);
+            const ownMembership = {
+                ...sessionMembershipTemplate,
+                user_id: client.getUserId()!,
+                device_id: client.getDeviceId()!,
+            };
+            const bob = { ...sessionMembershipTemplate, user_id: "@bob:user.example", device_id: "BBBBBB" };
+            const carl = { ...sessionMembershipTemplate, user_id: "@carl:user.example", device_id: "CCCCCC" };
+
+            const mockRoom = makeMockRoom([ownMembership, bob]);
+            const sess = MatrixRTCSession.sessionForSlot(client, mockRoom, callSession);
+            sess.joinRTCSession(owmMemberIdentity, [mockFocus], mockFocus, {
+                manageMediaKeys: true,
+                keyRotationParticipantLimit: 3,
+            });
+            await flushPromises();
+
+            const onKeyRotationSuppressedChanged = vi.fn();
+            sess.on(MatrixRTCSessionEvent.KeyRotationSuppressedChanged, onKeyRotationSuppressedChanged);
+
+            expect(sess.isKeyRotationSuppressed).toBe(false);
+
+            // A third participant takes us to the limit
+            mockRoomState(mockRoom, [ownMembership, bob, carl]);
+            await sess._onRTCSessionMemberUpdate();
+
+            expect(sess.isKeyRotationSuppressed).toBe(true);
+            expect(onKeyRotationSuppressedChanged).toHaveBeenCalledExactlyOnceWith(true);
+
+            // Back below the limit
+            mockRoomState(mockRoom, [ownMembership, bob]);
+            await sess._onRTCSessionMemberUpdate();
+
+            expect(sess.isKeyRotationSuppressed).toBe(false);
+            expect(onKeyRotationSuppressedChanged).toHaveBeenLastCalledWith(false);
+            expect(onKeyRotationSuppressedChanged).toHaveBeenCalledTimes(2);
+
+            await sess.leaveRoomSession();
+        });
     });
 
     describe("read status", () => {

--- a/spec/unit/matrixrtc/RTCEncryptionManager.spec.ts
+++ b/spec/unit/matrixrtc/RTCEncryptionManager.spec.ts
@@ -451,6 +451,175 @@ describe("RTCEncryptionManager", () => {
             );
         });
 
+        it("Should not rotate key when a user joins and the participant limit is reached", async () => {
+            vi.useFakeTimers();
+
+            const members = [
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+                aStateBaseMembership("@carl:example.org", "CARLDEVICE"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            const gracePeriod = 1_000;
+            // initial rollout
+            encryptionManager.join({ keyRotationGracePeriodMs: gracePeriod, keyRotationParticipantLimit: 4 });
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            onEncryptionKeysChanged.mockClear();
+            mockTransport.sendKey.mockClear();
+
+            // Well past the grace period, so only the participant limit can prevent a rotation here
+            await vi.advanceTimersByTimeAsync(gracePeriod + 5_000);
+            members.push(aStateBaseMembership("@dave:example.org", "DAVEDEVICE"));
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            expect(mockTransport.sendKey).toHaveBeenCalledTimes(1);
+            expect(mockTransport.sendKey).toHaveBeenCalledWith(
+                expect.any(String),
+                // The key index should not have been incremented
+                0,
+                // And the existing key only sent to the new joiner
+                [expect.objectContaining({ userId: "@dave:example.org", deviceId: "DAVEDEVICE" })],
+            );
+
+            // The key has not changed, so there is nothing to roll out locally
+            await vi.advanceTimersByTimeAsync(5_000);
+            expect(onEncryptionKeysChanged).not.toHaveBeenCalled();
+        });
+
+        it("Should rotate key when a user joins and the participant limit is not reached yet", async () => {
+            vi.useFakeTimers();
+
+            const members = [
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            const gracePeriod = 1_000;
+            // initial rollout
+            encryptionManager.join({ keyRotationGracePeriodMs: gracePeriod, keyRotationParticipantLimit: 4 });
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            onEncryptionKeysChanged.mockClear();
+            mockTransport.sendKey.mockClear();
+
+            await vi.advanceTimersByTimeAsync(gracePeriod + 5_000);
+            members.push(aStateBaseMembership("@carl:example.org", "CARLDEVICE"));
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            // 3 participants is still below the limit of 4, so this rotates as usual
+            expect(mockTransport.sendKey).toHaveBeenCalledWith(
+                expect.any(String),
+                1,
+                members.map((m) => ({ userId: m.sender, deviceId: m.deviceId, membershipTs: m.createdTs() })),
+            );
+
+            await vi.advanceTimersByTimeAsync(5_000);
+            expect(onEncryptionKeysChanged).toHaveBeenCalled();
+        });
+
+        it("Should not rotate key when a user leaves and the participant limit is reached", async () => {
+            vi.useFakeTimers();
+
+            const members = [
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+                aStateBaseMembership("@carl:example.org", "CARLDEVICE"),
+                aStateBaseMembership("@dave:example.org", "DAVEDEVICE"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            // initial rollout
+            encryptionManager.join({ keyRotationParticipantLimit: 3 });
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            onEncryptionKeysChanged.mockClear();
+            mockTransport.sendKey.mockClear();
+
+            // Dave leaves, 3 participants are left which is still at the limit
+            getMembershipMock.mockReturnValue(members.slice(0, 3));
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(5_000);
+
+            expect(mockTransport.sendKey).not.toHaveBeenCalled();
+            expect(onEncryptionKeysChanged).not.toHaveBeenCalled();
+        });
+
+        it("Should rotate key once the session shrinks below the participant limit", async () => {
+            vi.useFakeTimers();
+
+            const members = [
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+                aStateBaseMembership("@carl:example.org", "CARLDEVICE"),
+                aStateBaseMembership("@dave:example.org", "DAVEDEVICE"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            // initial rollout
+            encryptionManager.join({ keyRotationParticipantLimit: 3 });
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(1);
+
+            mockTransport.sendKey.mockClear();
+
+            // Dave leaves, the rotation is suppressed as we are still at the limit
+            getMembershipMock.mockReturnValue(members.slice(0, 3));
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(5_000);
+            expect(mockTransport.sendKey).not.toHaveBeenCalled();
+
+            // Carl leaves as well, we are now below the limit and the key is rotated. Dave, who left while we
+            // were above the limit, is excluded by this rotation too.
+            const remaining = members.slice(0, 2);
+            getMembershipMock.mockReturnValue(remaining);
+            encryptionManager.onMembershipsUpdate();
+            await vi.advanceTimersByTimeAsync(5_000);
+
+            expect(mockTransport.sendKey).toHaveBeenCalledTimes(1);
+            expect(mockTransport.sendKey).toHaveBeenCalledWith(
+                expect.any(String),
+                1,
+                remaining.map((m) => ({ userId: m.sender, deviceId: m.deviceId, membershipTs: m.createdTs() })),
+            );
+        });
+
+        it("Should expose whether key rotation is suppressed", () => {
+            const members = [
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+            ];
+            getMembershipMock.mockReturnValue(members);
+
+            encryptionManager.join({ keyRotationParticipantLimit: 3 });
+            expect(encryptionManager.isKeyRotationSuppressed).toBe(false);
+
+            members.push(aStateBaseMembership("@carl:example.org", "CARLDEVICE"));
+            expect(encryptionManager.isKeyRotationSuppressed).toBe(true);
+
+            getMembershipMock.mockReturnValue(members.slice(0, 2));
+            expect(encryptionManager.isKeyRotationSuppressed).toBe(false);
+        });
+
+        it("Should never report key rotation as suppressed if encryption is disabled", () => {
+            getMembershipMock.mockReturnValue([
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE"),
+                aStateBaseMembership("@bob:example.org", "BOBDEVICE2"),
+                aStateBaseMembership("@carl:example.org", "CARLDEVICE"),
+            ]);
+
+            encryptionManager.join({ manageMediaKeys: false, keyRotationParticipantLimit: 3 });
+
+            expect(encryptionManager.isKeyRotationSuppressed).toBe(false);
+        });
+
         it("Should not distribute keys if encryption is disabled", async () => {
             vi.useFakeTimers();
             const members = [

--- a/src/matrixrtc/EncryptionManager.ts
+++ b/src/matrixrtc/EncryptionManager.ts
@@ -16,6 +16,12 @@ export function getEncryptionKeyMapKey(membership: CallMembershipIdentityParts):
  */
 export interface IEncryptionManager {
     /**
+     * Whether the session currently has too many participants for the media key to be rotated.
+     * @see EncryptionConfig.keyRotationParticipantLimit
+     */
+    readonly isKeyRotationSuppressed: boolean;
+
+    /**
      * Joins the encryption manager with the provided configuration.
      *
      * @param joinConfig - The configuration for joining encryption, or undefined

--- a/src/matrixrtc/EncryptionManager.ts
+++ b/src/matrixrtc/EncryptionManager.ts
@@ -16,7 +16,7 @@ export function getEncryptionKeyMapKey(membership: CallMembershipIdentityParts):
  */
 export interface IEncryptionManager {
     /**
-     * Whether the session currently has too many participants for the media key to be rotated.
+     * Whether the key rotation is currently halted.
      * @see EncryptionConfig.keyRotationParticipantLimit
      */
     readonly isKeyRotationSuppressed: boolean;

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -835,6 +835,8 @@ export class MatrixRTCSession extends TypedEventEmitter<
         // Clear the flag.
         this.membershipNeedsRecalculation = false;
         const oldMemberships = this.memberships;
+        // Needs to be computed before `this.memberships` is updated below, since it is derived from it.
+        const wasKeyRotationSuppressed = this.isKeyRotationSuppressed;
 
         this.memberships = await MatrixRTCSession.sessionMembershipsForSlot(
             this.room,
@@ -876,7 +878,6 @@ export class MatrixRTCSession extends TypedEventEmitter<
         } else {
             this.logger.debug(`No membership changes detected for room ${this.roomSubset.roomId}`);
         }
-        const wasKeyRotationSuppressed = this.isKeyRotationSuppressed;
         // This also needs to be done if `changed` = false
         // A member might have updated their fingerprint (created_ts)
         this.encryptionManager?.onMembershipsUpdate(oldMemberships);

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -65,6 +65,8 @@ export enum MatrixRTCSessionEvent {
     MembershipManagerError = "membership_manager_error",
     /** The RTCSession did send a call notification caused by joining the call as the first member */
     DidSendCallNotification = "did_send_call_notification",
+    /** Whether the session is too large for the media key to be rotated has changed */
+    KeyRotationSuppressedChanged = "key_rotation_suppressed_changed",
 }
 
 export type MatrixRTCSessionEventHandlerMap = {
@@ -83,6 +85,7 @@ export type MatrixRTCSessionEventHandlerMap = {
     [MatrixRTCSessionEvent.DidSendCallNotification]: (
         notificationContentNew: { event_id: string } & IRTCNotificationContent,
     ) => void;
+    [MatrixRTCSessionEvent.KeyRotationSuppressedChanged]: (isKeyRotationSuppressed: boolean) => void;
 };
 
 export interface SessionConfig {
@@ -199,6 +202,17 @@ export interface EncryptionConfig {
     keyRotationGracePeriodMs?: number;
 
     /**
+     * The number of participants in the session at which the media key will no longer be rotated.
+     *
+     * Rotating a key requires sending it to every participant device, so in large sessions the cost of rotating
+     * on every join/leave becomes prohibitive. At this limit the current key is kept and
+     * distributed to new joiners. No new keys are generated for joiners/leavers.
+     *
+     * Defaults to 30.
+     */
+    keyRotationParticipantLimit?: number;
+
+    /**
      * The delay (in milliseconds) after a member leaves before we create and publish a new key, because people
      * tend to leave calls at the same time.
      * @deprecated - Not used by the new encryption manager.
@@ -288,6 +302,17 @@ export class MatrixRTCSession extends TypedEventEmitter<
     }
     public get delayId(): string | undefined {
         return this.membershipManager?.delayId;
+    }
+
+    /**
+     * Whether the session currently has too many participants for the media key to be rotated.
+     *
+     * While this is true, the current key is still shared with new joiners, but no new key is generated for
+     * joiners or leavers. Changes are signalled by {@link MatrixRTCSessionEvent.KeyRotationSuppressedChanged}.
+     * @see EncryptionConfig.keyRotationParticipantLimit
+     */
+    public get isKeyRotationSuppressed(): boolean {
+        return this.encryptionManager?.isKeyRotationSuppressed ?? false;
     }
 
     /**
@@ -844,9 +869,16 @@ export class MatrixRTCSession extends TypedEventEmitter<
         } else {
             this.logger.debug(`No membership changes detected for room ${this.roomSubset.roomId}`);
         }
+        const wasKeyRotationSuppressed = this.isKeyRotationSuppressed;
         // This also needs to be done if `changed` = false
         // A member might have updated their fingerprint (created_ts)
         this.encryptionManager?.onMembershipsUpdate(oldMemberships);
+        if (this.isKeyRotationSuppressed !== wasKeyRotationSuppressed) {
+            this.logger.info(
+                `Key rotation is now ${this.isKeyRotationSuppressed ? "suppressed" : "active again"} (${this.memberships.length} members)`,
+            );
+            this.emit(MatrixRTCSessionEvent.KeyRotationSuppressedChanged, this.isKeyRotationSuppressed);
+        }
 
         this.setExpiryTimer();
     };

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -214,7 +214,7 @@ export interface EncryptionConfig {
      * on every join/leave becomes prohibitive. At this limit the current key is kept and
      * distributed to new joiners. No new keys are generated for joiners/leavers.
      *
-     * Defaults to 30.
+     * Defaults to undefined.
      */
     keyRotationParticipantLimit?: number;
 
@@ -311,11 +311,8 @@ export class MatrixRTCSession extends TypedEventEmitter<
     }
 
     /**
-     * Whether the session currently has too many participants for the media key to be rotated.
-     *
-     * While this is true, the current key is still shared with new joiners, but no new key is generated for
-     * joiners or leavers. Changes are signalled by {@link MatrixRTCSessionEvent.KeyRotationSuppressedChanged}.
-     * @see EncryptionConfig.keyRotationParticipantLimit
+     * Whether the key rotation is currently halted.
+     * mirror of: EncryptionConfig.keyRotationParticipantLimit
      */
     public get isKeyRotationSuppressed(): boolean {
         return this.encryptionManager?.isKeyRotationSuppressed ?? false;

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -36,8 +36,14 @@ import { computeRtcIdentityRaw } from "./membershipData/rtc.ts";
 
 /**
  * Default for {@link EncryptionConfig.keyRotationParticipantLimit}.
+ *
+ * Setting this to undefined implies that we do not have a limit and full rotations are always done.
+ * This is the most secure and least performant option.
+ * It is highly recommended to set this to < 50 for acutal client deployments.
+ * But before setting this, make yourself familiar with the exact security implications.
+ * Key, rotations will stop when reaching this user limit in a call. The call will still be encrypted.
  */
-const DEFAULT_KEY_ROTATION_PARTICIPANT_LIMIT = 30;
+const DEFAULT_KEY_ROTATION_PARTICIPANT_LIMIT: number | undefined = undefined;
 
 /**
  * RTCEncryptionManager is used to manage the encryption keys for a call.
@@ -160,6 +166,7 @@ export class RTCEncryptionManager implements IEncryptionManager {
      */
     public get isKeyRotationSuppressed(): boolean {
         if (!this.manageMediaKeys) return false;
+        if (this.keyRotationParticipantLimit === undefined) return false;
         return this.getMemberships().length >= this.keyRotationParticipantLimit;
     }
 

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -452,10 +452,10 @@ export class RTCEncryptionManager implements IEncryptionManager {
                 toDistributeTo,
             );
             newOutboundEncryptionSession.sharedWith.push(...toDistributeTo);
-            const outboundSessionList = newOutboundEncryptionSession.sharedWith.map((m) => `${m.userId}:${m.deviceId}`).join(",");
-            this.logger?.trace(
-                `key index:${newOutboundEncryptionSession.keyId} sent to ${outboundSessionList}`,
-            );
+            const outboundSessionList = newOutboundEncryptionSession.sharedWith
+                .map((m) => `${m.userId}:${m.deviceId}`)
+                .join(",");
+            this.logger?.trace(`key index:${newOutboundEncryptionSession.keyId} sent to ${outboundSessionList}`);
             if (hasKeyChanged) {
                 // Delay a bit before using this key
                 // It is recommended not to start using a key immediately but instead wait for a short time to make sure it is delivered.

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -445,8 +445,9 @@ export class RTCEncryptionManager implements IEncryptionManager {
                 toDistributeTo,
             );
             newOutboundEncryptionSession.sharedWith.push(...toDistributeTo);
+            const outboundSessionList = newOutboundEncryptionSession.sharedWith.map((m) => `${m.userId}:${m.deviceId}`).join(",");
             this.logger?.trace(
-                `key index:${newOutboundEncryptionSession.keyId} sent to ${newOutboundEncryptionSession.sharedWith.map((m) => `${m.userId}:${m.deviceId}`).join(",")}`,
+                `key index:${newOutboundEncryptionSession.keyId} sent to ${outboundSessionList}`,
             );
             if (hasKeyChanged) {
                 // Delay a bit before using this key

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -404,9 +404,11 @@ export class RTCEncryptionManager implements IEncryptionManager {
 
         // Rotating means sending the new key to every participant, this is expensive in large session.
         if (this.isKeyRotationSuppressed) {
-            this.logger?.debug(
-                `New joiners detected, but the session has ${toShareWith.length} participants (limit:${this.keyRotationParticipantLimit}), keeping the key`,
-            );
+            if (anyJoined.length > 0) {
+                this.logger?.debug(
+                    `New joiners detected, but the session has ${toShareWith.length} participants (limit:${this.keyRotationParticipantLimit}), keeping the key`,
+                );
+            }
             toDistributeTo = anyJoined;
         } else {
             if (anyLeft.length > 0) {

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -39,7 +39,7 @@ import { computeRtcIdentityRaw } from "./membershipData/rtc.ts";
  *
  * Setting this to undefined implies that we do not have a limit and full rotations are always done.
  * This is the most secure and least performant option.
- * It is highly recommended to set this to < 50 for acutal client deployments.
+ * It is highly recommended to set this to < 50 for client deployments that are planned to be used for large calls.
  * But before setting this, make yourself familiar with the exact security implications.
  * Key, rotations will stop when reaching this user limit in a call. The call will still be encrypted.
  */
@@ -162,6 +162,11 @@ export class RTCEncryptionManager implements IEncryptionManager {
 
     /**
      * Whether the session currently has too many participants for the key to be rotated.
+     *
+     * This is computed by checking the participant count. If there are too many participants for efficient rotations,
+     * the key rotation will be suppressed.
+     * While this is true, the current key is still shared with new joiners and the current call is still fully encrypted,
+     * but no new key is generated for joiners or leavers. Changes are signalled by {@link MatrixRTCSessionEvent.KeyRotationSuppressedChanged}.
      * @see EncryptionConfig.keyRotationParticipantLimit
      */
     public get isKeyRotationSuppressed(): boolean {

--- a/src/matrixrtc/RTCEncryptionManager.ts
+++ b/src/matrixrtc/RTCEncryptionManager.ts
@@ -35,6 +35,11 @@ import { OutdatedKeyFilter } from "./utils.ts";
 import { computeRtcIdentityRaw } from "./membershipData/rtc.ts";
 
 /**
+ * Default for {@link EncryptionConfig.keyRotationParticipantLimit}.
+ */
+const DEFAULT_KEY_ROTATION_PARTICIPANT_LIMIT = 30;
+
+/**
  * RTCEncryptionManager is used to manage the encryption keys for a call.
  *
  * It is responsible for distributing the keys to the other participants and rotating the keys if needed.
@@ -94,6 +99,14 @@ export class RTCEncryptionManager implements IEncryptionManager {
     private keyRotationGracePeriodMs = 10_000;
 
     /**
+     * The number of participants at or above which we stop rotating the key altogether.
+     * The current key is still distributed to new joiners, but no new key is generated.
+     * @see EncryptionConfig.keyRotationParticipantLimit
+     * @private
+     */
+    private keyRotationParticipantLimit = DEFAULT_KEY_ROTATION_PARTICIPANT_LIMIT;
+
+    /**
      * If a new key distribution is being requested while one is going on, we will set this flag to true.
      * This will ensure that a new round is started after the current one.
      * @private
@@ -139,6 +152,15 @@ export class RTCEncryptionManager implements IEncryptionManager {
     ) {
         this.logger = parentLogger?.getChild(`[EncryptionManager]`);
         this.rtcIdentityProvider = rtcBackendIdProvider ?? computeRtcIdentityRaw;
+    }
+
+    /**
+     * Whether the session currently has too many participants for the key to be rotated.
+     * @see EncryptionConfig.keyRotationParticipantLimit
+     */
+    public get isKeyRotationSuppressed(): boolean {
+        if (!this.manageMediaKeys) return false;
+        return this.getMemberships().length >= this.keyRotationParticipantLimit;
     }
 
     private async getOwnRtcBackendIdentity(): Promise<string> {
@@ -221,6 +243,8 @@ export class RTCEncryptionManager implements IEncryptionManager {
         this.useHashedRtcBackendIdentity = joinConfig?.unstableSendStickyEvents ?? false;
         this.useKeyDelay = joinConfig?.useKeyDelay ?? 1000;
         this.keyRotationGracePeriodMs = joinConfig?.keyRotationGracePeriodMs ?? 10_000;
+        this.keyRotationParticipantLimit =
+            joinConfig?.keyRotationParticipantLimit ?? DEFAULT_KEY_ROTATION_PARTICIPANT_LIMIT;
 
         this.transport.on(KeyTransportEvents.ReceivedKeys, this.onNewKeyReceived);
         void this.getOwnRtcBackendIdentity(); // precompute own identity
@@ -374,53 +398,63 @@ export class RTCEncryptionManager implements IEncryptionManager {
         );
 
         let toDistributeTo: ParticipantDeviceInfo[] = [];
-        let outboundKey: OutboundEncryptionSession;
+        //default to current session
+        let newOutboundEncryptionSession: OutboundEncryptionSession = this.outboundSession!;
         let hasKeyChanged = false;
-        if (anyLeft.length > 0) {
-            // We need to rotate the key
-            const newOutboundKey = this.createNewOutboundSession();
-            hasKeyChanged = true;
-            toDistributeTo = toShareWith;
-            outboundKey = newOutboundKey;
-        } else if (anyJoined.length > 0) {
-            const now = Date.now();
-            const keyAge = now - this.outboundSession!.creationTS;
-            // If the current key is recently created (less than `keyRotationGracePeriodMs`), we can keep it and just distribute it to the new joiners.
-            if (keyAge < this.keyRotationGracePeriodMs) {
-                // keep the same key
-                // XXX In the future we want to distribute a ratcheted key, not the current one
-                this.logger?.debug(`New joiners detected, but the key is recent enough (age:${keyAge}), keeping it`);
-                toDistributeTo = anyJoined;
-                outboundKey = this.outboundSession!;
-            } else {
+
+        // Rotating means sending the new key to every participant, this is expensive in large session.
+        if (this.isKeyRotationSuppressed) {
+            this.logger?.debug(
+                `New joiners detected, but the session has ${toShareWith.length} participants (limit:${this.keyRotationParticipantLimit}), keeping the key`,
+            );
+            toDistributeTo = anyJoined;
+        } else {
+            if (anyLeft.length > 0) {
                 // We need to rotate the key
-                this.logger?.debug(`New joiners detected, rotating the key`);
-                const newOutboundKey = this.createNewOutboundSession();
+                newOutboundEncryptionSession = this.createNewOutboundSession();
                 hasKeyChanged = true;
                 toDistributeTo = toShareWith;
-                outboundKey = newOutboundKey;
+            } else if (anyJoined.length > 0) {
+                const keyAge = Date.now() - this.outboundSession!.creationTS;
+                if (keyAge < this.keyRotationGracePeriodMs) {
+                    this.logger?.debug(
+                        `New joiners detected, but the key is recent enough (age:${keyAge}), keeping it`,
+                    );
+                    toDistributeTo = anyJoined;
+                } else {
+                    this.logger?.debug(`New joiners detected, rotating the key`);
+                    // We need to rotate the key
+                    newOutboundEncryptionSession = this.createNewOutboundSession();
+                    hasKeyChanged = true;
+                    toDistributeTo = toShareWith;
+                }
             }
-        } else {
-            // no changes
+        }
+        // return early if we dont have anything to distribute.
+        if (toDistributeTo.length === 0) {
             return;
         }
 
         try {
             this.logger?.trace(`Sending key...`);
-            await this.transport.sendKey(encodeBase64(outboundKey.key), outboundKey.keyId, toDistributeTo);
-            outboundKey.sharedWith.push(...toDistributeTo);
+            await this.transport.sendKey(
+                encodeBase64(newOutboundEncryptionSession.key),
+                newOutboundEncryptionSession.keyId,
+                toDistributeTo,
+            );
+            newOutboundEncryptionSession.sharedWith.push(...toDistributeTo);
             this.logger?.trace(
-                `key index:${outboundKey.keyId} sent to ${outboundKey.sharedWith.map((m) => `${m.userId}:${m.deviceId}`).join(",")}`,
+                `key index:${newOutboundEncryptionSession.keyId} sent to ${newOutboundEncryptionSession.sharedWith.map((m) => `${m.userId}:${m.deviceId}`).join(",")}`,
             );
             if (hasKeyChanged) {
                 // Delay a bit before using this key
                 // It is recommended not to start using a key immediately but instead wait for a short time to make sure it is delivered.
-                this.logger?.trace(`Delay Rollout for key:${outboundKey.keyId}...`);
+                this.logger?.trace(`Delay Rollout for key:${newOutboundEncryptionSession.keyId}...`);
                 await sleep(this.useKeyDelay);
-                this.logger?.trace(`...Delayed rollout of index:${outboundKey.keyId} `);
+                this.logger?.trace(`...Delayed rollout of index:${newOutboundEncryptionSession.keyId} `);
                 this.addKeyToParticipantWithBackendIdentity(
-                    outboundKey.key,
-                    outboundKey.keyId,
+                    newOutboundEncryptionSession.key,
+                    newOutboundEncryptionSession.keyId,
                     this.ownMembership,
                     await this.getOwnRtcBackendIdentity(),
                 );


### PR DESCRIPTION

Part of the load test solutions (scale to 200users)

This needs to be used in element call. see: https://github.com/element-hq/element-call/pull/4172

The idea:
Currently we rotate the key each time someone joins or leaves:
"rotate the key": Generate a new key -> send it to everyone else in the call (this is done by each device as we do per sender keys)
This results in a ~ N^2 amount of keys being distributed.
This PR allows configuring a `key_rotation_participant_limit` at which clients will stop doing rotations. Instead
 - a new joiner will get the current in use key from all participants. (N keys per join, 0 keys per leave)
 
Security:
 - This is a tradeoff trading post compromising and forward secrecy for perfromance. This is why it is configurable in the js-sdk. Each call might have different requirements.
 - Up to 30 participants there is no perceived difference between the two approaches.
 - In larger calls it is common for most participants of a room to join. Things that ppl say target a wider audience. The full awareness who you are addressing (who is still in the call) is less present for users publishing media. In small calls chances are high that one says things just addressing the 3-10 users in the room. It is more imporatnat that leakead media cannot be decrypted.
 - This still is superior to a shared secret as we still only share the keys with the users that have been joined at least once. (a shared secret also would give access to the key for all room members independent of them joining the call)
 - **Edit** this PR was update to now [default to always rotate keys](https://github.com/matrix-org/matrix-js-sdk/pull/5486/commits/1d6dc4b753ad815d1362323c6ab4b9d04eaa8460) (also in large calls). This makes the key rotation limit an opt in property client publishers can activate by setting the introduced config value.
 
It is configurable via the join config.
To be discussed: should be configurable via slot? No. Not in the initial impl.
## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
