### PR TITLE
Add livekit rtc cs api endpoints to client (and embedded client)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "content-type": "^3.0.0",
         "loglevel": "^1.9.2",
         "matrix-events-sdk": "0.0.1",
-        "matrix-widget-api": "^1.18.0",
+        "matrix-widget-api": "^1.19.0",
         "p-retry": "8",
         "sdp-transform": "^3.0.0",
         "unhomoglyph": "^1.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       matrix-widget-api:
-        specifier: ^1.18.0
-        version: 1.18.0
+        specifier: ^1.19.0
+        version: 1.19.0
       p-retry:
         specifier: '8'
         version: 8.0.0
@@ -2307,8 +2307,8 @@ packages:
   matrix-mock-request@2.6.0:
     resolution: {integrity: sha512-D0n+FsoMvHBrBoo60IeGhyrNoCBdT8n+Wl+LMW+k5aR+k9QAxqGopPzJNk1tqeaJLFUhmvYLuNc8/VBKRpPy+Q==}
 
-  matrix-widget-api@1.18.0:
-    resolution: {integrity: sha512-4T2f2koWmx05p1BLcT/9YGGGPSXpPT+PA4Oap/5fjhXsWPxMGJiGL97YpANMYLKsnE1sScYFeuyxIgdc1Qo+Ew==}
+  matrix-widget-api@1.19.0:
+    resolution: {integrity: sha512-Qe7L6G1mQJphBC47/Bzp5ljPIK1UARgLiuGgS+/KmEs/eaNHkQ3+ArD0/0kvMV+d6kCGAZ9OKRqsnuPjizI+tw==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -4422,7 +4422,7 @@ snapshots:
     dependencies:
       expect: 30.4.1
 
-  matrix-widget-api@1.18.0:
+  matrix-widget-api@1.19.0:
     dependencies:
       '@types/events': 3.0.3
       events: 3.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,4 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
     - "@matrix-org/*"
+    - matrix-widget-api@1.19.0

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -100,6 +100,10 @@ class MockWidgetApi extends EventEmitter {
     public readStateEvents = vi.fn(async () => []);
     public getTurnServers = vi.fn(async () => []);
     public getRtcTransports = vi.fn(async () => ({ rtc_transports: [] }));
+    public requestCapabilityToGetRtcLivekitToken = vi.fn().mockResolvedValue(undefined);
+    public requestCapabilityToDelegateRtcLivekitDelayedLeave = vi.fn().mockResolvedValue(undefined);
+    public getRtcLivekitToken = vi.fn(async () => ({ jwt: "" }));
+    public delegateRtcLivekitDelayedLeave = vi.fn(async () => ({}));
     public sendContentLoaded = vi.fn().mockResolvedValue(undefined);
 
     public transport = {
@@ -1269,6 +1273,105 @@ describe("RoomWidgetClient", () => {
 
             await makeClient({ rtcTransports: true });
             await expect(client._unstable_getRTCTransports()).rejects.toThrow(ConnectionError);
+        });
+    });
+
+    describe("LiveKit token", () => {
+        const member = { id: "xyzABCDEF10123", claimed_device_id: "DEVICEID" };
+        const body = {
+            url: "wss://livekit.example.org",
+            room_id: "!1:example.org",
+            slot_id: "m.call#ROOM",
+            member,
+        };
+
+        it("requests the capability when opted in", async () => {
+            await makeClient({ rtcLivekitGetToken: true });
+            expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitGetToken);
+        });
+
+        it("does not request the capability when not opted in", async () => {
+            await makeClient({});
+            expect(widgetApi.requestCapability).not.toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitGetToken);
+        });
+
+        it("gets a token from the host", async () => {
+            widgetApi.getRtcLivekitToken.mockResolvedValue({ jwt: "thejwt" });
+
+            await makeClient({ rtcLivekitGetToken: true }, undefined, "@alice:example.org");
+            expect(await client._unstable_getLivekitToken({ ...body, server_name: "remote.example.org" })).toEqual({
+                jwt: "thejwt",
+            });
+            expect(widgetApi.getRtcLivekitToken).toHaveBeenCalledWith({ ...body, server_name: "remote.example.org" });
+        });
+
+        it("defaults the server name to our own homeserver", async () => {
+            widgetApi.getRtcLivekitToken.mockResolvedValue({ jwt: "thejwt" });
+
+            await makeClient({ rtcLivekitGetToken: true }, undefined, "@alice:example.org");
+            expect(await client._unstable_getLivekitToken(body)).toEqual({ jwt: "thejwt" });
+            expect(widgetApi.getRtcLivekitToken).toHaveBeenCalledWith({ ...body, server_name: "example.org" });
+        });
+
+        it("throws if the server name cannot be determined", async () => {
+            await makeClient({ rtcLivekitGetToken: true });
+            await expect(client._unstable_getLivekitToken(body)).rejects.toThrow("server name");
+            expect(widgetApi.getRtcLivekitToken).not.toHaveBeenCalled();
+        });
+
+        it("propagates errors from the host", async () => {
+            const error = new Error("Missing capability");
+            widgetApi.getRtcLivekitToken.mockRejectedValue(error);
+
+            await makeClient({ rtcLivekitGetToken: true }, undefined, "@alice:example.org");
+            await expect(client._unstable_getLivekitToken(body)).rejects.toThrow(error);
+        });
+
+        it("maps a widget timeout to a ConnectionError", async () => {
+            widgetApi.getRtcLivekitToken.mockRejectedValue(new Error("Request timed out"));
+
+            await makeClient({ rtcLivekitGetToken: true }, undefined, "@alice:example.org");
+            await expect(client._unstable_getLivekitToken(body)).rejects.toThrow(ConnectionError);
+        });
+    });
+
+    describe("delegated delayed leave", () => {
+        const body = {
+            room_id: "!1:example.org",
+            slot_id: "m.call#ROOM",
+            member: { id: "xyzABCDEF10123", claimed_device_id: "DEVICEID" },
+            delay_id: "1234567890",
+        };
+
+        it("requests the capability when opted in", async () => {
+            await makeClient({ rtcLivekitDelegateDelayedLeave: true });
+            expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
+        });
+
+        it("does not request the capability when not opted in", async () => {
+            await makeClient({});
+            expect(widgetApi.requestCapability).not.toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
+        });
+
+        it("delegates the delayed leave event via the host", async () => {
+            await makeClient({ rtcLivekitDelegateDelayedLeave: true });
+            expect(await client._unstable_delegateDelayedLeave(body)).toEqual({});
+            expect(widgetApi.delegateRtcLivekitDelayedLeave).toHaveBeenCalledWith(body);
+        });
+
+        it("propagates errors from the host", async () => {
+            const error = new Error("Missing capability");
+            widgetApi.delegateRtcLivekitDelayedLeave.mockRejectedValue(error);
+
+            await makeClient({ rtcLivekitDelegateDelayedLeave: true });
+            await expect(client._unstable_delegateDelayedLeave(body)).rejects.toThrow(error);
+        });
+
+        it("maps a widget timeout to a ConnectionError", async () => {
+            widgetApi.delegateRtcLivekitDelayedLeave.mockRejectedValue(new Error("Request timed out"));
+
+            await makeClient({ rtcLivekitDelegateDelayedLeave: true });
+            await expect(client._unstable_delegateDelayedLeave(body)).rejects.toThrow(ConnectionError);
         });
     });
 });

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -1337,6 +1337,7 @@ describe("RoomWidgetClient", () => {
 
     describe("delegated delayed leave", () => {
         const body = {
+            url: "wss://livekit.example.org",
             room_id: "!1:example.org",
             slot_id: "m.call#ROOM",
             member: { id: "xyzABCDEF10123", claimed_device_id: "DEVICEID" },

--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -1345,12 +1345,16 @@ describe("RoomWidgetClient", () => {
 
         it("requests the capability when opted in", async () => {
             await makeClient({ rtcLivekitDelegateDelayedLeave: true });
-            expect(widgetApi.requestCapability).toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
+            expect(widgetApi.requestCapability).toHaveBeenCalledWith(
+                MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave,
+            );
         });
 
         it("does not request the capability when not opted in", async () => {
             await makeClient({});
-            expect(widgetApi.requestCapability).not.toHaveBeenCalledWith(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
+            expect(widgetApi.requestCapability).not.toHaveBeenCalledWith(
+                MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave,
+            );
         });
 
         it("delegates the delayed leave event via the host", async () => {

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -4003,6 +4003,7 @@ describe("MatrixClient", function () {
         describe("_unstable_delegateDelayedLeave", () => {
             it("makes a well-formed request", async () => {
                 const body = {
+                    url: "wss://livekit.example.com",
                     room_id: "!room:example.com",
                     slot_id: "m.call#ROOM",
                     member,
@@ -4032,6 +4033,7 @@ describe("MatrixClient", function () {
                 ];
                 await expect(
                     client._unstable_delegateDelayedLeave({
+                        url: "wss://livekit.example.com",
                         room_id: "!room:example.com",
                         slot_id: "m.call#ROOM",
                         member,

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -89,7 +89,12 @@ import { makeDelegatedAuthMetadata } from "../test-utils/auth.ts";
 import { type CryptoBackend } from "../../src/common-crypto/CryptoBackend";
 import { SyncResponder } from "../test-utils/SyncResponder.ts";
 import { mockInitialApiRequests } from "../test-utils/mockEndpoints.ts";
-import { type Transport } from "../../src/matrixrtc/index.ts";
+import {
+    type LivekitDelegateDelayedLeaveRequest,
+    type LivekitGetTokenRequest,
+    type LivekitGetTokenResponse,
+    type Transport,
+} from "../../src/matrixrtc/index.ts";
 import { type IStore } from "../../src/store/index.ts";
 
 vi.useFakeTimers();
@@ -3926,6 +3931,115 @@ describe("MatrixClient", function () {
                     extra_field: "foobar",
                 },
             ]);
+        });
+    });
+
+    describe("MSC4195 LiveKit endpoints", () => {
+        const member = { id: "xyzABCDEF10123", claimed_device_id: "DEVICEID" };
+
+        describe("_unstable_getLivekitToken", () => {
+            it("makes a well-formed request", async () => {
+                const body = {
+                    url: "wss://livekit.example.com",
+                    room_id: "!room:example.com",
+                    slot_id: "m.call#ROOM",
+                    member,
+                } satisfies LivekitGetTokenRequest;
+                httpLookups = [
+                    {
+                        method: "POST",
+                        path: "/rtc/livekit/get_token",
+                        prefix: "/_matrix/client/unstable/io.element.msc4195",
+                        expectBody: body,
+                        data: { jwt: "thejwt" } satisfies LivekitGetTokenResponse,
+                    },
+                ];
+                expect(await client._unstable_getLivekitToken(body)).toEqual({ jwt: "thejwt" });
+                expect(httpLookups.length).toEqual(0);
+            });
+
+            it("passes on the server name of a remote homeserver", async () => {
+                const body = {
+                    url: "wss://livekit.remote.example.com",
+                    room_id: "!room:example.com",
+                    slot_id: "m.call#ROOM",
+                    member,
+                    server_name: "remote.example.com",
+                } satisfies LivekitGetTokenRequest;
+                httpLookups = [
+                    {
+                        method: "POST",
+                        path: "/rtc/livekit/get_token",
+                        prefix: "/_matrix/client/unstable/io.element.msc4195",
+                        expectBody: body,
+                        data: { jwt: "theremotejwt" } satisfies LivekitGetTokenResponse,
+                    },
+                ];
+                expect(await client._unstable_getLivekitToken(body)).toEqual({ jwt: "theremotejwt" });
+                expect(httpLookups.length).toEqual(0);
+            });
+
+            it("propagates errors from the homeserver", async () => {
+                httpLookups = [
+                    {
+                        method: "POST",
+                        path: "/rtc/livekit/get_token",
+                        prefix: "/_matrix/client/unstable/io.element.msc4195",
+                        error: { httpStatus: 400, errcode: "M_INVALID_PARAM" },
+                    },
+                ];
+                await expect(
+                    client._unstable_getLivekitToken({
+                        url: "wss://not-an-sfu.example.com",
+                        room_id: "!room:example.com",
+                        slot_id: "m.call#ROOM",
+                        member,
+                    }),
+                ).rejects.toThrow(expect.objectContaining({ errcode: "M_INVALID_PARAM" }));
+                expect(httpLookups.length).toEqual(0);
+            });
+        });
+
+        describe("_unstable_delegateDelayedLeave", () => {
+            it("makes a well-formed request", async () => {
+                const body = {
+                    room_id: "!room:example.com",
+                    slot_id: "m.call#ROOM",
+                    member,
+                    delay_id: "1234567890",
+                } satisfies LivekitDelegateDelayedLeaveRequest;
+                httpLookups = [
+                    {
+                        method: "POST",
+                        path: "/rtc/livekit/delegate_delayed_leave",
+                        prefix: "/_matrix/client/unstable/io.element.msc4195",
+                        expectBody: body,
+                        data: {},
+                    },
+                ];
+                expect(await client._unstable_delegateDelayedLeave(body)).toEqual({});
+                expect(httpLookups.length).toEqual(0);
+            });
+
+            it("propagates errors from the homeserver", async () => {
+                httpLookups = [
+                    {
+                        method: "POST",
+                        path: "/rtc/livekit/delegate_delayed_leave",
+                        prefix: "/_matrix/client/unstable/io.element.msc4195",
+                        error: { httpStatus: 404, errcode: "M_NOT_FOUND" },
+                    },
+                ];
+                await expect(
+                    client._unstable_delegateDelayedLeave({
+                        room_id: "!room:example.com",
+                        slot_id: "m.call#ROOM",
+                        member,
+                        delay_id: "1234567890",
+                    }),
+                ).rejects.toThrow(expect.objectContaining({ errcode: "M_NOT_FOUND" }));
+                expect(httpLookups.length).toEqual(0);
+            });
         });
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -245,7 +245,12 @@ import { sha256 } from "./digest.ts";
 import { type ValidatedAuthMetadata, OAuth2Error, isValidAuthMetadata } from "./oauth/index.ts";
 import { type EmptyObject } from "./@types/common.ts";
 import { UnsupportedDelayedEventsEndpointError, UnsupportedStickyEventsEndpointError } from "./errors.ts";
-import { type Transport } from "./matrixrtc/index.ts";
+import {
+    type LivekitDelegateDelayedLeaveRequest,
+    type LivekitGetTokenRequest,
+    type LivekitGetTokenResponse,
+    type Transport,
+} from "./matrixrtc/index.ts";
 import { RetentionPolicyService } from "./retentionPolicy.ts";
 import { createRtcTransportsCachedValue } from "./rtcTransportsCachedValue.ts";
 import { createWellKnownCachedValue } from "./wellKnownCachedValue.ts";
@@ -6179,6 +6184,57 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 prefix: `${ClientPrefix.Unstable}/org.matrix.msc4143`,
             })
         ).rtc_transports;
+    }
+
+    /**
+     * Requests a token to authenticate against a LiveKit SFU with (MSC4195).
+     *
+     * The homeserver checks that we are joined to `room_id` before obtaining a token from the SFU. If
+     * `server_name` names a remote homeserver, our homeserver forwards the request to it over federation,
+     * which is how a token for another homeserver's SFU is obtained.
+     *
+     * Requires homeserver support for MSC4195.
+     *
+     * @param body - The details of the `m.rtc.member` event to obtain a token for, and the SFU to obtain it from.
+     * @returns The JWT to authenticate with when connecting to the SFU.
+     * @throws A M_NOT_FOUND error if not supported by the homeserver, a M_FORBIDDEN error if we (or, when
+     * federating, our homeserver) are not joined to the room, or a M_INVALID_PARAM error if `url` is not one
+     * of the answering server's SFUs.
+     */
+    public async _unstable_getLivekitToken(body: LivekitGetTokenRequest): Promise<LivekitGetTokenResponse> {
+        // There is no /versions flag to check for support, so we just have to attempt a request.
+        return await this.http.authedRequest<LivekitGetTokenResponse>(
+            Method.Post,
+            "/rtc/livekit/get_token",
+            undefined,
+            body,
+            { prefix: `${ClientPrefix.Unstable}/io.element.msc4195` },
+        );
+    }
+
+    /**
+     * Hands over the management of a delayed MatrixRTC leave event to the homeserver (MSC4195).
+     *
+     * The homeserver restarts the delayed event for as long as it observes our connection to the SFU, and
+     * sends it once we disconnect, so the client does not have to restart it itself. This is more reliable
+     * than client-side restarts under poor network conditions.
+     *
+     * large timeouts are recommended for delayed delegation (in the range of hours)
+     * Requires homeserver support for MSC4195.
+     *
+     * @param body - The details of the `m.rtc.member` event and the delayed leave event to delegate.
+     * @throws A M_NOT_FOUND error if not supported by the homeserver, or a M_BAD_JSON error if the delayed
+     * event's timeout is below one hour.
+     */
+    public async _unstable_delegateDelayedLeave(body: LivekitDelegateDelayedLeaveRequest): Promise<EmptyObject> {
+        // There is no /versions flag to check for support, so we just have to attempt a request.
+        return await this.http.authedRequest<EmptyObject>(
+            Method.Post,
+            "/rtc/livekit/delegate_delayed_leave",
+            undefined,
+            body,
+            { prefix: `${ClientPrefix.Unstable}/io.element.msc4195` },
+        );
     }
 
     /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -6222,9 +6222,10 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * large timeouts are recommended for delayed delegation (in the range of hours)
      * Requires homeserver support for MSC4195.
      *
-     * @param body - The details of the `m.rtc.member` event and the delayed leave event to delegate.
-     * @throws A M_NOT_FOUND error if not supported by the homeserver, or a M_BAD_JSON error if the delayed
-     * event's timeout is below one hour.
+     * @param body - The details of the `m.rtc.member` event and the delayed leave event to delegate, and the SFU
+     * we are connected to.
+     * @throws A M_NOT_FOUND error if not supported by the homeserver, a M_BAD_JSON error if the delayed
+     * event's timeout is below one hour, or a M_INVALID_PARAM error if `url` is not one of the homeserver's SFUs.
      */
     public async _unstable_delegateDelayedLeave(body: LivekitDelegateDelayedLeaveRequest): Promise<EmptyObject> {
         // There is no /versions flag to check for support, so we just have to attempt a request.

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -32,7 +32,12 @@ import {
     UnstableApiVersion,
 } from "matrix-widget-api";
 
-import { type Transport } from "./matrixrtc/index.ts";
+import {
+    type LivekitDelegateDelayedLeaveRequest,
+    type LivekitGetTokenRequest,
+    type LivekitGetTokenResponse,
+    type Transport,
+} from "./matrixrtc/index.ts";
 import { MatrixEvent, type IEvent, EventStatus } from "./models/event.ts";
 import {
     type ISendEventResponse,
@@ -145,6 +150,21 @@ export interface ICapabilities {
      * @defaultValue false
      */
     rtcTransports?: boolean;
+
+    /**
+     * Whether this client needs to be able to obtain LiveKit SFU tokens through the host.
+     * @experimental Part of MSC4195 & MSC4533
+     * @defaultValue false
+     */
+    rtcLivekitGetToken?: boolean;
+
+    /**
+     * Whether this client needs to be able to hand delayed MatrixRTC leave events over to the
+     * homeserver through the host.
+     * @experimental Part of MSC4195 & MSC4533
+     * @defaultValue false
+     */
+    rtcLivekitDelegateDelayedLeave?: boolean;
 }
 
 export enum RoomWidgetClientEvent {
@@ -295,6 +315,12 @@ export class RoomWidgetClient extends MatrixClient {
         }
         if (capabilities.rtcTransports) {
             this.widgetApi.requestCapability(MatrixCapabilities.MSC4515RtcTransports);
+        }
+        if (capabilities.rtcLivekitGetToken) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4533RtcLivekitGetToken);
+        }
+        if (capabilities.rtcLivekitDelegateDelayedLeave) {
+            this.widgetApi.requestCapability(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
         }
     }
 
@@ -643,6 +669,41 @@ export class RoomWidgetClient extends MatrixClient {
             .getRtcTransports()
             .catch(timeoutToConnectionError);
         return rtcTransports;
+    }
+
+    /**
+     * Requests a token to authenticate against a LiveKit SFU with.
+     *
+     * Overrides the homeserver-side {@link MatrixClient._unstable_getLivekitToken} (MSC4195): a widget
+     * cannot make authenticated homeserver calls itself, so we ask the host to make the call on our
+     * behalf over the widget API instead (MSC4533). Requires the `rtcLivekitGetToken` capability and a
+     * host that advertises the `org.matrix.msc4533` API version (otherwise the request throws).
+     *
+     * `server_name` defaults to our own homeserver, matching what the endpoint would do server-side.
+     */
+    public override async _unstable_getLivekitToken(body: LivekitGetTokenRequest): Promise<LivekitGetTokenResponse> {
+        const serverName = body.server_name ?? this.getDomain();
+        if (serverName === null) throw new Error("Cannot determine the server name to request a token from");
+        const { jwt } = await this.widgetApi
+            .getRtcLivekitToken({ ...body, server_name: serverName })
+            .catch(timeoutToConnectionError);
+        return { jwt };
+    }
+
+    /**
+     * Hands over the management of a delayed MatrixRTC leave event to the homeserver.
+     *
+     * Overrides the homeserver-side {@link MatrixClient._unstable_delegateDelayedLeave} (MSC4195): a
+     * widget cannot make authenticated homeserver calls itself, so we ask the host to make the call on
+     * our behalf over the widget API instead (MSC4533). Requires the `rtcLivekitDelegateDelayedLeave`
+     * capability and a host that advertises the `org.matrix.msc4533` API version (otherwise the request
+     * throws).
+     */
+    public override async _unstable_delegateDelayedLeave(
+        body: LivekitDelegateDelayedLeaveRequest,
+    ): Promise<EmptyObject> {
+        await this.widgetApi.delegateRtcLivekitDelayedLeave(body).catch(timeoutToConnectionError);
+        return {};
     }
 
     public async queueToDevice({ eventType, batch }: ToDeviceBatch): Promise<void> {

--- a/src/matrixrtc/LivekitTransport.ts
+++ b/src/matrixrtc/LivekitTransport.ts
@@ -110,6 +110,10 @@ export interface LivekitGetTokenResponse {
  */
 export type LivekitDelegateDelayedLeaveRequest = {
     /**
+     * The WebSocket URL of the LiveKit SFU that we are connected to.
+     */
+    url: string;
+    /**
      * The room ID of the Matrix room the `m.rtc.member` event is in.
      */
     room_id: string;

--- a/src/matrixrtc/LivekitTransport.ts
+++ b/src/matrixrtc/LivekitTransport.ts
@@ -44,3 +44,85 @@ export interface LivekitFocusSelection extends Transport {
  */
 export const isLivekitFocusSelection = (object: any): object is LivekitFocusSelection =>
     object.type === "livekit" && "focus_selection" in object;
+
+/**
+ * Identifies the MatrixRTC membership that a LiveKit request is made for (MSC4195).
+ *
+ * Note that this is *not* the `member` field of an `m.rtc.member` event verbatim: the homeserver knows
+ * the user ID from the access token, and the device ID is only ever claimed, never verified.
+ */
+export interface LivekitRtcMember {
+    /**
+     * The ID of the member within the MatrixRTC session, i.e. the `member.id` of the `m.rtc.member` event.
+     */
+    id: string;
+    /**
+     * The device ID the member claims to be using, i.e. the `member.device_id` of the `m.rtc.member` event.
+     */
+    claimed_device_id?: string;
+}
+
+/**
+ * The body of a request to the LiveKit `get_token` endpoint (MSC4195).
+ *
+ * Declared as a type alias rather than an interface so that it can be passed to the widget API
+ * (MSC4533), which expects request data to be assignable to an index signature.
+ */
+export type LivekitGetTokenRequest = {
+    /**
+     * The WebSocket URL of the LiveKit SFU to obtain a token for.
+     */
+    url: string;
+    /**
+     * The room ID of the Matrix room the `m.rtc.member` event is in.
+     */
+    room_id: string;
+    /**
+     * The slot ID from the `m.rtc.member` event.
+     */
+    slot_id: string;
+    /**
+     * The MatrixRTC membership to obtain a token for.
+     */
+    member: LivekitRtcMember;
+    /**
+     * The server name of the `m.rtc.member` event's sender. If omitted, the homeserver uses its own
+     * server name. This is what makes it possible to obtain a token for an SFU of a remote homeserver.
+     */
+    server_name?: string;
+};
+
+/**
+ * The response of the LiveKit `get_token` endpoint (MSC4195).
+ */
+export interface LivekitGetTokenResponse {
+    /**
+     * The JWT to authenticate with when connecting to the SFU.
+     */
+    jwt: string;
+}
+
+/**
+ * The body of a request to the LiveKit `delegate_delayed_leave` endpoint (MSC4195).
+ *
+ * Declared as a type alias rather than an interface so that it can be passed to the widget API
+ * (MSC4533), which expects request data to be assignable to an index signature.
+ */
+export type LivekitDelegateDelayedLeaveRequest = {
+    /**
+     * The room ID of the Matrix room the `m.rtc.member` event is in.
+     */
+    room_id: string;
+    /**
+     * The slot ID from the `m.rtc.member` event.
+     */
+    slot_id: string;
+    /**
+     * The MatrixRTC membership the delayed leave event belongs to.
+     */
+    member: LivekitRtcMember;
+    /**
+     * The delay ID of the delayed leave event to hand over to the homeserver.
+     */
+    delay_id: string;
+};


### PR DESCRIPTION
The RTC endpoint to acquire livekit SFU tokens previously have been done via direct http requests to the jwt service directly. 
The spec proposals transitioned to make those requests proxy through the synapse authenticated ClientServerApi.
This PR wraps those endpoints in the js-sdk and also exposes this functionally through the widget api via the embedded.ts:
 - for http requests
 - for the embedded client via widget api

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
