### PR TITLE
Fix documentation for "at" parameter in members function

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6907,7 +6907,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * @param includeMembership - the membership type to include in the response
      * @param excludeMembership - the membership type to exclude from the response
-     * @param atEventId - the id of the event for which moment in the timeline the members should be returned for
+     * @param atSyncToken - the point in time, as a sync pagination token, for when the members should be returned for
      * @returns Promise which resolves: dictionary of userid to profile information
      * @returns Rejects: with an error response.
      */
@@ -6915,7 +6915,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         roomId: string,
         includeMembership?: string,
         excludeMembership?: string,
-        atEventId?: string,
+        atSyncToken?: string,
     ): Promise<{ [userId: string]: IStateEventWithRoomId[] }> {
         const queryParams: Record<string, string> = {};
         if (includeMembership) {
@@ -6924,8 +6924,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         if (excludeMembership) {
             queryParams.not_membership = excludeMembership;
         }
-        if (atEventId) {
-            queryParams.at = atEventId;
+        if (atSyncToken) {
+            queryParams.at = atSyncToken;
         }
 
         const queryString = utils.encodeParams(queryParams);


### PR DESCRIPTION
The [spec says](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv3roomsroomidmembers) that the "at" parameter is a pagination token obtained from sync, rather than an event ID.  (and that is how it is used in the [one place the parameter is used](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/models/room.ts#L1051-L1057))

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
