### PR TITLE
crypto-api: add isDehydratedDeviceKeyMissing() to detect an inaccessible dehydrated device

### DIFF
--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
 import fetchMock from "@fetch-mock/vitest";
 import { type CallLog } from "fetch-mock";
 import debug from "debug";
 
 import { ClientEvent, createClient, DebugLogger, type MatrixClient, MatrixEvent } from "../../../src";
-import { CryptoEvent } from "../../../src/crypto-api/index";
+import { type CryptoApi, CryptoEvent } from "../../../src/crypto-api/index";
 import { type RustCrypto } from "../../../src/rust-crypto/rust-crypto";
 import { type AddSecretStorageKeyOpts } from "../../../src/secret-storage";
 import { E2EKeyReceiver } from "../../test-utils/E2EKeyReceiver";
@@ -189,6 +190,78 @@ describe("Device dehydration", () => {
         await rehydrationErrorEventPromise;
 
         matrixClient.stopClient();
+    });
+});
+
+describe("isDehydratedDeviceKeyMissing", () => {
+    const DEHYDRATED_DEVICE_PATH = "path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device";
+    let matrixClient: MatrixClient;
+    let crypto: CryptoApi;
+
+    beforeEach(async () => {
+        // The rust crypto store uses a fixed indexeddb prefix, so reset the database to get a fresh
+        // account with no dehydration key cached by an earlier test in this file.
+        indexedDB = new IDBFactory();
+        matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+            cryptoCallbacks: {
+                getSecretStorageKey: async (keys: any) => [Object.keys(keys.keys)[0], new Uint8Array(32)],
+            },
+        });
+        await initializeSecretStorage(matrixClient, "@alice:localhost", "http://test.server");
+        crypto = matrixClient.getCrypto()!;
+    });
+
+    afterEach(() => {
+        matrixClient.stopClient();
+    });
+
+    it("is false when the server has no dehydrated device", async () => {
+        fetchMock.get(DEHYDRATED_DEVICE_PATH, { status: 404, body: { errcode: "M_NOT_FOUND", error: "Not found" } });
+        await expect(crypto.isDehydratedDeviceKeyMissing()).resolves.toBe(false);
+    });
+
+    it("is false when the server does not support dehydration", async () => {
+        fetchMock.get(DEHYDRATED_DEVICE_PATH, {
+            status: 400,
+            body: { errcode: "M_UNRECOGNIZED", error: "Unrecognised request" },
+        });
+        await expect(crypto.isDehydratedDeviceKeyMissing()).resolves.toBe(false);
+    });
+
+    it("is true when a dehydrated device exists but its key is not held locally", async () => {
+        fetchMock.get(DEHYDRATED_DEVICE_PATH, {
+            device_id: "DEHYDRATED",
+            device_data: { algorithm: "org.matrix.msc3814.v1.olm" },
+        });
+        await expect(crypto.isDehydratedDeviceKeyMissing()).resolves.toBe(true);
+    });
+
+    it("is false, without querying the server, once the dehydration key is held locally", async () => {
+        fetchMock.get(
+            DEHYDRATED_DEVICE_PATH,
+            { status: 404, body: { errcode: "M_NOT_FOUND", error: "Not found" } },
+            { name: "get-dehydrated-device" },
+        );
+        fetchMock.put(DEHYDRATED_DEVICE_PATH, {});
+        await crypto.startDehydration();
+
+        // The dehydration key is now cached locally, so the check must short-circuit without a
+        // request — even if the server would now error.
+        fetchMock.modifyRoute("get-dehydrated-device", {
+            response: { status: 500, body: { errcode: "M_UNKNOWN", error: "Internal server error" } },
+        });
+        await expect(crypto.isDehydratedDeviceKeyMissing()).resolves.toBe(false);
+    });
+
+    it("rethrows unexpected server errors", async () => {
+        fetchMock.get(DEHYDRATED_DEVICE_PATH, {
+            status: 500,
+            body: { errcode: "M_UNKNOWN", error: "Internal server error" },
+        });
+        await expect(crypto.isDehydratedDeviceKeyMissing()).rejects.toThrow();
     });
 });
 

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -714,6 +714,20 @@ export interface CryptoApi {
      */
     startDehydration(opts?: StartDehydrationOpts | boolean): Promise<void>;
 
+    /**
+     * Return whether there is a dehydrated device on the server for which this client does not hold the
+     * dehydration key.
+     *
+     * This happens when device dehydration was set up on another of the user's devices, so a dehydrated
+     * device exists on the server, but this device has never received the dehydration key (it is neither
+     * cached locally nor read from Secret Storage). Applications can use this to detect the situation and
+     * prompt the user to unlock Secret Storage so the key can be recovered.
+     *
+     * @returns `true` if a dehydrated device exists on the server but the dehydration key is not held by
+     *     this client; `false` otherwise (no dehydrated device, dehydration unsupported, or key present).
+     */
+    isDehydratedDeviceKeyMissing(): Promise<boolean>;
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //
     // Import/export of secret keys

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -167,6 +167,39 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
     }
 
     /**
+     * Backs {@link CryptoApi#isDehydratedDeviceKeyMissing}: returns whether the server has a dehydrated
+     * device whose dehydration key is not cached locally (false if we hold the key, there is no such
+     * device, or dehydration is unsupported).
+     */
+    public async isDehydratedDeviceKeyMissing(): Promise<boolean> {
+        // First, do we already hold the key? If so, nothing is missing.
+        const cachedKey = await this.olmMachine.dehydratedDevices().getDehydratedDeviceKey();
+        if (cachedKey) return false;
+
+        // Otherwise, check whether the server actually has a dehydrated device that we'd need the key for.
+        try {
+            await this.http.authedRequest<DehydratedDeviceResp>(
+                Method.Get,
+                "/dehydrated_device",
+                undefined,
+                undefined,
+                {
+                    prefix: UnstablePrefix,
+                },
+            );
+        } catch (error) {
+            const err = error as MatrixError;
+            // No dehydrated device (M_NOT_FOUND) or dehydration unsupported (M_UNRECOGNIZED): nothing missing.
+            if (err.errcode === "M_NOT_FOUND" || err.errcode === "M_UNRECOGNIZED") {
+                return false;
+            }
+            throw err;
+        }
+        // A dehydrated device exists on the server and we don't have its key.
+        return true;
+    }
+
+    /**
      * Reset the dehydration key.
      *
      * Creates a new key and stores it in secret storage.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -1520,6 +1520,13 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     }
 
     /**
+     * Implementation of {@link CryptoApi#isDehydratedDeviceKeyMissing}.
+     */
+    public async isDehydratedDeviceKeyMissing(): Promise<boolean> {
+        return await this.dehydratedDeviceManager.isDehydratedDeviceKeyMissing();
+    }
+
+    /**
      * Implementation of {@link CryptoApi#importSecretsBundle}.
      */
     public async importSecretsBundle(


### PR DESCRIPTION
Adds `CryptoApi.isDehydratedDeviceKeyMissing()`: returns true when a dehydrated device exists on the server (e.g. set up by another of the user's devices) but this device does not hold the dehydration key locally, so a client can prompt the user to recover it from Secret Storage.

Part of https://github.com/element-hq/element-web/issues/29579; the element-web side (a toast prompting recovery) is in https://github.com/element-hq/element-web/pull/34797.

This code was largely written with Claude, and rebased/revalidated against current develop (integration tests and tsc pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
