### PR TITLE
Speed up slow crypto test which timed out

### DIFF
--- a/spec/integ/crypto/crypto.spec.ts
+++ b/spec/integ/crypto/crypto.spec.ts
@@ -96,7 +96,7 @@ import {
 import { AccountDataAccumulator } from "../../test-utils/AccountDataAccumulator";
 import { UNSIGNED_MEMBERSHIP_FIELD } from "../../../src/@types/event";
 import { KnownMembership } from "../../../src/@types/membership";
-import { type KeyBackup } from "../../../src/rust-crypto/backup.ts";
+import { RustBackupManager, type KeyBackup } from "../../../src/rust-crypto/backup.ts";
 import { CryptoEvent } from "../../../src/crypto-api";
 
 afterEach(() => {
@@ -1914,6 +1914,10 @@ describe("crypto", () => {
 
         describe("Manage Key Backup", () => {
             it("Should be able to restore from 4S after bootstrap", async () => {
+                // Since we wait for the backup upload loop to run, make sure it doesn't sit around for 10 seconds
+                // doing random backoff.
+                vi.spyOn(RustBackupManager, "maxBackupLoopStartDelayMillis", "get").mockReturnValue(100);
+
                 const backupVersion = "1";
                 await bootstrapSecurity(backupVersion);
 
@@ -1953,7 +1957,7 @@ describe("crypto", () => {
                 await aliceClient.getCrypto()!.loadSessionBackupPrivateKeyFromSecretStorage();
                 const importResult = await aliceClient.getCrypto()!.restoreKeyBackup();
                 expect(importResult.imported).toStrictEqual(1);
-            }, 10000);
+            });
 
             it("Reset key backup should create a new backup and update 4S", async () => {
                 // First set up 4S and key backup

--- a/src/rust-crypto/backup.ts
+++ b/src/rust-crypto/backup.ts
@@ -61,6 +61,14 @@ interface KeyBackupCreationInfo {
  * @internal
  */
 export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents, RustBackupCryptoEventMap> {
+    /**
+     * When the backup upload loop starts, we delay the first request by a random amount to avoid backup
+     * requests from different clients hitting the server all at the same time when a new key is sent.
+     *
+     * This defines the maximum delay. It can be reduced in tests to make the test run faster.
+     */
+    public static readonly maxBackupLoopStartDelayMillis: number = 10000;
+
     /** Have we checked if there is a backup on the server which we can use */
     private checkedForBackup = false;
 
@@ -418,7 +426,7 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
         this.emit(CryptoEvent.KeyBackupStatus, false);
     }
 
-    private async backupKeysLoop(maxDelay = 10000): Promise<void> {
+    private async backupKeysLoop(): Promise<void> {
         if (this.backupKeysLoopRunning) {
             this.logger.debug(`Backup loop already running`);
             return;
@@ -427,10 +435,9 @@ export class RustBackupManager extends TypedEventEmitter<RustBackupCryptoEvents,
 
         this.logger.debug(`Backup: Starting keys upload loop for backup version:${this.activeBackupVersion}.`);
 
-        // wait between 0 and `maxDelay` seconds, to avoid backup
-        // requests from different clients hitting the server all at
-        // the same time when a new key is sent
-        const delay = Math.random() * maxDelay;
+        // Wait between 0 and `maxBackupLoopStartDelayMillis` milliseconds, to avoid backup requests from different
+        // clients hitting the server all at the same time when a new key is sent.
+        const delay = Math.random() * RustBackupManager.maxBackupLoopStartDelayMillis;
         await sleep(delay);
 
         try {


### PR DESCRIPTION
Sometimes this test used to time out, because it was waiting for a sleep of up to 10 seconds.

We don't need to wait this long for the test to run. Mock out the delay parameter so that the test can run quickly.

Fixes: #5534