### PR TITLE
Fix one-time keys being re-uploaded on every to-device/device-list sync with matrix-sdk-crypto-wasm ≥ 18.5.0

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -1452,6 +1452,43 @@ describe("crypto", () => {
             expect(res.keysCount).toBeGreaterThan(0);
             expect(res.fallbackKeysCount).toBeGreaterThan(0);
         });
+
+        it("should not upload one-time keys when a sync only carries to-device messages or device list changes", async () => {
+            // Regression test for https://github.com/matrix-org/matrix-js-sdk/issues/5501: the crypto layer has to
+            // give the OlmMachine a one-time key count when it processes to-device messages and device list changes,
+            // and if it passes an empty count, the OlmMachine (since matrix-sdk-crypto-wasm 18.5.0) takes that to
+            // mean that the server has no one-time keys, and generates a new batch on every such sync.
+            expectAliceKeyQuery({ device_keys: { "@alice:localhost": {} }, failures: {} });
+            await startClientAndAwaitFirstSync();
+
+            // Wait for the initial batch of one-time keys to be uploaded. The E2EKeyReceiver replies with the number
+            // of keys it now holds, so the OlmMachine knows that there are 50 keys on the server.
+            const initialKeys = await keyReceiver.awaitOneTimeKeyUpload();
+            const keyUploadsAfterInitialBatch = fetchMock.callHistory.calls("keys-upload").length;
+
+            // A sync which reports the count, and also carries a to-device message
+            syncResponder.sendOrQueueSyncResponse({
+                next_batch: 2,
+                to_device: { events: [{ type: "org.example.test", sender: "@bob:localhost", content: {} }] },
+                device_one_time_keys_count: { signed_curve25519: Object.keys(initialKeys).length },
+            });
+            await syncPromise(aliceClient);
+
+            // A sync which carries a to-device message and device list changes, but does not report the count
+            syncResponder.sendOrQueueSyncResponse({
+                next_batch: 3,
+                to_device: { events: [{ type: "org.example.test", sender: "@bob:localhost", content: {} }] },
+                device_lists: { changed: ["@bob:localhost"] },
+            });
+            await syncPromise(aliceClient);
+
+            // Give the outgoing request loop a chance to run, then check that no further keys were uploaded.
+            syncResponder.sendOrQueueSyncResponse({ next_batch: 4 });
+            await syncPromise(aliceClient);
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            await flushPromises();
+            expect(fetchMock.callHistory.calls("keys-upload").length).toEqual(keyUploadsAfterInitialBatch);
+        });
     });
 
     describe("getUserDeviceInfo", () => {

--- a/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
+++ b/spec/unit/rust-crypto/OutgoingRequestProcessor.spec.ts
@@ -271,6 +271,39 @@ describe("OutgoingRequestProcessor", () => {
         httpBackend.verifyNoOutstandingRequests();
     });
 
+    it("passes the one-time key counts from /keys/upload responses to the callback", async () => {
+        const onKeysUploadResponse = vi.fn();
+        const httpApi = processor["http"];
+        processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi, onKeysUploadResponse);
+
+        const reqProm = processor.makeOutgoingRequest(new KeysUploadRequest("1234", '{ "one_time_keys": {} }'));
+        httpBackend
+            .when("POST", "/_matrix/client/v3/keys/upload")
+            .respond(200, { one_time_key_counts: { signed_curve25519: 50 } });
+        await httpBackend.flushAllExpected();
+        await reqProm;
+
+        expect(onKeysUploadResponse).toHaveBeenCalledExactlyOnceWith({ signed_curve25519: 50 });
+        expect(olmMachine.markRequestAsSent).toHaveBeenCalledWith(
+            "1234",
+            RustSdkCryptoJs.RequestType.KeysUpload,
+            JSON.stringify({ one_time_key_counts: { signed_curve25519: 50 } }),
+        );
+    });
+
+    it("does not call the callback for other requests", async () => {
+        const onKeysUploadResponse = vi.fn();
+        const httpApi = processor["http"];
+        processor = new OutgoingRequestProcessor(logger, olmMachine, httpApi, onKeysUploadResponse);
+
+        const reqProm = processor.makeOutgoingRequest(new KeysQueryRequest("1234", "{}"));
+        httpBackend.when("POST", "/_matrix/client/v3/keys/query").respond(200, { device_keys: {} });
+        await httpBackend.flushAllExpected();
+        await reqProm;
+
+        expect(onKeysUploadResponse).not.toHaveBeenCalled();
+    });
+
     it("does not explode with unknown requests", async () => {
         const outgoingRequest = { id: "5678", type: 987 } as unknown as OutgoingRequest;
         const markSentCallPromise = awaitCallToMarkAsSent();

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -1138,6 +1138,85 @@ describe("RustCrypto", () => {
         });
     });
 
+    describe("one-time key counts", () => {
+        let rustCrypto: RustCrypto;
+        let olmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;
+
+        beforeEach(() => {
+            olmMachine = {
+                receiveSyncChanges: vi.fn().mockResolvedValue([]),
+            } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
+            rustCrypto = new RustCrypto(
+                new DebugLogger(debug("matrix-js-sdk:test:RustCrypto")),
+                olmMachine,
+                {} as MatrixClient["http"],
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+                {},
+            );
+        });
+
+        /** The one-time key counts passed to `OlmMachine.receiveSyncChanges` on its most recent call */
+        function lastReceivedOneTimeKeyCounts(): Map<string, number> {
+            return olmMachine.receiveSyncChanges.mock.lastCall![2];
+        }
+
+        it("passes the counts and unused fallback keys reported by the server to the OlmMachine", async () => {
+            await rustCrypto.processKeyCounts({ signed_curve25519: 42 }, ["signed_curve25519"]);
+
+            expect(olmMachine.receiveSyncChanges).toHaveBeenCalledTimes(1);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 42]]));
+            expect(olmMachine.receiveSyncChanges.mock.lastCall![3]).toEqual(new Set(["signed_curve25519"]));
+        });
+
+        it("passes an empty count map while the server has not reported any counts", async () => {
+            await rustCrypto.preprocessToDeviceMessages([]);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map());
+        });
+
+        it("reuses the last reported counts when processing to-device messages and device lists", async () => {
+            // `OlmMachine.receiveSyncChanges` needs a count on every call, and treats a missing count as "no
+            // one-time keys on the server", which would make it generate a new batch of keys. So, once the server
+            // has told us the count, we must keep passing it on the calls that don't have a count of their own.
+            // https://github.com/matrix-org/matrix-js-sdk/issues/5501
+            await rustCrypto.processKeyCounts({ signed_curve25519: 42 }, []);
+
+            await rustCrypto.preprocessToDeviceMessages([]);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 42]]));
+
+            await rustCrypto.processDeviceLists({ changed: ["@bob:example.com"] });
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 42]]));
+
+            // A new count from the server replaces the remembered one.
+            await rustCrypto.processKeyCounts({ signed_curve25519: 7 }, []);
+            await rustCrypto.preprocessToDeviceMessages([]);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 7]]));
+
+            expect(olmMachine.receiveSyncChanges).toHaveBeenCalledTimes(5);
+        });
+
+        it("uses the counts from the latest /keys/upload response", async () => {
+            // The server also tells us the count in the response to each `/keys/upload`, and the OlmMachine updates
+            // its own count from that; we must do the same, so that we don't pass a stale (or missing) count on the
+            // next to-device or device-list call.
+            await rustCrypto.processKeyCounts({ signed_curve25519: 10 }, []);
+            rustCrypto["onKeysUploadResponse"]({ signed_curve25519: 50 });
+
+            await rustCrypto.preprocessToDeviceMessages([]);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 50]]));
+        });
+
+        it("reuses the last reported counts when the server only reports unused fallback keys", async () => {
+            await rustCrypto.processKeyCounts({ signed_curve25519: 42 }, undefined);
+            await rustCrypto.processKeyCounts(undefined, ["signed_curve25519"]);
+
+            expect(olmMachine.receiveSyncChanges).toHaveBeenCalledTimes(2);
+            expect(lastReceivedOneTimeKeyCounts()).toEqual(new Map([["signed_curve25519", 42]]));
+            expect(olmMachine.receiveSyncChanges.mock.lastCall![3]).toEqual(new Set(["signed_curve25519"]));
+        });
+    });
+
     describe(".getEncryptionInfoForEvent", () => {
         let rustCrypto: RustCrypto;
         let olmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;

--- a/spec/unit/sync.spec.ts
+++ b/spec/unit/sync.spec.ts
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import debug from "debug";
+import { type MockInstance, type Mocked } from "vitest";
+
+import { DebugLogger, type ISyncResponse } from "../../src";
+import { SyncApi } from "../../src/sync";
+import { type SyncCryptoCallbacks } from "../../src/common-crypto/CryptoBackend";
+import { TestClient } from "../TestClient";
+
+describe("SyncApi", () => {
+    describe("processSyncResponse", () => {
+        let cryptoCallbacks: Mocked<SyncCryptoCallbacks>;
+        let syncApi: SyncApi;
+
+        beforeEach(() => {
+            cryptoCallbacks = {
+                preprocessToDeviceMessages: vi.fn().mockResolvedValue([]),
+                processKeyCounts: vi.fn().mockResolvedValue(undefined),
+                processDeviceLists: vi.fn().mockResolvedValue(undefined),
+                onCryptoEvent: vi.fn().mockResolvedValue(undefined),
+                onSyncCompleted: vi.fn(),
+            } as unknown as Mocked<SyncCryptoCallbacks>;
+
+            const testClient = new TestClient("@alice:localhost", "DEVICE_ID");
+            syncApi = new SyncApi(testClient.client, undefined, {
+                cryptoCallbacks,
+                logger: new DebugLogger(debug("matrix-js-sdk:test:sync")),
+            });
+        });
+
+        /** The position of the first call to `mock` in the overall sequence of mock invocations */
+        function firstCallOrder(mock: MockInstance): number {
+            return mock.mock.invocationCallOrder[0];
+        }
+
+        it("processes one-time key counts before to-device messages and device list changes", async () => {
+            const toDeviceEvent = { type: "org.example.test", sender: "@bob:localhost", content: {} };
+            const syncResponse: ISyncResponse = {
+                next_batch: "1",
+                rooms: { invite: {}, join: {}, leave: {}, knock: {} },
+                account_data: { events: [] },
+                to_device: { events: [toDeviceEvent] },
+                device_lists: { changed: ["@bob:localhost"] },
+                device_one_time_keys_count: { signed_curve25519: 42 },
+                device_unused_fallback_key_types: ["signed_curve25519"],
+            };
+
+            // @ts-ignore calling a private method
+            await syncApi.processSyncResponse({ nextSyncToken: "1" }, syncResponse);
+
+            expect(cryptoCallbacks.processKeyCounts).toHaveBeenCalledExactlyOnceWith({ signed_curve25519: 42 }, [
+                "signed_curve25519",
+            ]);
+            expect(cryptoCallbacks.preprocessToDeviceMessages).toHaveBeenCalledExactlyOnceWith([toDeviceEvent]);
+            expect(cryptoCallbacks.processDeviceLists).toHaveBeenCalledExactlyOnceWith({ changed: ["@bob:localhost"] });
+
+            // The crypto layer has to give the OlmMachine a one-time key count when processing to-device messages
+            // and device list changes, so it must learn the count from this sync response first.
+            expect(firstCallOrder(cryptoCallbacks.processKeyCounts)).toBeLessThan(
+                firstCallOrder(cryptoCallbacks.preprocessToDeviceMessages),
+            );
+            expect(firstCallOrder(cryptoCallbacks.processKeyCounts)).toBeLessThan(
+                firstCallOrder(cryptoCallbacks.processDeviceLists),
+            );
+        });
+
+        it("passes the unstable-prefixed unused fallback key types to the crypto layer", async () => {
+            const syncResponse: ISyncResponse = {
+                "next_batch": "1",
+                "rooms": { invite: {}, join: {}, leave: {}, knock: {} },
+                "account_data": { events: [] },
+                "device_one_time_keys_count": { signed_curve25519: 42 },
+                "org.matrix.msc2732.device_unused_fallback_key_types": ["signed_curve25519"],
+            };
+
+            // @ts-ignore calling a private method
+            await syncApi.processSyncResponse({ nextSyncToken: "1" }, syncResponse);
+
+            expect(cryptoCallbacks.processKeyCounts).toHaveBeenCalledExactlyOnceWith({ signed_curve25519: 42 }, [
+                "signed_curve25519",
+            ]);
+        });
+    });
+});

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -142,6 +142,9 @@ export interface SyncCryptoCallbacks {
     /**
      * Called by the /sync loop when one time key counts and unused fallback key details are received.
      *
+     * For a given /sync response, this is called before {@link preprocessToDeviceMessages} and
+     * {@link processDeviceLists}, so that the implementation has an up-to-date count when processing those.
+     *
      * @param oneTimeKeysCounts - the received one time key counts
      * @param unusedFallbackKeys - the received unused fallback keys
      */

--- a/src/rust-crypto/OutgoingRequestProcessor.ts
+++ b/src/rust-crypto/OutgoingRequestProcessor.ts
@@ -52,6 +52,11 @@ export class OutgoingRequestProcessor {
         private readonly logger: Logger,
         private readonly olmMachine: OlmMachine,
         private readonly http: MatrixHttpApi<IHttpOpts & { onlyData: true }>,
+        /**
+         * Optional callback, called with the `one_time_key_counts` from the response to each successful
+         * `POST /_matrix/client/v3/keys/upload` request.
+         */
+        private readonly onKeysUploadResponse?: (oneTimeKeyCounts: Record<string, number>) => void,
     ) {}
 
     public async makeOutgoingRequest<T>(
@@ -65,6 +70,7 @@ export class OutgoingRequestProcessor {
          */
         if (msg instanceof KeysUploadRequest) {
             resp = await this.requestWithRetry(Method.Post, "/_matrix/client/v3/keys/upload", {}, msg.body);
+            this.notifyKeysUploadResponse(resp);
         } else if (msg instanceof KeysQueryRequest) {
             resp = await this.requestWithRetry(Method.Post, "/_matrix/client/v3/keys/query", {}, msg.body);
         } else if (msg instanceof KeysClaimRequest) {
@@ -180,6 +186,23 @@ export class OutgoingRequestProcessor {
 
         const resp = await uiaCallback(makeRequest);
         return JSON.stringify(resp);
+    }
+
+    /**
+     * Pass the `one_time_key_counts` from a `/keys/upload` response to {@link onKeysUploadResponse}, if set.
+     *
+     * @param resp - the raw JSON response to the `/keys/upload` request.
+     */
+    private notifyKeysUploadResponse(resp: string): void {
+        if (!this.onKeysUploadResponse) return;
+        try {
+            const oneTimeKeyCounts = JSON.parse(resp)?.one_time_key_counts;
+            if (typeof oneTimeKeyCounts === "object" && oneTimeKeyCounts !== null) {
+                this.onKeysUploadResponse(oneTimeKeyCounts);
+            }
+        } catch (e) {
+            this.logger.warn("Unable to parse one_time_key_counts from /keys/upload response", e);
+        }
     }
 
     private async requestWithRetry(

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -175,7 +175,9 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         private readonly enableEncryptedStateEvents: boolean = false,
     ) {
         super();
-        this.outgoingRequestProcessor = new OutgoingRequestProcessor(logger, olmMachine, http);
+        this.outgoingRequestProcessor = new OutgoingRequestProcessor(logger, olmMachine, http, (oneTimeKeyCounts) =>
+            this.onKeysUploadResponse(oneTimeKeyCounts),
+        );
         this.outgoingRequestsManager = new OutgoingRequestsManager(
             this.logger,
             olmMachine,
@@ -1691,16 +1693,42 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
+     * The most recent one-time key counts reported by the server, either in a `/sync` response (see
+     * {@link processKeyCounts}) or in the response to a `/keys/upload` request (see {@link onKeysUploadResponse}).
+     *
+     * `OlmMachine.receiveSyncChanges` requires a one-time key count on every call and (since
+     * matrix-sdk-crypto-wasm 18.5.0) treats a missing `signed_curve25519` entry as "there are no one-time keys
+     * on the server", which makes the `OlmMachine` generate a fresh batch of keys for upload. To avoid that
+     * happening on the calls made from {@link preprocessToDeviceMessages} and {@link processDeviceLists}, which
+     * have no count of their own, we remember the last count the server actually reported and pass that instead.
+     * See https://github.com/matrix-org/matrix-js-sdk/issues/5501.
+     *
+     * `undefined` until the server has reported a count.
+     */
+    private lastOneTimeKeysCounts?: Map<string, number>;
+
+    /**
+     * Called with the `one_time_key_counts` from the response to each `/keys/upload` request.
+     *
+     * The `OlmMachine` updates its own idea of the number of uploaded keys from this response, so we do the same
+     * with {@link lastOneTimeKeysCounts}, to keep the two in step.
+     */
+    private onKeysUploadResponse(oneTimeKeyCounts: Record<string, number>): void {
+        this.lastOneTimeKeysCounts = new Map<string, number>(Object.entries(oneTimeKeyCounts));
+    }
+
+    /**
      * Apply sync changes to the olm machine
      * @param events - the received to-device messages
-     * @param oneTimeKeysCounts - the received one time key counts
+     * @param oneTimeKeysCounts - the received one time key counts. If omitted, the most recent counts reported by
+     *    the server are used (see {@link lastOneTimeKeysCounts}), or an empty map if there are none yet.
      * @param unusedFallbackKeys - the received unused fallback keys
      * @param devices - the received device list updates
      * @returns A list of processed to-device messages.
      */
     private async receiveSyncChanges({
         events,
-        oneTimeKeysCounts = new Map<string, number>(),
+        oneTimeKeysCounts = this.lastOneTimeKeysCounts ?? new Map<string, number>(),
         unusedFallbackKeys,
         devices = new RustSdkCryptoJs.DeviceLists(),
     }: {
@@ -1723,8 +1751,9 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
      * @returns A list of preprocessed to-device messages.
      */
     public async preprocessToDeviceMessages(events: IToDeviceEvent[]): Promise<ReceivedToDeviceMessage[]> {
-        // send the received to-device messages into receiveSyncChanges. We have no info on device-list changes,
-        // one-time-keys, or fallback keys, so just pass empty data.
+        // send the received to-device messages into receiveSyncChanges. We have no info on device-list changes or
+        // fallback keys, so pass empty data for those. The one-time key count defaults to the last count reported by
+        // the server (see `receiveSyncChanges`).
         const processed = await this.receiveSyncChanges({ events });
 
         const received: ReceivedToDeviceMessage[] = [];
@@ -1819,6 +1848,11 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     ): Promise<void> {
         const mapOneTimeKeysCount = oneTimeKeysCounts && new Map<string, number>(Object.entries(oneTimeKeysCounts));
         const setUnusedFallbackKeys = unusedFallbackKeys && new Set<string>(unusedFallbackKeys);
+
+        if (mapOneTimeKeysCount !== undefined) {
+            // Remember the count, for use on subsequent `receiveSyncChanges` calls which have no count of their own.
+            this.lastOneTimeKeysCounts = mapOneTimeKeysCount;
+        }
 
         if (mapOneTimeKeysCount !== undefined || setUnusedFallbackKeys !== undefined) {
             await this.receiveSyncChanges({

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1185,6 +1185,16 @@ export class SyncApi {
             }
         }
 
+        // Handle one_time_keys_count and unused fallback keys.
+        //
+        // This must happen before the to-device events and device list changes are processed: the crypto layer has
+        // to give the OlmMachine a one-time key count on every call it makes for those, and using a stale count from
+        // an earlier /sync response would make it generate (and upload) one-time keys that are not needed.
+        await this.syncOpts.cryptoCallbacks?.processKeyCounts(
+            data.device_one_time_keys_count,
+            data.device_unused_fallback_key_types ?? data["org.matrix.msc2732.device_unused_fallback_key_types"],
+        );
+
         // handle to-device events
         if (data.to_device && Array.isArray(data.to_device.events) && data.to_device.events.length > 0) {
             const toDeviceMessages: IToDeviceEvent[] = data.to_device.events.filter(noUnsafeEventProps);
@@ -1578,12 +1588,6 @@ export class SyncApi {
                 // substantial bit of rework :/.
             }
         }
-
-        // Handle one_time_keys_count and unused fallback keys
-        await this.syncOpts.cryptoCallbacks?.processKeyCounts(
-            data.device_one_time_keys_count,
-            data.device_unused_fallback_key_types ?? data["org.matrix.msc2732.device_unused_fallback_key_types"],
-        );
     }
 
     /**


### PR DESCRIPTION
Hello everyone.

This PR fixes https://github.com/matrix-org/matrix-js-sdk/issues/5501. The code was written with Claude Code (Claude Fable 5); I have tested it successfully in the Matrix client I am developing.

As explained in the issue, this is a pretty bad bug: an affected device keeps uploading a new batch of 50 one-time keys on almost every sync. The server accumulates tens of thousands of keys, and since vodozemac only keeps the private half of the most recent ~100, peers who claim an older key can no longer open an Olm session with the device — new conversations become permanently undecryptable, while existing sessions keep working, which makes it hard to diagnose.

Sable's unreleased dev branch already resolves crypto-wasm 18.5.0, so its next release would be affected, and other matrix-js-sdk clients will be as their lockfiles refresh. Element Web is not affected yet only because its lockfile still pins 18.4.0 — and, as the tests in this PR show, bumping it is currently blocked by this bug.

### Why

`RustCrypto` calls `OlmMachine.receiveSyncChanges` up to three times per `/sync` response, and the to-device and device-list calls passed an empty one-time-key count because they have none of their own. Since matrix-sdk-crypto-wasm 18.5.0 ([matrix-rust-sdk#6780](https://github.com/matrix-org/matrix-rust-sdk/pull/6780)) an empty count means "zero keys on the server", so each such sync made the `OlmMachine` generate and upload 50 new one-time keys. Details and measurements in the issue.

### What

`RustCrypto` now remembers the count the server last reported and passes it on those calls. The `OlmMachine` learns that count from two places, so both are mirrored:

- `processKeyCounts` stores the `/sync` count, and `SyncApi.processSyncResponse` now calls it *before* processing to-device events and device lists, so the stored count is the one from the same response.
- `OutgoingRequestProcessor` reports the `one_time_key_counts` from each `/keys/upload` response (new optional callback), covering the time before `/sync` has reported a count.

The `SyncCryptoCallbacks.processKeyCounts` TSDoc documents the new ordering.

### Testing

- Unit tests (`spec/unit/rust-crypto/rust-crypto.spec.ts`, `OutgoingRequestProcessor.spec.ts`, new `spec/unit/sync.spec.ts`) assert the count handed to the `OlmMachine` on each path, the `/keys/upload` callback, and the call order in `processSyncResponse`.
- End-to-end test in `spec/integ/crypto/crypto.spec.ts` with the real `OlmMachine`: a sync carrying only to-device events and device-list changes must not trigger a `/keys/upload`.
- To see the failure, bump the binding: `pnpm add -D @matrix-org/matrix-sdk-crypto-wasm@18.6.0 --ignore-scripts` and run `spec/integ/crypto`. Without this change the new test fails (`expected 2 to deeply equal 1`) and 18 existing tests in `crypto.spec.ts` / `verification.spec.ts` time out, because the first to-device sync triggers a second key upload that `E2EKeyReceiver` deliberately never answers. With it, all 215 pass on 18.6.0, and the full suite passes on the lockfile's 18.4.0. So this also unblocks bumping the binding past 18.4.0.
- Verified in a production third-party client against 18.5.0: one-time-key uploads stop after the initial batch.

### Notes for reviewers

- CI runs on 18.4.0, where an empty count is ignored, so the new end-to-end test passes either way today; it starts guarding the behaviour as soon as the binding is bumped.
- The changelog gate needs the maintainer-only `T-Defect` label.
- The code was written with the help of Claude Code; I reviewed and tested it.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
