### PR TITLE
Combine crypto-related `receiveSyncChanges` calls into one

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^8.0.0",
-        "@matrix-org/matrix-sdk-crypto-wasm": "^18.4.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^18.7.0",
         "another-json": "^0.2.0",
         "bs58": "^6.0.0",
         "content-type": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       '@matrix-org/matrix-sdk-crypto-wasm':
-        specifier: ^18.4.0
-        version: 18.4.0
+        specifier: ^18.7.0
+        version: 18.7.0
       another-json:
         specifier: ^0.2.0
         version: 0.2.0
@@ -982,8 +982,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.4.0':
-    resolution: {integrity: sha512-osxkU1DQ+05+anGHapjWyvZqdHUb94Id37gy54mCKn1Cq/D7iGT5oEUEhjp4oTnCLo4TOtI6ULJ/LHsapaIptQ==}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0':
+    resolution: {integrity: sha512-IiO8YrahwBN23iii4OBS6AUIEDZePa72bK7WN/DBjOXPc6g/wt891vn0vxmlopTahqFFOz/LErcHisdmzKVTsg==}
     engines: {node: '>= 18'}
 
   '@matrix-org/olm@3.2.15':
@@ -3485,7 +3485,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.4.0': {}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0': {}
 
   '@matrix-org/olm@3.2.15': {}
 

--- a/spec/integ/crypto/cross-signing.spec.ts
+++ b/spec/integ/crypto/cross-signing.spec.ts
@@ -93,10 +93,10 @@ describe("cross-signing", () => {
                 logger: new DebugLogger(debug(`matrix-js-sdk:cross-signing`)),
             });
 
-            syncResponder = new SyncResponder(homeserverUrl);
-            e2eKeyResponder = new E2EKeyResponder(homeserverUrl);
             /** an object which intercepts `/keys/upload` requests on the test homeserver */
-            new E2EKeyReceiver(homeserverUrl);
+            const e2eKeyReceiver = new E2EKeyReceiver(homeserverUrl);
+            syncResponder = new SyncResponder(homeserverUrl, { e2eKeyReceiver });
+            e2eKeyResponder = new E2EKeyResponder(homeserverUrl);
 
             // Silence warnings from the backup manager
             fetchMock.getOnce(new URL("/_matrix/client/v3/room_keys/version", homeserverUrl).toString(), {

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -139,6 +139,19 @@ describe("crypto", () => {
         logger.log(aliceClient.getUserId() + ": started");
     }
 
+    /** Return a promise which resolves the next time `CryptoEvent.UserTrustStatusChanged` is emitted for `userId`. */
+    function awaitUserTrustStatusChanged(userId: string): Promise<void> {
+        return new Promise((resolve) => {
+            const listener = (changedUserId: string): void => {
+                if (changedUserId === userId) {
+                    aliceClient.off(CryptoEvent.UserTrustStatusChanged, listener);
+                    resolve();
+                }
+            };
+            aliceClient.on(CryptoEvent.UserTrustStatusChanged, listener);
+        });
+    }
+
     /**
      * Set up expectations that the client will query device keys.
      *
@@ -2097,12 +2110,15 @@ describe("crypto", () => {
         });
 
         it("An unverified user changes identity", async () => {
-            // We have to be tracking Bob's keys, which means we need to share a room with him
+            // We have to be tracking Bob's keys, which means we need to share a room with him. Joining the room makes
+            // Bob a tracked user, which triggers a `/keys/query` for him: wait for his identity to arrive.
+            const bobIdentityReceived = awaitUserTrustStatusChanged(BOB_TEST_USER_ID);
             syncResponder.sendOrQueueSyncResponse({
                 ...getSyncResponse([BOB_TEST_USER_ID]),
                 device_lists: { changed: [BOB_TEST_USER_ID] },
             });
             await syncPromise(aliceClient);
+            await bobIdentityReceived;
 
             const hasCrossSigningKeysForUser = await aliceClient.getCrypto()!.userHasCrossSigningKeys(BOB_TEST_USER_ID);
             expect(hasCrossSigningKeysForUser).toBe(true);

--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -256,7 +256,7 @@ describe("crypto", () => {
 
             /* set up listeners for /keys/upload and /sync */
             keyReceiver = new E2EKeyReceiver(homeserverUrl);
-            syncResponder = new SyncResponder(homeserverUrl);
+            syncResponder = new SyncResponder(homeserverUrl, { e2eKeyReceiver: keyReceiver });
 
             await aliceClient.initRustCrypto();
 

--- a/spec/integ/crypto/device-dehydration.spec.ts
+++ b/spec/integ/crypto/device-dehydration.spec.ts
@@ -235,7 +235,7 @@ async function initializeSecretStorage(
     await matrixClient.initRustCrypto();
     const crypto = matrixClient.getCrypto()! as RustCrypto;
     // we need to process a sync so that the OlmMachine will upload keys
-    await crypto.preprocessToDeviceMessages([]);
+    await crypto.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
     crypto.onSyncCompleted({});
 
     // create initial secret storage

--- a/spec/integ/crypto/history-sharing.spec.ts
+++ b/spec/integ/crypto/history-sharing.spec.ts
@@ -82,6 +82,7 @@ async function setupClients(n: number, options = { setupNewCrossSigning: true })
         const userId = TEST_USER_IDS[i];
         const routePrefix = `${userId.split(":")[0].slice(1)}-`; // e.g. @alice:example.com -> alice-
         const homeserverUrl = `https://${routePrefix}server.com`; // e.g. @alice:example.com -> https://alice-homeserver.com
+        const keyReceiver = new E2EKeyReceiver(homeserverUrl, routePrefix);
 
         return {
             client: createClient({
@@ -93,10 +94,10 @@ async function setupClients(n: number, options = { setupNewCrossSigning: true })
             }),
             userId,
             homeserverUrl,
-            keyReceiver: new E2EKeyReceiver(homeserverUrl, routePrefix),
+            keyReceiver,
             keyResponder: new E2EKeyResponder(homeserverUrl),
             keyClaimResponder: new E2EOTKClaimResponder(homeserverUrl),
-            syncResponder: new SyncResponder(homeserverUrl),
+            syncResponder: new SyncResponder(homeserverUrl, { e2eKeyReceiver: keyReceiver }),
         };
     });
 

--- a/spec/integ/crypto/megolm-backup.spec.ts
+++ b/spec/integ/crypto/megolm-backup.spec.ts
@@ -129,8 +129,8 @@ describe("megolm-keys backup", () => {
         fetchMock.catch(404);
 
         mockInitialApiRequests(TEST_HOMESERVER_URL);
-        syncResponder = new SyncResponder(TEST_HOMESERVER_URL);
         e2eKeyReceiver = new E2EKeyReceiver(TEST_HOMESERVER_URL);
+        syncResponder = new SyncResponder(TEST_HOMESERVER_URL, { e2eKeyReceiver });
         e2eKeyResponder = new E2EKeyResponder(TEST_HOMESERVER_URL);
         e2eKeyResponder.addDeviceKeys(testData.SIGNED_TEST_DEVICE_DATA);
         e2eKeyResponder.addKeyReceiver(TEST_USER_ID, e2eKeyReceiver);

--- a/spec/integ/crypto/state-events.spec.ts
+++ b/spec/integ/crypto/state-events.spec.ts
@@ -90,7 +90,7 @@ describe("Encrypted State Events", () => {
         });
 
         keyReceiver = new E2EKeyReceiver(homeserverUrl);
-        syncResponder = new SyncResponder(homeserverUrl);
+        syncResponder = new SyncResponder(homeserverUrl, { e2eKeyReceiver: keyReceiver });
 
         await aliceClient.initRustCrypto();
 

--- a/spec/integ/crypto/to-device-messages.spec.ts
+++ b/spec/integ/crypto/to-device-messages.spec.ts
@@ -69,7 +69,7 @@ describe("to-device-messages", () => {
 
             e2eKeyResponder = new E2EKeyResponder(homeserverUrl);
             e2eKeyReceiver = new E2EKeyReceiver(homeserverUrl);
-            syncResponder = new SyncResponder(homeserverUrl);
+            syncResponder = new SyncResponder(homeserverUrl, { e2eKeyReceiver });
 
             // add bob as known user
             syncResponder.sendOrQueueSyncResponse(getSyncResponse([testData.BOB_TEST_USER_ID]));

--- a/spec/integ/crypto/verification.spec.ts
+++ b/spec/integ/crypto/verification.spec.ts
@@ -131,7 +131,7 @@ describe("verification", () => {
         e2eKeyReceiver = new E2EKeyReceiver(TEST_HOMESERVER_URL);
         e2eKeyResponder = new E2EKeyResponder(TEST_HOMESERVER_URL);
         e2eKeyResponder.addKeyReceiver(TEST_USER_ID, e2eKeyReceiver);
-        syncResponder = new SyncResponder(TEST_HOMESERVER_URL);
+        syncResponder = new SyncResponder(TEST_HOMESERVER_URL, { e2eKeyReceiver });
 
         mockInitialApiRequests(TEST_HOMESERVER_URL);
     });

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -509,6 +509,65 @@ describe("MatrixClient syncing", () => {
 
             return httpBackend!.flushAllExpected();
         });
+
+        it("should not pass a cached sync to the crypto layer", async () => {
+            // A cached sync carries no E2EE data. In particular it has no `device_one_time_keys_count`, which the
+            // crypto layer would interpret as "no one-time keys on the server" and upload a fresh batch on every
+            // restart (https://github.com/matrix-org/matrix-js-sdk/issues/5501).
+            const cryptoCallbacks = {
+                processSyncChanges: vi.fn().mockResolvedValue([]),
+                onSyncCompleted: vi.fn(),
+                stop: vi.fn(),
+            };
+            // @ts-ignore private field
+            client!.cryptoBackend = cryptoCallbacks;
+            client!.store.getSavedSync = vi.fn().mockResolvedValue({
+                nextBatch: "cached_token",
+                roomsData: { join: {}, invite: {}, leave: {}, knock: {} },
+                accountData: [],
+            });
+            httpBackend!
+                .when("GET", "/sync")
+                .respond(200, { ...syncData, device_one_time_keys_count: { signed_curve25519: 50 } });
+
+            client!.startClient();
+            await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent()]);
+
+            // only the live sync should have reached the crypto layer
+            expect(cryptoCallbacks.processSyncChanges).toHaveBeenCalledTimes(1);
+            expect(cryptoCallbacks.processSyncChanges).toHaveBeenCalledWith(
+                expect.objectContaining({ oneTimeKeysCounts: { signed_curve25519: 50 } }),
+            );
+        });
+
+        it("should still process room data if the crypto layer fails to process the sync", async () => {
+            const cryptoCallbacks = {
+                processSyncChanges: vi.fn().mockRejectedValue(new Error("crypto store is broken")),
+                onSyncCompleted: vi.fn(),
+                stop: vi.fn(),
+            };
+            // @ts-ignore private field
+            client!.cryptoBackend = cryptoCallbacks;
+            httpBackend!.when("GET", "/sync").respond(200, {
+                ...syncData,
+                rooms: {
+                    join: {
+                        [roomOne]: {
+                            timeline: { events: [], prev_batch: "prev" },
+                            state: { events: [] },
+                            ephemeral: { events: [] },
+                            account_data: { events: [] },
+                        },
+                    },
+                },
+            });
+
+            client!.startClient();
+            await Promise.all([httpBackend!.flushAllExpected(), emitPromise(client!, ClientEvent.Sync)]);
+
+            expect(cryptoCallbacks.processSyncChanges).toHaveBeenCalledTimes(1);
+            expect(client!.getRoom(roomOne)).toBeTruthy();
+        });
     });
 
     describe("resolving invites to profile info", () => {

--- a/spec/integ/matrix-client-syncing.spec.ts
+++ b/spec/integ/matrix-client-syncing.spec.ts
@@ -227,7 +227,8 @@ describe("MatrixClient syncing", () => {
 
             // noinspection ES6MissingAwait
             client!.startClient();
-            await httpBackend!.flushAllExpected();
+            // wait for all three syncs to be processed, not just for their responses to be delivered
+            await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent(3)]);
 
             expect(fires).toBe(3);
         });
@@ -342,7 +343,8 @@ describe("MatrixClient syncing", () => {
 
             // noinspection ES6MissingAwait
             client!.startClient();
-            await httpBackend!.flushAllExpected();
+            // wait for all three syncs to be processed, not just for their responses to be delivered
+            await Promise.all([httpBackend!.flushAllExpected(), awaitSyncEvent(3)]);
 
             expect(fires).toBe(3);
         });
@@ -2670,7 +2672,8 @@ describe("MatrixClient syncing (IndexedDB version)", () => {
 
         // noinspection ES6MissingAwait
         idbClient.startClient();
-        await idbHttpBackend.flushAllExpected();
+        // wait for the sync to be processed, not just for its response to be delivered
+        await Promise.all([idbHttpBackend.flushAllExpected(), utils.syncPromise(idbClient)]);
 
         expect(fires).toBe(1);
 

--- a/spec/integ/sliding-sync-sdk.spec.ts
+++ b/spec/integ/sliding-sync-sdk.spec.ts
@@ -656,31 +656,74 @@ describe("SlidingSyncSdk", () => {
             });
         });
 
-        it("can update device lists", () => {
-            syncCryptoCallback!.processDeviceLists = vi.fn();
-            ext.onResponse({
+        it("passes device lists, OTK counts and fallback keys to crypto in a single call once the response is complete", async () => {
+            syncCryptoCallback!.processSyncChanges = vi.fn().mockResolvedValue([]);
+            syncCryptoCallback!.onSyncCompleted = vi.fn();
+            await ext.onResponse({
                 device_lists: {
                     changed: ["@alice:localhost"],
                     left: ["@bob:localhost"],
                 },
-            });
-            expect(syncCryptoCallback!.processDeviceLists).toHaveBeenCalledWith({
-                changed: ["@alice:localhost"],
-                left: ["@bob:localhost"],
-            });
-        });
-
-        it("can update OTK counts and unused fallback keys", () => {
-            syncCryptoCallback!.processKeyCounts = vi.fn();
-            ext.onResponse({
                 device_one_time_keys_count: {
                     signed_curve25519: 42,
                 },
                 device_unused_fallback_key_types: ["signed_curve25519"],
             });
-            expect(syncCryptoCallback!.processKeyCounts).toHaveBeenCalledWith({ signed_curve25519: 42 }, [
-                "signed_curve25519",
-            ]);
+            // nothing should happen until all extensions in this response have been processed
+            expect(syncCryptoCallback!.processSyncChanges).not.toHaveBeenCalled();
+
+            await ext.onResponseComplete!();
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenCalledTimes(1);
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenCalledWith({
+                toDeviceEvents: [],
+                deviceLists: { changed: ["@alice:localhost"], left: ["@bob:localhost"] },
+                oneTimeKeysCounts: { signed_curve25519: 42 },
+                unusedFallbackKeys: ["signed_curve25519"],
+                useMsc4186: true,
+            });
+            expect(syncCryptoCallback!.onSyncCompleted).toHaveBeenCalledTimes(1);
+        });
+
+        it("passes omitted OTK counts and fallback keys through as undefined", async () => {
+            // In sliding sync, omitted counts mean "unchanged since the last response". That is for the crypto layer
+            // to interpret (via `useMsc4186`): we must not replay stale values ourselves.
+            syncCryptoCallback!.processSyncChanges = vi.fn().mockResolvedValue([]);
+            syncCryptoCallback!.onSyncCompleted = vi.fn();
+            await ext.onResponse({
+                device_one_time_keys_count: { signed_curve25519: 7 },
+                device_unused_fallback_key_types: [],
+            });
+            await ext.onResponseComplete!();
+
+            await ext.onResponse({ device_lists: { changed: ["@carol:localhost"] } });
+            await ext.onResponseComplete!();
+
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenCalledTimes(2);
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenLastCalledWith({
+                toDeviceEvents: [],
+                deviceLists: { changed: ["@carol:localhost"] },
+                oneTimeKeysCounts: undefined,
+                unusedFallbackKeys: undefined,
+                useMsc4186: true,
+            });
+        });
+
+        it("combines to-device events with the e2ee extension data into a single call", async () => {
+            const toDeviceExt = findExtension("to_device");
+            syncCryptoCallback!.processSyncChanges = vi.fn().mockResolvedValue([]);
+            syncCryptoCallback!.onSyncCompleted = vi.fn();
+            const events = [{ type: "m.dummy", sender: "@alice:localhost", content: {} }];
+
+            await toDeviceExt.onResponse({ next_batch: "tdb", events });
+            await ext.onResponse({ device_one_time_keys_count: { signed_curve25519: 3 } });
+            await toDeviceExt.onResponseComplete!();
+            await ext.onResponseComplete!();
+
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenCalledTimes(1);
+            expect(syncCryptoCallback!.processSyncChanges).toHaveBeenCalledWith(
+                expect.objectContaining({ toDeviceEvents: events, oneTimeKeysCounts: { signed_curve25519: 3 } }),
+            );
+            expect(syncCryptoCallback!.onSyncCompleted).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -837,10 +880,11 @@ describe("SlidingSyncSdk", () => {
         });
 
         it("updates the since value", async () => {
-            ext.onResponse({
+            await ext.onResponse({
                 next_batch: "12345",
                 events: [],
             });
+            await ext.onResponseComplete!();
             expect(await ext.onRequest(false)).toMatchObject({
                 since: "12345",
             });
@@ -848,10 +892,11 @@ describe("SlidingSyncSdk", () => {
 
         // eslint-disable-next-line @vitest/expect-expect
         it("can handle missing fields", async () => {
-            ext.onResponse({
+            await ext.onResponse({
                 next_batch: "23456",
                 // no events array
             });
+            await ext.onResponseComplete!();
         });
 
         it("emits to-device events on the client", async () => {
@@ -865,7 +910,7 @@ describe("SlidingSyncSdk", () => {
                 expect(ev.getType()).toEqual(toDeviceType);
                 called = true;
             });
-            ext.onResponse({
+            await ext.onResponse({
                 next_batch: "34567",
                 events: [
                     {
@@ -874,7 +919,26 @@ describe("SlidingSyncSdk", () => {
                     },
                 ],
             });
+            await ext.onResponseComplete!();
             expect(called).toBe(true);
+        });
+
+        it("drops to-device events with unsafe properties", async () => {
+            const received: string[] = [];
+            const listener = (ev: MatrixEvent): void => {
+                received.push(ev.getType());
+            };
+            client!.on(ClientEvent.ToDeviceEvent, listener);
+            await ext.onResponse({
+                next_batch: "34568",
+                events: [
+                    { type: "safe", sender: "@alice:localhost", content: {} },
+                    { type: "unsafe", sender: "__proto__", content: {} },
+                ],
+            });
+            await ext.onResponseComplete!();
+            client!.off(ClientEvent.ToDeviceEvent, listener);
+            expect(received).toEqual(["safe"]);
         });
 
         it("can cancel key verification requests", async () => {
@@ -887,7 +951,7 @@ describe("SlidingSyncSdk", () => {
                     evType === "m.key.verification.start" || evType === "m.key.verification.request",
                 );
             });
-            ext.onResponse({
+            await ext.onResponse({
                 next_batch: "45678",
                 events: [
                     // someone tries to verify keys
@@ -912,6 +976,12 @@ describe("SlidingSyncSdk", () => {
                     },
                 ],
             });
+            await ext.onResponseComplete!();
+            expect(Object.keys(seen).sort()).toEqual([
+                "m.key.verification.cancel",
+                "m.key.verification.request",
+                "m.key.verification.start",
+            ]);
         });
     });
 

--- a/spec/integ/sliding-sync.spec.ts
+++ b/spec/integ/sliding-sync.spec.ts
@@ -818,6 +818,7 @@ describe("SlidingSync", () => {
         const preExtName = "foobar";
         let onPreExtensionRequest: Extension<any, any>["onRequest"];
         let onPreExtensionResponse: Extension<any, any>["onResponse"];
+        let onPreExtensionResponseComplete: () => Promise<void> = async () => {};
 
         // Post-extensions get called AFTER processing the sync response
         const postExtName = "foobar2";
@@ -831,6 +832,9 @@ describe("SlidingSync", () => {
             },
             onResponse: (res) => {
                 return onPreExtensionResponse(res);
+            },
+            onResponseComplete: () => {
+                return onPreExtensionResponseComplete();
             },
             when: () => ExtensionState.PreProcess,
         };
@@ -922,6 +926,64 @@ describe("SlidingSync", () => {
             await httpBackend!.flushAllExpected();
             await p;
             expect(responseCalled).toBe(false);
+        });
+
+        it("calls onResponseComplete after onResponse, and before the response body is processed", async () => {
+            const callbackOrder: string[] = [];
+            onPreExtensionRequest = async () => extReq;
+            onPreExtensionResponse = async () => {
+                callbackOrder.push("onResponse");
+            };
+            onPreExtensionResponseComplete = async () => {
+                callbackOrder.push("onResponseComplete");
+            };
+            httpBackend!.when("POST", syncUrl).respond(200, {
+                pos: "b",
+                ops: [],
+                counts: [],
+                extensions: {
+                    [preExtName]: extResp,
+                },
+            });
+            slidingSync.resend();
+            const p = listenUntil(slidingSync, "SlidingSync.Lifecycle", (state) => {
+                if (state === SlidingSyncState.Complete) {
+                    callbackOrder.push("Lifecycle");
+                    return true;
+                }
+            });
+            await httpBackend!.flushAllExpected();
+            await p;
+            expect(callbackOrder).toEqual(["onResponse", "onResponseComplete", "Lifecycle"]);
+        });
+
+        it("calls onResponseComplete even when the extension is absent from the response", async () => {
+            let responseCalled = false;
+            let completeCalled = false;
+            onPreExtensionRequest = async () => extReq;
+            onPreExtensionResponse = async () => {
+                responseCalled = true;
+            };
+            onPreExtensionResponseComplete = async () => {
+                completeCalled = true;
+            };
+            httpBackend!.when("POST", syncUrl).respond(200, {
+                pos: "c",
+                ops: [],
+                counts: [],
+                extensions: {},
+            });
+            slidingSync.resend();
+            const p = listenUntil(slidingSync, "SlidingSync.Lifecycle", (state) => {
+                return state === SlidingSyncState.Complete;
+            });
+            await httpBackend!.flushAllExpected();
+            await p;
+            expect(responseCalled).toBe(false);
+            expect(completeCalled).toBe(true);
+            // restore the state the following tests expect (no pre-extension request, no completion callback)
+            onPreExtensionRequest = async () => undefined;
+            onPreExtensionResponseComplete = async () => {};
         });
 
         it("is possible to register extensions after start() has been called", async () => {

--- a/spec/test-utils/E2EKeyReceiver.ts
+++ b/spec/test-utils/E2EKeyReceiver.ts
@@ -239,6 +239,14 @@ export class E2EKeyReceiver implements IE2EKeyReceiver {
     }
 
     /**
+     * The number of one-time keys currently held for this device (uploaded, and not yet claimed via
+     * {@link getOneTimeKey}), as a real homeserver would report in `device_one_time_keys_count`.
+     */
+    public getOneTimeKeyCount(): number {
+        return Object.keys(this.oneTimeKeys).length;
+    }
+
+    /**
      * If no one-time keys have yet been uploaded, return `null`.
      * Otherwise, pop a key from the uploaded list.
      */

--- a/spec/test-utils/SyncResponder.ts
+++ b/spec/test-utils/SyncResponder.ts
@@ -19,6 +19,8 @@ import { type Debugger } from "debug";
 import fetchMock from "@fetch-mock/vitest";
 import { type RouteResponse } from "fetch-mock";
 
+import { type E2EKeyReceiver } from "./E2EKeyReceiver";
+
 /** Interface implemented by classes that intercept `/sync` requests from test clients
  *
  * Common interface implemented by {@link TestClient} and {@link SyncResponder}
@@ -72,8 +74,17 @@ export class SyncResponder implements ISyncResponder {
      * client and have overlapping /sync requests.
      *
      * @param homeserverUrl - the Homeserver Url of the client under test.
+     * @param opts - optional settings:
+     *   * `e2eKeyReceiver`: the {@link E2EKeyReceiver} which is intercepting the client's `/keys/upload` requests.
+     *     If supplied, responses which do not specify `device_one_time_keys_count` have it filled in with the number
+     *     of one-time keys uploaded so far, as a real homeserver would. (Per the spec, an absent
+     *     `device_one_time_keys_count` means that there are *zero* one-time keys on the server, which would cause the
+     *     client to upload a new batch after every sync.)
      */
-    public constructor(homeserverUrl: string) {
+    public constructor(
+        homeserverUrl: string,
+        private readonly opts: { e2eKeyReceiver?: E2EKeyReceiver } = {},
+    ) {
         this.debug = debugFunc(`sync-responder:[${homeserverUrl}]`);
         fetchMock.get("begin:" + new URL("/_matrix/client/v3/sync?", homeserverUrl).toString(), (callLog) =>
             this.onSyncRequest(),
@@ -81,31 +92,42 @@ export class SyncResponder implements ISyncResponder {
     }
 
     private async onSyncRequest(): Promise<RouteResponse> {
+        let response: object;
         switch (this.state) {
             case SyncResponderState.IDLE: {
                 this.debug("Got /sync request: waiting for response to be ready");
-                const res = await new Promise<object>((resolve) => {
+                response = await new Promise<object>((resolve) => {
                     this.onResponseReceived = resolve;
                     this.state = SyncResponderState.WAITING_FOR_RESPONSE;
                 });
                 this.debug("Responding to /sync");
                 this.state = SyncResponderState.IDLE;
                 this.onResponseReceived = null;
-                return res;
+                break;
             }
 
             case SyncResponderState.WAITING_FOR_REQUEST: {
                 this.debug("Got /sync request: responding immediately with queued response");
-                const res = this.pendingResponse!;
+                response = this.pendingResponse!;
                 this.state = SyncResponderState.IDLE;
                 this.pendingResponse = null;
-                return res;
+                break;
             }
 
             default:
                 // we must already be in WAITING_FOR_RESPONSE, ie we already have a /sync request in progress
                 throw new Error(`Got unexpected /sync request in state ${this.state}`);
         }
+
+        // Fill in `device_one_time_keys_count` from the E2EKeyReceiver, if we have one and the response does not
+        // already specify it. This is evaluated when the response is served, so it reflects the keys uploaded so far.
+        if (this.opts.e2eKeyReceiver && !("device_one_time_keys_count" in response)) {
+            return {
+                ...response,
+                device_one_time_keys_count: { signed_curve25519: this.opts.e2eKeyReceiver.getOneTimeKeyCount() },
+            };
+        }
+        return response;
     }
 
     /** Next time we see a sync request (or immediately, if there is one waiting), send the given response

--- a/spec/unit/rust-crypto/rust-crypto.spec.ts
+++ b/spec/unit/rust-crypto/rust-crypto.spec.ts
@@ -586,7 +586,9 @@ describe("RustCrypto", () => {
             const inputs: IToDeviceEvent[] = [
                 { content: { key: "value" }, type: "org.matrix.test", sender: "@alice:example.com" },
             ];
-            const res = (await rustCrypto.preprocessToDeviceMessages(inputs)).map((p) => p.message);
+            const res = (await rustCrypto.processSyncChanges({ toDeviceEvents: inputs, oneTimeKeysCounts: {} })).map(
+                (p) => p.message,
+            );
             expect(res).toEqual(inputs);
         });
 
@@ -610,7 +612,7 @@ describe("RustCrypto", () => {
                 },
             ];
 
-            const res = await rustCrypto.preprocessToDeviceMessages(inputs);
+            const res = await rustCrypto.processSyncChanges({ toDeviceEvents: inputs, oneTimeKeysCounts: {} });
             expect(res.length).toEqual(0);
         });
 
@@ -621,7 +623,7 @@ describe("RustCrypto", () => {
                 // decrypted room key bundle.
 
                 // @ts-ignore Overriding a private function
-                rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent(type)]);
+                rustCrypto.olmMachine.receiveSyncChanges = vi.fn().mockResolvedValue([keyBundleEvent(type)]);
 
                 // And that there is a pending key bundle
 
@@ -633,7 +635,7 @@ describe("RustCrypto", () => {
 
                 // When we process to-device messages
                 rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
-                await rustCrypto.preprocessToDeviceMessages([]);
+                await rustCrypto.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
 
                 // Then we accepted the key bundle
                 expect(rustCrypto.maybeAcceptKeyBundle).toHaveBeenCalledWith("!r:s.co", "@inv:s.co");
@@ -645,7 +647,9 @@ describe("RustCrypto", () => {
             // like a room key bundle, except it has the wrong type.
 
             // @ts-ignore Overriding a private function
-            rustCrypto.receiveSyncChanges = vi.fn().mockReturnValue([keyBundleEvent("foo.some_other_type")]);
+            rustCrypto.olmMachine.receiveSyncChanges = vi
+                .fn()
+                .mockResolvedValue([keyBundleEvent("foo.some_other_type")]);
 
             // And that there is a pending key bundle
 
@@ -657,7 +661,7 @@ describe("RustCrypto", () => {
 
             // When we process to-device messages
             rustCrypto.maybeAcceptKeyBundle = vi.fn().mockName("maybeAcceptKeyBundle").mockResolvedValue(null);
-            await rustCrypto.preprocessToDeviceMessages([]);
+            await rustCrypto.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
 
             // Then we do not try to accepted a key bundle
             expect(rustCrypto.maybeAcceptKeyBundle).not.toHaveBeenCalledWith();
@@ -716,7 +720,7 @@ describe("RustCrypto", () => {
 
             const onEvent = vi.fn<CryptoEventHandlerMap[CryptoEvent.VerificationRequestReceived]>();
             rustCrypto.on(CryptoEvent.VerificationRequestReceived, onEvent);
-            await rustCrypto.preprocessToDeviceMessages([toDeviceEvent]);
+            await rustCrypto.processSyncChanges({ toDeviceEvents: [toDeviceEvent], oneTimeKeysCounts: {} });
             expect(onEvent).toHaveBeenCalledTimes(1);
 
             const [req]: [VerificationRequest] = onEvent.mock.lastCall!;
@@ -727,6 +731,75 @@ describe("RustCrypto", () => {
     it("getCrossSigningKeyId when there is no cross signing keys", async () => {
         const rustCrypto = await makeTestRustCrypto();
         await expect(rustCrypto.getCrossSigningKeyId()).resolves.toBe(null);
+    });
+
+    describe("processSyncChanges", () => {
+        let olmMachine: Mocked<RustSdkCryptoJs.OlmMachine>;
+        let rustCrypto: RustCrypto;
+
+        beforeEach(() => {
+            olmMachine = {
+                receiveSyncChanges: vi.fn().mockResolvedValue([]),
+                receiveSyncChangesMsc4186: vi.fn().mockResolvedValue([]),
+            } as unknown as Mocked<RustSdkCryptoJs.OlmMachine>;
+            rustCrypto = new RustCrypto(
+                new DebugLogger(debug("matrix-js-sdk:test:RustCrypto")),
+                olmMachine,
+                {} as MatrixClient["http"],
+                TEST_USER,
+                TEST_DEVICE_ID,
+                {} as ServerSideSecretStorage,
+                {},
+            );
+        });
+
+        it("passes all the sync data to the OlmMachine in a single call", async () => {
+            const toDeviceEvents = [{ type: "m.dummy", sender: "@bob:example.org", content: {} }];
+
+            await rustCrypto.processSyncChanges({
+                toDeviceEvents,
+                deviceLists: { changed: ["@bob:example.org"], left: ["@carol:example.org"] },
+                oneTimeKeysCounts: { signed_curve25519: 42 },
+                unusedFallbackKeys: ["signed_curve25519"],
+            });
+
+            expect(olmMachine.receiveSyncChanges).toHaveBeenCalledTimes(1);
+            expect(olmMachine.receiveSyncChangesMsc4186).not.toHaveBeenCalled();
+            const [events, deviceLists, counts, fallbackKeys] = olmMachine.receiveSyncChanges.mock.calls[0];
+            expect(JSON.parse(events)).toEqual(toDeviceEvents);
+            expect(deviceLists).toBeInstanceOf(RustSdkCryptoJs.DeviceLists);
+            expect(deviceLists.changed.map((u: RustSdkCryptoJs.UserId) => u.toString())).toEqual(["@bob:example.org"]);
+            expect(deviceLists.left.map((u: RustSdkCryptoJs.UserId) => u.toString())).toEqual(["@carol:example.org"]);
+            expect(counts).toEqual(new Map([["signed_curve25519", 42]]));
+            expect(fallbackKeys).toEqual(new Set(["signed_curve25519"]));
+        });
+
+        it("passes an empty one-time key count map through unchanged, and omits fallback keys when unknown", async () => {
+            // A sync v2 response which omits `device_one_time_keys_count` means "zero keys": the caller passes `{}`
+            // and we must forward that as an empty map (not skip the call, and not invent a value).
+            await rustCrypto.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
+
+            expect(olmMachine.receiveSyncChanges).toHaveBeenCalledTimes(1);
+            const [events, deviceLists, counts, fallbackKeys] = olmMachine.receiveSyncChanges.mock.calls[0];
+            expect(JSON.parse(events)).toEqual([]);
+            expect(deviceLists.changed).toEqual([]);
+            expect(deviceLists.left).toEqual([]);
+            expect(counts).toEqual(new Map());
+            expect(fallbackKeys).toBeUndefined();
+        });
+
+        it("uses the MSC4186 semantics for sliding sync, where a missing one-time key count means unchanged", async () => {
+            // In sliding sync, `device_one_time_keys_count` is omitted when it is unchanged, so we must not tell the
+            // OlmMachine that there are zero keys: `receiveSyncChangesMsc4186` interprets a missing entry as unchanged.
+            await rustCrypto.processSyncChanges({ toDeviceEvents: [], useMsc4186: true });
+
+            expect(olmMachine.receiveSyncChanges).not.toHaveBeenCalled();
+            expect(olmMachine.receiveSyncChangesMsc4186).toHaveBeenCalledTimes(1);
+            const [events, , counts, fallbackKeys] = olmMachine.receiveSyncChangesMsc4186.mock.calls[0];
+            expect(JSON.parse(events)).toEqual([]);
+            expect(counts).toEqual(new Map());
+            expect(fallbackKeys).toBeUndefined();
+        });
     });
 
     describe("getCrossSigningStatus", () => {
@@ -1926,7 +1999,7 @@ describe("RustCrypto", () => {
             });
 
             // we need to process a sync so that the OlmMachine will upload keys
-            await rustCrypto1.preprocessToDeviceMessages([]);
+            await rustCrypto1.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
             rustCrypto1.onSyncCompleted({});
 
             fetchMock.get("path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device", {
@@ -1974,7 +2047,7 @@ describe("RustCrypto", () => {
             await rustCrypto2.bootstrapCrossSigning({ setupNewCrossSigning: true });
 
             // we need to process a sync so that the OlmMachine will upload keys
-            await rustCrypto2.preprocessToDeviceMessages([]);
+            await rustCrypto2.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
             rustCrypto2.onSyncCompleted({});
 
             fetchMock.get("path:/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device", {
@@ -2073,7 +2146,7 @@ describe("RustCrypto", () => {
                     setupNewKeyBackup: false,
                 });
                 // we need to process a sync so that the OlmMachine will upload keys
-                await rustCrypto.preprocessToDeviceMessages([]);
+                await rustCrypto.processSyncChanges({ toDeviceEvents: [], oneTimeKeysCounts: {} });
                 rustCrypto.onSyncCompleted({});
 
                 // set up mocks needed for device dehydration

--- a/src/common-crypto/CryptoBackend.ts
+++ b/src/common-crypto/CryptoBackend.ts
@@ -118,42 +118,64 @@ export interface CryptoBackend extends SyncCryptoCallbacks, CryptoApi {
     markRoomAsPendingKeyBundle(roomId: string, inviterId: string): Promise<void>;
 }
 
+/**
+ * The parts of a sync response which are relevant to encryption, as passed to
+ * {@link SyncCryptoCallbacks.processSyncChanges}.
+ *
+ * @internal
+ */
+export interface SyncCryptoChanges {
+    /** The to-device events from the sync response (`to_device.events`), or an empty list if there were none. */
+    toDeviceEvents: IToDeviceEvent[];
+
+    /** The `device_lists` field from the sync response, if any. */
+    deviceLists?: IDeviceLists;
+
+    /**
+     * The `device_one_time_keys_count` field from the sync response, if any.
+     *
+     * The meaning of an algorithm missing from the map (or of an absent field) depends on {@link useMsc4186}: in
+     * sync v2 it means that there are no one-time keys of that algorithm on the server; in sliding sync it means that
+     * the count is unchanged since the previous response.
+     */
+    oneTimeKeysCounts?: Record<string, number>;
+
+    /**
+     * The `device_unused_fallback_key_types` field from the sync response, or `undefined` if the response did not
+     * include it (which means that the server does not support fallback keys).
+     */
+    unusedFallbackKeys?: string[];
+
+    /**
+     * Whether to interpret the response with MSC4186 (simplified sliding sync) semantics rather than sync v2. This
+     * selects the meaning of missing one-time key counts: see {@link oneTimeKeysCounts}. Defaults to `false`.
+     */
+    useMsc4186?: boolean;
+}
+
 /** The methods which crypto implementations should expose to the Sync api
  *
  * @internal
  */
 export interface SyncCryptoCallbacks {
     /**
-     * Called by the /sync loop whenever there are incoming to-device messages.
+     * Called by the sync loop once per sync response, with the parts of the response which are relevant to
+     * encryption: to-device messages, device list changes, one-time key counts and unused fallback key types.
      *
-     * The implementation may preprocess the received messages (eg, decrypt them) and return an
-     * updated list of messages for dispatch to the rest of the system.
+     * All of this data must be passed together, in a single call per sync response, because the OlmMachine
+     * interprets it as the complete E2EE state from a sync response. In particular, per the sync v2 specification,
+     * an absent `device_one_time_keys_count` means that there are no one-time keys on the server, so calling this
+     * without the counts from the response would trigger a spurious one-time key upload. (Sliding sync responses
+     * omit the count when it is unchanged; {@link SyncCryptoChanges.useMsc4186} selects that interpretation.)
      *
-     * Note that, unlike {@link ClientEvent.ToDeviceEvent} events, this is called on the raw to-device
-     * messages, rather than the results of any decryption attempts.
+     * This must be called before the room events in the sync response are processed, so that any room keys received
+     * in to-device messages are available when decrypting room events.
      *
-     * @param events - the received to-device messages
-     * @returns A list of preprocessed to-device messages. This will not map 1:1 to the input list, as some messages may be invalid or
-     * failed to decrypt, and so will be omitted from the output list.
-     *
+     * @param changes - the E2EE-relevant parts of the sync response
+     * @returns A list of processed to-device messages. This will not map 1:1 to the input list, as some messages may
+     *    be invalid or fail to decrypt, and so will be omitted from the output list.
      */
-    preprocessToDeviceMessages(events: IToDeviceEvent[]): Promise<ReceivedToDeviceMessage[]>;
-
-    /**
-     * Called by the /sync loop when one time key counts and unused fallback key details are received.
-     *
-     * @param oneTimeKeysCounts - the received one time key counts
-     * @param unusedFallbackKeys - the received unused fallback keys
-     */
-    processKeyCounts(oneTimeKeysCounts?: Record<string, number>, unusedFallbackKeys?: string[]): Promise<void>;
-
-    /**
-     * Handle the notification from /sync that device lists have
-     * been changed.
-     *
-     * @param deviceLists - device_lists field from /sync
-     */
-    processDeviceLists(deviceLists: IDeviceLists): Promise<void>;
+    processSyncChanges(changes: SyncCryptoChanges): Promise<ReceivedToDeviceMessage[]>;
 
     /**
      * Called by the /sync loop whenever an m.room.encryption event is received.

--- a/src/rust-crypto/rust-crypto.ts
+++ b/src/rust-crypto/rust-crypto.ts
@@ -19,7 +19,7 @@ import * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
 import type { IMegolmSessionData } from "../@types/crypto.ts";
 import { KnownMembership } from "../@types/membership.ts";
-import { type IDeviceLists, type IToDeviceEvent, type ReceivedToDeviceMessage } from "../sync-accumulator.ts";
+import { type IToDeviceEvent, type ReceivedToDeviceMessage } from "../sync-accumulator.ts";
 import type { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
 import { type MatrixEvent, MatrixEventEvent } from "../models/event.ts";
 import { type Room } from "../models/room.ts";
@@ -30,6 +30,7 @@ import {
     DecryptionError,
     type EventDecryptionResult,
     type OnSyncCompletedData,
+    type SyncCryptoChanges,
 } from "../common-crypto/CryptoBackend.ts";
 import { type Logger, LogSpan } from "../logger.ts";
 import { type IHttpOpts, type MatrixHttpApi, Method } from "../http-api/index.ts";
@@ -292,12 +293,12 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     public async decryptEvent(event: MatrixEvent): Promise<EventDecryptionResult> {
         const roomId = event.getRoomId();
         if (!roomId) {
-            // presumably, a to-device message. These are normally decrypted in preprocessToDeviceMessages
+            // presumably, a to-device message. These are normally decrypted in processSyncChanges
             // so the fact it has come back here suggests that decryption failed.
             //
             // once we drop support for the libolm crypto implementation, we can stop passing to-device messages
             // through decryptEvent and hence get rid of this case.
-            throw new Error("to-device event was not decrypted in preprocessToDeviceMessages");
+            throw new Error("to-device event was not decrypted in processSyncChanges");
         }
         return await this.eventDecryptor.attemptEventDecryption(event, this.deviceIsolationMode);
     }
@@ -1691,41 +1692,31 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Apply sync changes to the olm machine
-     * @param events - the received to-device messages
-     * @param oneTimeKeysCounts - the received one time key counts
-     * @param unusedFallbackKeys - the received unused fallback keys
-     * @param devices - the received device list updates
-     * @returns A list of processed to-device messages.
-     */
-    private async receiveSyncChanges({
-        events,
-        oneTimeKeysCounts = new Map<string, number>(),
-        unusedFallbackKeys,
-        devices = new RustSdkCryptoJs.DeviceLists(),
-    }: {
-        events?: IToDeviceEvent[];
-        oneTimeKeysCounts?: Map<string, number>;
-        unusedFallbackKeys?: Set<string>;
-        devices?: RustSdkCryptoJs.DeviceLists;
-    }): Promise<RustSdkCryptoJs.ProcessedToDeviceEvent[]> {
-        return await this.olmMachine.receiveSyncChanges(
-            events ? JSON.stringify(events) : "[]",
-            devices,
-            oneTimeKeysCounts,
-            unusedFallbackKeys,
-        );
-    }
-
-    /** called by the sync loop to preprocess incoming to-device messages
+     * Implementation of {@link SyncCryptoCallbacks.processSyncChanges}.
      *
-     * @param events - the received to-device messages
-     * @returns A list of preprocessed to-device messages.
+     * Passes all of the encryption-relevant data from a sync response to the OlmMachine in a single call, and
+     * post-processes the resulting to-device messages.
      */
-    public async preprocessToDeviceMessages(events: IToDeviceEvent[]): Promise<ReceivedToDeviceMessage[]> {
-        // send the received to-device messages into receiveSyncChanges. We have no info on device-list changes,
-        // one-time-keys, or fallback keys, so just pass empty data.
-        const processed = await this.receiveSyncChanges({ events });
+    public async processSyncChanges({
+        toDeviceEvents,
+        deviceLists,
+        oneTimeKeysCounts,
+        unusedFallbackKeys,
+        useMsc4186 = false,
+    }: SyncCryptoChanges): Promise<ReceivedToDeviceMessage[]> {
+        const events = JSON.stringify(toDeviceEvents);
+        const devices = new RustSdkCryptoJs.DeviceLists(
+            deviceLists?.changed?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
+            deviceLists?.left?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
+        );
+        const counts = new Map(Object.entries(oneTimeKeysCounts ?? {}));
+        const fallbackKeys = unusedFallbackKeys && new Set(unusedFallbackKeys);
+
+        // The two variants differ only in how they treat a missing one-time key count: zero keys on the server (sync
+        // v2) versus unchanged (sliding sync).
+        const processed = useMsc4186
+            ? await this.olmMachine.receiveSyncChangesMsc4186(events, devices, counts, fallbackKeys)
+            : await this.olmMachine.receiveSyncChanges(events, devices, counts, fallbackKeys);
 
         const received: ReceivedToDeviceMessage[] = [];
 
@@ -1806,39 +1797,6 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
         }
 
         return received;
-    }
-
-    /** called by the sync loop to process one time key counts and unused fallback keys
-     *
-     * @param oneTimeKeysCounts - the received one time key counts
-     * @param unusedFallbackKeys - the received unused fallback keys
-     */
-    public async processKeyCounts(
-        oneTimeKeysCounts?: Record<string, number>,
-        unusedFallbackKeys?: string[],
-    ): Promise<void> {
-        const mapOneTimeKeysCount = oneTimeKeysCounts && new Map<string, number>(Object.entries(oneTimeKeysCounts));
-        const setUnusedFallbackKeys = unusedFallbackKeys && new Set<string>(unusedFallbackKeys);
-
-        if (mapOneTimeKeysCount !== undefined || setUnusedFallbackKeys !== undefined) {
-            await this.receiveSyncChanges({
-                oneTimeKeysCounts: mapOneTimeKeysCount,
-                unusedFallbackKeys: setUnusedFallbackKeys,
-            });
-        }
-    }
-
-    /** called by the sync loop to process the notification that device lists have
-     * been changed.
-     *
-     * @param deviceLists - device_lists field from /sync
-     */
-    public async processDeviceLists(deviceLists: IDeviceLists): Promise<void> {
-        const devices = new RustSdkCryptoJs.DeviceLists(
-            deviceLists.changed?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
-            deviceLists.left?.map((userId) => new RustSdkCryptoJs.UserId(userId)),
-        );
-        await this.receiveSyncChanges({ devices });
     }
 
     /** called by the sync loop on m.room.encryption events

--- a/src/sliding-sync-sdk.ts
+++ b/src/sliding-sync-sdk.ts
@@ -28,7 +28,7 @@ import {
     defaultClientOpts,
     defaultSyncApiOpts,
     type SetPresence,
-    processToDeviceMessages,
+    processSyncCryptoChanges,
 } from "./sync.ts";
 import { type MatrixEvent } from "./models/event.ts";
 import {
@@ -39,7 +39,7 @@ import {
     type IStickyStateEvent,
     type IStrippedState,
     type ISyncResponse,
-    type ReceivedToDeviceMessage,
+    type IToDeviceEvent,
 } from "./sync-accumulator.ts";
 import { MatrixError } from "./http-api/index.ts";
 import {
@@ -74,8 +74,63 @@ type ExtensionE2EEResponse = Pick<
     | "org.matrix.msc2732.device_unused_fallback_key_types"
 >;
 
+/**
+ * Collects the encryption-relevant parts of a sliding sync response, which arrive via two separate extensions
+ * (`e2ee` and `to_device`), so that they can be passed to the crypto layer in a single call once the whole response
+ * has been processed. See {@link SyncCryptoCallbacks.processSyncChanges} for why this matters.
+ */
+class E2EESyncChangesCollector {
+    private toDeviceEvents: IToDeviceEvent[] = [];
+    private e2ee?: ExtensionE2EEResponse;
+    private hasChanges = false;
+
+    public constructor(
+        private readonly client: MatrixClient,
+        private readonly cryptoCallbacks?: SyncCryptoCallbacks,
+    ) {}
+
+    public onToDeviceEvents(events: IToDeviceEvent[]): void {
+        this.toDeviceEvents = events;
+        this.hasChanges = true;
+    }
+
+    public onE2EEChanges(data: ExtensionE2EEResponse): void {
+        this.e2ee = data;
+        this.hasChanges = true;
+    }
+
+    /**
+     * Pass the collected changes to the crypto layer, and emit the resulting to-device messages on the client.
+     *
+     * A no-op if nothing has been collected since the last flush, so it is safe to call once per extension.
+     */
+    public async flush(): Promise<void> {
+        if (!this.hasChanges) return;
+        const toDeviceEvents = this.toDeviceEvents;
+        const e2ee = this.e2ee;
+        this.toDeviceEvents = [];
+        this.e2ee = undefined;
+        this.hasChanges = false;
+
+        // Fields omitted from the `e2ee` extension are unchanged since the last response; the crypto layer knows to
+        // interpret them that way given `useMsc4186`.
+        await processSyncCryptoChanges(this.client, this.cryptoCallbacks, {
+            toDeviceEvents,
+            deviceLists: e2ee?.device_lists,
+            oneTimeKeysCounts: e2ee?.device_one_time_keys_count,
+            unusedFallbackKeys:
+                e2ee?.device_unused_fallback_key_types ?? e2ee?.["org.matrix.msc2732.device_unused_fallback_key_types"],
+            useMsc4186: true,
+        });
+        this.cryptoCallbacks?.onSyncCompleted({});
+    }
+}
+
 class ExtensionE2EE implements Extension<ExtensionE2EERequest, ExtensionE2EEResponse> {
-    public constructor(private readonly crypto: SyncCryptoCallbacks) {}
+    public constructor(
+        private readonly crypto: SyncCryptoCallbacks,
+        private readonly collector: E2EESyncChangesCollector,
+    ) {}
 
     public name(): string {
         return "e2ee";
@@ -102,18 +157,11 @@ class ExtensionE2EE implements Extension<ExtensionE2EERequest, ExtensionE2EEResp
     }
 
     public async onResponse(data: ExtensionE2EEResponse): Promise<void> {
-        // Handle device list updates
-        if (data.device_lists) {
-            await this.crypto.processDeviceLists(data.device_lists);
-        }
+        this.collector.onE2EEChanges(data);
+    }
 
-        // Handle one_time_keys_count and unused_fallback_key_types
-        await this.crypto.processKeyCounts(
-            data.device_one_time_keys_count,
-            data["device_unused_fallback_key_types"] || data["org.matrix.msc2732.device_unused_fallback_key_types"],
-        );
-
-        this.crypto.onSyncCompleted({});
+    public async onResponseComplete(): Promise<void> {
+        await this.collector.flush();
     }
 }
 
@@ -131,10 +179,7 @@ type ExtensionToDeviceResponse = {
 class ExtensionToDevice implements Extension<ExtensionToDeviceRequest, ExtensionToDeviceResponse> {
     private nextBatch: string | null = null;
 
-    public constructor(
-        private readonly client: MatrixClient,
-        private readonly cryptoCallbacks?: SyncCryptoCallbacks,
-    ) {}
+    public constructor(private readonly collector: E2EESyncChangesCollector) {}
 
     public name(): string {
         return "to_device";
@@ -153,20 +198,12 @@ class ExtensionToDevice implements Extension<ExtensionToDeviceRequest, Extension
     }
 
     public async onResponse(data: ExtensionToDeviceResponse): Promise<void> {
-        const events = data["events"] || [];
-        let receivedToDeviceMessages: ReceivedToDeviceMessage[];
-        if (this.cryptoCallbacks) {
-            receivedToDeviceMessages = await this.cryptoCallbacks.preprocessToDeviceMessages(events);
-        } else {
-            // Crypto is not enabled, so we just return the events.
-            receivedToDeviceMessages = events.map((rawEvent) => ({
-                message: rawEvent,
-                encryptionInfo: null,
-            }));
-        }
-        processToDeviceMessages(receivedToDeviceMessages, this.client);
-
+        this.collector.onToDeviceEvents(data["events"] || []);
         this.nextBatch = data.next_batch;
+    }
+
+    public async onResponseComplete(): Promise<void> {
+        await this.collector.flush();
     }
 }
 
@@ -408,15 +445,18 @@ export class SlidingSyncSdk {
 
         this.slidingSync.on(SlidingSyncEvent.Lifecycle, this.onLifecycle.bind(this));
         this.slidingSync.on(SlidingSyncEvent.RoomData, this.onRoomData.bind(this));
+        // The `e2ee` and `to_device` extensions feed a shared collector, so that the crypto layer sees all the
+        // encryption-relevant data from a response in a single call.
+        const e2eeCollector = new E2EESyncChangesCollector(this.client, this.syncOpts.cryptoCallbacks);
         const extensions: Extension<any, any>[] = [
-            new ExtensionToDevice(this.client, this.syncOpts.cryptoCallbacks),
+            new ExtensionToDevice(e2eeCollector),
             new ExtensionAccountData(this.client),
             new ExtensionTyping(this.client),
             new ExtensionReceipts(this.client),
             new ExtensionStickyEvents(this.client),
         ];
         if (this.syncOpts.cryptoCallbacks) {
-            extensions.push(new ExtensionE2EE(this.syncOpts.cryptoCallbacks));
+            extensions.push(new ExtensionE2EE(this.syncOpts.cryptoCallbacks, e2eeCollector));
         }
         extensions.forEach((ext) => {
             this.slidingSync.registerExtension(ext);

--- a/src/sliding-sync.ts
+++ b/src/sliding-sync.ts
@@ -249,6 +249,15 @@ export interface Extension<Req extends object, Res extends object> {
      * @returns The state when it should be called.
      */
     when(): ExtensionState;
+    /**
+     * An optional function which is called once per sync response, after `onResponse` has been called on all of
+     * the extensions (of the same `when()` stage) which were present in the response. It is called even if this
+     * extension was not itself present in the response.
+     *
+     * This allows extensions which need to combine their data with that of other extensions (such as `e2ee` and
+     * `to_device`) to act once the whole response has been seen.
+     */
+    onResponseComplete?(): Promise<void>;
 }
 
 /**
@@ -487,23 +496,31 @@ export class SlidingSync extends TypedEventEmitter<SlidingSyncEvent, SlidingSync
     }
 
     private async onPreExtensionsResponse(ext: Record<string, object>): Promise<void> {
-        await Promise.all(
-            Object.keys(ext).map(async (extName) => {
-                if (this.extensions[extName].when() == ExtensionState.PreProcess) {
-                    await this.extensions[extName].onResponse(ext[extName]);
-                }
-            }),
-        );
+        await this.onExtensionsResponse(ext, ExtensionState.PreProcess);
     }
 
     private async onPostExtensionsResponse(ext: Record<string, object>): Promise<void> {
-        await Promise.all(
-            Object.keys(ext).map(async (extName) => {
-                if (this.extensions[extName].when() == ExtensionState.PostProcess) {
-                    await this.extensions[extName].onResponse(ext[extName]);
-                }
-            }),
-        );
+        await this.onExtensionsResponse(ext, ExtensionState.PostProcess);
+    }
+
+    /**
+     * Call `onResponse` on each registered extension of the given stage which is present in the response, and then
+     * `onResponseComplete` on every registered extension of that stage.
+     *
+     * Extensions are processed sequentially, in registration order, so that extensions whose data must be combined
+     * (such as `e2ee` and `to_device`) see a deterministic order.
+     */
+    private async onExtensionsResponse(ext: Record<string, object>, state: ExtensionState): Promise<void> {
+        const extensions = Object.values(this.extensions).filter((extension) => extension.when() === state);
+        for (const extension of extensions) {
+            const data = ext[extension.name()];
+            if (data !== undefined) {
+                await extension.onResponse(data);
+            }
+        }
+        for (const extension of extensions) {
+            await extension.onResponseComplete?.();
+        }
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,7 +23,7 @@ limitations under the License.
  * for HTTP and WS at some point.
  */
 
-import type { SyncCryptoCallbacks } from "./common-crypto/CryptoBackend.ts";
+import type { SyncCryptoCallbacks, SyncCryptoChanges } from "./common-crypto/CryptoBackend.ts";
 import { type SyncUserProfile, User } from "./models/user.ts";
 import { NotificationCountType, Room, RoomEvent } from "./models/room.ts";
 import { deepCopy, noUnsafeEventProps, unsafeProp } from "./utils.ts";
@@ -1185,24 +1185,29 @@ export class SyncApi {
             }
         }
 
-        // handle to-device events
-        if (data.to_device && Array.isArray(data.to_device.events) && data.to_device.events.length > 0) {
-            const toDeviceMessages: IToDeviceEvent[] = data.to_device.events.filter(noUnsafeEventProps);
+        // Handle to-device events, device list changes, one-time key counts and unused fallback keys.
+        //
+        // These are passed to the crypto layer together, in a single call: see the documentation of
+        // `SyncCryptoCallbacks.processSyncChanges` for why they must not be split up. This has to happen before we
+        // process the room events, so that any room keys received in to-device messages can be used to decrypt them.
+        const toDeviceEvents: IToDeviceEvent[] = Array.isArray(data.to_device?.events) ? data.to_device.events : [];
 
-            let receivedToDeviceMessages: ReceivedToDeviceMessage[];
-            if (this.syncOpts.cryptoCallbacks) {
-                receivedToDeviceMessages =
-                    await this.syncOpts.cryptoCallbacks.preprocessToDeviceMessages(toDeviceMessages);
-            } else {
-                // Crypto is not enabled, so we just return the events.
-                receivedToDeviceMessages = toDeviceMessages.map((rawEvent) => ({
-                    message: rawEvent,
-                    encryptionInfo: null,
-                }));
-            }
+        // A cached sync (see `syncFromCache`) carries no E2EE data at all, so we skip the crypto layer for it: an
+        // absent `device_one_time_keys_count` would otherwise be taken to mean that there are no one-time keys on the
+        // server, triggering a spurious key upload on every restart.
+        if (!syncEventData.fromCache) {
+            await processSyncCryptoChanges(client, this.syncOpts.cryptoCallbacks, {
+                toDeviceEvents,
+                deviceLists: data.device_lists,
+                // Per the spec, an absent `device_one_time_keys_count` means there are no one-time keys on the server.
+                oneTimeKeysCounts: data.device_one_time_keys_count ?? {},
+                unusedFallbackKeys:
+                    data.device_unused_fallback_key_types ??
+                    data["org.matrix.msc2732.device_unused_fallback_key_types"],
+            });
+        }
 
-            processToDeviceMessages(receivedToDeviceMessages, client);
-        } else {
+        if (toDeviceEvents.length === 0) {
             // no more to-device events: we can stop polling with a short timeout.
             this.catchingUp = false;
         }
@@ -1567,23 +1572,6 @@ export class SyncApi {
                 client.getNotifTimelineSet()?.addLiveEvent(event, { addToState: true });
             });
         }
-
-        // Handle device list updates
-        if (data.device_lists) {
-            if (this.syncOpts.cryptoCallbacks) {
-                await this.syncOpts.cryptoCallbacks.processDeviceLists(data.device_lists);
-            } else {
-                // FIXME if we *don't* have a crypto module, we still need to
-                // invalidate the device lists. But that would require a
-                // substantial bit of rework :/.
-            }
-        }
-
-        // Handle one_time_keys_count and unused fallback keys
-        await this.syncOpts.cryptoCallbacks?.processKeyCounts(
-            data.device_one_time_keys_count,
-            data.device_unused_fallback_key_types ?? data["org.matrix.msc2732.device_unused_fallback_key_types"],
-        );
     }
 
     /**
@@ -1999,6 +1987,41 @@ export function _createAndReEmitRoom(client: MatrixClient, roomId: string, opts:
     });
 
     return room;
+}
+
+/**
+ * Pass the encryption-relevant parts of a sync response to the crypto layer, and dispatch the resulting to-device
+ * messages on the client.
+ *
+ * `changes.toDeviceEvents` is first filtered with {@link noUnsafeEventProps}. If crypto is not enabled, the to-device
+ * messages are dispatched as received.
+ */
+export async function processSyncCryptoChanges(
+    client: MatrixClient,
+    cryptoCallbacks: SyncCryptoCallbacks | undefined,
+    changes: SyncCryptoChanges,
+): Promise<void> {
+    const toDeviceEvents = changes.toDeviceEvents.filter(noUnsafeEventProps);
+
+    let receivedToDeviceMessages: ReceivedToDeviceMessage[];
+    if (cryptoCallbacks) {
+        try {
+            receivedToDeviceMessages = await cryptoCallbacks.processSyncChanges({ ...changes, toDeviceEvents });
+        } catch (e) {
+            // Don't let a failure in the crypto layer stop the rest of the sync response from being processed: the
+            // sync token has already been advanced, so the room data would otherwise be lost.
+            logger.error("Error passing sync changes to the crypto layer", e);
+            return;
+        }
+    } else {
+        // Crypto is not enabled, so we just return the events.
+        //
+        // FIXME if we *don't* have a crypto module, we still need to invalidate the device lists. But that would
+        // require a substantial bit of rework :/.
+        receivedToDeviceMessages = toDeviceEvents.map((message) => ({ message, encryptionInfo: null }));
+    }
+
+    processToDeviceMessages(receivedToDeviceMessages, client);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

https://github.com/matrix-org/matrix-rust-sdk/pull/6780 fixed a long-standing issue in the Rust SDK where `OlmMachine::receive_sync_changes` incorrectly treated a missing `one_time_keys_counts` as "no change", when (for sync v2) this means "no keys". This behaviour made it into the WASM SDK in [release v18.5.0](https://github.com/matrix-org/matrix-sdk-crypto-wasm/releases/tag/v18.5.0), which causes clients written using the JS SDK to endlessly upload OTKs on every sync.

This is resolved by this PR by correctly calling either `OlmMachine.receiveSyncChanges` or the new `OlmMachine.receiveSyncChanges` once per sync, as opposed to the three calls previously made by `preprocessToDeviceMessages`, `processDeviceLists`, and `processKeyCounts`.

Fixes #5501

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
