### PR TITLE
Log OAuth requests and responses

### DIFF
--- a/spec/unit/oauth/fetch.spec.ts
+++ b/spec/unit/oauth/fetch.spec.ts
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fetchMock from "@fetch-mock/vitest";
+import { type Mocked } from "vitest";
+
+import { type Logger } from "../../../src/logger";
+import { OAuth2, startDeviceAuthorization } from "../../../src/oauth";
+import { fetchWithLogging } from "../../../src/oauth/fetch";
+import { makeDelegatedAuthMetadata } from "../../test-utils/auth";
+import { OAuthGrantType } from "../../../src/oauth/register";
+
+describe("fetchWithLogging()", () => {
+    let mockLogger: Mocked<Logger>;
+
+    beforeEach(() => {
+        mockLogger = {
+            debug: vi.fn(),
+        } as unknown as Mocked<Logger>;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("should log the request and the response", async () => {
+        vi.useFakeTimers();
+        const responseResolvers = Promise.withResolvers<Response>();
+        fetchMock.post("https://auth.org/token", responseResolvers.promise);
+
+        const prom = fetchWithLogging(mockLogger, "https://auth.org/token", { method: "POST" });
+        vi.advanceTimersByTime(1234);
+        responseResolvers.resolve(new Response("{}", { status: 200 }));
+        await prom;
+
+        expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+        expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> POST https://auth.org/token"]);
+        expect(mockLogger.debug.mock.calls[1]).toEqual(["OAuth2: <-- POST https://auth.org/token [1234ms 200]"]);
+    });
+
+    it("should not log the values of query parameters", async () => {
+        fetchMock.get("https://auth.org/whatever?token=super-secret", { status: 200, body: "{}" });
+
+        await fetchWithLogging(mockLogger, "https://auth.org/whatever?token=super-secret");
+
+        for (const call of mockLogger.debug.mock.calls) {
+            expect(call[0]).not.toContain("super-secret");
+        }
+        expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> GET https://auth.org/whatever?token=xxx"]);
+    });
+
+    it("should log the response status even when it is an error", async () => {
+        fetchMock.post("https://auth.org/token", { status: 400, body: "{}" });
+
+        await fetchWithLogging(mockLogger, "https://auth.org/token", { method: "POST" });
+
+        expect(mockLogger.debug.mock.calls[1]).toEqual([
+            expect.stringMatching(/^OAuth2: <-- POST https:\/\/auth\.org\/token \[\d+ms 400\]$/),
+        ]);
+    });
+
+    it("should log and rethrow network errors", async () => {
+        const error = new Error("Network error");
+        fetchMock.post("https://auth.org/token", { throws: error });
+
+        await expect(fetchWithLogging(mockLogger, "https://auth.org/token", { method: "POST" })).rejects.toThrow(error);
+
+        expect(mockLogger.debug.mock.calls[1]).toEqual([
+            expect.stringMatching(/^OAuth2: <-- POST https:\/\/auth\.org\/token \[\d+ms Error: Network error\]$/),
+        ]);
+    });
+
+    describe("integration", () => {
+        const delegatedAuthConfig = makeDelegatedAuthMetadata("https://auth.org/", [
+            OAuthGrantType.DeviceAuthorization,
+        ]);
+
+        it("should log token endpoint requests made by OAuth2", async () => {
+            fetchMock.post(delegatedAuthConfig.token_endpoint, {
+                status: 200,
+                body: { access_token: "abc123", token_type: "Bearer", expires_in: 300 },
+            });
+
+            const auth = new OAuth2(
+                delegatedAuthConfig,
+                { clientId: "test-client-id", redirectUri: "https://test.com" },
+                mockLogger,
+            );
+            await auth.completeAuthorizationCodeGrant("code123");
+
+            expect(mockLogger.debug.mock.calls).toEqual([
+                ["OAuth2: --> POST https://auth.org/token"],
+                [expect.stringMatching(/^OAuth2: <-- POST https:\/\/auth\.org\/token \[\d+ms 200\]$/)],
+            ]);
+        });
+
+        it("should log revocation endpoint requests made by OAuth2", async () => {
+            fetchMock.post(delegatedAuthConfig.revocation_endpoint, { status: 200, body: "{}" });
+
+            const auth = new OAuth2(
+                delegatedAuthConfig,
+                { clientId: "test-client-id", redirectUri: "https://test.com" },
+                mockLogger,
+            );
+            await auth.revokeToken("abc123", "access_token");
+
+            expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> POST https://auth.org/revoke"]);
+        });
+
+        it("should log registration endpoint requests made by registerClient", async () => {
+            fetchMock.post(delegatedAuthConfig.registration_endpoint, {
+                status: 200,
+                body: { client_id: "xyz789" },
+            });
+
+            await OAuth2.registerClient(
+                delegatedAuthConfig,
+                {
+                    client_uri: "https://just.testing",
+                    redirect_uris: ["https://just.testing"],
+                    client_name: "Element",
+                    application_type: "web",
+                },
+                mockLogger,
+            );
+
+            expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> POST https://auth.org/registration"]);
+        });
+
+        it("should log device authorization endpoint requests", async () => {
+            fetchMock.post(delegatedAuthConfig.device_authorization_endpoint!, {
+                status: 200,
+                body: {
+                    device_code: "device123",
+                    user_code: "USER123",
+                    verification_uri: "https://auth.org/link",
+                    expires_in: 300,
+                },
+            });
+
+            await startDeviceAuthorization({
+                clientId: "test-client-id",
+                scope: "test-scope",
+                metadata: delegatedAuthConfig,
+                logger: mockLogger,
+            });
+
+            expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> POST https://auth.org/device"]);
+        });
+    });
+});

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -31,6 +31,7 @@ import {
     type Body,
 } from "./interface.ts";
 import { anySignal, parseErrorResponse, timeoutSignal } from "./utils.ts";
+import { sanitizeUrlForLogs } from "./logging.ts";
 import { type QueryDict } from "../utils.ts";
 import { TokenRefresher, TokenRefreshOutcome } from "./refresh.ts";
 
@@ -241,7 +242,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
             throw new Error("Invalid call to `FetchHttpApi` sets both `opts.json` and `opts.rawResponseBody`");
         }
 
-        const urlForLogs = this.sanitizeUrlForLogs(url);
+        const urlForLogs = sanitizeUrlForLogs(url);
 
         this.opts.logger?.debug(`FetchHttpApi: --> ${method} ${urlForLogs}`);
 
@@ -330,28 +331,6 @@ export class FetchHttpApi<O extends IHttpOpts> {
         }
     }
 
-    private sanitizeUrlForLogs(url: URL | string): string {
-        try {
-            let asUrl: URL;
-            if (typeof url === "string") {
-                asUrl = new URL(url);
-            } else {
-                asUrl = url;
-            }
-            // Remove the values of any URL params that could contain potential secrets
-            const sanitizedQs = new URLSearchParams();
-            for (const key of asUrl.searchParams.keys()) {
-                sanitizedQs.append(key, "xxx");
-            }
-            const sanitizedQsString = sanitizedQs.toString();
-            const sanitizedQsUrlPiece = sanitizedQsString ? `?${sanitizedQsString}` : "";
-
-            return asUrl.origin + asUrl.pathname + sanitizedQsUrlPiece;
-        } catch {
-            // defensive coding for malformed url
-            return "??";
-        }
-    }
     /**
      * Form and return a homeserver request URL based on the given path params and prefix.
      * @param path - The HTTP path <b>after</b> the supplied prefix e.g. "/createRoom".

--- a/src/http-api/logging.ts
+++ b/src/http-api/logging.ts
@@ -18,6 +18,7 @@ limitations under the License.
  * Produce a version of the given URL which is safe to write to logs, by redacting the values of any query parameters,
  * as they may contain secrets.
  *
+ * @internal
  * @param url - the URL to sanitize.
  * @returns the sanitized URL, or `"??"` if the URL could not be parsed.
  */

--- a/src/http-api/logging.ts
+++ b/src/http-api/logging.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Produce a version of the given URL which is safe to write to logs, by redacting the values of any query parameters,
+ * as they may contain secrets.
+ *
+ * @param url - the URL to sanitize.
+ * @returns the sanitized URL, or `"??"` if the URL could not be parsed.
+ */
+export function sanitizeUrlForLogs(url: URL | string): string {
+    try {
+        let asUrl: URL;
+        if (typeof url === "string") {
+            asUrl = new URL(url);
+        } else {
+            asUrl = url;
+        }
+        // Remove the values of any URL params that could contain potential secrets
+        const sanitizedQs = new URLSearchParams();
+        for (const key of asUrl.searchParams.keys()) {
+            sanitizedQs.append(key, "xxx");
+        }
+        const sanitizedQsString = sanitizedQs.toString();
+        const sanitizedQsUrlPiece = sanitizedQsString ? `?${sanitizedQsString}` : "";
+
+        return asUrl.origin + asUrl.pathname + sanitizedQsUrlPiece;
+    } catch {
+        // defensive coding for malformed url
+        return "??";
+    }
+}

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -27,6 +27,8 @@ import {
 import { Method } from "../http-api/index.ts";
 import { OAuthGrantType } from "./register.ts";
 import { sleep } from "../utils.ts";
+import { type Logger, logger as rootLogger } from "../logger.ts";
+import { fetchWithLogging } from "./fetch.ts";
 
 /**
  * The expected response type from the token endpoint during authorization code flow
@@ -185,6 +187,7 @@ export function validateDeviceAuthorizationResponse(
  * @param options.clientId - the client ID returned from client registration.
  * @param options.scope - the scope to request for authorization.
  * @param options.metadata - the validated OAuth2 metadata for the Identity Provider.
+ * @param options.logger - optional logger to use for the request, defaults to the root logger of the js-sdk.
  * @returns a promise that resolves to a device access token response,
  *   or an error response if the user denies authorization or the device code expires.
  */
@@ -192,10 +195,12 @@ export const startDeviceAuthorization = async ({
     clientId,
     scope,
     metadata,
+    logger = rootLogger,
 }: {
     clientId: string;
     scope: string;
     metadata: ValidatedAuthMetadata;
+    logger?: Logger;
 }): Promise<DeviceAuthorizationResponse> => {
     const body = new URLSearchParams({ client_id: clientId, scope: scope }).toString();
 
@@ -204,7 +209,7 @@ export const startDeviceAuthorization = async ({
         throw new Error("No device_authorization_endpoint given");
     }
 
-    const response = await fetch(url, {
+    const response = await fetchWithLogging(logger, url, {
         method: Method.Post,
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -223,6 +228,7 @@ export const startDeviceAuthorization = async ({
  * @param options.session - The session returned from a previous call to {@link startDeviceAuthorization}.
  * @param options.metadata - The validated OAuth2 metadata for the Identity Provider.
  * @param options.clientId - The client ID returned from client registration.
+ * @param options.logger - optional logger to use for the requests, defaults to the root logger of the js-sdk.
  * @returns a promise that resolves to a device access token response,
  *   or an error response if the user denies authorization or the device code expires.
  */
@@ -230,10 +236,12 @@ export const waitForDeviceAuthorization = async ({
     session,
     metadata,
     clientId,
+    logger = rootLogger,
 }: {
     session: DeviceAuthorizationResponse;
     metadata: ValidatedAuthMetadata;
     clientId: string;
+    logger?: Logger;
 }): Promise<DeviceAccessTokenResponse | DeviceAccessTokenError> => {
     let interval = (session.interval ?? 5) * 1000; // poll interval
     const expiration = Date.now() + session.expires_in * 1000;
@@ -243,7 +251,7 @@ export const waitForDeviceAuthorization = async ({
             grant_type: OAuthGrantType.DeviceAuthorization,
             client_id: clientId,
         }).toString();
-        const response = await fetch(metadata.token_endpoint, {
+        const response = await fetchWithLogging(logger, metadata.token_endpoint, {
             method: Method.Post,
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body,

--- a/src/oauth/fetch.ts
+++ b/src/oauth/fetch.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { sanitizeUrlForLogs } from "../http-api/logging.ts";
+import { Method } from "../http-api/method.ts";
+import { type Logger } from "../logger.ts";
+
+/**
+ * Perform a `fetch` request, logging the request and response in the same manner as
+ * `FetchHttpApi` does for Client-Server API requests.
+ *
+ * Neither the request nor the response body is logged, as they routinely contain credentials.
+ * Query parameter values are redacted for the same reason.
+ *
+ * @param logger - the logger to write the request and response lines to.
+ * @param resource - the URL to request.
+ * @param options - the options to pass to `fetch`.
+ * @returns the `Response`, whatever its status code.
+ * @throws rethrows whatever `fetch` threw, having logged it.
+ */
+export async function fetchWithLogging(
+    logger: Logger,
+    resource: URL | string,
+    options: RequestInit = {},
+): Promise<Response> {
+    const method = options.method ?? Method.Get;
+    const urlForLogs = sanitizeUrlForLogs(resource);
+
+    logger.debug(`OAuth2: --> ${method} ${urlForLogs}`);
+
+    const start = Date.now();
+    try {
+        const res = await globalThis.fetch(resource, options);
+        logger.debug(`OAuth2: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${res.status}]`);
+        return res;
+    } catch (e) {
+        logger.debug(`OAuth2: <-- ${method} ${urlForLogs} [${Date.now() - start}ms ${e}]`);
+        throw e;
+    }
+}

--- a/src/oauth/fetch.ts
+++ b/src/oauth/fetch.ts
@@ -25,6 +25,7 @@ import { type Logger } from "../logger.ts";
  * Neither the request nor the response body is logged, as they routinely contain credentials.
  * Query parameter values are redacted for the same reason.
  *
+ * @internal
  * @param logger - the logger to write the request and response lines to.
  * @param resource - the URL to request.
  * @param options - the options to pass to `fetch`.

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -35,7 +35,8 @@ import {
 import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { sha256 } from "../digest.ts";
 import { HTTPError, isMatrixErrorResponse, MatrixError, Method } from "../http-api/index.ts";
-import { logger } from "../logger.ts";
+import { type Logger, logger as rootLogger } from "../logger.ts";
+import { fetchWithLogging } from "./fetch.ts";
 import { isOAuth2ErrorResponse, OAuth2Error, OAuth2HTTPError } from "./error.ts";
 import { secureRandomString } from "../randomstring.ts";
 import { type NonEmptyArray } from "../@types/common.ts";
@@ -67,12 +68,14 @@ export class OAuth2 {
      * @param authMetadata - Auth config from {@link MatrixClient.getAuthMetadata}
      * @param clientMetadata - The metadata for the client which to register,
      *     grant_types & response_types & token_endpoint_auth_method will be sanely calculated if omitted.
+     * @param logger - Optional logger to use for the request, defaults to the root logger of the js-sdk.
      * @returns Promise<string> resolved with registered clientId
      * @throws when registration is not supported, on failed request or invalid response
      */
     public static async registerClient(
         authMetadata: ValidatedAuthMetadata,
         clientMetadata: OAuthRegistrationRequest,
+        logger: Logger = rootLogger,
     ): Promise<string> {
         const defaultGrantTypes: NonEmptyArray<string> = [
             OAuthGrantType.AuthorizationCode,
@@ -102,7 +105,7 @@ export class OAuth2 {
         };
 
         try {
-            const response = await fetch(authMetadata.registration_endpoint, {
+            const response = await fetchWithLogging(logger, authMetadata.registration_endpoint, {
                 method: Method.Post,
                 headers: {
                     "Accept": "application/json",
@@ -133,9 +136,16 @@ export class OAuth2 {
 
     public readonly context: Required<Context>;
 
+    /**
+     * @param metadata - The validated OAuth 2.0 metadata for the Identity Provider.
+     * @param context - The persistent context needed for the OAuth flows.
+     * @param logger - Optional logger to use for the requests made by this instance,
+     *     defaults to the root logger of the js-sdk.
+     */
     public constructor(
         public readonly metadata: ValidatedAuthMetadata,
         context: Context,
+        private readonly logger: Logger = rootLogger,
     ) {
         this.context = {
             clientId: context.clientId,
@@ -254,6 +264,7 @@ export class OAuth2 {
             scope: scope ?? generateScope(this.context.deviceId),
             metadata: this.metadata,
             clientId: this.context.clientId,
+            logger: this.logger,
         });
     }
 
@@ -270,6 +281,7 @@ export class OAuth2 {
             session,
             metadata: this.metadata,
             clientId: this.context.clientId,
+            logger: this.logger,
         });
     }
 
@@ -279,7 +291,7 @@ export class OAuth2 {
         error: OAuth2Error,
     ): Promise<unknown> {
         const url = this.metadata[`${target}_endpoint`];
-        const res = await fetch(url, {
+        const res = await fetchWithLogging(this.logger, url, {
             method: Method.Post,
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
The OAuth 2.0 flows in [src/oauth/](src/oauth/) called `fetch` directly, so none of the requests to the identity provider's registration, device authorization, token or revocation endpoints showed up in the logs. That makes debugging login and token refresh problems noticeably harder than debugging Client-Server API calls, which `FetchHttpApi` logs.

This adds a `fetchWithLogging` wrapper that emits the same `-->` / `<--` debug lines as `FetchHttpApi`, and uses it for every OAuth 2.0 request:

```
OAuth2: --> POST https://auth.org/token
OAuth2: <-- POST https://auth.org/token [42ms 200]
```

As in `FetchHttpApi`, neither the request nor the response body is logged, and query parameter values are redacted — these requests routinely carry credentials. `sanitizeUrlForLogs` has been lifted out of `FetchHttpApi` into `src/http-api/logging.ts` so both can share it, with no change in behaviour.

`OAuth2`, `OAuth2.registerClient`, `startDeviceAuthorization` and `waitForDeviceAuthorization` now accept an optional `Logger` so callers can route these lines to the logger of their choice (e.g. a `MatrixClient`'s logger). All of them default to the js-sdk root logger, so this is backwards compatible.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (with review by human)