### PR TITLE
OAuth refresh token logout handling as per MSC4526

### DIFF
--- a/spec/unit/oauth/tokenRefresher.spec.ts
+++ b/spec/unit/oauth/tokenRefresher.spec.ts
@@ -297,5 +297,33 @@ describe("OidcTokenRefresher", () => {
 
             await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
+
+        // [MSC4526](https://github.com/matrix-org/matrix-spec-proposals/pull/4526) narrowed the list of errors which
+        // should cause a logout to only include `invalid_grant`. This test asserts that the other RFC 6749 error codes
+        // (that are expected from the token endpoint) do not cause a logout.
+        ["invalid_request", "unauthorized_client", "invalid_scope", "invalid_client", "unsupported_grant_type"].forEach(
+            (error) => {
+                it(`should not throw TokenRefreshLogoutError for an OAuth 2.0 ${error} error`, async () => {
+                    fetchMock.modifyRoute("token-endpoint", {
+                        response: {
+                            status: 401,
+                            headers: {
+                                "Content-Type": "application/json",
+                            },
+                            body: {
+                                error,
+                            },
+                        },
+                    });
+
+                    const fn = vi.fn();
+                    const refresher = new TokenRefresher(auth, fn);
+
+                    await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(
+                        TokenRefreshLogoutError,
+                    );
+                });
+            },
+        );
     });
 });

--- a/src/oauth/tokenRefresher.ts
+++ b/src/oauth/tokenRefresher.ts
@@ -55,14 +55,8 @@ export class TokenRefresher {
     };
 
     private shouldLogoutOnError(error: HTTPError): boolean {
-        // Treat as logout as per https://spec.matrix.org/v1.18/client-server-api/#refresh-token-grant
-        // after making sure it is an RFC 6749 section 5.2 error response
-        return (
-            error instanceof OAuth2HTTPError &&
-            typeof error.httpStatus === "number" &&
-            error.httpStatus < 500 &&
-            error.httpStatus >= 400
-        );
+        // Treat as logout using logic from [MSC4526](https://github.com/matrix-org/matrix-spec-proposals/pull/4526)
+        return error instanceof OAuth2HTTPError && error.error === "invalid_grant";
     }
 
     private async getNewTokens(refreshToken: string): Promise<AccessTokens> {


### PR DESCRIPTION
To-do:

- [ ] Is backwards compatibility important for this? (i.e. does the behaviour need to be opt-in/out?)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
