### PR TITLE
Threads: cap concurrent initial-events fetches at 3

### DIFF
--- a/spec/unit/models/thread.spec.ts
+++ b/spec/unit/models/thread.spec.ts
@@ -714,6 +714,69 @@ describe("Thread", () => {
         });
     });
 
+    describe("initial events fetch", () => {
+        it("fetches the initial events of at most 3 threads at a time", async () => {
+            const previousSupport = Thread.hasServerSideSupport;
+            Thread.setServerSideSupport(FeatureSupport.Stable);
+            try {
+                const myUserId = "@alice:example.org";
+                const testClient = new TestClient(myUserId, "DEVICE", "ACCESS_TOKEN", undefined, {
+                    timelineSupport: false,
+                });
+                const client = testClient.client;
+                client.supportsThreads = vi.fn().mockReturnValue(true);
+                const room = new Room("!room:z", client, myUserId, {
+                    pendingEventOrdering: PendingEventOrdering.Detached,
+                });
+                vi.spyOn(client, "getRoom").mockReturnValue(room);
+                const roots = new Map<string, MatrixEvent>();
+                vi.spyOn(client, "fetchRoomEvent").mockImplementation(
+                    async (_roomId, eventId) => roots.get(eventId)!.event,
+                );
+                const pending: (() => void)[] = [];
+                vi.spyOn(client, "paginateEventTimeline").mockImplementation(
+                    () => new Promise((resolve) => pending.push(() => resolve(true))),
+                );
+
+                // Opening a thread list creates every thread in the room at once; each wants its initial events.
+                for (let i = 0; i < 5; i++) {
+                    const root = mkMessage({ room: room.roomId, user: myUserId, msg: `Root ${i}`, event: true });
+                    roots.set(root.getId()!, root);
+                    const reply = mkMessage({
+                        room: room.roomId,
+                        user: myUserId,
+                        msg: "Reply",
+                        relatesTo: { rel_type: THREAD_RELATION_TYPE.name, event_id: root.getId()! },
+                        event: true,
+                    });
+                    root.setUnsigned({
+                        "m.relations": {
+                            [THREAD_RELATION_TYPE.name]: {
+                                count: 1,
+                                current_user_participated: true,
+                                latest_event: reply.event,
+                            },
+                        },
+                    });
+                    room.createThread(root.getId()!, root, [], false);
+                }
+                await sleep(0);
+                expect(client.paginateEventTimeline).toHaveBeenCalledTimes(3);
+                pending.shift()!();
+                await sleep(0);
+                expect(client.paginateEventTimeline).toHaveBeenCalledTimes(4);
+                pending.shift()!();
+                pending.shift()!();
+                await sleep(0);
+                expect(client.paginateEventTimeline).toHaveBeenCalledTimes(5);
+                for (const finish of pending) finish();
+                await sleep(0);
+            } finally {
+                Thread.setServerSideSupport(previousSupport);
+            }
+        });
+    });
+
     describe("addEvent", () => {
         describe("Given server support for threads", () => {
             let previousThreadHasServerSideSupport: FeatureSupport;

--- a/src/models/thread.ts
+++ b/src/models/thread.ts
@@ -68,6 +68,28 @@ export function determineFeatureSupport(stable: boolean, unstable: boolean): Fea
     }
 }
 
+/**
+ * Cap on how many threads fetch their initial events at the same time. Each fetch is a (recursive) `/relations`
+ * request, and opening a thread list creates every thread in the room at once; without a cap a room with dozens
+ * of threads fires dozens of concurrent heavy requests, which can starve everything else the homeserver worker is doing.
+ */
+const MAX_CONCURRENT_INITIAL_FETCHES = 3;
+let runningInitialFetches = 0;
+const waitingInitialFetches: (() => void)[] = [];
+
+async function withInitialFetchSlot<T>(fn: () => Promise<T>): Promise<T> {
+    if (runningInitialFetches >= MAX_CONCURRENT_INITIAL_FETCHES) {
+        await new Promise<void>((resolve) => waitingInitialFetches.push(resolve));
+    }
+    runningInitialFetches++;
+    try {
+        return await fn();
+    } finally {
+        runningInitialFetches--;
+        waitingInitialFetches.shift()?.();
+    }
+}
+
 export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerMap> {
     public static hasServerSideSupport = FeatureSupport.None;
     public static hasServerSideListSupport = FeatureSupport.None;
@@ -670,9 +692,9 @@ export class Thread extends ReadReceipt<ThreadEmittedEvents, ThreadEventHandlerM
                         this.timelineSet.addEventsToTimeline([this.rootEvent], true, false, this.liveTimeline, null);
                         this.liveTimeline.setPaginationToken(null, Direction.Backward);
                     } else {
-                        this.initalEventFetchProm = this.client.paginateEventTimeline(this.liveTimeline, {
-                            backwards: true,
-                        });
+                        this.initalEventFetchProm = withInitialFetchSlot(() =>
+                            this.client.paginateEventTimeline(this.liveTimeline, { backwards: true }),
+                        );
                         await this.initalEventFetchProm;
                     }
                     // We have now fetched the initial events, so set the flag. We need to do this before


### PR DESCRIPTION
This is the root cause of folks repeatedly getting kicked out of MatrixRTC calls on the element.io homeserver; it turns out that a single user opening the ThreadPanel in EW is enough to stall the server enough to cause delayed events to be starved and all users to timeout of calls.

Opening a thread list (`Room.fetchRoomThreads`) creates a `Thread` for every root in the room, and each one immediately paginates its timeline to load its initial events, which is a recursive `/relations` request. In a room with 30 threads that is 30 heavy requests fired at once; in element-hq/element-call-rageshakes#17271-17276 one user opening the Threads panel did exactly this, the requests held every database connection of the homeserver's only client-reader worker for ~55s, and everyone else on that server (including every MatrixRTC delayed-leave keep-alive) stalled behind them. Run at most 3 initial-events fetches at a time; the rest queue in creation order and nothing else about thread loading changes.

(generated by fable).