### PR TITLE
Support the v1.19 version of mutual rooms

### DIFF
--- a/spec/unit/room-member.spec.ts
+++ b/spec/unit/room-member.spec.ts
@@ -26,6 +26,7 @@ import {
     UNSTABLE_MSC2666_MUTUAL_ROOMS,
     UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS,
     UNSTABLE_MSC2666_SHARED_ROOMS,
+    STABLE_MSC2666_QUERY_MUTUAL_ROOMS,
 } from "../../src";
 import { KnownMembership } from "../../src/@types/membership";
 
@@ -485,7 +486,7 @@ describe("MutualRooms", () => {
             };
         });
 
-        const rooms = await client._unstable_getSharedRooms(QUERIED_USER);
+        const rooms = await client.getMutualRooms(QUERIED_USER);
 
         expect(rooms).toEqual(["!test:example.com"]);
     });
@@ -504,12 +505,12 @@ describe("MutualRooms", () => {
             };
         });
 
-        const rooms = await client._unstable_getSharedRooms(QUERIED_USER);
+        const rooms = await client.getMutualRooms(QUERIED_USER);
 
         expect(rooms).toEqual(["!test2:example.com"]);
     });
 
-    describe("can work the latest MSC version (query mutual rooms)", () => {
+    describe("can work with the latest MSC version (query mutual rooms)", () => {
         beforeEach(() => {
             enableFeature(UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS);
         });
@@ -525,7 +526,7 @@ describe("MutualRooms", () => {
                 };
             });
 
-            const rooms = await client._unstable_getSharedRooms(QUERIED_USER);
+            const rooms = await client.getMutualRooms(QUERIED_USER);
 
             expect(rooms).toEqual(["!test3:example.com"]);
         });
@@ -550,7 +551,54 @@ describe("MutualRooms", () => {
                 }
             });
 
-            const rooms = await client._unstable_getSharedRooms(QUERIED_USER);
+            const rooms = await client.getMutualRooms(QUERIED_USER);
+
+            expect(rooms).toEqual(["!rock:example.com", "!korok:example.com"]);
+        });
+    });
+
+    describe("can work with the stable spec version", () => {
+        beforeEach(() => {
+            enableFeature(STABLE_MSC2666_QUERY_MUTUAL_ROOMS);
+        });
+
+        it("works with a simple response", async () => {
+            fetchMock.get("express:/_matrix/client/v1/mutual_rooms", (callLog) => {
+                const url = new URL(callLog.url);
+
+                expect(url.searchParams.get("user_id")).toEqual(QUERIED_USER);
+
+                return {
+                    joined: ["!test4:example.com"],
+                };
+            });
+
+            const rooms = await client.getMutualRooms(QUERIED_USER);
+
+            expect(rooms).toEqual(["!test4:example.com"]);
+        });
+
+        it("works with a paginated response", async () => {
+            fetchMock.get("express:/_matrix/client/v1/mutual_rooms", (callLog) => {
+                const url = new URL(callLog.url);
+
+                expect(url.searchParams.get("user_id")).toEqual(QUERIED_USER);
+
+                const token = url.searchParams.get("from");
+
+                if (token == "yahaha") {
+                    return {
+                        joined: ["!korok:example.com"],
+                    };
+                } else {
+                    return {
+                        joined: ["!rock:example.com"],
+                        next_batch: "yahaha",
+                    };
+                }
+            });
+
+            const rooms = await client.getMutualRooms(QUERIED_USER);
 
             expect(rooms).toEqual(["!rock:example.com", "!korok:example.com"]);
         });

--- a/src/client.ts
+++ b/src/client.ts
@@ -556,6 +556,7 @@ export const GET_LOGIN_TOKEN_CAPABILITY = new NamespacedValue(
 export const UNSTABLE_MSC2666_SHARED_ROOMS = "uk.half-shot.msc2666";
 export const UNSTABLE_MSC2666_MUTUAL_ROOMS = "uk.half-shot.msc2666.mutual_rooms";
 export const UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_mutual_rooms";
+export const STABLE_MSC2666_QUERY_MUTUAL_ROOMS = "uk.half-shot.msc2666.query_mutual_rooms.stable";
 
 export const UNSTABLE_MSC4140_DELAYED_EVENTS = "org.matrix.msc4140";
 export const UNSTABLE_MSC4354_STICKY_EVENTS = "org.matrix.msc4354";
@@ -6095,72 +6096,110 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     }
 
     /**
-     * Gets a set of room IDs in common with another user.
+     * Determine if the server supports finding mutual rooms, as described by MSC2666.
      *
-     * Note: This endpoint is unstable, and can throw an `Error`.
-     *   Check progress on [MSC2666](https://github.com/matrix-org/matrix-spec-proposals/pull/2666) for more details.
+     * @returns `true` if supported, otherwise `false`
+     */
+    public async doesServerSupportMutualRooms(): Promise<boolean> {
+        return (
+            (await this.isVersionSupported("v1.19")) ||
+            (await this.doesServerSupportUnstableFeature(STABLE_MSC2666_QUERY_MUTUAL_ROOMS)) ||
+            (await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS)) ||
+            (await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_MUTUAL_ROOMS)) ||
+            (await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_SHARED_ROOMS))
+        );
+    }
+
+    /**
+     * Gets a set of room IDs in common with another user.
      *
      * @param userId - The userId to check.
      * @returns Promise which resolves to an array of rooms
      * @returns Rejects: with an error response.
      */
-    // TODO: on spec release, rename this to getMutualRooms
-    public async _unstable_getSharedRooms(userId: string): Promise<string[]> {
-        // Initial variant of the MSC
-        const sharedRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_SHARED_ROOMS);
-
-        // Newer variant that renamed shared rooms to mutual rooms
-        const mutualRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_MUTUAL_ROOMS);
-
-        // Latest variant that changed from path elements to query elements
-        const queryMutualRoomsSupport = await this.doesServerSupportUnstableFeature(
-            UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS,
-        );
-
-        if (!sharedRoomsSupport && !mutualRoomsSupport && !queryMutualRoomsSupport) {
+    public async getMutualRooms(userId: string): Promise<string[]> {
+        if (!(await this.doesServerSupportMutualRooms())) {
             throw Error("Server does not support the Mutual Rooms API");
         }
 
-        let path;
-        let query;
-
-        // Cascading unstable support switching.
-        if (queryMutualRoomsSupport) {
-            path = "/uk.half-shot.msc2666/user/mutual_rooms";
-            query = { user_id: userId };
-        } else {
-            path = utils.encodeUri(
-                `/uk.half-shot.msc2666/user/${mutualRoomsSupport ? "mutual_rooms" : "shared_rooms"}/$userId`,
-                { $userId: userId },
-            );
-            query = {};
-        }
+        // Stable version found in the spec
+        const stableMutualRoomsSupport = await this.isVersionSupported("v1.19")
+            || (await this.doesServerSupportUnstableFeature(STABLE_MSC2666_QUERY_MUTUAL_ROOMS));
 
         // Accumulated rooms
         const rooms: string[] = [];
-        let token = null;
 
-        do {
-            const tokenQuery: Record<string, string> = {};
-            if (token != null && queryMutualRoomsSupport) {
-                tokenQuery["batch_token"] = token;
-            }
+        if (stableMutualRoomsSupport) {
+            let token = null;
+            do {
+                const query: Record<string, string> = { user_id: userId };
+                if (token != null) {
+                    query["from"] = token;
+                }
 
-            const res = await this.http.authedRequest<{
-                joined: string[];
-                next_batch_token?: string;
-            }>(Method.Get, path, { ...query, ...tokenQuery }, undefined, {
-                prefix: ClientPrefix.Unstable,
-            });
+                const res = await this.http.authedRequest<{
+                    joined: string[];
+                    next_batch?: string;
+                }>(Method.Get, "/mutual_rooms", query, undefined, {
+                    prefix: ClientPrefix.V1,
+                });
 
-            rooms.push(...res.joined);
+                rooms.push(...res.joined);
 
-            if (res.next_batch_token !== undefined) {
-                token = res.next_batch_token;
+                if (res.next_batch !== undefined) {
+                    token = res.next_batch;
+                } else {
+                    token = null;
+                }
+            } while (token != null);
+        }
+        // Handle unstable support in its own block since it's different in
+        // enough ways to be annoying to do in one (token names are different,
+        // different prefix, no pagination in some versions)
+        else {
+            // Newer variant that renamed shared rooms to mutual rooms
+            const mutualRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_MUTUAL_ROOMS);
+
+            // Latest unstable variant that changed from path elements to query elements
+            const queryMutualRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS);
+
+            let path;
+            let query;
+
+            if (queryMutualRoomsSupport) {
+                path = "/uk.half-shot.msc2666/user/mutual_rooms";
+                query = { user_id: userId };
             } else {
-                token = null;
+                path = utils.encodeUri(
+                    `/uk.half-shot.msc2666/user/${mutualRoomsSupport ? "mutual_rooms" : "shared_rooms"}/$userId`,
+                    { $userId: userId },
+                );
+                query = {};
             }
-        } while (token != null);
+
+            let token = null;
+            do {
+                const tokenQuery: Record<string, string> = {};
+                if (token != null && queryMutualRoomsSupport) {
+                    tokenQuery["batch_token"] = token;
+                }
+
+                const res = await this.http.authedRequest<{
+                    joined: string[];
+                    next_batch_token?: string;
+                }>(Method.Get, path, { ...query, ...tokenQuery }, undefined, {
+                    prefix: ClientPrefix.Unstable,
+                });
+
+                rooms.push(...res.joined);
+
+                if (res.next_batch_token !== undefined) {
+                    token = res.next_batch_token;
+                } else {
+                    token = null;
+                }
+            } while (token != null);
+        }
 
         return rooms;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -6123,8 +6123,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
         }
 
         // Stable version found in the spec
-        const stableMutualRoomsSupport = await this.isVersionSupported("v1.19")
-            || (await this.doesServerSupportUnstableFeature(STABLE_MSC2666_QUERY_MUTUAL_ROOMS));
+        const stableMutualRoomsSupport =
+            (await this.isVersionSupported("v1.19")) ||
+            (await this.doesServerSupportUnstableFeature(STABLE_MSC2666_QUERY_MUTUAL_ROOMS));
 
         // Accumulated rooms
         const rooms: string[] = [];
@@ -6161,7 +6162,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             const mutualRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_MUTUAL_ROOMS);
 
             // Latest unstable variant that changed from path elements to query elements
-            const queryMutualRoomsSupport = await this.doesServerSupportUnstableFeature(UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS);
+            const queryMutualRoomsSupport = await this.doesServerSupportUnstableFeature(
+                UNSTABLE_MSC2666_QUERY_MUTUAL_ROOMS,
+            );
 
             let path;
             let query;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Adds support for the latest version (v1.19) of [mutual rooms](https://spec.matrix.org/latest/client-server-api/#mutual-rooms) in the spec.

I made sure to maintain support for the older unstable versions, since I'm not sure what the policy is on those. I tested it on a real server as well, seems to work.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
