### PR TITLE
Bring OAuth token refresh into the js-sdk

### DIFF
--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import fetchMock from "@fetch-mock/vitest";
 import { type Mocked, type MockedFunction } from "vitest";
 
 import { FetchHttpApi } from "../../../src/http-api/fetch";
 import { TypedEventEmitter } from "../../../src/models/typed-event-emitter";
 import {
     ClientPrefix,
-    ConnectionError,
     HttpApiEvent,
     type HttpApiEventHandlerMap,
     IdentityPrefix,
@@ -32,6 +32,20 @@ import {
 import { emitPromise } from "../../test-utils/test-utils";
 import { type QueryDict, sleep } from "../../../src/utils";
 import { type Logger } from "../../../src/logger";
+import { makeDelegatedAuthMetadata } from "../../test-utils/auth";
+
+function makeTokenResponse(
+    accessToken: string,
+    refreshToken?: string,
+    expiresIn?: number,
+): { access_token: string; refresh_token?: string; token_type: string; expires_in?: number } {
+    return {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        token_type: "Bearer",
+        expires_in: expiresIn,
+    };
+}
 
 describe("FetchHttpApi", () => {
     const baseUrl = "http://baseUrl";
@@ -317,6 +331,14 @@ describe("FetchHttpApi", () => {
         describe("with refresh token", () => {
             const accessToken = "test-access-token";
             const refreshToken = "test-refresh-token";
+            const clientId = "test-client-id";
+            const redirectUri = "https://test.org";
+            const authMetadata = makeDelegatedAuthMetadata("https://issuer.org/");
+            const oauth2ClientConfig = {
+                clientId,
+                redirectUri,
+                getAuthMetadata: () => Promise.resolve(authMetadata),
+            };
 
             describe("when an unknown token error is encountered", () => {
                 const unknownTokenErrBody = {
@@ -347,7 +369,7 @@ describe("FetchHttpApi", () => {
                     json: vi.fn().mockResolvedValue({ x: 1 }),
                 };
 
-                describe("without a tokenRefreshFunction", () => {
+                describe("without an oauth2ClientConfig", () => {
                     it("should emit logout and throw", async () => {
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
                         const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
@@ -367,10 +389,12 @@ describe("FetchHttpApi", () => {
                     });
                 });
 
-                describe("with a tokenRefreshFunction", () => {
+                describe("with an oauth2ClientConfig", () => {
                     it("should emit logout and throw when token refresh fails", async () => {
-                        const error = new MatrixError();
-                        const tokenRefreshFunction = vi.fn().mockRejectedValue(error);
+                        fetchMock.post(authMetadata.token_endpoint, {
+                            status: 400,
+                            body: { errcode: "M_UNKNOWN", error: "failed" },
+                        });
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
                         const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
                         vi.spyOn(emitter, "emit");
@@ -378,7 +402,7 @@ describe("FetchHttpApi", () => {
                             baseUrl,
                             prefix,
                             fetchFn,
-                            tokenRefreshFunction,
+                            oauth2ClientConfig,
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -386,13 +410,12 @@ describe("FetchHttpApi", () => {
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrow(
                             unknownTokenErr,
                         );
-                        expect(tokenRefreshFunction).toHaveBeenCalledWith(refreshToken);
+                        expect(fetchMock).toHaveFetched(authMetadata.token_endpoint);
                         expect(emitter.emit).toHaveBeenCalledWith(HttpApiEvent.SessionLoggedOut, unknownTokenErr);
                     });
 
                     it("should not emit logout but still throw when token refresh fails due to transitive fault", async () => {
-                        const error = new ConnectionError("transitive fault");
-                        const tokenRefreshFunction = vi.fn().mockRejectedValue(error);
+                        fetchMock.post(authMetadata.token_endpoint, { throws: new Error("transitive fault") });
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
                         const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
                         vi.spyOn(emitter, "emit");
@@ -400,7 +423,7 @@ describe("FetchHttpApi", () => {
                             baseUrl,
                             prefix,
                             fetchFn,
-                            tokenRefreshFunction,
+                            oauth2ClientConfig,
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -408,16 +431,17 @@ describe("FetchHttpApi", () => {
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrow(
                             new TokenRefreshError(unknownTokenErr),
                         );
-                        expect(tokenRefreshFunction).toHaveBeenCalledWith(refreshToken);
+                        expect(fetchMock).toHaveFetched(authMetadata.token_endpoint);
                         expect(emitter.emit).not.toHaveBeenCalledWith(HttpApiEvent.SessionLoggedOut, unknownTokenErr);
                     });
 
                     it("should refresh token and retry request", async () => {
                         const newAccessToken = "new-access-token";
                         const newRefreshToken = "new-refresh-token";
-                        const tokenRefreshFunction = vi.fn().mockResolvedValue({
-                            accessToken: newAccessToken,
-                            refreshToken: newRefreshToken,
+                        fetchMock.post(authMetadata.token_endpoint, {
+                            status: 200,
+                            headers: { "Content-Type": "application/json" },
+                            body: makeTokenResponse(newAccessToken, newRefreshToken),
                         });
                         const fetchFn = vi
                             .fn()
@@ -429,7 +453,7 @@ describe("FetchHttpApi", () => {
                             baseUrl,
                             prefix,
                             fetchFn,
-                            tokenRefreshFunction,
+                            oauth2ClientConfig,
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -438,7 +462,7 @@ describe("FetchHttpApi", () => {
                             headers: {},
                         });
                         expect(result).toEqual({ x: 1 });
-                        expect(tokenRefreshFunction).toHaveBeenCalledWith(refreshToken);
+                        expect(fetchMock).toHaveFetchedTimes(1, authMetadata.token_endpoint);
 
                         expect(fetchFn).toHaveBeenCalledTimes(2);
                         // uses new access token
@@ -456,12 +480,12 @@ describe("FetchHttpApi", () => {
                         // count because it's only to get a token with an expiry)
                         const newAccessToken = "new-access-token";
                         const newRefreshToken = "new-refresh-token";
-                        const tokenRefreshFunction = vi.fn().mockReturnValue({
-                            accessToken: newAccessToken,
-                            refreshToken: newRefreshToken,
+                        fetchMock.post(authMetadata.token_endpoint, {
+                            status: 200,
+                            headers: { "Content-Type": "application/json" },
                             // This needs to be sufficiently high that it's over the threshold for
                             // 'plenty of time' (which is a minute in practice).
-                            expiry: new Date(Date.now() + 5 * 60 * 1000),
+                            body: makeTokenResponse(newAccessToken, newRefreshToken, 5 * 60),
                         });
 
                         // fetch doesn't like our new or old tokens
@@ -473,7 +497,7 @@ describe("FetchHttpApi", () => {
                             baseUrl,
                             prefix,
                             fetchFn,
-                            tokenRefreshFunction,
+                            oauth2ClientConfig,
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -483,8 +507,7 @@ describe("FetchHttpApi", () => {
                         );
 
                         // tried to refresh the token once (to get the one with an expiry)
-                        expect(tokenRefreshFunction).toHaveBeenCalledWith(refreshToken);
-                        expect(tokenRefreshFunction).toHaveBeenCalledTimes(1);
+                        expect(fetchMock).toHaveFetchedTimes(1, authMetadata.token_endpoint);
 
                         expect(fetchFn).toHaveBeenCalledTimes(2);
                         // uses new access token on retry
@@ -494,32 +517,28 @@ describe("FetchHttpApi", () => {
                         expect(emitter.emit).toHaveBeenCalledWith(HttpApiEvent.SessionLoggedOut, unknownTokenErr);
                     });
 
-                    it("should try to refresh the token if it will expire soon", async () => {
+                    it("should try to refresh the token if it will expire soon", { timeout: 20_000 }, async () => {
                         const newAccessToken = "new-access-token";
                         const newRefreshToken = "new-refresh-token";
 
-                        // first refresh is to get a token with an expiry at all, because we
-                        // can't specify an expiry on the token we inject
-                        const tokenRefreshFunction = vi.fn().mockResolvedValueOnce({
-                            accessToken: newAccessToken,
-                            refreshToken: newRefreshToken,
-                            expiry: new Date(Date.now() + 1000),
-                        });
-
-                        // next refresh is to return a token that will expire 'soon'
-                        tokenRefreshFunction.mockResolvedValueOnce({
-                            accessToken: newAccessToken,
-                            refreshToken: newRefreshToken,
-                            expiry: new Date(Date.now() + 1000),
-                        });
-
-                        // ...and finally we return a token that has adequate time left
-                        // so that it will cease retrying and fail the request.
-                        tokenRefreshFunction.mockResolvedValueOnce({
-                            accessToken: newAccessToken,
-                            refreshToken: newRefreshToken,
-                            expiry: new Date(Date.now() + 5 * 60 * 1000),
-                        });
+                        // first two refreshes return a token that will expire 'soon'; the third
+                        // returns one with adequate time left so it stops retrying and fails the request.
+                        fetchMock
+                            .postOnce(authMetadata.token_endpoint, {
+                                status: 200,
+                                headers: { "Content-Type": "application/json" },
+                                body: makeTokenResponse(newAccessToken, newRefreshToken, 1),
+                            })
+                            .postOnce(authMetadata.token_endpoint, {
+                                status: 200,
+                                headers: { "Content-Type": "application/json" },
+                                body: makeTokenResponse(newAccessToken, newRefreshToken, 1),
+                            })
+                            .postOnce(authMetadata.token_endpoint, {
+                                status: 200,
+                                headers: { "Content-Type": "application/json" },
+                                body: makeTokenResponse(newAccessToken, newRefreshToken, 5 * 60),
+                            });
 
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
 
@@ -529,7 +548,7 @@ describe("FetchHttpApi", () => {
                             baseUrl,
                             prefix,
                             fetchFn,
-                            tokenRefreshFunction,
+                            oauth2ClientConfig,
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -539,8 +558,7 @@ describe("FetchHttpApi", () => {
                         );
 
                         // We should have seen the 3 token refreshes, as above.
-                        expect(tokenRefreshFunction).toHaveBeenCalledWith(refreshToken);
-                        expect(tokenRefreshFunction).toHaveBeenCalledTimes(3);
+                        expect(fetchMock).toHaveFetchedTimes(3, authMetadata.token_endpoint);
                     });
                 });
             });
@@ -721,7 +739,15 @@ describe("FetchHttpApi", () => {
     });
 
     it("should not make multiple concurrent refresh token requests", async () => {
-        const deferredTokenRefresh = Promise.withResolvers<{ accessToken: string; refreshToken: string }>();
+        const authMetadata = makeDelegatedAuthMetadata("https://issuer-concurrent.org/");
+        const oauth2ClientConfig = {
+            clientId: "test-client-id",
+            redirectUri: "https://test.org",
+            getAuthMetadata: () => Promise.resolve(authMetadata),
+        };
+        const deferredTokenRefresh = Promise.withResolvers<Parameters<typeof fetchMock.post>[1]>();
+        fetchMock.post(authMetadata.token_endpoint, () => deferredTokenRefresh.promise);
+
         const fetchFn = vi.fn().mockResolvedValue({
             ok: false,
             status: tokenInactiveError.httpStatus,
@@ -735,14 +761,12 @@ describe("FetchHttpApi", () => {
                 get: vi.fn().mockReturnValue("application/json"),
             },
         });
-        const tokenRefreshFunction = vi.fn().mockReturnValue(deferredTokenRefresh.promise);
 
         const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {
             baseUrl,
             prefix,
             fetchFn,
-            doNotAttemptTokenRefresh: false,
-            tokenRefreshFunction,
+            oauth2ClientConfig,
             accessToken: "ACCESS_TOKEN",
             refreshToken: "REFRESH_TOKEN",
             onlyData: true,
@@ -766,18 +790,30 @@ describe("FetchHttpApi", () => {
                 get: vi.fn().mockReturnValue("application/json"),
             },
         });
-        deferredTokenRefresh.resolve({ accessToken: "NEW_ACCESS_TOKEN", refreshToken: "NEW_REFRESH_TOKEN" });
+        deferredTokenRefresh.resolve({
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: makeTokenResponse("NEW_ACCESS_TOKEN", "NEW_REFRESH_TOKEN"),
+        });
 
         await prom1;
         await prom2;
         expect(fetchFn).toHaveBeenCalledTimes(4); // 2 original calls + 2 retries
-        expect(tokenRefreshFunction).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveFetchedTimes(1, authMetadata.token_endpoint);
         expect(api.opts.accessToken).toBe("NEW_ACCESS_TOKEN");
         expect(api.opts.refreshToken).toBe("NEW_REFRESH_TOKEN");
     });
 
     it("should use newly refreshed token if request starts mid-refresh", async () => {
-        const deferredTokenRefresh = Promise.withResolvers<{ accessToken: string; refreshToken: string }>();
+        const authMetadata = makeDelegatedAuthMetadata("https://issuer-midrefresh.org/");
+        const oauth2ClientConfig = {
+            clientId: "test-client-id",
+            redirectUri: "https://test.org",
+            getAuthMetadata: () => Promise.resolve(authMetadata),
+        };
+        const deferredTokenRefresh = Promise.withResolvers<Parameters<typeof fetchMock.post>[1]>();
+        fetchMock.post(authMetadata.token_endpoint, () => deferredTokenRefresh.promise);
+
         const fetchFn = vi.fn().mockResolvedValue({
             ok: false,
             status: tokenInactiveError.httpStatus,
@@ -791,14 +827,12 @@ describe("FetchHttpApi", () => {
                 get: vi.fn().mockReturnValue("application/json"),
             },
         });
-        const tokenRefreshFunction = vi.fn().mockReturnValue(deferredTokenRefresh.promise);
 
         const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {
             baseUrl,
             prefix,
             fetchFn,
-            doNotAttemptTokenRefresh: false,
-            tokenRefreshFunction,
+            oauth2ClientConfig,
             accessToken: "ACCESS_TOKEN",
             refreshToken: "REFRESH_TOKEN",
             onlyData: true,
@@ -810,7 +844,11 @@ describe("FetchHttpApi", () => {
         const prom2 = api.authedRequest(Method.Get, "/path2");
         await sleep(0); // wait for request to fire
 
-        deferredTokenRefresh.resolve({ accessToken: "NEW_ACCESS_TOKEN", refreshToken: "NEW_REFRESH_TOKEN" });
+        deferredTokenRefresh.resolve({
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: makeTokenResponse("NEW_ACCESS_TOKEN", "NEW_REFRESH_TOKEN"),
+        });
         fetchFn.mockResolvedValue({
             ok: true,
             status: 200,
@@ -834,7 +872,7 @@ describe("FetchHttpApi", () => {
         expect(fetchFn.mock.calls[2][1]).toEqual(
             expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer NEW_ACCESS_TOKEN" }) }),
         );
-        expect(tokenRefreshFunction).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveFetchedTimes(1, authMetadata.token_endpoint);
         expect(api.opts.accessToken).toBe("NEW_ACCESS_TOKEN");
         expect(api.opts.refreshToken).toBe("NEW_REFRESH_TOKEN");
     });

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -705,8 +705,8 @@ describe("FetchHttpApi", () => {
         `);
     });
 
-    it("should not make multiple concurrent refresh token requests", async () => {
-        const authMetadata = makeDelegatedAuthMetadata("https://issuer-concurrent.org/");
+    const makeUnknownTokenRefreshSetup = (issuer: string) => {
+        const authMetadata = makeDelegatedAuthMetadata(issuer);
         const oauth2ClientConfig = {
             clientId: "test-client-id",
             redirectUri: "https://test.org",
@@ -739,24 +739,34 @@ describe("FetchHttpApi", () => {
             onlyData: true,
         });
 
+        return { authMetadata, deferredTokenRefresh, fetchFn, api };
+    };
+
+    const makeSuccessFetchResponse = () => ({
+        ok: true,
+        status: 200,
+        async text() {
+            return "{}";
+        },
+        async json() {
+            return {};
+        },
+        headers: {
+            get: vi.fn().mockReturnValue("application/json"),
+        },
+    });
+
+    it("should not make multiple concurrent refresh token requests", async () => {
+        const { authMetadata, deferredTokenRefresh, fetchFn, api } = makeUnknownTokenRefreshSetup(
+            "https://issuer-concurrent.org/",
+        );
+
         const prom1 = api.authedRequest(Method.Get, "/path1");
         const prom2 = api.authedRequest(Method.Get, "/path2");
 
         await sleep(0); // wait for requests to fire
         expect(fetchFn).toHaveBeenCalledTimes(2);
-        fetchFn.mockResolvedValue({
-            ok: true,
-            status: 200,
-            async text() {
-                return "{}";
-            },
-            async json() {
-                return {};
-            },
-            headers: {
-                get: vi.fn().mockReturnValue("application/json"),
-            },
-        });
+        fetchFn.mockResolvedValue(makeSuccessFetchResponse());
         deferredTokenRefresh.resolve({
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -772,38 +782,9 @@ describe("FetchHttpApi", () => {
     });
 
     it("should use newly refreshed token if request starts mid-refresh", async () => {
-        const authMetadata = makeDelegatedAuthMetadata("https://issuer-midrefresh.org/");
-        const oauth2ClientConfig = {
-            clientId: "test-client-id",
-            redirectUri: "https://test.org",
-            getAuthMetadata: () => Promise.resolve(authMetadata),
-        };
-        const deferredTokenRefresh = Promise.withResolvers<Parameters<typeof fetchMock.post>[1]>();
-        fetchMock.post(authMetadata.token_endpoint, () => deferredTokenRefresh.promise);
-
-        const fetchFn = vi.fn().mockResolvedValue({
-            ok: false,
-            status: tokenInactiveError.httpStatus,
-            async text() {
-                return JSON.stringify(tokenInactiveError.data);
-            },
-            async json() {
-                return tokenInactiveError.data;
-            },
-            headers: {
-                get: vi.fn().mockReturnValue("application/json"),
-            },
-        });
-
-        const api = new FetchHttpApi(new TypedEventEmitter<any, any>(), {
-            baseUrl,
-            prefix,
-            fetchFn,
-            oauth2ClientConfig,
-            accessToken: "ACCESS_TOKEN",
-            refreshToken: "REFRESH_TOKEN",
-            onlyData: true,
-        });
+        const { authMetadata, deferredTokenRefresh, fetchFn, api } = makeUnknownTokenRefreshSetup(
+            "https://issuer-midrefresh.org/",
+        );
 
         const prom1 = api.authedRequest(Method.Get, "/path1");
         await sleep(0); // wait for request to fire
@@ -816,19 +797,7 @@ describe("FetchHttpApi", () => {
             headers: { "Content-Type": "application/json" },
             body: makeTokenResponse("NEW_ACCESS_TOKEN", "NEW_REFRESH_TOKEN"),
         });
-        fetchFn.mockResolvedValue({
-            ok: true,
-            status: 200,
-            async text() {
-                return "{}";
-            },
-            async json() {
-                return {};
-            },
-            headers: {
-                get: vi.fn().mockReturnValue("application/json"),
-            },
-        });
+        fetchFn.mockResolvedValue(makeSuccessFetchResponse());
 
         await prom1;
         await prom2;

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -390,12 +390,9 @@ describe("FetchHttpApi", () => {
                 });
 
                 describe("with an oauth2ClientConfig", () => {
-                    it("should emit logout and throw when token refresh fails", async () => {
-                        fetchMock.post(authMetadata.token_endpoint, {
-                            status: 400,
-                            body: { errcode: "M_UNKNOWN", error: "failed" },
-                        });
-                        const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
+                    const makeOAuthApi = (
+                        fetchFn: MockedFunction<Window["fetch"]>,
+                    ): { api: FetchHttpApi<any>; emitter: TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap> } => {
                         const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
                         vi.spyOn(emitter, "emit");
                         const api = new FetchHttpApi(emitter, {
@@ -407,6 +404,16 @@ describe("FetchHttpApi", () => {
                             refreshToken,
                             onlyData: true,
                         });
+                        return { api, emitter };
+                    };
+
+                    it("should emit logout and throw when token refresh fails", async () => {
+                        fetchMock.post(authMetadata.token_endpoint, {
+                            status: 400,
+                            body: { errcode: "M_UNKNOWN", error: "failed" },
+                        });
+                        const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
+                        const { api, emitter } = makeOAuthApi(fetchFn);
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrow(
                             unknownTokenErr,
                         );
@@ -417,17 +424,7 @@ describe("FetchHttpApi", () => {
                     it("should not emit logout but still throw when token refresh fails due to transitive fault", async () => {
                         fetchMock.post(authMetadata.token_endpoint, { throws: new Error("transitive fault") });
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
-                        const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
-                        vi.spyOn(emitter, "emit");
-                        const api = new FetchHttpApi(emitter, {
-                            baseUrl,
-                            prefix,
-                            fetchFn,
-                            oauth2ClientConfig,
-                            accessToken,
-                            refreshToken,
-                            onlyData: true,
-                        });
+                        const { api, emitter } = makeOAuthApi(fetchFn);
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrow(
                             new TokenRefreshError(unknownTokenErr),
                         );
@@ -447,17 +444,7 @@ describe("FetchHttpApi", () => {
                             .fn()
                             .mockResolvedValueOnce(unknownTokenResponse)
                             .mockResolvedValueOnce(okayResponse);
-                        const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
-                        vi.spyOn(emitter, "emit");
-                        const api = new FetchHttpApi(emitter, {
-                            baseUrl,
-                            prefix,
-                            fetchFn,
-                            oauth2ClientConfig,
-                            accessToken,
-                            refreshToken,
-                            onlyData: true,
-                        });
+                        const { api, emitter } = makeOAuthApi(fetchFn);
                         const result = await api.authedRequest(Method.Post, "/account/password", undefined, undefined, {
                             headers: {},
                         });
@@ -491,17 +478,7 @@ describe("FetchHttpApi", () => {
                         // fetch doesn't like our new or old tokens
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
 
-                        const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
-                        vi.spyOn(emitter, "emit");
-                        const api = new FetchHttpApi(emitter, {
-                            baseUrl,
-                            prefix,
-                            fetchFn,
-                            oauth2ClientConfig,
-                            accessToken,
-                            refreshToken,
-                            onlyData: true,
-                        });
+                        const { api, emitter } = makeOAuthApi(fetchFn);
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrowError(
                             unknownTokenErr,
                         );
@@ -542,17 +519,7 @@ describe("FetchHttpApi", () => {
 
                         const fetchFn = vi.fn().mockResolvedValue(unknownTokenResponse);
 
-                        const emitter = new TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>();
-                        vi.spyOn(emitter, "emit");
-                        const api = new FetchHttpApi(emitter, {
-                            baseUrl,
-                            prefix,
-                            fetchFn,
-                            oauth2ClientConfig,
-                            accessToken,
-                            refreshToken,
-                            onlyData: true,
-                        });
+                        const { api } = makeOAuthApi(fetchFn);
                         await expect(api.authedRequest(Method.Post, "/account/password")).rejects.toThrowError(
                             unknownTokenErr,
                         );

--- a/spec/unit/http-api/fetch.spec.ts
+++ b/spec/unit/http-api/fetch.spec.ts
@@ -337,7 +337,6 @@ describe("FetchHttpApi", () => {
             const oauth2ClientConfig = {
                 clientId,
                 redirectUri,
-                getAuthMetadata: () => Promise.resolve(authMetadata),
             };
 
             describe("when an unknown token error is encountered", () => {
@@ -400,6 +399,7 @@ describe("FetchHttpApi", () => {
                             prefix,
                             fetchFn,
                             oauth2ClientConfig,
+                            authMetadataCallback: () => Promise.resolve(authMetadata),
                             accessToken,
                             refreshToken,
                             onlyData: true,
@@ -710,7 +710,6 @@ describe("FetchHttpApi", () => {
         const oauth2ClientConfig = {
             clientId: "test-client-id",
             redirectUri: "https://test.org",
-            getAuthMetadata: () => Promise.resolve(authMetadata),
         };
         const deferredTokenRefresh = Promise.withResolvers<Parameters<typeof fetchMock.post>[1]>();
         fetchMock.post(authMetadata.token_endpoint, () => deferredTokenRefresh.promise);
@@ -734,6 +733,7 @@ describe("FetchHttpApi", () => {
             prefix,
             fetchFn,
             oauth2ClientConfig,
+            authMetadataCallback: () => Promise.resolve(authMetadata),
             accessToken: "ACCESS_TOKEN",
             refreshToken: "REFRESH_TOKEN",
             onlyData: true,

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -3852,21 +3852,6 @@ describe("MatrixClient", function () {
             await expect(client.getAuthMetadata()).resolves.toEqual(metadata);
             expect(httpLookups.length).toEqual(0);
         });
-
-        it("should use unstable prefix", async () => {
-            const metadata = makeDelegatedAuthMetadata();
-            httpLookups = [
-                {
-                    method: "GET",
-                    path: `/auth_metadata`,
-                    data: metadata,
-                    prefix: "/_matrix/client/unstable/org.matrix.msc2965",
-                },
-            ];
-
-            await expect(client.getAuthMetadata()).resolves.toEqual(metadata);
-            expect(httpLookups.length).toEqual(0);
-        });
     });
 
     describe("logout", () => {
@@ -3895,7 +3880,7 @@ describe("MatrixClient", function () {
                 accessToken,
                 refreshToken,
                 userId,
-                oauth2ClientConfig: { clientId: "test-client-id", redirectUri: "https://app.example.org" },
+                oauthClientId: "test-client-id",
             });
             await expect(client.logout()).resolves.toEqual({});
 

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -3869,6 +3869,41 @@ describe("MatrixClient", function () {
         });
     });
 
+    describe("logout", () => {
+        const baseUrl = "https://logout-test.example.org";
+        const userId = "@alice:logout-test.example.org";
+        const accessToken = "test-access-token";
+        const refreshToken = "test-refresh-token";
+
+        it("should call /logout for a non-OAuth2-native session", async () => {
+            fetchMock.postOnce(`${baseUrl}/_matrix/client/v3/logout`, {});
+
+            const client = createClient({ baseUrl, accessToken, userId });
+            await expect(client.logout()).resolves.toEqual({});
+
+            expect(fetchMock.callHistory.called(`${baseUrl}/_matrix/client/v3/logout`)).toBe(true);
+        });
+
+        it("should revoke tokens with the delegated auth server instead of calling /logout for an OAuth2-native session", async () => {
+            const authMetadata = makeDelegatedAuthMetadata("https://auth.logout-test.example.org/");
+            fetchMock.get(`${baseUrl}/_matrix/client/versions`, { versions: ["v1.15"] });
+            fetchMock.get(`${baseUrl}/_matrix/client/v1/auth_metadata`, authMetadata);
+            fetchMock.post(authMetadata.revocation_endpoint, 200);
+
+            const client = createClient({
+                baseUrl,
+                accessToken,
+                refreshToken,
+                userId,
+                oauth2ClientConfig: { clientId: "test-client-id", redirectUri: "https://app.example.org" },
+            });
+            await expect(client.logout()).resolves.toEqual({});
+
+            expect(fetchMock.callHistory.called(`${baseUrl}/_matrix/client/v3/logout`)).toBe(false);
+            expect(fetchMock.callHistory.calls(authMetadata.revocation_endpoint)).toHaveLength(2);
+        });
+    });
+
     describe("identityHashedLookup", () => {
         it("should return hashed lookup results", async () => {
             const ID_ACCESS_TOKEN = "hello_id_server_please_let_me_make_a_request";

--- a/spec/unit/oauth/authorize.spec.ts
+++ b/spec/unit/oauth/authorize.spec.ts
@@ -34,7 +34,6 @@ describe("authorization", () => {
 
     const auth = new OAuth2(delegatedAuthConfig, {
         clientId,
-        redirectUri: baseUrl,
         deviceId,
         codeVerifier: "test-code-verifier",
     });
@@ -52,7 +51,7 @@ describe("authorization", () => {
         const state = "abc123";
 
         it("should generate url with correct parameters", async () => {
-            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state));
+            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state, baseUrl));
 
             expect(authUrl.searchParams.get("response_mode")).toEqual("fragment");
             expect(authUrl.searchParams.get("response_type")).toEqual("code");
@@ -67,13 +66,13 @@ describe("authorization", () => {
         });
 
         it("should generate url with create prompt", async () => {
-            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state, "fragment", "create"));
+            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state, baseUrl, "fragment", "create"));
 
             expect(authUrl.searchParams.get("prompt")).toEqual("create");
         });
 
         it("should generate url with response_mode=query", async () => {
-            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state, "query"));
+            const authUrl = new URL(await auth.generateAuthorizationCodeGrantUrl(state, baseUrl, "query"));
 
             expect(authUrl.searchParams.get("response_mode")).toEqual("query");
         });
@@ -120,7 +119,7 @@ describe("authorization", () => {
         it("should make correct request to the token endpoint", async () => {
             const [code] = await setupState();
             const codeVerifier = auth.context.codeVerifier;
-            await auth.completeAuthorizationCodeGrant(code);
+            await auth.completeAuthorizationCodeGrant(code, baseUrl);
 
             expect(fetchMock.callHistory.lastCall(metadata.token_endpoint)?.options).toStrictEqual(
                 expect.objectContaining({
@@ -145,7 +144,7 @@ describe("authorization", () => {
         it("should make correct request to the token endpoint with response_mode=fragment", async () => {
             const [code] = await setupState({ responseMode: "fragment" });
             const codeVerifier = auth.context.codeVerifier;
-            await auth.completeAuthorizationCodeGrant(code);
+            await auth.completeAuthorizationCodeGrant(code, baseUrl);
 
             expect(fetchMock.callHistory.lastCall(metadata.token_endpoint)?.options).toStrictEqual(
                 expect.objectContaining({
@@ -169,7 +168,7 @@ describe("authorization", () => {
 
         it("should return with valid bearer token", async () => {
             const [code, scope] = await setupState();
-            const result = await auth.completeAuthorizationCodeGrant(code);
+            const result = await auth.completeAuthorizationCodeGrant(code, baseUrl);
 
             expect(result).toEqual({
                 access_token: validBearerTokenResponse.access_token,
@@ -193,7 +192,7 @@ describe("authorization", () => {
                 response: tokenResponse,
             });
 
-            const result = await auth.completeAuthorizationCodeGrant(code);
+            const result = await auth.completeAuthorizationCodeGrant(code, baseUrl);
 
             expect(result).toEqual({
                 access_token: validBearerTokenResponse.access_token,
@@ -213,7 +212,7 @@ describe("authorization", () => {
             fetchMock.modifyRoute("token-endpoint", {
                 response: { status: 500 },
             });
-            await expect(auth.completeAuthorizationCodeGrant(code)).rejects.toThrow(
+            await expect(auth.completeAuthorizationCodeGrant(code, baseUrl)).rejects.toThrow(
                 new HTTPError(OAuth2Error.CodeExchangeFailed, 500, expect.anything()),
             );
         });
@@ -227,7 +226,7 @@ describe("authorization", () => {
             fetchMock.modifyRoute("token-endpoint", {
                 response: invalidBearerTokenResponse,
             });
-            await expect(auth.completeAuthorizationCodeGrant(code)).rejects.toThrow(
+            await expect(auth.completeAuthorizationCodeGrant(code, baseUrl)).rejects.toThrow(
                 new Error(OAuth2Error.InvalidBearerTokenResponse),
             );
         });

--- a/spec/unit/oauth/fetch.spec.ts
+++ b/spec/unit/oauth/fetch.spec.ts
@@ -94,12 +94,8 @@ describe("fetchWithLogging()", () => {
                 body: { access_token: "abc123", token_type: "Bearer", expires_in: 300 },
             });
 
-            const auth = new OAuth2(
-                delegatedAuthConfig,
-                { clientId: "test-client-id", redirectUri: "https://test.com" },
-                mockLogger,
-            );
-            await auth.completeAuthorizationCodeGrant("code123");
+            const auth = new OAuth2(delegatedAuthConfig, { clientId: "test-client-id" }, mockLogger);
+            await auth.completeAuthorizationCodeGrant("code123", "https://test.com");
 
             expect(mockLogger.debug.mock.calls).toEqual([
                 ["OAuth2: --> POST https://auth.org/token"],
@@ -110,11 +106,7 @@ describe("fetchWithLogging()", () => {
         it("should log revocation endpoint requests made by OAuth2", async () => {
             fetchMock.post(delegatedAuthConfig.revocation_endpoint, { status: 200, body: "{}" });
 
-            const auth = new OAuth2(
-                delegatedAuthConfig,
-                { clientId: "test-client-id", redirectUri: "https://test.com" },
-                mockLogger,
-            );
+            const auth = new OAuth2(delegatedAuthConfig, { clientId: "test-client-id" }, mockLogger);
             await auth.revokeToken("abc123", "access_token");
 
             expect(mockLogger.debug.mock.calls[0]).toEqual(["OAuth2: --> POST https://auth.org/revoke"]);

--- a/spec/unit/oauth/tokenRefresher.spec.ts
+++ b/spec/unit/oauth/tokenRefresher.spec.ts
@@ -20,12 +20,11 @@ limitations under the License.
 
 import fetchMock from "@fetch-mock/vitest";
 
-import { OAuth2, TokenRefresher, TokenRefreshLogoutError } from "../../../src";
+import { OAuth2, TokenRefreshLogoutError } from "../../../src";
+import { TokenRefresher } from "../../../src/oauth/tokenRefresher";
 import { makeDelegatedAuthMetadata } from "../../test-utils/auth";
 
-describe("OidcTokenRefresher", () => {
-    // OidcTokenRefresher props
-    // see class declaration for info
+describe("TokenRefresher", () => {
     const authConfig = {
         issuer: "https://issuer.org/",
     };
@@ -66,12 +65,12 @@ describe("OidcTokenRefresher", () => {
         vi.restoreAllMocks();
     });
 
-    describe("doRefreshAccessToken()", () => {
+    describe("doRefresh()", () => {
         it("should refresh the tokens", async () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            const result = await refresher.tokenRefreshFunction("refresh-token");
+            const result = await refresher.doRefresh("refresh-token");
 
             expect(fetchMock).toHaveFetched(config.token_endpoint, {
                 method: "POST",
@@ -89,7 +88,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await refresher.tokenRefreshFunction("refresh-token");
+            await refresher.doRefresh("refresh-token");
 
             expect(fn).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -123,8 +122,8 @@ describe("OidcTokenRefresher", () => {
             fetchMock.clearHistory();
 
             const refreshToken = "refresh-token";
-            const first = refresher.tokenRefreshFunction(refreshToken);
-            const second = refresher.tokenRefreshFunction(refreshToken);
+            const first = refresher.doRefresh(refreshToken);
+            const second = refresher.doRefresh(refreshToken);
 
             const result1 = await second;
             const result2 = await first;
@@ -141,7 +140,7 @@ describe("OidcTokenRefresher", () => {
             expect(result1).toEqual(result2);
 
             // call again after first request resolves
-            const third = await refresher.tokenRefreshFunction("first-new-refresh-token");
+            const third = await refresher.doRefresh("first-new-refresh-token");
 
             // called token endpoint, got new tokens
             expect(third).toEqual(
@@ -165,7 +164,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.toThrow();
+            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow();
         });
 
         it("should make fresh request after a failed request", async () => {
@@ -192,10 +191,10 @@ describe("OidcTokenRefresher", () => {
             fetchMock.clearHistory();
 
             // first call fails
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.toThrow();
+            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow();
 
             // call again after first request resolves
-            const result = await refresher.tokenRefreshFunction("first-new-refresh-token");
+            const result = await refresher.doRefresh("first-new-refresh-token");
 
             // called token endpoint, got new tokens
             expect(result).toEqual(
@@ -223,7 +222,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError when hitting temporal http error", async () => {
@@ -236,7 +235,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx without a JSON body", async () => {
@@ -253,7 +252,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx with a JSON body which is not an OAuth 2.0 error", async () => {
@@ -272,7 +271,7 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx Matrix API error code which looks like an OAuth 2.0 error", async () => {
@@ -295,7 +294,29 @@ describe("OidcTokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.tokenRefreshFunction("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+        });
+    });
+
+    describe("revokeToken()", () => {
+        it("should revoke the given token", async () => {
+            fetchMock.post(config.revocation_endpoint, { status: 200 }, { name: "revocation-endpoint" });
+
+            const fn = vi.fn();
+            const refresher = new TokenRefresher(auth, fn);
+
+            await refresher.revokeToken("access-token", "access_token");
+
+            expect(fetchMock).toHaveFetched("revocation-endpoint", { method: "POST" });
+        });
+
+        it("should throw when revocation fails", async () => {
+            fetchMock.post(config.revocation_endpoint, { status: 500 }, { name: "revocation-endpoint" });
+
+            const fn = vi.fn();
+            const refresher = new TokenRefresher(auth, fn);
+
+            await expect(refresher.revokeToken("access-token", "access_token")).rejects.toThrow();
         });
     });
 });

--- a/spec/unit/oauth/tokenRefresher.spec.ts
+++ b/spec/unit/oauth/tokenRefresher.spec.ts
@@ -69,7 +69,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            const result = await refresher.doRefresh("refresh-token");
+            const result = await refresher.refreshTokens("refresh-token");
 
             expect(fetchMock).toHaveFetched(config.token_endpoint, {
                 method: "POST",
@@ -87,7 +87,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await refresher.doRefresh("refresh-token");
+            await refresher.refreshTokens("refresh-token");
 
             expect(fn).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -121,8 +121,8 @@ describe("TokenRefresher", () => {
             fetchMock.clearHistory();
 
             const refreshToken = "refresh-token";
-            const first = refresher.doRefresh(refreshToken);
-            const second = refresher.doRefresh(refreshToken);
+            const first = refresher.refreshTokens(refreshToken);
+            const second = refresher.refreshTokens(refreshToken);
 
             const result1 = await second;
             const result2 = await first;
@@ -139,7 +139,7 @@ describe("TokenRefresher", () => {
             expect(result1).toEqual(result2);
 
             // call again after first request resolves
-            const third = await refresher.doRefresh("first-new-refresh-token");
+            const third = await refresher.refreshTokens("first-new-refresh-token");
 
             // called token endpoint, got new tokens
             expect(third).toEqual(
@@ -163,7 +163,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow();
+            await expect(refresher.refreshTokens("refresh-token")).rejects.toThrow();
         });
 
         it("should make fresh request after a failed request", async () => {
@@ -190,10 +190,10 @@ describe("TokenRefresher", () => {
             fetchMock.clearHistory();
 
             // first call fails
-            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow();
+            await expect(refresher.refreshTokens("refresh-token")).rejects.toThrow();
 
             // call again after first request resolves
-            const result = await refresher.doRefresh("first-new-refresh-token");
+            const result = await refresher.refreshTokens("first-new-refresh-token");
 
             // called token endpoint, got new tokens
             expect(result).toEqual(
@@ -221,7 +221,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.refreshTokens("refresh-token")).rejects.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError when hitting temporal http error", async () => {
@@ -234,7 +234,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.refreshTokens("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx without a JSON body", async () => {
@@ -251,7 +251,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.refreshTokens("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx with a JSON body which is not an OAuth 2.0 error", async () => {
@@ -270,7 +270,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.refreshTokens("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
 
         it("should not throw TokenRefreshLogoutError on a 4xx Matrix API error code which looks like an OAuth 2.0 error", async () => {
@@ -293,7 +293,7 @@ describe("TokenRefresher", () => {
             const fn = vi.fn();
             const refresher = new TokenRefresher(auth, fn);
 
-            await expect(refresher.doRefresh("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
+            await expect(refresher.refreshTokens("refresh-token")).rejects.not.toThrow(TokenRefreshLogoutError);
         });
     });
 

--- a/spec/unit/oauth/tokenRefresher.spec.ts
+++ b/spec/unit/oauth/tokenRefresher.spec.ts
@@ -29,7 +29,6 @@ describe("TokenRefresher", () => {
         issuer: "https://issuer.org/",
     };
     const clientId = "test-client-id";
-    const redirectUri = "https://test.org";
     const deviceId = "abc123";
     // used to mock a valid token response
     const scope = `urn:matrix:client:api:* urn:matrix:client:device:${deviceId}`;
@@ -37,7 +36,7 @@ describe("TokenRefresher", () => {
     // auth config used in mocked calls to OP .well-known
     const config = makeDelegatedAuthMetadata(authConfig.issuer);
 
-    const auth = new OAuth2(config, { clientId, redirectUri, deviceId });
+    const auth = new OAuth2(config, { clientId, deviceId });
 
     const makeTokenResponse = (accessToken: string, refreshToken?: string) => ({
         access_token: accessToken,

--- a/spec/unit/oauth/tokenRevocation.spec.ts
+++ b/spec/unit/oauth/tokenRevocation.spec.ts
@@ -22,11 +22,10 @@ import { makeDelegatedAuthMetadata } from "../../test-utils/auth";
 describe("tokenRevocation", () => {
     const issuer = "https://issuer.org/";
     const clientId = "test-client-id";
-    const redirectUri = "https://test.org";
     const deviceId = "abc123";
 
     const metadata = makeDelegatedAuthMetadata(issuer);
-    const auth = new OAuth2(metadata, { clientId, redirectUri, deviceId });
+    const auth = new OAuth2(metadata, { clientId, deviceId });
 
     beforeEach(() => {
         // A successful revocation response as described by RFC 7009 § 2.2: the authorization server

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,8 @@ import {
     MediaPrefix,
     Method,
     retryNetworkOperation,
-    type TokenRefreshFunction,
+    type onTokenRefreshCallback,
+    type OAuth2ClientConfig,
     type Upload,
     type UploadOpts,
     type UploadResponse,
@@ -318,11 +319,24 @@ export interface ICreateClientOpts {
     refreshToken?: string;
 
     /**
-     * Function used to attempt refreshing access and refresh tokens
-     * Called by http-api when a possibly expired token is encountered
-     * and a refreshToken is found
+     * Called when the access tokens are refreshed.
+     * The client must replace the tokens it had stored previously which will no
+     * longer be valid.
+     *
+     * Required if a {@link IHttpOpts.onTokenRefresh} is provided.
+     *
+     * @param newAccessToken The new access token.
+     * @param newRefreshToken The new refresh token.
      */
-    tokenRefreshFunction?: TokenRefreshFunction;
+    onTokenRefresh?: onTokenRefreshCallback;
+
+    /**
+     * If this is an OAuth2-native session (as per MSC2965/MSC3861), the client ID and redirect URI this
+     * application is registered with the delegated auth server under. Required for the SDK to be able to
+     * refresh (given `refreshToken`) and revoke (e.g. on logout) tokens for the session; the auth server's
+     * metadata will be discovered lazily, and the OAuth2 client constructed, the first time this is needed.
+     */
+    oauth2ClientConfig?: Pick<OAuth2ClientConfig, "clientId" | "redirectUri">;
 
     /**
      * Identity server provider to retrieve the user's access token when accessing
@@ -1349,7 +1363,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             idBaseUrl: opts.idBaseUrl,
             accessToken: opts.accessToken,
             refreshToken: opts.refreshToken,
-            tokenRefreshFunction: opts.tokenRefreshFunction,
+            onTokenRefresh: opts.onTokenRefresh,
+            oauth2ClientConfig: opts.oauth2ClientConfig && {
+                ...opts.oauth2ClientConfig,
+                deviceId: this.deviceId ?? undefined,
+                getAuthMetadata: (): Promise<ValidatedAuthMetadata> => this.getAuthMetadata(),
+            },
             prefix: ClientPrefix.V3,
             onlyData: true,
             extraParams: opts.queryParams,
@@ -6199,6 +6218,7 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
     /**
      * Get the API versions supported by the server, along with any
      * unstable APIs it supports
+     *
      * @returns The server /versions response
      */
     public async getVersions(): Promise<IServerVersions> {
@@ -6747,13 +6767,23 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * method is called. The state of the MatrixClient object is not affected:
      * it is up to the caller to either reset or destroy the MatrixClient after
      * this method succeeds.
-     * @param stopClient - whether to stop the client before calling /logout to prevent invalid token errors.
+     *
+     * For an OAuth2-native session (ie. one created with `oauth2ClientConfig`), this revokes the access
+     * and refresh tokens directly with the delegated auth server instead of calling the `/logout` API,
+     * since the homeserver does not own the tokens in that case.
+     *
+     * @param stopClient - whether to stop the client before logging out to prevent invalid token errors.
      * @returns Promise which resolves: On success, the empty object `{}`
      */
     public async logout(stopClient = false): Promise<EmptyObject> {
         if (stopClient) {
             this.stopClient();
             this.http.abort();
+        }
+
+        if (this.http.opts.oauth2ClientConfig) {
+            await this.http.revokeOAuthTokens();
+            return {};
         }
 
         return this.http.authedRequest(Method.Post, "/logout");
@@ -8882,9 +8912,8 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
      * @throws when delegated auth config is invalid or unreachable
      */
     public async getAuthMetadata(): Promise<ValidatedAuthMetadata> {
-        const useStable = await this.isVersionSupported("v1.15");
         const authMetadata = await this.http.request(Method.Get, "/auth_metadata", undefined, undefined, {
-            prefix: useStable ? ClientPrefix.V1 : ClientPrefix.Unstable + "/org.matrix.msc2965",
+            prefix: ClientPrefix.V1,
         });
 
         if (isValidAuthMetadata(authMetadata)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -74,7 +74,6 @@ import {
     Method,
     retryNetworkOperation,
     type onTokenRefreshCallback,
-    type OAuth2ClientConfig,
     type Upload,
     type UploadOpts,
     type UploadResponse,
@@ -331,12 +330,10 @@ export interface ICreateClientOpts {
     onTokenRefresh?: onTokenRefreshCallback;
 
     /**
-     * If this is an OAuth2-native session (as per MSC2965/MSC3861), the client ID and redirect URI this
-     * application is registered with the delegated auth server under. Required for the SDK to be able to
-     * refresh (given `refreshToken`) and revoke (e.g. on logout) tokens for the session; the auth server's
-     * metadata will be discovered lazily, and the OAuth2 client constructed, the first time this is needed.
+     * If this is an OAuth2-native session (as per MSC2965/MSC3861), the OAuth client ID this
+     * application is registered with the delegated auth server under.
      */
-    oauth2ClientConfig?: Pick<OAuth2ClientConfig, "clientId" | "redirectUri">;
+    oauthClientId?: string;
 
     /**
      * Identity server provider to retrieve the user's access token when accessing
@@ -1364,11 +1361,13 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
             accessToken: opts.accessToken,
             refreshToken: opts.refreshToken,
             onTokenRefresh: opts.onTokenRefresh,
-            oauth2ClientConfig: opts.oauth2ClientConfig && {
-                ...opts.oauth2ClientConfig,
-                deviceId: this.deviceId ?? undefined,
-                getAuthMetadata: (): Promise<ValidatedAuthMetadata> => this.getAuthMetadata(),
-            },
+            oauth2ClientConfig: opts.oauthClientId
+                ? {
+                      clientId: opts.oauthClientId,
+                      deviceId: this.deviceId ?? undefined,
+                      getAuthMetadata: (): Promise<ValidatedAuthMetadata> => this.getAuthMetadata(),
+                  }
+                : undefined,
             prefix: ClientPrefix.V3,
             onlyData: true,
             extraParams: opts.queryParams,

--- a/src/client.ts
+++ b/src/client.ts
@@ -319,7 +319,16 @@ export interface ICreateClientOpts {
      */
     deviceId?: string;
 
+    /**
+     * The access token to use. Can be omitted if to call only unauthenticated APIs, or provided to
+     * create an authenticated client.
+     */
     accessToken?: string;
+
+    /**
+     * The current refresh token, or omit if the session has no refresh token in which case the tokens
+     * will not be refreshed.
+     */
     refreshToken?: string;
 
     /**
@@ -327,10 +336,7 @@ export interface ICreateClientOpts {
      * The client must replace the tokens it had stored previously which will no
      * longer be valid.
      *
-     * Required if a {@link IHttpOpts.onTokenRefresh} is provided.
-     *
-     * @param newAccessToken The new access token.
-     * @param newRefreshToken The new refresh token.
+     * Required if a {@link refreshToken} is provided.
      */
     onTokenRefresh?: onTokenRefreshCallback;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1380,9 +1380,9 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
                 ? {
                       clientId: opts.oauthClientId,
                       deviceId: this.deviceId ?? undefined,
-                      getAuthMetadata: (): Promise<ValidatedAuthMetadata> => this.getAuthMetadata(),
                   }
                 : undefined,
+            authMetadataCallback: this.getAuthMetadata.bind(this),
             prefix: ClientPrefix.V3,
             onlyData: true,
             extraParams: opts.queryParams,

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,7 @@ import {
     MediaPrefix,
     Method,
     retryNetworkOperation,
-    type onTokenRefreshCallback,
+    type TokenRefreshCallback,
     type Upload,
     type UploadOpts,
     type UploadResponse,
@@ -338,7 +338,7 @@ export interface ICreateClientOpts {
      *
      * Required if a {@link refreshToken} is provided.
      */
-    onTokenRefresh?: onTokenRefreshCallback;
+    onTokenRefresh?: TokenRefreshCallback;
 
     /**
      * If this is an OAuth2-native session (as per MSC2965/MSC3861), the OAuth client ID this

--- a/src/http-api/fetch.ts
+++ b/src/http-api/fetch.ts
@@ -33,11 +33,11 @@ import {
 import { anySignal, parseErrorResponse, timeoutSignal } from "./utils.ts";
 import { sanitizeUrlForLogs } from "./logging.ts";
 import { type QueryDict } from "../utils.ts";
-import { TokenRefresher, TokenRefreshOutcome } from "./refresh.ts";
+import { TokenManager, TokenRefreshOutcome } from "./refresh.ts";
 
 export class FetchHttpApi<O extends IHttpOpts> {
     private abortController = new AbortController();
-    private readonly tokenRefresher: TokenRefresher;
+    private readonly tokenManager: TokenManager;
 
     public constructor(
         private eventEmitter: TypedEventEmitter<HttpApiEvent, HttpApiEventHandlerMap>,
@@ -49,12 +49,21 @@ export class FetchHttpApi<O extends IHttpOpts> {
         }
         opts.useAuthorizationHeader = opts.useAuthorizationHeader ?? true;
 
-        this.tokenRefresher = new TokenRefresher(opts);
+        this.tokenManager = new TokenManager(opts);
     }
 
     public abort(): void {
         this.abortController.abort();
         this.abortController = new AbortController();
+    }
+
+    /**
+     * Attempt to revoke the current access and refresh tokens with the OAuth2 authorization server, e.g. as
+     * part of logging out an OAuth2-native session. Does nothing if `opts.oauth2ClientConfig` was not supplied.
+     * @throws when discovery of the auth server metadata, or revocation of either token, fails
+     */
+    public async revokeOAuthTokens(): Promise<void> {
+        return this.tokenManager.revokeTokens();
     }
 
     public fetch(resource: URL | string, options?: RequestInit): ReturnType<typeof globalThis.fetch> {
@@ -147,7 +156,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
         opts.abortSignal = paramOpts.abortSignal;
 
         // Take a snapshot of the current token state before we start the request so we can reference it if we error
-        const requestSnapshot = await this.tokenRefresher.prepareForRequest();
+        const requestSnapshot = await this.tokenManager.prepareForRequest();
         if (requestSnapshot.accessToken) {
             if (this.opts.useAuthorizationHeader) {
                 if (!opts.headers) {
@@ -173,7 +182,7 @@ export class FetchHttpApi<O extends IHttpOpts> {
             }
 
             if (error.errcode === "M_UNKNOWN_TOKEN") {
-                const outcome = await this.tokenRefresher.handleUnknownToken(requestSnapshot, attempt);
+                const outcome = await this.tokenManager.handleUnknownToken(requestSnapshot, attempt);
                 if (outcome === TokenRefreshOutcome.Success) {
                     // if we got a new token retry the request
                     return this.doAuthedRequest(attempt + 1, method, path, queryParams, body, paramOpts);

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -56,8 +56,6 @@ export type onTokenRefreshCallback = (newTokens: AccessTokens) => void;
 export interface OAuth2ClientConfig {
     /** The OAuth2 client ID this application is registered with the delegated auth server under. */
     clientId: string;
-    /** The redirect URI this application is registered with the delegated auth server under. */
-    redirectUri: string;
     /** The device ID of the current session, used to scope refreshed/revoked tokens to this session. */
     deviceId?: string;
     /**

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { type MatrixError } from "./errors.ts";
 import { type Logger } from "../logger.ts";
 import { type QueryDict } from "../utils.ts";
+import { type ValidatedAuthMetadata } from "../oauth/discover.ts";
 
 export type Body = Record<string, any> | BodyInit;
 
@@ -39,12 +40,33 @@ export type AccessTokens = {
 };
 
 /**
- * Function that performs token refresh using the given refreshToken.
- * Returns a promise that resolves to the refreshed access and (optional) refresh tokens.
- *
- * Can be passed to HttpApi instance as {@link IHttpOpts.tokenRefreshFunction} during client creation {@link ICreateClientOpts}
+ * A callback function called when tokens are refreshed such that stored tokens can be updated with
+ * the refreshed ones.
  */
-export type TokenRefreshFunction = (refreshToken: string) => Promise<AccessTokens>;
+export type onTokenRefreshCallback = (newTokens: AccessTokens) => void;
+
+/**
+ * Configuration required for {@link IHttpOpts} to allow the SDK to manage the full lifecycle of tokens for an
+ * OAuth2-native session (as per MSC2965/MSC3861): discovering the delegated auth server's metadata, refreshing
+ * access/refresh tokens, and revoking them (e.g. on logout).
+ *
+ * The SDK constructs the underlying OAuth2 client itself, lazily, the first time it is actually needed (so that,
+ * for example, a client started with no network connection does not fail to ever set up token refresh).
+ */
+export interface OAuth2ClientConfig {
+    /** The OAuth2 client ID this application is registered with the delegated auth server under. */
+    clientId: string;
+    /** The redirect URI this application is registered with the delegated auth server under. */
+    redirectUri: string;
+    /** The device ID of the current session, used to scope refreshed/revoked tokens to this session. */
+    deviceId?: string;
+    /**
+     * Discovers and validates the delegated auth server's metadata for the current homeserver.
+     * @returns validated authentication metadata
+     * @throws when delegated auth config is invalid or unreachable
+     */
+    getAuthMetadata: () => Promise<ValidatedAuthMetadata>;
+}
 
 /** Options object for `FetchHttpApi` and {@link MatrixHttpApi}. */
 export interface IHttpOpts {
@@ -57,14 +79,18 @@ export interface IHttpOpts {
 
     accessToken?: string;
     /**
-     * Used in conjunction with tokenRefreshFunction to attempt token refresh
+     * Used in conjunction with oauth2ClientConfig to attempt token refresh
      */
     refreshToken?: string;
     /**
-     * Function to attempt token refresh when a possibly expired token is encountered
-     * Optional, only called when a refreshToken is present
+     * Callback called when tokens are refreshed. Must be supplied if refreshToken is supplied.
      */
-    tokenRefreshFunction?: TokenRefreshFunction;
+    onTokenRefresh?: onTokenRefreshCallback;
+    /**
+     * Configuration needed to refresh (given refreshToken) and revoke (e.g. on logout) tokens for an
+     * OAuth2-native session. Optional; if omitted, tokens will not be refreshed or revoked by the SDK.
+     */
+    oauth2ClientConfig?: OAuth2ClientConfig;
 
     /**
      * Whether to use the HTTP Authorization header over the `access_token` query parameter

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -43,7 +43,7 @@ export type AccessTokens = {
  * A callback function called when tokens are refreshed such that stored tokens can be updated with
  * the refreshed ones.
  */
-export type onTokenRefreshCallback = (newTokens: AccessTokens) => void;
+export type TokenRefreshCallback = (newTokens: AccessTokens) => void;
 
 /**
  * Configuration required for {@link IHttpOpts} to allow the SDK to manage the full lifecycle of tokens for an
@@ -83,7 +83,7 @@ export interface IHttpOpts {
     /**
      * Callback called when tokens are refreshed. Must be supplied if refreshToken is supplied.
      */
-    onTokenRefresh?: onTokenRefreshCallback;
+    onTokenRefresh?: TokenRefreshCallback;
     /**
      * Configuration needed to refresh (given refreshToken) and revoke (e.g. on logout) tokens for an
      * OAuth2-native session. Optional; if omitted, tokens will not be refreshed or revoked by the SDK.

--- a/src/http-api/interface.ts
+++ b/src/http-api/interface.ts
@@ -58,12 +58,6 @@ export interface OAuth2ClientConfig {
     clientId: string;
     /** The device ID of the current session, used to scope refreshed/revoked tokens to this session. */
     deviceId?: string;
-    /**
-     * Discovers and validates the delegated auth server's metadata for the current homeserver.
-     * @returns validated authentication metadata
-     * @throws when delegated auth config is invalid or unreachable
-     */
-    getAuthMetadata: () => Promise<ValidatedAuthMetadata>;
 }
 
 /** Options object for `FetchHttpApi` and {@link MatrixHttpApi}. */
@@ -87,8 +81,18 @@ export interface IHttpOpts {
     /**
      * Configuration needed to refresh (given refreshToken) and revoke (e.g. on logout) tokens for an
      * OAuth2-native session. Optional; if omitted, tokens will not be refreshed or revoked by the SDK.
+     * authMetadataCallback must also be supplied to refresh tokens.
      */
     oauth2ClientConfig?: OAuth2ClientConfig;
+
+    /**
+     * Discovers and validates the delegated auth server's metadata for the current homeserver.
+     * Must be supplied along with oauth2ClientConfig in order to refresh tokens.
+     *
+     * @returns validated authentication metadata
+     * @throws when delegated auth config is invalid or unreachable
+     */
+    authMetadataCallback?: () => Promise<ValidatedAuthMetadata>;
 
     /**
      * Whether to use the HTTP Authorization header over the `access_token` query parameter

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -159,7 +159,7 @@ export class TokenManager {
                 return TokenRefreshOutcome.Logout;
             }
 
-            const { accessToken, refreshToken, expiry } = await tokenRefresher.doRefresh(this.opts.refreshToken);
+            const { accessToken, refreshToken, expiry } = await tokenRefresher.refreshTokens(this.opts.refreshToken);
             this.opts.accessToken = accessToken;
             this.opts.refreshToken = refreshToken;
             this.latestTokenRefreshExpiry = expiry;

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixError, TokenRefreshLogoutError } from "./errors.ts";
-import { type IHttpOpts } from "./interface.ts";
+import { ConnectionError, MatrixError, TokenRefreshLogoutError } from "./errors.ts";
+import { type AccessTokens, type IHttpOpts, type OAuth2ClientConfig } from "./interface.ts";
 import { sleep } from "../utils.ts";
+import { TokenRefresher } from "../oauth/tokenRefresher.ts";
+import { OAuth2 } from "../oauth/index.ts";
 
 /**
  * This is an internal module. See {@link MatrixHttpApi} for the public class.
@@ -28,25 +30,26 @@ export const enum TokenRefreshOutcome {
     Logout = "logout",
 }
 
-interface Snapshot {
-    accessToken: string;
-    refreshToken?: string;
-    expiry?: Date;
-}
-
 // If the token expires in less than this time amount of time, we will eagerly refresh it before making the intended request.
 const REFRESH_IF_TOKEN_EXPIRES_WITHIN_MS = 500;
 // If we get an unknown token error and the token expires in less than this time amount of time, we will refresh it before making the intended request.
 // Otherwise, we will error as the token should not have expired yet and we need to avoid retrying indefinitely.
 const REFRESH_ON_ERROR_IF_TOKEN_EXPIRES_WITHIN_MS = 60 * 1000;
 
-type Opts = Pick<IHttpOpts, "tokenRefreshFunction" | "logger" | "refreshToken" | "accessToken">;
+// How many times to retry discovering the OAuth2 auth server metadata if it fails due to a connectivity
+// problem, e.g. if the client starts up with no network connection at all.
+const MAX_AUTH_METADATA_DISCOVERY_ATTEMPTS = 5;
+
+type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "accessToken" | "oauth2ClientConfig">;
 
 /**
  * This class is responsible for managing the access token and refresh token for authenticated requests.
- * It will automatically refresh the access token when it is about to expire, and will handle unknown token errors.
+ * It will automatically refresh the tokens when the access token is about to expire and can handle
+ * Unknown Token errors (via @{link handleUnknownToken})
+ *
+ * It will update the @{link opts} object with new tokens as they are refreshed, and also call the onTokenRefresh callback if provided.
  */
-export class TokenRefresher {
+export class TokenManager {
     public constructor(private readonly opts: Opts) {}
 
     /**
@@ -57,12 +60,22 @@ export class TokenRefresher {
 
     private latestTokenRefreshExpiry?: Date;
 
+    // The object at the OAuth API layer that actually does the refreshing
+    // This needs OAuth params to be fetched before it can be constructed so it starts
+    // off as undefined and is constructed once we are able to do so.
+    private tokenRefresher?: TokenRefresher;
+
+    // Tracks an in-progress attempt to discover the OAuth2 auth server metadata and construct
+    // `tokenRefresher`, so that concurrent callers wait for (and share the result of) the same attempt
+    // rather than racing to discover it independently.
+    private tokenRefresherPromise?: Promise<TokenRefresher>;
+
     /**
      * This function is called before every request to ensure that the access token is valid.
      * @returns a snapshot containing the access token and other properties which must be passed to the handleUnknownToken
      *     handler if an M_UNKNOWN_TOKEN error is encountered.
      */
-    public async prepareForRequest(): Promise<Snapshot> {
+    public async prepareForRequest(): Promise<AccessTokens> {
         // Ensure our token is refreshed before we build the headers/params
         await this.refreshIfNeeded();
 
@@ -93,13 +106,13 @@ export class TokenRefresher {
      * @param attempt - the number of attempts made for this request so far
      * @returns a TokenRefreshOutcome indicating the result of the refresh attempt
      */
-    public async handleUnknownToken(snapshot: Snapshot, attempt: number): Promise<TokenRefreshOutcome> {
+    public async handleUnknownToken(snapshot: AccessTokens, attempt: number): Promise<TokenRefreshOutcome> {
         return this._handleUnknownToken(snapshot, attempt);
     }
 
     private async _handleUnknownToken(): Promise<TokenRefreshOutcome>;
-    private async _handleUnknownToken(snapshot: Snapshot, attempt: number): Promise<TokenRefreshOutcome>;
-    private async _handleUnknownToken(snapshot?: Snapshot, attempt?: number): Promise<TokenRefreshOutcome> {
+    private async _handleUnknownToken(snapshot: AccessTokens, attempt: number): Promise<TokenRefreshOutcome>;
+    private async _handleUnknownToken(snapshot?: AccessTokens, attempt?: number): Promise<TokenRefreshOutcome> {
         if (snapshot?.expiry) {
             // If our token is unknown, but it should not have expired yet, then we should not refresh
             const expiresIn = snapshot.expiry.getTime() - Date.now();
@@ -132,8 +145,8 @@ export class TokenRefresher {
      * @returns Promise that resolves to a boolean - true when token was refreshed successfully
      */
     private async doTokenRefresh(attempt?: number): Promise<TokenRefreshOutcome> {
-        if (!this.opts.refreshToken || !this.opts.tokenRefreshFunction) {
-            this.opts.logger?.error("Unable to refresh token - no refresh token or refresh function");
+        if (!this.opts.refreshToken || !this.opts.oauth2ClientConfig) {
+            this.opts.logger?.error("Unable to refresh token - no refresh token or OAuth2 client config");
             return TokenRefreshOutcome.Logout;
         }
 
@@ -144,7 +157,13 @@ export class TokenRefresher {
 
         try {
             this.opts.logger?.debug("Attempting to refresh token");
-            const { accessToken, refreshToken, expiry } = await this.opts.tokenRefreshFunction(this.opts.refreshToken);
+            const tokenRefresher = await this.ensureTokenRefresher();
+            if (!tokenRefresher) {
+                // We already checked `oauth2ClientConfig` is set above, so this should be unreachable.
+                return TokenRefreshOutcome.Logout;
+            }
+
+            const { accessToken, refreshToken, expiry } = await tokenRefresher.doRefresh(this.opts.refreshToken);
             this.opts.accessToken = accessToken;
             this.opts.refreshToken = refreshToken;
             this.latestTokenRefreshExpiry = expiry;
@@ -162,5 +181,65 @@ export class TokenRefresher {
             this.opts.logger?.warn("Failed to refresh token", error);
             return TokenRefreshOutcome.Failure;
         }
+    }
+
+    /**
+     * Attempt to revoke the current access and refresh tokens with the OAuth2 authorization server, e.g. as
+     * part of logging out. Does nothing if this is not an OAuth2-native session (ie. no `oauth2ClientConfig`
+     * was supplied).
+     * @throws when discovery of the auth server metadata, or revocation of either token, fails
+     */
+    public async revokeTokens(): Promise<void> {
+        const tokenRefresher = await this.ensureTokenRefresher();
+        if (!tokenRefresher) return;
+
+        await Promise.all(
+            [
+                this.opts.accessToken ? tokenRefresher.revokeToken(this.opts.accessToken, "access_token") : undefined,
+                this.opts.refreshToken
+                    ? tokenRefresher.revokeToken(this.opts.refreshToken, "refresh_token")
+                    : undefined,
+            ].filter((p): p is Promise<void> => p !== undefined),
+        );
+    }
+
+    /**
+     * Lazily constructs (and caches) the {@link TokenRefresher} used to talk to the OAuth2 authorization
+     * server, discovering its metadata first if this is the first time it's needed.
+     * @returns the token refresher, or undefined if no `oauth2ClientConfig` was supplied
+     * @throws when discovery of the auth server metadata fails in a way that isn't worth retrying
+     */
+    private async ensureTokenRefresher(): Promise<TokenRefresher | undefined> {
+        if (this.tokenRefresher) return this.tokenRefresher;
+        if (!this.opts.oauth2ClientConfig) return undefined;
+
+        if (!this.tokenRefresherPromise) {
+            this.tokenRefresherPromise = this.discoverTokenRefresher(this.opts.oauth2ClientConfig);
+        }
+
+        try {
+            this.tokenRefresher = await this.tokenRefresherPromise;
+            return this.tokenRefresher;
+        } finally {
+            // Either we now have `tokenRefresher` cached and won't need this again, or discovery
+            // failed and a future call should be free to retry from scratch.
+            this.tokenRefresherPromise = undefined;
+        }
+    }
+
+    /**
+     * Discovers the OAuth2 auth server metadata and constructs the OAuth2 client and token refresher from it.
+     * Throws if the request fails.
+     */
+    private async discoverTokenRefresher(config: OAuth2ClientConfig, attempt: number = 1): Promise<TokenRefresher> {
+        const metadata = await config.getAuthMetadata();
+
+        const oauth2 = new OAuth2(metadata, {
+            clientId: config.clientId,
+            redirectUri: config.redirectUri,
+            deviceId: config.deviceId,
+        });
+
+        return new TokenRefresher(oauth2, (tokens) => this.opts.onTokenRefresh?.(tokens));
     }
 }

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ConnectionError, MatrixError, TokenRefreshLogoutError } from "./errors.ts";
+import { MatrixError, TokenRefreshLogoutError } from "./errors.ts";
 import { type AccessTokens, type IHttpOpts, type OAuth2ClientConfig } from "./interface.ts";
 import { sleep } from "../utils.ts";
 import { TokenRefresher } from "../oauth/tokenRefresher.ts";
@@ -35,10 +35,6 @@ const REFRESH_IF_TOKEN_EXPIRES_WITHIN_MS = 500;
 // If we get an unknown token error and the token expires in less than this time amount of time, we will refresh it before making the intended request.
 // Otherwise, we will error as the token should not have expired yet and we need to avoid retrying indefinitely.
 const REFRESH_ON_ERROR_IF_TOKEN_EXPIRES_WITHIN_MS = 60 * 1000;
-
-// How many times to retry discovering the OAuth2 auth server metadata if it fails due to a connectivity
-// problem, e.g. if the client starts up with no network connection at all.
-const MAX_AUTH_METADATA_DISCOVERY_ATTEMPTS = 5;
 
 type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "accessToken" | "oauth2ClientConfig">;
 
@@ -236,7 +232,6 @@ export class TokenManager {
 
         const oauth2 = new OAuth2(metadata, {
             clientId: config.clientId,
-            redirectUri: config.redirectUri,
             deviceId: config.deviceId,
         });
 

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -43,7 +43,7 @@ type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "acce
  * It will automatically refresh the tokens when the access token is about to expire and can handle
  * Unknown Token errors (via @{link handleUnknownToken})
  *
- * It will update the @{link opts} object with new tokens as they are refreshed, and also call the onTokenRefresh callback if provided.
+ * It will update the @{link opts} object with new tokens as they are refreshed, and also call the {@link onTokenRefresh} callback if provided.
  */
 export class TokenManager {
     public constructor(private readonly opts: Opts) {}

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -41,9 +41,9 @@ type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "acce
 /**
  * This class is responsible for managing the access token and refresh token for authenticated requests.
  * It will automatically refresh the tokens when the access token is about to expire and can handle
- * Unknown Token errors (via @{link handleUnknownToken})
+ * Unknown Token errors (via {@link TokenManager.handleUnknownToken})
  *
- * It will update the @{link opts} object with new tokens as they are refreshed, and also call the {@link opts.onTokenRefresh} callback if provided.
+ * It will update the {@link Opts} object with new tokens as they are refreshed, and also call the {@link IHttpOpts.onTokenRefresh} callback if provided.
  */
 export class TokenManager {
     public constructor(private readonly opts: Opts) {}

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -227,7 +227,7 @@ export class TokenManager {
      * Discovers the OAuth2 auth server metadata and constructs the OAuth2 client and token refresher from it.
      * Throws if the request fails.
      */
-    private async discoverTokenRefresher(config: OAuth2ClientConfig, attempt: number = 1): Promise<TokenRefresher> {
+    private async discoverTokenRefresher(config: OAuth2ClientConfig): Promise<TokenRefresher> {
         const metadata = await config.getAuthMetadata();
 
         const oauth2 = new OAuth2(metadata, {

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -43,7 +43,7 @@ type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "acce
  * It will automatically refresh the tokens when the access token is about to expire and can handle
  * Unknown Token errors (via @{link handleUnknownToken})
  *
- * It will update the @{link opts} object with new tokens as they are refreshed, and also call the {@link onTokenRefresh} callback if provided.
+ * It will update the @{link opts} object with new tokens as they are refreshed, and also call the {@link opts.onTokenRefresh} callback if provided.
  */
 export class TokenManager {
     public constructor(private readonly opts: Opts) {}

--- a/src/http-api/refresh.ts
+++ b/src/http-api/refresh.ts
@@ -18,7 +18,7 @@ import { MatrixError, TokenRefreshLogoutError } from "./errors.ts";
 import { type AccessTokens, type IHttpOpts, type OAuth2ClientConfig } from "./interface.ts";
 import { sleep } from "../utils.ts";
 import { TokenRefresher } from "../oauth/tokenRefresher.ts";
-import { OAuth2 } from "../oauth/index.ts";
+import { OAuth2, type ValidatedAuthMetadata } from "../oauth/index.ts";
 
 /**
  * This is an internal module. See {@link MatrixHttpApi} for the public class.
@@ -36,7 +36,10 @@ const REFRESH_IF_TOKEN_EXPIRES_WITHIN_MS = 500;
 // Otherwise, we will error as the token should not have expired yet and we need to avoid retrying indefinitely.
 const REFRESH_ON_ERROR_IF_TOKEN_EXPIRES_WITHIN_MS = 60 * 1000;
 
-type Opts = Pick<IHttpOpts, "onTokenRefresh" | "logger" | "refreshToken" | "accessToken" | "oauth2ClientConfig">;
+type Opts = Pick<
+    IHttpOpts,
+    "onTokenRefresh" | "logger" | "refreshToken" | "accessToken" | "oauth2ClientConfig" | "authMetadataCallback"
+>;
 
 /**
  * This class is responsible for managing the access token and refresh token for authenticated requests.
@@ -208,9 +211,13 @@ export class TokenManager {
     private async ensureTokenRefresher(): Promise<TokenRefresher | undefined> {
         if (this.tokenRefresher) return this.tokenRefresher;
         if (!this.opts.oauth2ClientConfig) return undefined;
+        if (!this.opts.authMetadataCallback) return undefined;
 
         if (!this.tokenRefresherPromise) {
-            this.tokenRefresherPromise = this.discoverTokenRefresher(this.opts.oauth2ClientConfig);
+            this.tokenRefresherPromise = this.discoverTokenRefresher(
+                this.opts.oauth2ClientConfig,
+                this.opts.authMetadataCallback,
+            );
         }
 
         try {
@@ -227,8 +234,11 @@ export class TokenManager {
      * Discovers the OAuth2 auth server metadata and constructs the OAuth2 client and token refresher from it.
      * Throws if the request fails.
      */
-    private async discoverTokenRefresher(config: OAuth2ClientConfig): Promise<TokenRefresher> {
-        const metadata = await config.getAuthMetadata();
+    private async discoverTokenRefresher(
+        config: OAuth2ClientConfig,
+        authMetaDataCallback: () => Promise<ValidatedAuthMetadata>,
+    ): Promise<TokenRefresher> {
+        const metadata = await authMetaDataCallback();
 
         const oauth2 = new OAuth2(metadata, {
             clientId: config.clientId,

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -24,7 +24,7 @@ import {
     hasRequiredStringProperty,
     isRecord,
 } from "../@types/type-guards.ts";
-import { Method } from "../http-api/index.ts";
+import { Method } from "../http-api/method.ts";
 import { OAuthGrantType } from "./register.ts";
 import { sleep } from "../utils.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -56,8 +56,6 @@ type Context = {
     deviceId?: string;
     /** The seed used to generate the challenge code */
     codeVerifier?: string;
-    /** The URI to redirect the user to with credentials after auth */
-    redirectUri: string;
 };
 
 export class OAuth2 {
@@ -148,7 +146,6 @@ export class OAuth2 {
     ) {
         this.context = {
             clientId: context.clientId,
-            redirectUri: context.redirectUri,
             deviceId: context.deviceId ?? secureRandomString(10),
             codeVerifier: context.codeVerifier ?? secureRandomString(96),
         };
@@ -161,12 +158,14 @@ export class OAuth2 {
      *     that will allow the client to maintain state between the authorization request and the callback.
      *     The app should use this to key the storage for where the rest of the auth context is saved.
      * @param responseMode - The manner in which the IdP should send the secrets back to the app. Defaults to `fragment` for privacy.
+     * @param redirectUri - The redirect URI this application is registered with the delegated auth server under.
      * @param prompt - Optional prompt parameter to pass to the IdP to signal intent, e.g. `create` for User registration.
      * @param scope - The OAuth2 scope to request, will be generated based on the device ID if omitted.
      * @returns a Promise with the url as a string
      */
     public async generateAuthorizationCodeGrantUrl(
         state: string,
+        redirectUri: string,
         responseMode: "fragment" | "query" = "fragment",
         prompt?: string,
         scope?: string,
@@ -177,7 +176,7 @@ export class OAuth2 {
         url.searchParams.set("response_type", "code");
         url.searchParams.set("response_mode", responseMode);
         url.searchParams.set("client_id", this.context.clientId);
-        url.searchParams.set("redirect_uri", this.context.redirectUri);
+        url.searchParams.set("redirect_uri", redirectUri);
         url.searchParams.set("scope", scope ?? generateScope(this.context.deviceId));
         url.searchParams.set("state", state);
         url.searchParams.set("code_challenge_method", "S256");
@@ -201,12 +200,12 @@ export class OAuth2 {
      * @throws An `Error` with `message` set to an entry in {@link OAuth2Error},
      *      when the request fails, or the returned token response is invalid.
      */
-    public async completeAuthorizationCodeGrant(code: string): Promise<BearerTokenResponse> {
+    public async completeAuthorizationCodeGrant(code: string, redirectUri: string): Promise<BearerTokenResponse> {
         const params = new URLSearchParams();
         params.append("grant_type", "authorization_code");
         params.append("client_id", this.context.clientId);
         params.append("code_verifier", this.context.codeVerifier);
-        params.append("redirect_uri", this.context.redirectUri);
+        params.append("redirect_uri", redirectUri);
         params.append("code", code);
 
         const res = await this.fetch("token", params, OAuth2Error.CodeExchangeFailed);

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -44,7 +44,6 @@ import { type NonEmptyArray } from "../@types/common.ts";
 export * from "./authorize.ts";
 export * from "./error.ts";
 export * from "./register.ts";
-export * from "./tokenRefresher.ts";
 export * from "./discover.ts";
 
 /**

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -34,7 +34,8 @@ import {
 } from "./register.ts";
 import { encodeUnpaddedBase64Url } from "../base64.ts";
 import { sha256 } from "../digest.ts";
-import { HTTPError, isMatrixErrorResponse, MatrixError, Method } from "../http-api/index.ts";
+import { HTTPError, isMatrixErrorResponse, MatrixError } from "../http-api/errors.ts";
+import { Method } from "../http-api/method.ts";
 import { type Logger, logger as rootLogger } from "../logger.ts";
 import { fetchWithLogging } from "./fetch.ts";
 import { isOAuth2ErrorResponse, OAuth2Error, OAuth2HTTPError } from "./error.ts";

--- a/src/oauth/tokenRefresher.ts
+++ b/src/oauth/tokenRefresher.ts
@@ -35,7 +35,7 @@ export class TokenRefresher {
      * @param refreshToken - refresh token to use in request with token issuer
      * @throws when token refresh fails
      */
-    public async doRefresh(refreshToken: string): Promise<AccessTokens> {
+    public async refreshTokens(refreshToken: string): Promise<AccessTokens> {
         if (!this.inflightRefreshRequest) {
             this.inflightRefreshRequest = this.getNewTokens(refreshToken);
         }

--- a/src/oauth/tokenRefresher.ts
+++ b/src/oauth/tokenRefresher.ts
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type AccessTokens, HTTPError, type TokenRefreshFunction, TokenRefreshLogoutError } from "../http-api/index.ts";
+import { HTTPError, TokenRefreshLogoutError } from "../http-api/errors.ts";
+import { type AccessTokens } from "../http-api/interface.ts";
 import { OAuth2HTTPError } from "./error.ts";
 import { type OAuth2 } from "./index.ts";
 
@@ -26,16 +27,15 @@ export class TokenRefresher {
 
     public constructor(
         private readonly auth: OAuth2,
-        private readonly onRefresh: (tokens: AccessTokens) => Promise<void>,
+        private readonly onRefresh: (tokens: AccessTokens) => void | Promise<void>,
     ) {}
 
     /**
      * Attempt token refresh using given refresh token
      * @param refreshToken - refresh token to use in request with token issuer
-     * @returns tokens - Promise that resolves with new access and refresh tokens
      * @throws when token refresh fails
      */
-    public tokenRefreshFunction: TokenRefreshFunction = async (refreshToken: string): Promise<AccessTokens> => {
+    public async doRefresh(refreshToken: string): Promise<AccessTokens> {
         if (!this.inflightRefreshRequest) {
             this.inflightRefreshRequest = this.getNewTokens(refreshToken);
         }
@@ -52,7 +52,17 @@ export class TokenRefresher {
         } finally {
             this.inflightRefreshRequest = undefined;
         }
-    };
+    }
+
+    /**
+     * Revoke a token with the OP, e.g. as part of logging out.
+     * @param token - the token to revoke
+     * @param type - the type of token, acts as a hint to the OP
+     * @throws when revocation fails
+     */
+    public async revokeToken(token: string, type?: "access_token" | "refresh_token"): Promise<void> {
+        await this.auth.revokeToken(token, type);
+    }
 
     private shouldLogoutOnError(error: HTTPError): boolean {
         // Treat as logout as per https://spec.matrix.org/v1.18/client-server-api/#refresh-token-grant


### PR DESCRIPTION
Changes the API so that refreshing tokens is now js-sdk's job rather than the client, so the js-sdk fetches the auth metadata. This allows it to construct the OAuth object lazily which means it can retry if, for example, there was no internet when the client started (otherwise the app would have to wait until it could fetch auth metadata before starting the client).

Also removes support for the unstable prefixed MSC2965: this has been stable for about a year now. Supporting stable/unstable meant we had to check /versions before requesting auth metadata, which of course we had to do without auth, else get infinite loops, which would have added a buncvh of complexity to manage fetching and caching authed/ unauthed /versions requests.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
