### PR TITLE
Set hasCurrentUserParticipated when the current user sends a thread reply

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -714,6 +714,60 @@ describe("Thread", () => {
         });
     });
 
+    describe("hasCurrentUserParticipated", () => {
+        const myUserId = "@bob:example.org";
+        const otherUserId = "@alice:example.org";
+        const roomId = "!room:example.org";
+
+        let previousThreadHasServerSideSupport: FeatureSupport;
+
+        beforeAll(() => {
+            previousThreadHasServerSideSupport = Thread.hasServerSideSupport;
+            Thread.setServerSideSupport(FeatureSupport.Stable);
+        });
+
+        afterAll(() => {
+            Thread.setServerSideSupport(previousThreadHasServerSideSupport);
+        });
+
+        /**
+         * Create a client whose user is `myUserId`, plus a thread rooted by someone else which
+         * the current user has not participated in (the root carries no bundled relation, so the
+         * server's `current_user_participated` flag is absent).
+         */
+        async function createThreadWithoutMe(): Promise<{ client: MatrixClient; thread: Thread }> {
+            const client = createClient();
+            vi.spyOn(client, "getUserId").mockReturnValue(myUserId);
+            const thread = await createThread(client, otherUserId, roomId);
+            expect(thread.hasCurrentUserParticipated).toBe(false);
+            return { client, thread };
+        }
+
+        it("is set when the current user replies in the thread", async () => {
+            const { thread } = await createThreadWithoutMe();
+
+            thread.addEvent(createThreadMessage(thread.id, myUserId, roomId, "my reply"), false);
+
+            expect(thread.hasCurrentUserParticipated).toBe(true);
+        });
+
+        it("is not set when another user replies in the thread", async () => {
+            const { thread } = await createThreadWithoutMe();
+
+            thread.addEvent(createThreadMessage(thread.id, otherUserId, roomId, "their reply"), false);
+
+            expect(thread.hasCurrentUserParticipated).toBe(false);
+        });
+
+        it("is not set by the current user's reaction to a thread event", async () => {
+            const { client, thread } = await createThreadWithoutMe();
+
+            thread.addEvent(mkReaction(thread.rootEvent!, client, myUserId, roomId), false);
+
+            expect(thread.hasCurrentUserParticipated).toBe(false);
+        });
+    });
+
     describe("addEvent", () => {
         describe("Given server support for threads", () => {
             let previousThreadHasServerSideSupport: FeatureSupport;

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -369,6 +369,15 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
         // Modify this event to point at our room's state, and mark its thread
         // as this.
         this.setEventMetadata(event);
+
+        // The bundled `current_user_participated` flag from the server lags behind local activity,
+        // so relying on it alone drops just-sent replies out of "participated" views until the next
+        // root event bundle refresh. Latch it as soon as the current user authors a thread reply,
+        // matching the server's participated semantics: an m.thread relation, not a reaction or edit.
+        if (event.getSender() === this.client.getUserId() && event.isRelation(THREAD_RELATION_TYPE.name)) {
+            this._currentUserParticipated = true;
+        }
+
         const eventId = event.getId();
         if (
             !this.initialEventsFetched &&


### PR DESCRIPTION
Fixes #5515

### Problem

`Thread.hasCurrentUserParticipated` is only populated from the homeserver's
bundled `current_user_participated` field on the thread root (`processRootEvent()`),
and that refresh is guarded to run only once. Nothing sets the flag when the
current user replies, so it stays `false` after a local reply until the server
re-sends the root's bundled relation.

Since `Room.updateThreadRootEvents` only adds a root to the participated timeline
set when the flag is set, a just-replied thread is missing from that set.

### Fix

In `addEvent()`, latch the flag when the current user authors an `m.thread` reply

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).