### PR TITLE
Do not cache profiles when requested via `getExtendedProfileProperty`

### DIFF
--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -1370,29 +1370,6 @@ describe("MatrixClient", function () {
             expect(httpLookups).toHaveLength(0);
         });
 
-        it("preserves previously cached keys when writing through the profile cache", async () => {
-            const storedProfile = { other_key: "bar" };
-            const testProfile = { test_key: "foo" };
-            (client.store as MockedObject<IStore>).getUserProfile.mockImplementation(async (requestedUserId) => {
-                expect(requestedUserId).toEqual(userId);
-                return storedProfile;
-            });
-            httpLookups = [
-                {
-                    method: "GET",
-                    prefix: unstableMSC4133Prefix,
-                    path: "/profile/" + encodeURIComponent(userId) + "/test_key",
-                    data: testProfile,
-                },
-            ];
-
-            await expect(client.getExtendedProfileProperty(userId, "test_key")).resolves.toEqual("foo");
-
-            expect(client.store.storeUserProfiles).toHaveBeenCalledWith(
-                new Map([[userId, { ...storedProfile, ...testProfile }]]),
-            );
-        });
-
         it("can set a property in our extended profile", async () => {
             httpLookups = [
                 {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7412,19 +7412,6 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             throw e;
         }
 
-        // write through to the cache
-        await this.store.storeUserProfiles(
-            new Map([
-                [
-                    userId,
-                    {
-                        ...storedProfile,
-                        ...profile,
-                    },
-                ],
-            ]),
-        );
-
         return profile[key];
     }
 


### PR DESCRIPTION
The JS-SDK recently (#5246) introduced a cache that would locally store the state of a user's profile, which persists forever until /sync updates it with fresh information. Unfortunately, there is no upstream support for tracking federated users and so the profile ends up being incomplete.

The current behavior also stores a copy of a profile field when `getExtendedProfileProperty` is explicitly called, however since we can't tell if that user is "subscribed to" we don't know for sure if the cache will ever be updated.

This PR therefore removes the mechanism to cache on profile request, but keeps it for profiles we are syncing via /sync. The end result is hopefully that we always have up-to-date information for users at the cost of extra requests made to the homeserver for federated users. When the syncing mechanism matures to support federated users, this should improve still further.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
