### PR TITLE
Treat an event as read if the user sent a later one

### DIFF
--- a/spec/unit/models/room-receipts.spec.ts
+++ b/spec/unit/models/room-receipts.spec.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {
+    EventStatus,
     FeatureSupport,
     type MatrixClient,
     MatrixEvent,
@@ -294,6 +295,77 @@ describe("RoomReceipts", () => {
         expect(room.hasUserReadEvent(readerId, thread1Id)).toBe(false);
     });
 
+    it("reports read for an event in a thread if we sent a later one, even if we didn't send the last", () => {
+        // Given a thread where we replied and someone else replied after us,
+        // and we have no receipt for the thread (e.g. because we paginated the
+        // thread in rather than seeing it live)
+        const room = createRoom();
+        const [root] = createEvent();
+        const [theirEvent, theirEventId] = createThreadedEvent(root);
+        const [myEvent] = createThreadedEventSentBy(root, readerId);
+        const [laterEvent] = createThreadedEvent(root);
+        setupPaginatedThread(room, root, [theirEvent, myEvent, laterEvent]);
+
+        // Then the event we replied after is read, even though our reply is not
+        // the last event in the thread
+        expect(room.hasUserReadEvent(readerId, theirEventId)).toBe(true);
+    });
+
+    it("reports unread for an event in a thread that arrived after the last one we sent", () => {
+        // Given a thread where we replied and someone else replied after us
+        const room = createRoom();
+        const [root] = createEvent();
+        const [myEvent] = createThreadedEventSentBy(root, readerId);
+        const [laterEvent, laterEventId] = createThreadedEvent(root);
+        setupPaginatedThread(room, root, [myEvent, laterEvent]);
+
+        // Then their reply is unread, since we sent nothing after it
+        expect(room.hasUserReadEvent(readerId, laterEventId)).toBe(false);
+    });
+
+    it("ignores events that are still being sent when deciding what we have read", () => {
+        // Given a thread where our reply failed to send
+        const room = createRoom();
+        const [root] = createEvent();
+        const [theirEvent, theirEventId] = createThreadedEvent(root);
+        const [myEvent] = createThreadedEventSentBy(root, readerId);
+        myEvent.setStatus(EventStatus.NOT_SENT);
+        setupPaginatedThread(room, root, [theirEvent, myEvent]);
+
+        // Then their event is still unread: a send that never landed tells us
+        // nothing about what we have seen
+        expect(room.hasUserReadEvent(readerId, theirEventId)).toBe(false);
+    });
+
+    it("reports a thread root as read if we replied in its thread", () => {
+        // Given a thread rooted at someone else's event, where we replied and
+        // someone else's event arrived after our reply
+        const room = createRoom();
+        const [root, rootId] = createEvent();
+        const [myEvent] = createThreadedEventSentBy(root, readerId);
+        const [laterEvent] = createThreadedEvent(root);
+        setupThread(room, root);
+        room.addLiveEvents([root, myEvent, laterEvent], { addToState: false });
+
+        // Then the root is read: we can't have replied without seeing it.
+        // (Note: our reply is in the thread, but the root is in the main
+        // timeline, so no receipt of ours covers it.)
+        expect(room.hasUserReadEvent(readerId, rootId)).toBe(true);
+    });
+
+    it("reports a thread root as unread if we did not reply in its thread", () => {
+        // Given a thread rooted at someone else's event, where only other
+        // people replied
+        const room = createRoom();
+        const [root, rootId] = createEvent();
+        const [theirEvent] = createThreadedEvent(root);
+        setupThread(room, root);
+        room.addLiveEvents([root, theirEvent], { addToState: false });
+
+        // Then the root is unread
+        expect(room.hasUserReadEvent(readerId, rootId)).toBe(false);
+    });
+
     it("correctly reports readness even when threaded receipts arrive out of order", () => {
         // Given we have 3 events
         const room = createRoom();
@@ -478,9 +550,17 @@ function createEventSentBy(customSenderId: string): [MatrixEvent, string] {
  * Create an event in the thread of the supplied root and return it and its ID.
  */
 function createThreadedEvent(root: MatrixEvent): [MatrixEvent, string] {
+    return createThreadedEventSentBy(root, senderId);
+}
+
+/**
+ * Create an event in the thread of the supplied root, with the supplied sender,
+ * and return it and its ID.
+ */
+function createThreadedEventSentBy(root: MatrixEvent, customSenderId: string): [MatrixEvent, string] {
     const rootEventId = root.getId()!;
     const event = new MatrixEvent({
-        sender: senderId,
+        sender: customSenderId,
         event_id: nextId(),
         content: {
             "m.relates_to": {
@@ -545,4 +625,18 @@ function createOldTimeline(room: Room, events: MatrixEvent[]) {
 function setupThread(room: Room, root: MatrixEvent) {
     const thread = room.createThread(root.getId()!, root, [root], false);
     thread.initialEventsFetched = true;
+}
+
+/**
+ * Create a thread whose events were paginated in rather than received live, so
+ * no synthetic receipts are created for their senders. The events must be
+ * supplied in chronological order.
+ */
+function setupPaginatedThread(room: Room, root: MatrixEvent, events: MatrixEvent[]) {
+    room.addLiveEvents([root], { addToState: false });
+    const thread = room.createThread(root.getId()!, root, [], false);
+    thread.initialEventsFetched = true;
+    // Back-pagination adds events to the start of the timeline one at a time,
+    // so supply them newest-first for them to end up in chronological order.
+    thread.addEvents([root, ...events].reverse(), true);
 }

--- a/src/models/room-receipts.ts
+++ b/src/models/room-receipts.ts
@@ -158,13 +158,22 @@ export class RoomReceipts {
             }
         }
 
-        // TODO: what if they sent the second-last event in the thread?
-        if (this.userSentLatestEventInThread(threadId, userId)) {
-            // The user sent the latest message in this event's thread, so we
-            // consider everything in the thread to be read.
+        if (this.userSentEventAfterOrSame(threadId, userId, eventId)) {
+            // The user sent an event at or after this one, so they must have
+            // seen this one: we consider it read.
             //
-            // Note: maybe we don't need this because synthetic receipts should
-            // do this job for us?
+            // Note: the synthetic receipts we create when we see an event
+            // usually do this job for us, but not always - e.g. we don't create
+            // them for events we paginated in.
+            return true;
+        }
+
+        if (event.isThreadRoot && this.userRepliedInThread(eventId, userId)) {
+            // The user replied in the thread rooted at this event, and you
+            // can't reply to a thread without seeing its root. We have to check
+            // this separately because their reply is in the thread's timeline
+            // whereas the root is in the main one, so no receipt of theirs can
+            // cover the root.
             return true;
         }
 
@@ -173,17 +182,52 @@ export class RoomReceipts {
     }
 
     /**
-     * @returns true if the thread with this ID can be found, and the supplied
-     *          user sent the latest message in it.
+     * @returns true if the timeline for this thread ID can be found, and the
+     *          supplied user sent an event in it that is the same as, or after,
+     *          the event with the supplied ID.
      */
-    private userSentLatestEventInThread(threadId: string, userId: string): boolean {
+    private userSentEventAfterOrSame(threadId: string, userId: string, eventId: string): boolean {
         const timeline =
             threadId === MAIN_ROOM_TIMELINE
                 ? this.room.getLiveTimeline().getEvents()
                 : this.room.getThread(threadId)?.timeline;
 
-        return !!(timeline && timeline.length > 0 && timeline[timeline.length - 1].getSender() === userId);
+        const latestEventId = latestEventIdSentByUser(timeline, userId);
+        return !!latestEventId && isAfterOrSame(latestEventId, eventId, this.room);
     }
+
+    /**
+     * @returns true if the thread rooted at the event with the supplied ID can
+     *          be found, and the supplied user sent a reply in it.
+     */
+    private userRepliedInThread(rootEventId: string, userId: string): boolean {
+        // The root is part of the thread's timeline, but it is not a reply to
+        // the thread, so leave it out.
+        const replies = this.room.getThread(rootEventId)?.timeline.filter((event) => event.getId() !== rootEventId);
+        return !!latestEventIdSentByUser(replies, userId);
+    }
+}
+
+/**
+ * Find the last event in the supplied timeline that was sent by this user.
+ *
+ * Events that are still on their way to the server (or failed to get there) are
+ * ignored: they have no place in the timeline yet, and a failed send tells us
+ * nothing about what the user has seen.
+ *
+ * @returns the ID of the found event, or undefined if there is no such event.
+ */
+function latestEventIdSentByUser(timeline: Array<MatrixEvent> | undefined, userId: string): string | undefined {
+    if (!timeline) return undefined;
+
+    for (let index = timeline.length - 1; index >= 0; index--) {
+        const event = timeline[index];
+        if (event.getSender() === userId && !event.status) {
+            return event.getId();
+        }
+    }
+
+    return undefined;
 }
 
 // --- implementation details ---


### PR DESCRIPTION
Moved here from element-hq/element-web#34905 at @Half-Shot's request: the fix belongs in the js-sdk rather than being patched around in Element Web.

Fixes element-hq/element-web#34904

### Problem

When no receipt covers an event, `RoomReceipts.hasUserReadEvent` falls back to a shortcut: if the user sent the *literal last* event in that event's timeline, treat everything in the timeline as read.

```ts
// TODO: what if they sent the second-last event in the thread?
if (this.userSentLatestEventInThread(threadId, userId)) { ... }
```

```ts
return !!(timeline && timeline.length > 0 && timeline[timeline.length - 1].getSender() === userId);
```

That leaves the TODO's own question unanswered, plus two gaps:

1. **Anything landing after our own message takes the timeline back to unread.** A reaction, an edit, a redaction or a membership change arrives after our reply and the shortcut stops applying — judged against a message we had already read before replying.
2. **A thread root is never covered by it.** Our reply lives in the thread's timeline, the root lives in the main one (`inMainTimelineForReceipt` returns true for thread roots), so no receipt of ours — synthetic or real — can point at the root, and the shortcut looks at the main timeline, where the root itself is typically the last event.

Gap 2 is what Element Web hits in element-hq/element-web#34904: `doesTimelineHaveUnreadMessages` asks whether we have read the latest *important* event of a thread, our own events are never "important", so the question becomes "have we read this thread root?" — and the answer was no, however many times we had replied in it.

### Change

Ask the right questions instead:

- did the user send an event at or after this one, in this event's timeline? (`userSentEventAfterOrSame`, using the existing `isAfterOrSame` ordering rather than "is it the last one");
- and, for a thread root, did the user reply in the thread it roots? (`userRepliedInThread` — you can't reply to a thread without seeing its root.)

Events that are still on their way to the server, or failed to get there, are ignored: they have no place in the timeline yet, and a failed send tells us nothing about what the user has seen.

### Tests

Five tests in `spec/unit/models/room-receipts.spec.ts`, three of which fail on `develop`:

| test | on `develop` |
| --- | --- |
| read if we sent a later event in the thread, even if we didn't send the last | ❌ fails |
| unread for a thread event that arrived after the last one we sent | ✅ passes (guard against over-eagerness) |
| events still being sent are ignored | ❌ fails |
| a thread root is read if we replied in its thread | ❌ fails |
| a thread root is unread if we did not reply in its thread | ✅ passes (guard) |

The first three need a thread whose events came in via pagination rather than live, so that no synthetic receipts exist for their senders and the fallback is actually exercised — hence the new `setupPaginatedThread` helper.

`vitest run spec/` shows no new failures (the 16 pre-existing failures in this working copy are all in `spec/unit/crypto/**` and `spec/integ/crypto/**`, untouched here), and `tsc --noEmit` and `oxfmt --check` are clean for the changed files.

### Follow-up

element-hq/element-web#34905 becomes unnecessary with this: `doesTimelineHaveUnreadMessages` gets the right answer from the js-sdk with no change of its own. I'll close it once this lands, along with the local guard that element-hq/element-web#32851 currently carries in `useUnreadThreadRooms.ts`.

<!-- Please note the changelog check needs a type label, which I cannot add: T-Defect would be right here. -->
