### PR TITLE
MatrixRTC: restart the delayed leave event before extending a membership's expiry

### DIFF
--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -709,6 +709,77 @@ describe("MembershipManager", () => {
             expect((vi.mocked(client.sendStateEvent).mock.calls[0][2] as SessionMembershipData).expires).toBe(10_000);
             expect(manager.status).toBe(Status.Connected);
         });
+
+        it("retries extending `expires` when restarting the delayed leave event is rate limited", async () => {
+            const manager = new MembershipManager(
+                { membershipEventExpiryMs: 10_000, delayedLeaveEventRestartMs: 60_000 },
+                room,
+                client,
+                { id: "", application: "m.call" },
+            );
+            manager.join([focus], focusActive);
+            await waitForMockCall(client.sendStateEvent);
+            await vi.advanceTimersByTimeAsync(1);
+            vi.mocked(client.sendStateEvent).mockClear();
+
+            vi.mocked(client._unstable_restartScheduledDelayedEvent).mockRejectedValueOnce(
+                new MatrixError(
+                    { errcode: "M_LIMIT_EXCEEDED" },
+                    429,
+                    undefined,
+                    undefined,
+                    new Headers({ "Retry-After": "1" }),
+                ),
+            );
+            // The update is due at 5s and retried 1s later.
+            await vi.advanceTimersByTimeAsync(5_500);
+            // Nothing was sent while rate limited: the membership must not be re-sent unprotected.
+            expect(client.sendStateEvent).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(1_000);
+            expect(client.sendStateEvent).toHaveBeenCalledTimes(1);
+            expect((vi.mocked(client.sendStateEvent).mock.calls[0][2] as SessionMembershipData).expires).toBe(20_000);
+        });
+
+        it("extends `expires` without a restart if delayed events are unsupported", async () => {
+            const manager = new MembershipManager(
+                { membershipEventExpiryMs: 10_000, delayedLeaveEventRestartMs: 60_000 },
+                room,
+                client,
+                { id: "", application: "m.call" },
+            );
+            manager.join([focus], focusActive);
+            await waitForMockCall(client.sendStateEvent);
+            await vi.advanceTimersByTimeAsync(1);
+            vi.mocked(client.sendStateEvent).mockClear();
+
+            vi.mocked(client._unstable_restartScheduledDelayedEvent).mockRejectedValueOnce(
+                new UnsupportedDelayedEventsEndpointError("unsupported", "restartScheduledDelayedEvent"),
+            );
+            await vi.advanceTimersByTimeAsync(6_000);
+            expect(client.sendStateEvent).toHaveBeenCalledTimes(1);
+            expect((vi.mocked(client.sendStateEvent).mock.calls[0][2] as SessionMembershipData).expires).toBe(20_000);
+        });
+
+        it("stops if restarting the delayed leave event before extending `expires` fails unexpectedly", async () => {
+            const unrecoverableError = vi.fn();
+            const manager = new MembershipManager(
+                { membershipEventExpiryMs: 10_000, delayedLeaveEventRestartMs: 60_000 },
+                room,
+                client,
+                { id: "", application: "m.call" },
+            );
+            manager.join([focus], focusActive, unrecoverableError);
+            await waitForMockCall(client.sendStateEvent);
+            await vi.advanceTimersByTimeAsync(1);
+            vi.mocked(client.sendStateEvent).mockClear();
+
+            vi.mocked(client._unstable_restartScheduledDelayedEvent).mockRejectedValueOnce(
+                new MatrixError({ errcode: "M_FORBIDDEN" }, 403),
+            );
+            await vi.advanceTimersByTimeAsync(6_000);
+            expect(client.sendStateEvent).not.toHaveBeenCalled();
+            expect(unrecoverableError).toHaveBeenCalled();
+        });
     });
 
     describe("status updates", () => {

--- a/spec/unit/matrixrtc/MembershipManager.spec.ts
+++ b/spec/unit/matrixrtc/MembershipManager.spec.ts
@@ -653,6 +653,62 @@ describe("MembershipManager", () => {
         it("extends `expires` using headroom configuration", async () => {
             await testExpires(10_000, 1_000);
         });
+
+        it("restarts the delayed leave event before extending `expires`", async () => {
+            // Restarts are far apart so that only the expiry update touches the delayed event.
+            const manager = new MembershipManager(
+                { membershipEventExpiryMs: 10_000, delayedLeaveEventRestartMs: 60_000 },
+                room,
+                client,
+                { id: "", application: "m.call" },
+            );
+            manager.join([focus], focusActive);
+            await waitForMockCall(client.sendStateEvent);
+            await vi.advanceTimersByTimeAsync(1);
+            // The restart after joining checks that the delayed event survived the join.
+            expect(client._unstable_restartScheduledDelayedEvent).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(10_000);
+            expect(client.sendStateEvent).toHaveBeenCalledTimes(2);
+            expect(client._unstable_restartScheduledDelayedEvent).toHaveBeenCalledTimes(2);
+            // The restart must come before the membership is re-sent, so that it is never on the server unprotected.
+            expect(vi.mocked(client._unstable_restartScheduledDelayedEvent).mock.invocationCallOrder[1]).toBeLessThan(
+                vi.mocked(client.sendStateEvent).mock.invocationCallOrder[1],
+            );
+        });
+
+        it("rejoins instead of extending `expires` when the server already sent the delayed leave event", async () => {
+            const manager = new MembershipManager(
+                { membershipEventExpiryMs: 10_000, delayedLeaveEventRestartMs: 60_000 },
+                room,
+                client,
+                { id: "", application: "m.call" },
+            );
+            manager.join([focus], focusActive);
+            await waitForMockCall(client.sendStateEvent);
+            await vi.advanceTimersByTimeAsync(1);
+            vi.mocked(client.sendStateEvent).mockClear();
+            vi.mocked(client._unstable_sendDelayedStateEvent).mockClear();
+            vi.mocked(client._unstable_restartScheduledDelayedEvent).mockClear();
+
+            // The device sleeps, no restarts reach the server and it sends our delayed leave event. When we wake up
+            // the expiry update is due, and the restart it makes first finds the delayed event gone.
+            vi.mocked(client._unstable_restartScheduledDelayedEvent).mockRejectedValueOnce(
+                new MatrixError({ errcode: "M_NOT_FOUND" }, 404),
+            );
+            // The expiry update is due 5s (the headroom) before `expires`.
+            await vi.advanceTimersByTimeAsync(6_000);
+
+            // We did not resurrect the membership without a delayed leave event: a new delayed event was
+            // scheduled before the membership was sent again, as a fresh join.
+            expect(client._unstable_sendDelayedStateEvent).toHaveBeenCalledTimes(1);
+            expect(client.sendStateEvent).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(client._unstable_sendDelayedStateEvent).mock.invocationCallOrder[0]).toBeLessThan(
+                vi.mocked(client.sendStateEvent).mock.invocationCallOrder[0],
+            );
+            expect((vi.mocked(client.sendStateEvent).mock.calls[0][2] as SessionMembershipData).expires).toBe(10_000);
+            expect(manager.status).toBe(Status.Connected);
+        });
     });
 
     describe("status updates", () => {

--- a/src/matrixrtc/MembershipManager.ts
+++ b/src/matrixrtc/MembershipManager.ts
@@ -724,6 +724,36 @@ export class MembershipManager
     }
 
     private async updateExpiryOnJoinedEvent(): Promise<ActionUpdate> {
+        // Re-sending our membership is only safe while our delayed leave event is still scheduled: if the server has
+        // already sent it (e.g. because the device was asleep and no restarts reached the server), the membership we
+        // would send here would come back to life without any delayed leave event to clean it up, and stay until
+        // `expires` runs out. So restart the delayed event first. A success guarantees it will outlive the membership
+        // update; a 404 tells us it is gone, and we need to fully rejoin instead.
+        if (this.state.delayId) {
+            try {
+                await this.client._unstable_restartScheduledDelayedEvent(this.state.delayId);
+                this.state.expectedServerDelayLeaveTs = Date.now() + this.delayedLeaveEventDelayMs;
+            } catch (e) {
+                if (this.isNotFoundError(e)) {
+                    // The delayed leave event has been sent, which also means our membership is gone.
+                    this.logger.warn(
+                        "Delayed leave event was already sent by the server, rejoining instead of updating expiry",
+                    );
+                    this.setAndEmitDelayId(undefined);
+                    this.state.hasMemberStateEvent = false;
+                    return createReplaceActionUpdate(MembershipActionType.SendDelayedEvent);
+                }
+                if (!this.isUnsupportedDelayedEndpoint(e)) {
+                    const update = this.actionUpdateFromErrors(
+                        e,
+                        MembershipActionType.UpdateExpiry,
+                        "restartScheduledDelayedEvent",
+                    );
+                    if (update) return update;
+                    throw e;
+                }
+            }
+        }
         const nextExpireUpdateIteration = this.state.expireUpdateIterations + 1;
         return await this.clientSendMembership(
             this.makeMyMembership(this.membershipEventExpiryMs * nextExpireUpdateIteration),


### PR DESCRIPTION
Fixes a way for a MatrixRTC membership to end up on the server with no delayed leave event behind it, so that nothing removes it when the client goes away.

**Scenario** (from [element-call-rageshakes#17311](https://github.com/element-hq/element-call-rageshakes/issues/17311), confirmed against the Synapse logs): a laptop sleeps mid-call. No restarts reach the server, so it sends the delayed leave and the membership is gone. On laptop wake, there's a race between the /sync response which tells the client that their membership has expired, and the client setting up a delayed event: the `MembershipManager`'s overdue `UpdateExpiry` action fires before the sync carrying the leave is processed and re-sends the full membership as a plain state event, with `created_ts` preserved. That resurrects the membership with no delayed leave event scheduled for it. The tab then had its browser quit, and the membership stayed for the full `expires` (50 hours with Element Call's config).

**Fix**: `updateExpiryOnJoinedEvent` now restarts the delayed leave event before sending the update. A success is the server's guarantee that the leave outlives the membership update, so the ordering is safe regardless of local clocks. A 404 means the leave has been sent, and we go through the normal re-join path (new delayed event first, then the membership) rather than re-sending blind. Other errors are handled as they are for restarts. Two tests cover the ordering and the re-join.

Generated by Fable.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).