### PR TITLE
Fix OAuth token revocation against a spec-compliant authorization server

### DIFF
--- a/spec/unit/oauth/tokenRevocation.spec.ts
+++ b/spec/unit/oauth/tokenRevocation.spec.ts
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fetchMock from "@fetch-mock/vitest";
+
+import { OAuth2 } from "../../../src";
+import { makeDelegatedAuthMetadata } from "../../test-utils/auth";
+
+describe("tokenRevocation", () => {
+    const issuer = "https://issuer.org/";
+    const clientId = "test-client-id";
+    const redirectUri = "https://test.org";
+    const deviceId = "abc123";
+
+    const metadata = makeDelegatedAuthMetadata(issuer);
+    const auth = new OAuth2(metadata, { clientId, redirectUri, deviceId });
+
+    beforeEach(() => {
+        // A successful revocation response as described by RFC 7009 § 2.2: the authorization server
+        // responds with HTTP 200 and can have anything as the body including empty.
+        // https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
+        fetchMock.post(
+            metadata.revocation_endpoint,
+            {
+                status: 200,
+                headers: {
+                    "Content-Length": "0",
+                },
+                body: "",
+            },
+            { name: "revocation-endpoint" },
+        );
+    });
+
+    it("should resolve on the empty 200 response the RFC mandates for a successful revocation", async () => {
+        await expect(auth.revokeToken("access-token", "access_token")).resolves.toBeUndefined();
+
+        expect(fetchMock).toHaveFetchedTimes(1, metadata.revocation_endpoint);
+    });
+
+    it("should make correct request to the revocation endpoint", async () => {
+        await auth.revokeToken("access-token", "access_token");
+
+        expect(fetchMock.callHistory.lastCall(metadata.revocation_endpoint)?.options).toStrictEqual(
+            expect.objectContaining({
+                method: "post",
+                headers: {
+                    "accept": "application/json",
+                    "content-type": "application/x-www-form-urlencoded",
+                },
+            }),
+        );
+
+        // check body is correctly formed
+        const queryParams = fetchMock.callHistory.lastCall(metadata.revocation_endpoint)!.options
+            .body as URLSearchParams;
+        expect(queryParams.get("token")).toEqual("access-token");
+        expect(queryParams.get("client_id")).toEqual(clientId);
+        expect(queryParams.get("token_type_hint")).toEqual("access_token");
+    });
+
+    it("should omit the token_type_hint when no token type is given", async () => {
+        await auth.revokeToken("refresh-token");
+
+        const queryParams = fetchMock.callHistory.lastCall(metadata.revocation_endpoint)!.options
+            .body as URLSearchParams;
+        expect(queryParams.get("token")).toEqual("refresh-token");
+        expect(queryParams.has("token_type_hint")).toBe(false);
+    });
+});

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -200,7 +200,8 @@ export class OAuth2 {
         params.append("redirect_uri", this.context.redirectUri);
         params.append("code", code);
 
-        const tokenResponse = await this.fetch("token", params, OAuth2Error.CodeExchangeFailed);
+        const res = await this.fetch("token", params, OAuth2Error.CodeExchangeFailed);
+        const tokenResponse = await res.json();
 
         // throws when response is invalid
         validateBearerTokenResponse(tokenResponse);
@@ -217,7 +218,8 @@ export class OAuth2 {
         params.append("client_id", this.context.clientId);
         params.append("refresh_token", refreshToken);
 
-        const tokenResponse = await this.fetch("token", params, OAuth2Error.RefreshTokenFailed);
+        const res = await this.fetch("token", params, OAuth2Error.RefreshTokenFailed);
+        const tokenResponse = await res.json();
 
         // throws when response is invalid
         validateBearerTokenResponse(tokenResponse);
@@ -237,6 +239,10 @@ export class OAuth2 {
             params.append("token_type_hint", type);
         }
 
+        // [RFC 7009 section 2.2](https://www.rfc-editor.org/rfc/rfc7009.html#section-2.2) says:
+        // > The content of the response body is ignored by the client as all
+        // > necessary information is conveyed in the response code.
+        // so, we don't do anything with the response body.
         await this.fetch("revocation", params, OAuth2Error.RevokeTokenFailed);
 
         const headers = new Headers();
@@ -273,11 +279,15 @@ export class OAuth2 {
         });
     }
 
+    /**
+     * Make a request to one of the OAuth 2.0 endpoints, throwing if it responds with an error.
+     * @returns the {@link Response}, for the caller to parse if the endpoint returns a body.
+     */
     private async fetch(
         target: "token" | "registration" | "revocation",
         params: URLSearchParams,
         error: OAuth2Error,
-    ): Promise<unknown> {
+    ): Promise<Response> {
         const url = this.metadata[`${target}_endpoint`];
         const res = await fetch(url, {
             method: Method.Post,
@@ -309,6 +319,6 @@ export class OAuth2 {
             throw new HTTPError(error, res.status, res.headers);
         }
 
-        return await res.json();
+        return res;
     }
 }


### PR DESCRIPTION
OAuth2.revokeToken went through the shared fetch helper, which ended with
an unconditional res.json(). [RFC 7009 § 2.2](https://www.rfc-editor.org/rfc/rfc7009.html#section-2.2) says a successful revocation
is answered with HTTP 200 and that the body should be ignored.
In the case of an empty body (which should be valid) it threw
"Unexpected end of JSON input" and revokeToken rejected.

Have the helper return the Response once it has handled error statuses,
and parse the body only at the two token-endpoint call sites that expect
one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
