### PR TITLE
MatrixRTC: don't let a superseded membership recalculation overwrite a newer one

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -833,6 +833,27 @@ describe("MatrixRTCSession", () => {
             expect(onMembershipsChanged).toHaveBeenCalled();
         });
 
+        it("does not let an older recalculation overwrite a newer one", async () => {
+            const bob = { ...sessionMembershipTemplate, user_id: "@bob:example.org", device_id: "BBBBBBB" };
+            const mockRoom = makeMockRoom([sessionMembershipTemplate, bob]);
+            sess = MatrixRTCSession.sessionForSlot(client, mockRoom, callSession);
+            await sess.initialMembershipCalculated;
+            expect(sess.memberships).toHaveLength(2);
+
+            // Two membership state events land in one sync batch, so two updates are
+            // requested back to back before either recalculation has finished: Bob leaves,
+            // then Alice leaves. Parsing memberships is async and takes longer the more
+            // there are, so the stale (larger) result would otherwise finish last and win.
+            mockRoomState(mockRoom, [sessionMembershipTemplate]);
+            const first = sess._onRTCSessionMemberUpdate();
+            mockRoomState(mockRoom, []);
+            const second = sess._onRTCSessionMemberUpdate();
+            await Promise.all([first, second]);
+            await flushPromises();
+
+            expect(sess.memberships).toHaveLength(0);
+        });
+
         // TODO: re-enable this test when expiry is implemented
         it.skip("emits an event at the time a membership event expires", () => {
             vi.useFakeTimers();

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -801,6 +801,9 @@ export class MatrixRTCSession extends TypedEventEmitter<
 
     // helper variables to make sure we do not have parallel running recalculations.
     private recalculateSessionMembersPromise: Promise<void> = Promise.resolve();
+    // Incremented by each recalculation, so one that has been overtaken can tell.
+    private recalculationGeneration = 0;
+    private latestRecalculation: Promise<void> = Promise.resolve();
 
     /**
      * Ensures that membership is recalculated when the state of the session may have changed.
@@ -828,18 +831,37 @@ export class MatrixRTCSession extends TypedEventEmitter<
      *
      * This function should be called when the room members or call memberships might have changed.
      */
-    private readonly recalculateSessionMembers = async (): Promise<void> => {
+    private readonly recalculateSessionMembers = (): Promise<void> => {
+        const recalculation = this.doRecalculateSessionMembers();
+        this.latestRecalculation = recalculation;
+        return recalculation;
+    };
+
+    private readonly doRecalculateSessionMembers = async (): Promise<void> => {
         // Clear the flag.
         this.membershipNeedsRecalculation = false;
+        const generation = ++this.recalculationGeneration;
         const oldMemberships = this.memberships;
         // Needs to be computed before `this.memberships` is updated below, since it is derived from it.
         const wasKeyRotationSuppressed = this.isKeyRotationSuppressed;
 
-        this.memberships = await MatrixRTCSession.sessionMembershipsForSlot(
+        const memberships = await MatrixRTCSession.sessionMembershipsForSlot(
             this.room,
             this.slotDescription,
             this.calculateMembershipsOpts,
         );
+        // Recalculations are async and can overlap: `_onRTCSessionMemberUpdate` is called once per
+        // membership state event, so a batch of them starts several at once. Each reads the room
+        // state when it starts, and parsing takes longer the more memberships there are, so an
+        // older one can finish last. Its result is stale: drop it and let the newest one win,
+        // otherwise members who have since left linger until the next state change.
+        if (generation !== this.recalculationGeneration) {
+            this.logger.debug("Discarding superseded membership recalculation");
+            // Still let our caller see the final state before continuing.
+            await this.latestRecalculation;
+            return;
+        }
+        this.memberships = memberships;
 
         const changed =
             oldMemberships.length != this.memberships.length ||


### PR DESCRIPTION
Fixes ghost call members lingering after a sync that carries several membership state events at once.

**Scenario** (from [element-call-rageshakes#17311](https://github.com/element-hq/element-call-rageshakes/issues/17311)): Element Call is reopened after a few hours away. The first incremental sync's `state_after` holds a handful of `m.call.member` changes, which `RoomState.setStateEvents` emits one by one. `MatrixRTCSessionManager` calls `session._onRTCSessionMemberUpdate()` for each, so several `recalculateSessionMembers` runs start back to back. Each reads the room state at its start, then awaits `CallMembership.parseFromEvent` per member, so a run that started earlier (seeing more members still present) finishes later and overwrites the result of the run that saw the final state. The client log shows exactly this: five recalculations emitting 1, 1, 2, 2, 3 members in that order, ending with two users the server had removed hours earlier, who then vanished on the next sync response. The sync data itself was correct.

**Fix**: each recalculation takes a generation number; one that has been overtaken discards its result and awaits the newest run, so callers (the session manager's started/ended detection, joining) still observe the final state. Serialising through `ensureRecalculateSessionMembers` instead changed the timing that the join/notification path relies on, so this keeps the immediate recalculation and just drops stale results.

The new test drives two updates back to back with the state changing in between and fails on develop (the stale one-member result wins).

Generated by Fable.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).