### PR TITLE
MatrixRTC: reset network error retries on successful (re-)join

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -866,6 +866,37 @@ describe("MembershipManager", () => {
             );
             expect(client.sendStateEvent).not.toHaveBeenCalled();
         });
+        it("does not carry network error retries over to a new membership after re-joining", async () => {
+            const onError = vi.fn();
+            const manager = new MembershipManager(
+                { delayedLeaveEventDelayMs: 10000, maximumNetworkErrorRetryCount: 6 },
+                room,
+                client,
+                callSession,
+            );
+            const { promise: stuckPromise, reject: rejectStuckPromise } = Promise.withResolvers<EmptyObject>();
+            manager.join([focus], focusActive, onError);
+            try {
+                await waitForMockCall(client._unstable_restartScheduledDelayedEvent);
+                // The server stops answering restarts: each hits the 2s local timeout and is retried immediately.
+                client._unstable_restartScheduledDelayedEvent = vi.fn((_) => stuckPromise);
+                await vi.advanceTimersByTimeAsync(10000);
+                expect(onError).not.toHaveBeenCalled();
+                // The server sent our delayed leave; we notice via sync and re-join successfully.
+                await manager.onRTCSessionMemberUpdate([]);
+                // The in-flight restart has to hit its local timeout before the re-join actions run.
+                await vi.advanceTimersByTimeAsync(2000);
+                expect(client.sendStateEvent).toHaveBeenCalledTimes(2);
+                // Restarts of the new delayed event keep timing out. The new membership gets the full retry budget
+                // rather than the remainder left over from the previous one (which would give up after ~9s here).
+                await vi.advanceTimersByTimeAsync(12000);
+                expect(onError).not.toHaveBeenCalled();
+                await vi.advanceTimersByTimeAsync(8000);
+                expect(onError).toHaveBeenCalled();
+            } finally {
+                rejectStuckPromise();
+            }
+        });
         it("falls back to using pure state events when UnsupportedDelayedEventsEndpointError encountered for delayed events", async () => {
             const unrecoverableError = vi.fn();
             (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -693,6 +693,9 @@ export class MembershipManager
                 this.state.expireUpdateIterations = 1;
                 this.state.hasMemberStateEvent = true;
                 this.resetRateLimitCounter(MembershipActionType.SendJoinEvent);
+                // A successful (re-)join is a fresh membership: failures accumulated by the previous one
+                // (e.g. delayed event restarts that timed out before the server sent our leave) must not carry over.
+                this.state.networkErrorRetries.clear();
                 // An UpdateExpiry action might be left over from a previous join event.
                 // We can reach sendJoinEvent when the delayed leave event gets send by the HS.
                 // The branch where we might have a leftover UpdateExpiry action is:


### PR DESCRIPTION
`networkErrorRetries` is only reset per action type when that action succeeds, so retries accumulated by a membership's delayed-event restarts survive the server sending our leave and the subsequent forced re-join. Seen in element-hq/element-call-rageshakes#17271-17276: after a 55s homeserver stall, the freshly re-joined membership inherited 8/10 restart failures and hit `Reached maximum (10) retries` three restarts later, taking the call down with a "Connection lost" screen. Clear the map on a successful join so a new membership starts with the full budget.

(generated by fable)