### PR TITLE
MatrixRTC: do not treat repeated local timeouts as unrecoverable

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -866,6 +866,28 @@ describe("MembershipManager", () => {
             );
             expect(client.sendStateEvent).not.toHaveBeenCalled();
         });
+        it("does not give up when delayed event restarts keep hitting the local timeout", async () => {
+            const onError = vi.fn();
+            const manager = new MembershipManager({ maximumNetworkErrorRetryCount: 3 }, room, client, callSession);
+            const { promise: stuckPromise, reject: rejectStuckPromise } = Promise.withResolvers<EmptyObject>();
+            const probablyLeftEmit = vi.fn();
+            manager.on(MembershipManagerEvent.ProbablyLeft, probablyLeftEmit);
+            manager.join([focus], focusActive, onError);
+            try {
+                await waitForMockCall(client._unstable_restartScheduledDelayedEvent);
+                // The server never answers restarts: each hits the 2s local timeout and is retried immediately.
+                client._unstable_restartScheduledDelayedEvent = vi.fn((_) => stuckPromise);
+                await vi.advanceTimersByTimeAsync(60000);
+                // Way past `maximumNetworkErrorRetryCount` timeouts, but the server-side delayed leave bounds this
+                // failure mode, so we keep retrying (and report probablyLeft) instead of shutting down.
+                expect(client._unstable_restartScheduledDelayedEvent).toHaveBeenCalledTimes(29);
+                expect(probablyLeftEmit).toHaveBeenCalledWith(true);
+                expect(onError).not.toHaveBeenCalled();
+                expect(manager.status).toBe(Status.Connected);
+            } finally {
+                rejectStuckPromise();
+            }
+        });
         it("falls back to using pure state events when UnsupportedDelayedEventsEndpointError encountered for delayed events", async () => {
             const unrecoverableError = vi.fn();
             (client._unstable_sendDelayedStateEvent as Mock<any>).mockRejectedValue(

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -919,15 +919,15 @@ export class MembershipManager
         const retryCounterString = "(" + retries + "/" + this.maximumNetworkErrorRetryCount + ")";
 
         // Variables for scheduling the new event
-        let retryDuration = this.networkErrorRetryMs;
+        const retryDuration = this.networkErrorRetryMs;
 
         if (error instanceof Error && error.name === "AbortError") {
-            // We do not wait for the timeout on local timeouts.
-            retryDuration = 0;
-            this.logger.warn(
-                "Network local timeout error while sending event, immediate retry (" + retryCounterString + ")",
-                error,
-            );
+            // A local timeout means the server accepted the request but is slow to answer. Retry immediately and
+            // do not count it towards the fatal retry limit: the server's delayed leave already bounds how long a
+            // stalled restart can go unnoticed, and the resulting forced re-join recovers the membership. Giving
+            // up here would only replace a temporary media pause with a "connection lost" error for the user.
+            this.logger.warn("Network local timeout error while sending event, immediate retry", error);
+            return createInsertActionUpdate(type, 0);
         } else if (error instanceof Error && error.message.includes("updating delayed event")) {
             // TODO: We do not want error message matching here but instead the error should be a typed HTTPError
             // and be handled below automatically (the same as in the SPA case).


### PR DESCRIPTION
A delayed-event restart that hits the 2s local timeout (`AbortError` from the `Promise.race`) currently counts towards `maximumNetworkErrorRetryCount`, so a homeserver that is slow to answer restarts for ~24s shuts the MembershipManager down with `Reached maximum (10) retries` and Element Call shows a full-screen "Connection lost" needing a manual reconnect, even though sync and event sending are fine. Seen in element-hq/element-call-rageshakes#17271-17276 where a 55s stall on one Synapse worker did this to every element.io participant. The server-side delayed leave already bounds this failure mode (it fires, we notice via sync, we re-join), so keep the immediate retry but stop counting local timeouts towards the fatal limit; real network and 5xx errors still do.

(generated by fable)