### PR TITLE
Add methods for ensuring a slot is open / closed

### DIFF
--- a/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
+++ b/spec/unit/matrixrtc/MatrixRTCSession.spec.ts
@@ -30,7 +30,11 @@ import {
 } from "./mocks";
 import { RoomStickyEventsEvent, type StickyMatrixEvent } from "../../../src/models/room-sticky-events.ts";
 import { RoomStateEvent } from "../../../src/models/room-state.ts";
-import { type RtcSlotEventContent } from "../../../src/matrixrtc/types.ts";
+import {
+    RTC_SLOT_ENCRYPTION_PER_MEMBER,
+    type RtcSlotEncryptionContent,
+    type RtcSlotEventContent,
+} from "../../../src/matrixrtc/types.ts";
 import { StickyEventMembershipManager } from "../../../src/matrixrtc/MembershipManager.ts";
 import { flushPromises } from "../../test-utils/flushPromises.ts";
 import {
@@ -1097,6 +1101,244 @@ describe("MatrixRTCSession", () => {
 
             expect(sess.memberships).toHaveLength(0);
             expect(sess.isSlotClosed()).toBe(true);
+        });
+
+        describe("ensureRtcSlotOpen", () => {
+            const perMemberEncryption: RtcSlotEncryptionContent = { type: RTC_SLOT_ENCRYPTION_PER_MEMBER };
+            let mockRoom: Room;
+
+            beforeEach(() => {
+                client.sendStateEvent = vi.fn().mockResolvedValue({ event_id: "success" });
+                mockRoom = makeMockRoom([], false);
+                sess = MatrixRTCSession.sessionForSlot(client, mockRoom, callSession);
+            });
+
+            it("creates the slot from the slot description when no slot event exists", async () => {
+                await sess!.ensureRtcSlotOpen();
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { status: "open", application: { type: "m.call" } },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("declares the given encryption when creating the slot", async () => {
+                await sess!.ensureRtcSlotOpen({ encryption: perMemberEncryption });
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { status: "open", application: { type: "m.call" }, encryption: perMemberEncryption },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("reopens a closed slot, rewriting application from the slot description", async () => {
+                const existingContent: RtcSlotEventContent = {
+                    status: "closed",
+                    application: { type: "m.call", foo: "bar" },
+                };
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, existingContent, mockRoom.roomId));
+
+                await sess!.ensureRtcSlotOpen();
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { status: "open", application: { type: "m.call" } },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("adds encryption when reopening a closed slot that had none", async () => {
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(callSession, closedSlotContentWithApplication, mockRoom.roomId),
+                );
+
+                await sess!.ensureRtcSlotOpen({ encryption: perMemberEncryption });
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { status: "open", application: { type: "m.call" }, encryption: perMemberEncryption },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("removes encryption when reopening a closed slot without it", async () => {
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(
+                        callSession,
+                        { ...closedSlotContentWithApplication, encryption: perMemberEncryption },
+                        mockRoom.roomId,
+                    ),
+                );
+
+                await sess!.ensureRtcSlotOpen();
+
+                const sentContent = vi.mocked(client.sendStateEvent).mock.calls[0][2] as RtcSlotEventContent;
+                expect(sentContent.status).toBe("open");
+                expect(sentContent.encryption).toBeUndefined();
+            });
+
+            it("replaces already-declared encryption when reopening a closed slot", async () => {
+                const existingEncryption: RtcSlotEncryptionContent = { ...perMemberEncryption, extra: "old" };
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(
+                        callSession,
+                        { ...closedSlotContentWithApplication, encryption: existingEncryption },
+                        mockRoom.roomId,
+                    ),
+                );
+
+                await sess!.ensureRtcSlotOpen({ encryption: perMemberEncryption });
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    expect.objectContaining({ encryption: perMemberEncryption }),
+                    "m.call#ROOM",
+                );
+            });
+
+            it("does nothing when the slot is already open with matching application and no encryption", async () => {
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, openSlotContent, mockRoom.roomId));
+
+                await sess!.ensureRtcSlotOpen();
+
+                expect(client.sendStateEvent).not.toHaveBeenCalled();
+            });
+
+            it("does nothing when the slot is already open with matching application and encryption", async () => {
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(
+                        callSession,
+                        { ...openSlotContent, encryption: perMemberEncryption },
+                        mockRoom.roomId,
+                    ),
+                );
+
+                await sess!.ensureRtcSlotOpen({ encryption: perMemberEncryption });
+
+                expect(client.sendStateEvent).not.toHaveBeenCalled();
+            });
+
+            it("rewrites an open slot whose application differs from the slot description", async () => {
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(
+                        callSession,
+                        { status: "open", application: { type: "m.call", foo: "bar" } },
+                        mockRoom.roomId,
+                    ),
+                );
+
+                await sess!.ensureRtcSlotOpen();
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { status: "open", application: { type: "m.call" } },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("rewrites an open slot to add encryption", async () => {
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, openSlotContent, mockRoom.roomId));
+
+                await sess!.ensureRtcSlotOpen({ encryption: perMemberEncryption });
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { ...openSlotContent, encryption: perMemberEncryption },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("rewrites an open slot to remove encryption", async () => {
+                mockRoomState(
+                    mockRoom,
+                    [],
+                    mockSlotEvent(
+                        callSession,
+                        { ...openSlotContent, encryption: perMemberEncryption },
+                        mockRoom.roomId,
+                    ),
+                );
+
+                await sess!.ensureRtcSlotOpen();
+
+                const sentContent = vi.mocked(client.sendStateEvent).mock.calls[0][2] as RtcSlotEventContent;
+                expect(sentContent.status).toBe("open");
+                expect(sentContent.encryption).toBeUndefined();
+            });
+
+            it("propagates errors from sending the state event", async () => {
+                client.sendStateEvent = vi.fn().mockRejectedValue(new Error("M_FORBIDDEN"));
+
+                await expect(sess!.ensureRtcSlotOpen()).rejects.toThrow("M_FORBIDDEN");
+            });
+        });
+
+        describe("ensureRtcSlotClosed", () => {
+            let mockRoom: Room;
+
+            beforeEach(() => {
+                client.sendStateEvent = vi.fn().mockResolvedValue({ event_id: "success" });
+                mockRoom = makeMockRoom([], false);
+                sess = MatrixRTCSession.sessionForSlot(client, mockRoom, callSession);
+            });
+
+            it("closes an open slot preserving its other content", async () => {
+                const existingContent: RtcSlotEventContent = {
+                    status: "open",
+                    application: { type: "m.call" },
+                    encryption: { type: RTC_SLOT_ENCRYPTION_PER_MEMBER },
+                };
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, existingContent, mockRoom.roomId));
+
+                await sess!.ensureRtcSlotClosed();
+
+                expect(client.sendStateEvent).toHaveBeenCalledWith(
+                    mockRoom.roomId,
+                    EventType.RTCSlot,
+                    { ...existingContent, status: "closed" },
+                    "m.call#ROOM",
+                );
+            });
+
+            it("does nothing when no slot event exists", async () => {
+                await sess!.ensureRtcSlotClosed();
+
+                expect(client.sendStateEvent).not.toHaveBeenCalled();
+            });
+
+            it("does nothing when the slot is already closed", async () => {
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, closedSlotContent, mockRoom.roomId));
+
+                await sess!.ensureRtcSlotClosed();
+
+                expect(client.sendStateEvent).not.toHaveBeenCalled();
+            });
+
+            it("propagates errors from sending the state event", async () => {
+                mockRoomState(mockRoom, [], mockSlotEvent(callSession, openSlotContent, mockRoom.roomId));
+                client.sendStateEvent = vi.fn().mockRejectedValue(new Error("M_FORBIDDEN"));
+
+                await expect(sess!.ensureRtcSlotClosed()).rejects.toThrow("M_FORBIDDEN");
+            });
         });
     });
     it("ensureRecalculateSessionMembers still runs after a rejected promise (React Native / Hermes regression)", async () => {

--- a/src/matrixrtc/MatrixRTCSession.ts
+++ b/src/matrixrtc/MatrixRTCSession.ts
@@ -26,7 +26,7 @@ import { CallMembership } from "./CallMembership.ts";
 import { RoomStateEvent } from "../models/room-state.ts";
 import { MembershipManager, StickyEventMembershipManager } from "./MembershipManager.ts";
 import { type CallMembershipIdentityParts, type IEncryptionManager } from "./EncryptionManager.ts";
-import { logDurationSync } from "../utils.ts";
+import { deepCompare, logDurationSync } from "../utils.ts";
 import type {
     Statistics,
     RTCNotificationType,
@@ -36,6 +36,7 @@ import type {
     Transport,
     SlotDescription,
     RtcSlotEventContent,
+    RtcSlotEncryptionContent,
 } from "./types.ts";
 import {
     MembershipManagerEvent,
@@ -355,6 +356,55 @@ export class MatrixRTCSession extends TypedEventEmitter<
      */
     public isSlotClosed(): boolean | undefined {
         return isSlotClosed(this.roomSubset, this.slotDescription);
+    }
+
+    /**
+     * Ensures this session's slot is open, sending a slot state event to open (or create) it if needed.
+     *
+     * The event's `application` is set from this session's slot description and its `encryption` from
+     * `opts.encryption`, replacing whatever an existing slot event declares. Other content is preserved.
+     * No-op if the slot is already open with matching `application` and `encryption`.
+     *
+     * @param opts.encryption - The encryption to declare on the slot, or `undefined` for none.
+     * @throws if sending the state event fails.
+     */
+    public async ensureRtcSlotOpen(opts: { encryption?: RtcSlotEncryptionContent } = {}): Promise<void> {
+        const application = { type: this.slotDescription.application };
+        const existingContent = this.getRtcSlot();
+        if (
+            existingContent?.status === "open" &&
+            deepCompare(existingContent.application, application) &&
+            deepCompare(existingContent.encryption, opts.encryption)
+        ) {
+            return;
+        }
+        await this.sendRtcSlot({
+            ...existingContent,
+            status: "open",
+            application,
+            encryption: opts.encryption,
+        });
+    }
+
+    /**
+     * Ensures this session's slot is closed, sending a slot state event to close it if needed.
+     * The other content of the existing slot event is preserved. No-op if no slot event exists.
+     *
+     * @throws if sending the state event fails.
+     */
+    public async ensureRtcSlotClosed(): Promise<void> {
+        const existingContent = this.getRtcSlot();
+        if (!existingContent || existingContent.status === "closed") return;
+        await this.sendRtcSlot({ ...existingContent, status: "closed" });
+    }
+
+    private async sendRtcSlot(content: RtcSlotEventContent): Promise<void> {
+        await this.client.sendStateEvent(
+            this.roomSubset.roomId,
+            EventType.RTCSlot,
+            content,
+            computeSlotId(this.slotDescription),
+        );
     }
 
     /**


### PR DESCRIPTION
This extracts the `ensureOpen` / `ensureClosed` methods from https://github.com/element-hq/element-web/pull/34392.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
