### PR TITLE
DehydratedDeviceManager: reconcile the dehydration key with 4S before rotating

### DIFF
--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -15,12 +15,14 @@ limitations under the License.
 */
 
 import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
 import fetchMock from "@fetch-mock/vitest";
 import { type CallLog } from "fetch-mock";
 import debug from "debug";
 
 import { ClientEvent, createClient, DebugLogger, type MatrixClient, MatrixEvent } from "../../../src";
-import { CryptoEvent } from "../../../src/crypto-api/index";
+import { encodeBase64 } from "../../../src/base64";
+import { type CryptoApi, CryptoEvent } from "../../../src/crypto-api/index";
 import { type RustCrypto } from "../../../src/rust-crypto/rust-crypto";
 import { type AddSecretStorageKeyOpts } from "../../../src/secret-storage";
 import { E2EKeyReceiver } from "../../test-utils/E2EKeyReceiver";
@@ -189,6 +191,64 @@ describe("Device dehydration", () => {
         await rehydrationErrorEventPromise;
 
         matrixClient.stopClient();
+    });
+});
+
+describe("reconciling the dehydration key with secret storage", () => {
+    const DEHYDRATED_DEVICE_PATH = "path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device";
+    let matrixClient: MatrixClient;
+    let crypto: CryptoApi;
+    let keyCachedCounter: EventCounter;
+
+    beforeEach(async () => {
+        // The rust crypto store uses a fixed indexeddb prefix, so reset the database for a fresh account.
+        indexedDB = new IDBFactory();
+        matrixClient = createClient({
+            baseUrl: "http://test.server",
+            userId: "@alice:localhost",
+            deviceId: "aliceDevice",
+            cryptoCallbacks: {
+                getSecretStorageKey: async (keys: any) => [Object.keys(keys.keys)[0], new Uint8Array(32)],
+            },
+        });
+        await initializeSecretStorage(matrixClient, "@alice:localhost", "http://test.server");
+        crypto = matrixClient.getCrypto()!;
+
+        // Start dehydration: this stores a fresh key in secret storage and caches it locally.
+        fetchMock.get(DEHYDRATED_DEVICE_PATH, { status: 404, body: { errcode: "M_NOT_FOUND", error: "Not found" } });
+        fetchMock.put(DEHYDRATED_DEVICE_PATH, {});
+        await crypto.startDehydration();
+
+        // Count dehydration-key caching from here on (i.e. only what reconciliation triggers).
+        keyCachedCounter = new EventCounter(matrixClient, CryptoEvent.DehydrationKeyCached);
+    });
+
+    afterEach(() => {
+        matrixClient.stopClient();
+    });
+
+    it("keeps using the cached key when secret storage is unchanged", async () => {
+        await crypto.startDehydration({ rehydrate: false });
+        expect(keyCachedCounter.counter).toBe(0);
+    });
+
+    it("adopts a dehydration key that another device rotated in secret storage", async () => {
+        // Another of the user's devices replaced the key in 4S with a different one.
+        const rotatedKey = encodeBase64(new Uint8Array(32).fill(1));
+        await matrixClient.secretStorage.store("org.matrix.msc3814", rotatedKey);
+
+        await crypto.startDehydration({ rehydrate: false });
+
+        // The changed key was read from 4S and adopted (re-cached) locally.
+        expect(keyCachedCounter.counter).toBe(1);
+    });
+
+    it("keeps the cached key (best-effort) when secret storage can't be read", async () => {
+        vi.spyOn(matrixClient.secretStorage, "get").mockRejectedValueOnce(new Error("4S is locked"));
+
+        // Reconciliation must not throw or block on a recovery-key prompt.
+        await expect(crypto.startDehydration({ rehydrate: false })).resolves.toBeUndefined();
+        expect(keyCachedCounter.counter).toBe(0);
     });
 });
 

--- a/src/rust-crypto/DehydratedDeviceManager.ts
+++ b/src/rust-crypto/DehydratedDeviceManager.ts
@@ -297,11 +297,48 @@ export class DehydratedDeviceManager extends TypedEventEmitter<DehydratedDevices
     }
 
     /**
+     * Reconcile our cached dehydration key with the one in Secret Storage.
+     *
+     * Another of the user's devices may have rotated the dehydration key in 4S (e.g. by changing the
+     * recovery key). If we keep using our locally-cached key we will upload a dehydrated device encrypted
+     * with a key that no other device can read, defeating dehydration. So, before creating a dehydrated
+     * device, re-read the key from 4S and adopt it if it differs from our cache.
+     *
+     * This is best-effort: if 4S is not currently accessible the read is skipped and we keep using the
+     * cached key (a background rotation must not block on prompting the user for their recovery key).
+     * See https://github.com/element-hq/element-web/issues/28760.
+     */
+    private async reconcileKeyWithSecretStorage(): Promise<void> {
+        const cachedKey = await this.olmMachine.dehydratedDevices().getDehydratedDeviceKey();
+        if (!cachedKey) return; // nothing cached yet — getKey() will read 4S as usual
+
+        let keyB64: string | undefined;
+        try {
+            keyB64 = await this.secretStorage.get(SECRET_STORAGE_NAME);
+        } catch (e) {
+            // 4S not accessible right now (e.g. no key cached): keep the cached key rather than failing.
+            this.logger.info("dehydration: could not read dehydration key from secret storage to reconcile", e);
+            return;
+        }
+        if (keyB64 === undefined) return; // no key in 4S
+        if (keyB64 === cachedKey.toBase64()) return; // already in sync
+
+        this.logger.info("dehydration: dehydration key in secret storage changed; adopting the new key");
+        const bytes = decodeBase64(keyB64);
+        try {
+            await this.cacheKey(RustSdkCryptoJs.DehydratedDeviceKey.createKeyFromArray(bytes));
+        } finally {
+            bytes.fill(0);
+        }
+    }
+
+    /**
      * Creates and uploads a new dehydrated device.
      *
      * Creates and stores a new key in secret storage if none is available.
      */
     public async createAndUploadDehydratedDevice(): Promise<void> {
+        await this.reconcileKeyWithSecretStorage();
         const key = (await this.getKey(true))!;
 
         const dehydratedDevice = await this.olmMachine.dehydratedDevices().create();


### PR DESCRIPTION
Before rotating the dehydrated device, re-read the dehydration key from Secret Storage and prefer it over the locally-cached copy, so that a device whose cached key has been superseded by another device converges instead of clobbering the other device's key.

Fixes https://github.com/element-hq/element-web/issues/28760.

This code was largely written with Claude, and rebased/revalidated against current develop (integration tests and tsc pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)