### PR TITLE
Fix type definitions on `import|exportSecretsBundle`

### DIFF
--- a/src/@types/matrix-sdk-crypto-wasm.d.ts
+++ b/src/@types/matrix-sdk-crypto-wasm.d.ts
@@ -16,20 +16,23 @@ limitations under the License.
 
 import type * as RustSdkCryptoJs from "@matrix-org/matrix-sdk-crypto-wasm";
 
+/** Return type of `SecretsBundle.to_json` */
+type SecretsBundleJson = {
+    cross_signing: {
+        master_key: string;
+        self_signing_key: string;
+        user_signing_key: string;
+    };
+    backup?: {
+        algorithm: string;
+        key: string;
+        backup_version: string;
+    };
+};
+
 declare module "@matrix-org/matrix-sdk-crypto-wasm" {
     interface SecretsBundle {
-        to_json(): Promise<{
-            cross_signing: {
-                master_key: string;
-                self_signing_key: string;
-                user_signing_key: string;
-            };
-            backup?: {
-                algorithm: string;
-                key: string;
-                backup_version: string;
-            };
-        }>;
+        to_json(): Promise<SecretsBundleJson>;
     }
 
     interface Device {

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { SecretsBundle } from "@matrix-org/matrix-sdk-crypto-wasm";
 import type { IMegolmSessionData } from "../@types/crypto.ts";
 import type { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
 import { type Room } from "../models/room.ts";
@@ -31,6 +30,7 @@ import {
 } from "./keybackup.ts";
 import { type ISignatures } from "../@types/signed.ts";
 import { type MatrixEvent } from "../models/event.ts";
+import { type SecretsBundleJson } from "../@types/matrix-sdk-crypto-wasm";
 
 /**
  * `matrix-js-sdk/lib/crypto-api`: End-to-end encryption support.
@@ -723,13 +723,13 @@ export interface CryptoApi {
     /**
      * Export secrets bundle for transmitting to another device as part of OAuth2 QR login
      */
-    exportSecretsBundle?(): Promise<Awaited<ReturnType<SecretsBundle["to_json"]>>>;
+    exportSecretsBundle?(): Promise<SecretsBundleJson>;
 
     /**
      * Import secrets bundle transmitted from another device.
      * @param secrets - The secrets bundle received from the other device
      */
-    importSecretsBundle?(secrets: Awaited<ReturnType<SecretsBundle["to_json"]>>): Promise<void>;
+    importSecretsBundle?(secrets: SecretsBundleJson): Promise<void>;
 }
 
 /** A reason code for a failure to decrypt an event. */

--- a/src/crypto-api/index.ts
+++ b/src/crypto-api/index.ts
@@ -30,7 +30,7 @@ import {
 } from "./keybackup.ts";
 import { type ISignatures } from "../@types/signed.ts";
 import { type MatrixEvent } from "../models/event.ts";
-import { type SecretsBundleJson } from "../@types/matrix-sdk-crypto-wasm";
+import type { SecretsBundleJson } from "../@types/matrix-sdk-crypto-wasm.d.ts";
 
 /**
  * `matrix-js-sdk/lib/crypto-api`: End-to-end encryption support.


### PR DESCRIPTION
Currently these are defined in terms of the return type of `SecretsBundle.to_json`. The problem is that `SecretsBundle.to_json` is only typed via a `declare module` doodad in matrix-js-sdk, which means it is not visible to downstream projects. Instead, they end up thinking that `exportSecretsBundle` returns an `unknown`.

Fix this by factoring out the definition to a new type, and returning that explicitly.