### PR TITLE
Add stable m.room.policy types for MSC4284 policy servers

### DIFF
--- a/src/@types/event.ts
+++ b/src/@types/event.ts
@@ -30,6 +30,7 @@ import {
     type RoomNameEventContent,
     type RoomPinnedEventsEventContent,
     type RoomPolicyContent,
+    type UnstableRoomPolicyContent,
     type RoomPowerLevelsEventContent,
     type RoomServerAclEventContent,
     type RoomThirdPartyInviteEventContent,
@@ -164,7 +165,13 @@ export enum EventType {
     RTCDecline = "org.matrix.msc4310.rtc.decline",
 
     // Policy servers
-    RoomPolicy = "org.matrix.msc4284.policy",
+    RoomPolicy = "m.room.policy",
+    /**
+     * The unstable identifier for `m.room.policy` used before MSC4284 was stabilised in Matrix v1.18.
+     * Only present so that rooms configured with the unstable event can still be read and migrated.
+     * @deprecated Use {@link EventType.RoomPolicy} instead.
+     */
+    RoomPolicyUnstable = "org.matrix.msc4284.policy",
 
     // Retention
     RetentionPolicy = "m.room.retention",
@@ -391,8 +398,9 @@ export interface StateEvents {
     [EventType.PolicyRuleRoom]: PolicyRuleEventContent | EmptyObject;
     [EventType.PolicyRuleServer]: PolicyRuleEventContent | EmptyObject;
 
-    // MSC4284: Policy servers
+    // Policy servers
     [EventType.RoomPolicy]: RoomPolicyContent | EmptyObject;
+    [EventType.RoomPolicyUnstable]: UnstableRoomPolicyContent | EmptyObject;
 
     // MSC3401
     [EventType.GroupCallPrefix]: IGroupCallRoomState;

--- a/src/@types/state_events.ts
+++ b/src/@types/state_events.ts
@@ -147,7 +147,46 @@ export interface PolicyRuleEventContent {
     recommendation: PolicyRecommendation;
 }
 
+/**
+ * The public signing keys of a Policy Server, keyed by algorithm.
+ * Must contain at least `ed25519`. Keys are unpadded base64.
+ */
+export interface RoomPolicyPublicKeys {
+    ed25519: string;
+    [algorithm: string]: string;
+}
+
+/**
+ * Content of the `m.room.policy` state event, which designates the room's Policy Server.
+ * An empty content object means the room does not use a Policy Server.
+ *
+ * @see https://spec.matrix.org/v1.18/client-server-api/#mroompolicy
+ */
 export interface RoomPolicyContent {
+    /** The server name of the Policy Server. It must have a joined user in the room. */
     via: string;
-    public_key: string;
+    /** The public signing keys of the Policy Server. */
+    public_keys: RoomPolicyPublicKeys;
+}
+
+/**
+ * Content of the unstable `org.matrix.msc4284.policy` state event used before MSC4284 was stabilised.
+ * Early implementations used a single `public_key` string instead of `public_keys`.
+ *
+ * @deprecated Rooms should be migrated to `m.room.policy` with {@link RoomPolicyContent}.
+ */
+export interface UnstableRoomPolicyContent {
+    via: string;
+    public_key?: string;
+    public_keys?: RoomPolicyPublicKeys;
+}
+
+/**
+ * Response body of `GET /.well-known/matrix/policy_server`, served on a Policy Server's server name.
+ * Clients use it to populate the `m.room.policy` state event.
+ *
+ * @see https://spec.matrix.org/v1.18/client-server-api/#getwell-knownmatrixpolicy_server
+ */
+export interface PolicyServerWellKnown {
+    public_keys: RoomPolicyPublicKeys;
 }


### PR DESCRIPTION
MSC4284 was merged and shipped in Matrix v1.18, so `EventType.RoomPolicy` now points at the stable `m.room.policy` identifier and `RoomPolicyContent` uses the stable `public_keys` object (with a required `ed25519` key) instead of the pre-stabilisation single `public_key` string.

The unstable `org.matrix.msc4284.policy` identifier is kept as the deprecated `EventType.RoomPolicyUnstable` with `UnstableRoomPolicyContent` so clients can read rooms configured before stabilisation and migrate them. `PolicyServerWellKnown` types the `/.well-known/matrix/policy_server` response clients use to populate the state event.
