### PR TITLE
Remove redundant code from OAuth2.revokeToken

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -238,9 +238,6 @@ export class OAuth2 {
         }
 
         await this.fetch("revocation", params, OAuth2Error.RevokeTokenFailed);
-
-        const headers = new Headers();
-        headers.set("Content-Type", "application/x-www-form-urlencoded");
     }
 
     /**


### PR DESCRIPTION
`headers` isn't used, so no point initialising it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
