### PR TITLE
Don't fetch the client well-known when clientWellKnownPollPeriod is unset

### DIFF
--- a/spec/unit/embedded.spec.ts
+++ b/spec/unit/embedded.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 // We have to use EventEmitter here to mock part of the matrix-widget-api
 // project, which doesn't know about our TypeEventEmitter implementation at all
 import { EventEmitter } from "node:events";
-import { type MockedObject } from "vitest";
+import { type MockedObject, type MockInstance } from "vitest";
 import {
     type WidgetApi,
     WidgetApiToWidgetAction,
@@ -38,7 +38,13 @@ import {
     MsgType,
     UpdateDelayedEventAction,
 } from "../../src/matrix";
-import { MatrixClient, ClientEvent, type ITurnServer as IClientTurnServer } from "../../src/client";
+import {
+    MatrixClient,
+    ClientEvent,
+    type IStartClientOpts,
+    type ITurnServer as IClientTurnServer,
+} from "../../src/client";
+import { AutoDiscovery } from "../../src/autodiscovery";
 import { SyncState } from "../../src/sync";
 import { type ICapabilities, type RoomWidgetClient } from "../../src/embedded";
 import { MatrixEvent } from "../../src/models/event";
@@ -1377,6 +1383,42 @@ describe("RoomWidgetClient", () => {
 
             await makeClient({ rtcLivekitDelegateDelayedLeave: true });
             await expect(client._unstable_delegateDelayedLeave(body)).rejects.toThrow(ConnectionError);
+        });
+    });
+
+    describe("well-known", () => {
+        let getRawClientConfig: MockInstance<typeof AutoDiscovery.getRawClientConfig>;
+
+        beforeEach(() => {
+            getRawClientConfig = vi.spyOn(AutoDiscovery, "getRawClientConfig").mockResolvedValue({});
+        });
+
+        afterEach(() => {
+            getRawClientConfig.mockRestore();
+        });
+
+        const startClient = async (opts: IStartClientOpts): Promise<void> => {
+            client = createRoomWidgetClient(widgetApi, {}, "!1:example.org", {
+                baseUrl: "https://example.org",
+                userId: "@alice:example.org",
+            });
+            widgetApi.emit("ready");
+            await client.startClient(opts);
+            await flushPromises();
+        };
+
+        it("does not fetch the well-known when clientWellKnownPollPeriod is undefined", async () => {
+            await startClient({});
+
+            expect(getRawClientConfig).not.toHaveBeenCalled();
+            expect(client.getClientWellKnown()).toBeUndefined();
+        });
+
+        it("fetches the well-known when clientWellKnownPollPeriod is set", async () => {
+            await startClient({ clientWellKnownPollPeriod: 3600 });
+
+            expect(getRawClientConfig).toHaveBeenCalledWith("example.org");
+            expect(client.getClientWellKnown()).toStrictEqual({});
         });
     });
 });

--- a/spec/unit/matrix-client.spec.ts
+++ b/spec/unit/matrix-client.spec.ts
@@ -19,7 +19,7 @@ limitations under the License.
  */
 
 import fetchMock from "@fetch-mock/vitest";
-import { type MockedObject, type Mocked } from "vitest";
+import { type MockedObject, type Mocked, type MockInstance } from "vitest";
 
 import { logger } from "../../src/logger";
 import {
@@ -46,6 +46,7 @@ import { EventStatus, MatrixEvent } from "../../src/models/event";
 import { Preset } from "../../src/@types/partials";
 import { ReceiptType } from "../../src/@types/read_receipts";
 import * as testUtils from "../test-utils/test-utils";
+import { flushPromises } from "../test-utils/flushPromises";
 import { makeBeaconInfoContent } from "../../src/content-helpers";
 import { M_BEACON_INFO } from "../../src/@types/beacon";
 import {
@@ -4061,25 +4062,54 @@ describe("MatrixClient", function () {
     });
 
     describe("Well-known", () => {
+        const A_WELLKNOWN: IClientWellKnown = {
+            "m.homeserver": {
+                base_url: "https://hs.org",
+            },
+            "m.identity_server": {
+                base_url: "https://is.org",
+            },
+        };
+
+        let getRawClientConfig: MockInstance<typeof AutoDiscovery.getRawClientConfig>;
+
+        beforeEach(() => {
+            getRawClientConfig = vi.spyOn(AutoDiscovery, "getRawClientConfig").mockResolvedValue(A_WELLKNOWN);
+        });
+
+        afterEach(() => {
+            getRawClientConfig.mockRestore();
+        });
+
         it("caches the well-known value", async () => {
-            const A_WELLKNOWN: IClientWellKnown = {
-                "m.homeserver": {
-                    base_url: "https://hs.org",
-                },
-                "m.identity_server": {
-                    base_url: "https://is.org",
-                },
-            };
-
             void client.startClient();
-
-            vi.spyOn(AutoDiscovery, "getRawClientConfig").mockResolvedValue(A_WELLKNOWN);
 
             const value = await client.waitForClientWellKnown();
             expect(value).toStrictEqual(A_WELLKNOWN);
 
             const cached = client.getClientWellKnown();
             expect(cached).toStrictEqual(A_WELLKNOWN);
+        });
+
+        it("does not fetch the well-known when clientWellKnownPollPeriod is undefined", async () => {
+            await client.startClient();
+            await flushPromises();
+
+            expect(getRawClientConfig).not.toHaveBeenCalled();
+            expect(client.getClientWellKnown()).toBeUndefined();
+        });
+
+        it("fetches the well-known on startup and polls it when clientWellKnownPollPeriod is set", async () => {
+            await client.startClient({ clientWellKnownPollPeriod: 3600 });
+            await flushPromises();
+
+            expect(getRawClientConfig).toHaveBeenCalledTimes(1);
+            expect(client.getClientWellKnown()).toStrictEqual(A_WELLKNOWN);
+
+            await vi.advanceTimersByTimeAsync(3600 * 1000);
+            expect(getRawClientConfig).toHaveBeenCalledTimes(2);
+
+            client.stopClient();
         });
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -530,6 +530,10 @@ export interface IStartClientOpts {
     /**
      * The number of seconds between polls to /.well-known/matrix/client, undefined to disable.
      * This should be in the order of hours. Default: undefined.
+     *
+     * When disabled, the client never requests the well-known on its own: nothing is fetched on
+     * startup and {@link MatrixClient.getClientWellKnown} stays undefined. Callers that still need
+     * it can fetch it on demand via {@link MatrixClient.waitForClientWellKnown}.
      */
     clientWellKnownPollPeriod?: number;
 
@@ -1523,11 +1527,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
 
         this.syncApi.sync().catch((e) => this.logger.info("Sync startup aborted with an error:", e));
 
-        this.cachedWellKnown.start(
-            this.clientOpts.clientWellKnownPollPeriod !== undefined
-                ? 1000 * this.clientOpts.clientWellKnownPollPeriod
-                : undefined,
-        );
+        // Only poll the client well-known when a poll period was configured: leaving
+        // `clientWellKnownPollPeriod` undefined disables the lookups entirely.
+        if (this.clientOpts.clientWellKnownPollPeriod !== undefined) {
+            this.cachedWellKnown.start(1000 * this.clientOpts.clientWellKnownPollPeriod);
+        }
 
         this.toDeviceMessageQueue.start();
         this.serverCapabilitiesService.start();

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -383,9 +383,11 @@ export class RoomWidgetClient extends MatrixClient {
             );
         }
 
-        this.cachedWellKnown.start(
-            opts.clientWellKnownPollPeriod !== undefined ? 1000 * opts.clientWellKnownPollPeriod : undefined,
-        );
+        // Only poll the client well-known when a poll period was configured: leaving
+        // `clientWellKnownPollPeriod` undefined disables the lookups entirely.
+        if (opts.clientWellKnownPollPeriod !== undefined) {
+            this.cachedWellKnown.start(1000 * opts.clientWellKnownPollPeriod);
+        }
         this.setSyncState(SyncState.Syncing);
         logger.info("Finished initial sync");
 


### PR DESCRIPTION
#5470 moved the client well-known polling onto PollingCachedValue and started the cache unconditionally from startClient(), passing `undefined` as the TTL when no poll period was configured. PollingCachedValue.start() always performs an initial fetch, so `undefined` stopped meaning "disabled": every MatrixClient (and RoomWidgetClient) fetched `/.well-known/matrix/client` once on startup, even when the embedding application had turned the lookups off.

Only start the cache when a poll period is configured, as before, spell the contract out on the option, and add regression tests for both clients.


